### PR TITLE
Make GUI dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,24 @@ A professional Python package for controlling Siglent SD824x HD oscilloscopes vi
 pip install Siglent-Oscilloscope
 ```
 
+To include the optional GUI dependencies, install with the `gui` extra:
+
+```bash
+pip install "Siglent-Oscilloscope[gui]"
+```
+
 ### From source
 
 ```bash
 git clone git@github.com:little-did-I-know/Siglent-Oscilloscope.git
 cd siglent
 pip install -e .
+```
+
+Install with GUI support from source:
+
+```bash
+pip install -e ".[gui]"
 ```
 
 ### Development installation
@@ -82,9 +94,10 @@ main()
 ## Requirements
 
 - Python 3.8+
-- PyQt6
 - NumPy
 - Matplotlib
+
+For the GUI application, install the `gui` extra to add PyQt6 and PyQt6-WebEngine.
 
 ## Connection
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ classifiers = [
 ]
 
 dependencies = [
-    "PyQt6>=6.6.0",
-    "PyQt6-WebEngine>=6.6.0",
     "numpy>=1.24.0",
     "matplotlib>=3.7.0",
     "scipy>=1.10.0",
@@ -59,8 +57,14 @@ dev = [
 hdf5 = [
     "h5py>=3.8.0",
 ]
+gui = [
+    "PyQt6>=6.6.0",
+    "PyQt6-WebEngine>=6.6.0",
+]
 all = [
     "h5py>=3.8.0",
+    "PyQt6>=6.6.0",
+    "PyQt6-WebEngine>=6.6.0",
 ]
 
 [project.scripts]

--- a/siglent/gui/app.py
+++ b/siglent/gui/app.py
@@ -1,11 +1,7 @@
 """GUI application entry point for Siglent oscilloscope control."""
 
-import sys
 import logging
-from PyQt6.QtWidgets import QApplication
-from PyQt6.QtCore import Qt
-
-from siglent.gui.main_window import MainWindow
+import sys
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -13,8 +9,26 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(level
 logger = logging.getLogger(__name__)
 
 
+def _require_gui_dependencies():
+    """Import PyQt6 dependencies with a helpful error if missing."""
+    try:
+        from PyQt6.QtWidgets import QApplication
+        from PyQt6.QtCore import Qt
+    except ModuleNotFoundError as exc:
+        raise ImportError(
+            "PyQt6 is required for the GUI. Install the GUI extras with:\n"
+            '  pip install "Siglent-Oscilloscope[gui]"'
+        ) from exc
+
+    return QApplication, Qt
+
+
 def main():
     """Main entry point for the GUI application."""
+    QApplication, Qt = _require_gui_dependencies()
+
+    from siglent.gui.main_window import MainWindow
+
     # Enable OpenGL context sharing for QtWebEngine (required for VNC window)
     QApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts)
 

--- a/tests/test_core_imports_without_gui.py
+++ b/tests/test_core_imports_without_gui.py
@@ -1,0 +1,35 @@
+"""Ensure core modules import when GUI dependencies are unavailable."""
+
+import builtins
+import importlib
+
+
+def test_core_imports_without_gui(monkeypatch):
+    """Verify importing core modules does not require PyQt6."""
+
+    real_import = builtins.__import__
+
+    def _no_gui_import(name, *args, **kwargs):
+        if name.startswith("PyQt6"):
+            raise ModuleNotFoundError("PyQt6 not available in this environment")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_gui_import)
+
+    modules = [
+        "siglent",
+        "siglent.oscilloscope",
+        "siglent.connection",
+        "siglent.connection.base",
+        "siglent.connection.socket",
+        "siglent.scpi_commands",
+        "siglent.waveform",
+        "siglent.math_channel",
+        "siglent.analysis",
+        "siglent.protocol_decode",
+        "siglent.protocol_decoders",
+        "siglent.reference_waveform",
+    ]
+
+    for module in modules:
+        importlib.import_module(module)

--- a/tests/test_gui_initialization.py
+++ b/tests/test_gui_initialization.py
@@ -1,8 +1,10 @@
 """Test GUI initialization and widget creation."""
 
 import pytest
-from PyQt6.QtWidgets import QApplication
 import sys
+
+pytest.importorskip("PyQt6")
+from PyQt6.QtWidgets import QApplication
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -68,20 +68,28 @@ def test_import_reference_waveform():
 
 def test_import_gui_main_window():
     """Test that main window imports successfully."""
-    from siglent.gui.main_window import MainWindow
+    pytest.importorskip("PyQt6")
+    try:
+        from siglent.gui.main_window import MainWindow
+    except ImportError as exc:  # noqa: PERF203
+        pytest.skip(f"Skipping GUI import tests due to missing Qt runtime: {exc}")
 
     assert MainWindow is not None
 
 
 def test_import_gui_widgets():
     """Test that GUI widgets import successfully."""
-    from siglent.gui.widgets.waveform_display import WaveformDisplay
-    from siglent.gui.widgets.channel_control import ChannelControl
-    from siglent.gui.widgets.cursor_panel import CursorPanel
-    from siglent.gui.widgets.math_panel import MathPanel
-    from siglent.gui.widgets.fft_display import FFTDisplay
-    from siglent.gui.widgets.reference_panel import ReferencePanel
-    from siglent.gui.widgets.protocol_decode_panel import ProtocolDecodePanel
+    pytest.importorskip("PyQt6")
+    try:
+        from siglent.gui.widgets.waveform_display import WaveformDisplay
+        from siglent.gui.widgets.channel_control import ChannelControl
+        from siglent.gui.widgets.cursor_panel import CursorPanel
+        from siglent.gui.widgets.math_panel import MathPanel
+        from siglent.gui.widgets.fft_display import FFTDisplay
+        from siglent.gui.widgets.reference_panel import ReferencePanel
+        from siglent.gui.widgets.protocol_decode_panel import ProtocolDecodePanel
+    except ImportError as exc:  # noqa: PERF203
+        pytest.skip(f"Skipping GUI widget import tests due to missing Qt runtime: {exc}")
 
     assert WaveformDisplay is not None
     assert ChannelControl is not None

--- a/tests/test_waveform_display.py
+++ b/tests/test_waveform_display.py
@@ -2,6 +2,10 @@
 
 import sys
 import numpy as np
+import pytest
+
+pytest.importorskip("PyQt6")
+
 from PyQt6.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget, QPushButton
 from PyQt6.QtCore import Qt
 


### PR DESCRIPTION
## Summary
- move GUI dependencies to an optional `gui` extra and guard the GUI entrypoint for headless installs
- document installing the GUI extras via pip for PyPI and source workflows
- add import coverage that works without GUI deps and skip GUI import tests when Qt runtime is unavailable

## Testing
- python -m pytest tests/test_core_imports_without_gui.py tests/test_imports.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951f81fbb80832c992beb9ceebe88e6)