### PR TITLE
Improve connection error messaging and add socket error tests

### DIFF
--- a/siglent/automation.py
+++ b/siglent/automation.py
@@ -108,7 +108,7 @@ class DataCollector:
             >>> print(f"Sample rate: {data[1].sample_rate} Hz")
         """
         if not self._connected:
-            raise SiglentError("Not connected to oscilloscope")
+            raise SiglentError(f"Not connected to oscilloscope at {self.scope.host}:{self.scope.port}")
 
         if auto_setup:
             self.scope.auto_setup()
@@ -156,7 +156,7 @@ class DataCollector:
             >>> print(f"Collected {len(results)} captures")
         """
         if not self._connected:
-            raise SiglentError("Not connected to oscilloscope")
+            raise SiglentError(f"Not connected to oscilloscope at {self.scope.host}:{self.scope.port}")
 
         results = []
 
@@ -242,7 +242,7 @@ class DataCollector:
             ... )
         """
         if not self._connected:
-            raise SiglentError("Not connected to oscilloscope")
+            raise SiglentError(f"Not connected to oscilloscope at {self.scope.host}:{self.scope.port}")
 
         if output_dir:
             output_path = Path(output_dir)

--- a/tests/test_connection_error_messages.py
+++ b/tests/test_connection_error_messages.py
@@ -1,0 +1,71 @@
+import socket
+
+import pytest
+
+from siglent import exceptions
+from siglent.connection.socket import SocketConnection
+
+
+class FakeSocket:
+    def __init__(self, *, send_exception=None, recv_exception=None, recv_sequence=None):
+        self.timeout = None
+        self.address = None
+        self.send_exception = send_exception
+        self.recv_exception = recv_exception
+        self.recv_sequence = recv_sequence or []
+        self._recv_index = 0
+
+    def settimeout(self, value):
+        self.timeout = value
+
+    def connect(self, address):
+        self.address = address
+
+    def sendall(self, data):
+        if self.send_exception:
+            raise self.send_exception
+
+    def recv(self, _buffer_size):
+        if self.recv_exception:
+            raise self.recv_exception
+        if self._recv_index < len(self.recv_sequence):
+            chunk = self.recv_sequence[self._recv_index]
+            self._recv_index += 1
+            return chunk
+        return b""
+
+    def close(self):
+        return None
+
+
+def test_socket_write_timeout_has_command_and_host(monkeypatch):
+    fake = FakeSocket(send_exception=socket.timeout("timed out"))
+    monkeypatch.setattr("siglent.connection.socket.socket.socket", lambda *_args, **_kwargs: fake)
+
+    conn = SocketConnection("1.2.3.4", port=1111, timeout=0.1)
+    conn.connect()
+
+    with pytest.raises(exceptions.TimeoutError) as excinfo:
+        conn.write("MEASure?")
+
+    message = str(excinfo.value)
+    assert "1.2.3.4:1111" in message
+    assert "MEASure?" in message
+    assert "timeout" in message.lower()
+
+
+def test_socket_read_error_has_command_and_host(monkeypatch):
+    fake = FakeSocket(recv_exception=socket.error("boom"))
+    monkeypatch.setattr("siglent.connection.socket.socket.socket", lambda *_args, **_kwargs: fake)
+
+    conn = SocketConnection("5.6.7.8", port=2222, timeout=0.1)
+    conn.connect()
+    conn.write("STAT?")
+
+    with pytest.raises(exceptions.ConnectionError) as excinfo:
+        conn.read()
+
+    message = str(excinfo.value)
+    assert "5.6.7.8:2222" in message
+    assert "STAT?" in message
+    assert "boom" in message


### PR DESCRIPTION
## Summary
- add host/command context to connection, waveform parsing, and automation error messages
- include waveform command context when parsing responses for clearer diagnostics
- add tests simulating socket timeouts/errors to ensure user-friendly messaging

## Testing
- python -m pytest tests/test_connection_error_messages.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69529c6a104c832cb56065eae390d624)