### PR TITLE
Format code to satisfy CI linting

### DIFF
--- a/siglent/gui/app.py
+++ b/siglent/gui/app.py
@@ -70,6 +70,7 @@ def _check_gui_dependencies():
 
         # Give user a moment to read the warning
         import time
+
         time.sleep(2)
 
 

--- a/siglent/gui/main_window.py
+++ b/siglent/gui/main_window.py
@@ -17,11 +17,13 @@ from siglent.exceptions import ConnectionError, SiglentError
 # Try to use PyQtGraph for high-performance plotting, fallback to matplotlib
 try:
     from siglent.gui.widgets.waveform_display_pg import WaveformDisplayPG as WaveformDisplay
+
     USING_PYQTGRAPH = True
     logger = logging.getLogger(__name__)
     logger.info("Using PyQtGraph for waveform display (high performance mode)")
 except ImportError:
     from siglent.gui.widgets.waveform_display import WaveformDisplay
+
     USING_PYQTGRAPH = False
     logger = logging.getLogger(__name__)
     logger.warning("PyQtGraph not available, using matplotlib (install with: pip install 'Siglent-Oscilloscope[gui]')")

--- a/siglent/gui/widgets/measurement_marker.py
+++ b/siglent/gui/widgets/measurement_marker.py
@@ -78,22 +78,14 @@ class MeasurementMarker(ABC):
 
     # Default visual styling
     DEFAULT_LINE_WIDTH = 2
-    DEFAULT_LINE_STYLE = '--'
+    DEFAULT_LINE_STYLE = "--"
     DEFAULT_ALPHA = 0.8
     DEFAULT_SELECTED_ALPHA = 1.0
     HANDLE_SIZE = 8  # pixels
     LABEL_FONTSIZE = 9
     LABEL_PADDING = 4
 
-    def __init__(
-        self,
-        marker_id: str,
-        measurement_type: str,
-        channel: int,
-        ax: 'Axes',
-        canvas: 'FigureCanvasQTAgg',
-        color: Optional[str] = None
-    ):
+    def __init__(self, marker_id: str, measurement_type: str, channel: int, ax: "Axes", canvas: "FigureCanvasQTAgg", color: Optional[str] = None):
         """Initialize measurement marker.
 
         Args:
@@ -235,14 +227,14 @@ class MeasurementMarker(ABC):
         alpha = self.DEFAULT_SELECTED_ALPHA if selected else self.DEFAULT_ALPHA
 
         for artist in self.artists:
-            if hasattr(artist, 'set_alpha'):
+            if hasattr(artist, "set_alpha"):
                 artist.set_alpha(alpha)
 
         # Add white outline if selected
         if selected:
             for artist in self.artists:
                 if isinstance(artist, Line2D):
-                    artist.set_markeredgecolor('white')
+                    artist.set_markeredgecolor("white")
                     artist.set_markeredgewidth(2)
 
     def update_measurement(self, waveform: WaveformData) -> None:
@@ -359,23 +351,9 @@ class MeasurementMarker(ABC):
         label_text = self._create_label_text()
 
         # Create text with background box
-        bbox_props = dict(
-            boxstyle=f'round,pad={self.LABEL_PADDING}',
-            facecolor='#000000DD',
-            edgecolor=self.color if self.selected else '#444444',
-            linewidth=2 if self.selected else 1
-        )
+        bbox_props = dict(boxstyle=f"round,pad={self.LABEL_PADDING}", facecolor="#000000DD", edgecolor=self.color if self.selected else "#444444", linewidth=2 if self.selected else 1)
 
-        self.label_artist = self.ax.text(
-            x, y,
-            label_text,
-            fontsize=self.LABEL_FONTSIZE,
-            color=self.color,
-            bbox=bbox_props,
-            verticalalignment='top',
-            horizontalalignment='left',
-            zorder=100  # Draw on top
-        )
+        self.label_artist = self.ax.text(x, y, label_text, fontsize=self.LABEL_FONTSIZE, color=self.color, bbox=bbox_props, verticalalignment="top", horizontalalignment="left", zorder=100)  # Draw on top
 
     def _get_default_color(self) -> str:
         """Get default color based on measurement type.
@@ -385,22 +363,22 @@ class MeasurementMarker(ABC):
         """
         # Color scheme matching oscilloscope conventions
         color_map = {
-            'FREQ': '#00CED1',  # Cyan
-            'PER': '#00CED1',   # Cyan
-            'PKPK': '#FFD700',  # Yellow/Gold
-            'AMPL': '#FFD700',  # Yellow/Gold
-            'MAX': '#FFD700',   # Yellow/Gold
-            'MIN': '#FFD700',   # Yellow/Gold
-            'RMS': '#FFD700',   # Yellow/Gold
-            'MEAN': '#FFD700',  # Yellow/Gold
-            'RISE': '#FF1493',  # Magenta
-            'FALL': '#FF1493',  # Magenta
-            'WID': '#00FF00',   # Green
-            'NWID': '#00FF00',  # Green
-            'DUTY': '#00FF00',  # Green
+            "FREQ": "#00CED1",  # Cyan
+            "PER": "#00CED1",  # Cyan
+            "PKPK": "#FFD700",  # Yellow/Gold
+            "AMPL": "#FFD700",  # Yellow/Gold
+            "MAX": "#FFD700",  # Yellow/Gold
+            "MIN": "#FFD700",  # Yellow/Gold
+            "RMS": "#FFD700",  # Yellow/Gold
+            "MEAN": "#FFD700",  # Yellow/Gold
+            "RISE": "#FF1493",  # Magenta
+            "FALL": "#FF1493",  # Magenta
+            "WID": "#00FF00",  # Green
+            "NWID": "#00FF00",  # Green
+            "DUTY": "#00FF00",  # Green
         }
 
-        return color_map.get(self.measurement_type, '#FFFFFF')  # White default
+        return color_map.get(self.measurement_type, "#FFFFFF")  # White default
 
     def get_config(self) -> Dict[str, Any]:
         """Get marker configuration for saving.
@@ -408,16 +386,7 @@ class MeasurementMarker(ABC):
         Returns:
             Configuration dictionary
         """
-        return {
-            'id': self.marker_id,
-            'type': self.measurement_type,
-            'channel': self.channel,
-            'enabled': self.enabled,
-            'gates': self.gates.copy(),
-            'color': self.color,
-            'result': self.result,
-            'unit': self.unit
-        }
+        return {"id": self.marker_id, "type": self.measurement_type, "channel": self.channel, "enabled": self.enabled, "gates": self.gates.copy(), "color": self.color, "result": self.result, "unit": self.unit}
 
     def set_config(self, config: Dict[str, Any]) -> None:
         """Load marker configuration.
@@ -425,11 +394,11 @@ class MeasurementMarker(ABC):
         Args:
             config: Configuration dictionary
         """
-        self.enabled = config.get('enabled', True)
-        self.gates = config.get('gates', {}).copy()
-        self.color = config.get('color', self._get_default_color())
-        self.result = config.get('result')
-        self.unit = config.get('unit')
+        self.enabled = config.get("enabled", True)
+        self.gates = config.get("gates", {}).copy()
+        self.color = config.get("color", self._get_default_color())
+        self.result = config.get("result")
+        self.unit = config.get("unit")
         self.is_dirty = True
 
     def _extract_gate_data(self, waveform: WaveformData) -> Tuple[np.ndarray, np.ndarray]:
@@ -444,11 +413,11 @@ class MeasurementMarker(ABC):
         Raises:
             ValueError: If gates are not properly defined
         """
-        if 'start_x' not in self.gates or 'end_x' not in self.gates:
+        if "start_x" not in self.gates or "end_x" not in self.gates:
             raise ValueError("Gates not properly defined (missing start_x or end_x)")
 
-        start_x = self.gates['start_x']
-        end_x = self.gates['end_x']
+        start_x = self.gates["start_x"]
+        end_x = self.gates["end_x"]
 
         # Create mask for data within gates
         mask = (waveform.time >= start_x) & (waveform.time <= end_x)

--- a/siglent/gui/widgets/measurement_markers/__init__.py
+++ b/siglent/gui/widgets/measurement_markers/__init__.py
@@ -29,4 +29,4 @@ from .frequency_marker import FrequencyMarker
 from .voltage_marker import VoltageMarker
 from .timing_marker import TimingMarker
 
-__all__ = ['FrequencyMarker', 'VoltageMarker', 'TimingMarker']
+__all__ = ["FrequencyMarker", "VoltageMarker", "TimingMarker"]

--- a/siglent/gui/widgets/measurement_markers/frequency_marker.py
+++ b/siglent/gui/widgets/measurement_markers/frequency_marker.py
@@ -33,13 +33,13 @@ class FrequencyMarker(MeasurementMarker):
             canvas: Qt canvas
             color: Marker color (defaults to cyan)
         """
-        super().__init__(marker_id, measurement_type, channel, ax, canvas, color or '#00CED1')
+        super().__init__(marker_id, measurement_type, channel, ax, canvas, color or "#00CED1")
 
         # Set unit based on measurement type
-        self.unit = 'Hz' if measurement_type == 'FREQ' else 's'
+        self.unit = "Hz" if measurement_type == "FREQ" else "s"
 
         # Initialize gates (will be set when placed)
-        self.gates = {'start_x': 0.0, 'end_x': 0.0}
+        self.gates = {"start_x": 0.0, "end_x": 0.0}
 
     def render(self) -> None:
         """Draw frequency marker on axes."""
@@ -51,11 +51,11 @@ class FrequencyMarker(MeasurementMarker):
                 pass
         self.artists.clear()
 
-        if not self.gates.get('start_x') or not self.gates.get('end_x'):
+        if not self.gates.get("start_x") or not self.gates.get("end_x"):
             return
 
-        start_x = self.gates['start_x']
-        end_x = self.gates['end_x']
+        start_x = self.gates["start_x"]
+        end_x = self.gates["end_x"]
 
         ylim = self.ax.get_ylim()
         y_range = ylim[1] - ylim[0]
@@ -63,24 +63,10 @@ class FrequencyMarker(MeasurementMarker):
         # Draw vertical gates
         alpha = self.DEFAULT_SELECTED_ALPHA if self.selected else self.DEFAULT_ALPHA
 
-        line1 = self.ax.axvline(
-            start_x,
-            color=self.color,
-            linestyle=self.DEFAULT_LINE_STYLE,
-            linewidth=self.DEFAULT_LINE_WIDTH,
-            alpha=alpha,
-            picker=5
-        )
+        line1 = self.ax.axvline(start_x, color=self.color, linestyle=self.DEFAULT_LINE_STYLE, linewidth=self.DEFAULT_LINE_WIDTH, alpha=alpha, picker=5)
         self.artists.append(line1)
 
-        line2 = self.ax.axvline(
-            end_x,
-            color=self.color,
-            linestyle=self.DEFAULT_LINE_STYLE,
-            linewidth=self.DEFAULT_LINE_WIDTH,
-            alpha=alpha,
-            picker=5
-        )
+        line2 = self.ax.axvline(end_x, color=self.color, linestyle=self.DEFAULT_LINE_STYLE, linewidth=self.DEFAULT_LINE_WIDTH, alpha=alpha, picker=5)
         self.artists.append(line2)
 
         # Draw arc connecting the gates at top
@@ -88,14 +74,7 @@ class FrequencyMarker(MeasurementMarker):
         mid_x = (start_x + end_x) / 2
 
         # Create arc using a simple line
-        arc_line = self.ax.plot(
-            [start_x, mid_x, end_x],
-            [arc_y, arc_y + y_range * 0.02, arc_y],
-            color=self.color,
-            linestyle='-',
-            linewidth=self.DEFAULT_LINE_WIDTH,
-            alpha=alpha
-        )[0]
+        arc_line = self.ax.plot([start_x, mid_x, end_x], [arc_y, arc_y + y_range * 0.02, arc_y], color=self.color, linestyle="-", linewidth=self.DEFAULT_LINE_WIDTH, alpha=alpha)[0]
         self.artists.append(arc_line)
 
         # Draw label at top center
@@ -112,17 +91,17 @@ class FrequencyMarker(MeasurementMarker):
         Args:
             **kwargs: Can include 'start_x', 'end_x', or 'center_x' with 'width'
         """
-        if 'start_x' in kwargs:
-            self.gates['start_x'] = kwargs['start_x']
-        if 'end_x' in kwargs:
-            self.gates['end_x'] = kwargs['end_x']
+        if "start_x" in kwargs:
+            self.gates["start_x"] = kwargs["start_x"]
+        if "end_x" in kwargs:
+            self.gates["end_x"] = kwargs["end_x"]
 
         # Alternative: specify center and width
-        if 'center_x' in kwargs and 'width' in kwargs:
-            center = kwargs['center_x']
-            width = kwargs['width']
-            self.gates['start_x'] = center - width / 2
-            self.gates['end_x'] = center + width / 2
+        if "center_x" in kwargs and "width" in kwargs:
+            center = kwargs["center_x"]
+            width = kwargs["width"]
+            self.gates["start_x"] = center - width / 2
+            self.gates["end_x"] = center + width / 2
 
         self.is_dirty = True
         self.last_waveform_hash = None  # Force recalculation
@@ -150,7 +129,7 @@ class FrequencyMarker(MeasurementMarker):
             if period is None or period <= 0:
                 return None
 
-            if self.measurement_type == 'FREQ':
+            if self.measurement_type == "FREQ":
                 return 1.0 / period
             else:  # PER
                 return period
@@ -224,8 +203,8 @@ class FrequencyMarker(MeasurementMarker):
                 # Use middle portion of waveform
                 mid_idx = len(waveform.time) // 2
                 quarter_len = len(waveform.time) // 4
-                search_time = waveform.time[mid_idx - quarter_len:mid_idx + quarter_len]
-                search_voltage = waveform.voltage[mid_idx - quarter_len:mid_idx + quarter_len]
+                search_time = waveform.time[mid_idx - quarter_len : mid_idx + quarter_len]
+                search_voltage = waveform.voltage[mid_idx - quarter_len : mid_idx + quarter_len]
 
             # Estimate period
             period = self._estimate_period(search_time, search_voltage)
@@ -233,8 +212,8 @@ class FrequencyMarker(MeasurementMarker):
             if period is not None and period > 0:
                 # Center gates on hint or middle
                 center = x_hint if x_hint is not None else np.mean(waveform.time)
-                self.gates['start_x'] = center - period / 2
-                self.gates['end_x'] = center + period / 2
+                self.gates["start_x"] = center - period / 2
+                self.gates["end_x"] = center + period / 2
 
                 logger.debug(f"Auto-placed frequency marker with period {period:.6e} s")
                 self.is_dirty = True

--- a/siglent/gui/widgets/measurement_markers/timing_marker.py
+++ b/siglent/gui/widgets/measurement_markers/timing_marker.py
@@ -35,20 +35,20 @@ class TimingMarker(MeasurementMarker):
         """
         # Determine default color based on type
         if color is None:
-            if measurement_type in ['RISE', 'FALL']:
-                color = '#FF1493'  # Magenta
+            if measurement_type in ["RISE", "FALL"]:
+                color = "#FF1493"  # Magenta
             else:  # WID, NWID, DUTY
-                color = '#00FF00'  # Green
+                color = "#00FF00"  # Green
 
         super().__init__(marker_id, measurement_type, channel, ax, canvas, color)
 
-        self.unit = 's' if measurement_type != 'DUTY' else '%'
+        self.unit = "s" if measurement_type != "DUTY" else "%"
 
         # Initialize gates
-        if measurement_type in ['RISE', 'FALL']:
-            self.gates = {'start_x': 0.0, 'end_x': 0.0}
+        if measurement_type in ["RISE", "FALL"]:
+            self.gates = {"start_x": 0.0, "end_x": 0.0}
         else:  # WID, NWID, DUTY
-            self.gates = {'start_x': 0.0, 'end_x': 0.0}
+            self.gates = {"start_x": 0.0, "end_x": 0.0}
 
         # Store threshold levels for rise/fall
         self.threshold_10: Optional[float] = None
@@ -64,74 +64,38 @@ class TimingMarker(MeasurementMarker):
                 pass
         self.artists.clear()
 
-        if not self.gates.get('start_x') or not self.gates.get('end_x'):
+        if not self.gates.get("start_x") or not self.gates.get("end_x"):
             return
 
-        start_x = self.gates['start_x']
-        end_x = self.gates['end_x']
+        start_x = self.gates["start_x"]
+        end_x = self.gates["end_x"]
 
         alpha = self.DEFAULT_SELECTED_ALPHA if self.selected else self.DEFAULT_ALPHA
 
         # Draw vertical gates
-        line1 = self.ax.axvline(
-            start_x,
-            color=self.color,
-            linestyle=self.DEFAULT_LINE_STYLE,
-            linewidth=self.DEFAULT_LINE_WIDTH,
-            alpha=alpha,
-            picker=5
-        )
+        line1 = self.ax.axvline(start_x, color=self.color, linestyle=self.DEFAULT_LINE_STYLE, linewidth=self.DEFAULT_LINE_WIDTH, alpha=alpha, picker=5)
         self.artists.append(line1)
 
-        line2 = self.ax.axvline(
-            end_x,
-            color=self.color,
-            linestyle=self.DEFAULT_LINE_STYLE,
-            linewidth=self.DEFAULT_LINE_WIDTH,
-            alpha=alpha,
-            picker=5
-        )
+        line2 = self.ax.axvline(end_x, color=self.color, linestyle=self.DEFAULT_LINE_STYLE, linewidth=self.DEFAULT_LINE_WIDTH, alpha=alpha, picker=5)
         self.artists.append(line2)
 
         # Type-specific rendering
-        if self.measurement_type in ['RISE', 'FALL'] and self.threshold_10 is not None and self.threshold_90 is not None:
+        if self.measurement_type in ["RISE", "FALL"] and self.threshold_10 is not None and self.threshold_90 is not None:
             # Draw horizontal threshold lines
             xlim = self.ax.get_xlim()
             x_start_norm = (start_x - xlim[0]) / (xlim[1] - xlim[0])
             x_end_norm = (end_x - xlim[0]) / (xlim[1] - xlim[0])
 
-            thresh_10_line = self.ax.axhline(
-                self.threshold_10,
-                xmin=x_start_norm,
-                xmax=x_end_norm,
-                color=self.color,
-                linestyle=':',
-                linewidth=1.5,
-                alpha=alpha * 0.7
-            )
+            thresh_10_line = self.ax.axhline(self.threshold_10, xmin=x_start_norm, xmax=x_end_norm, color=self.color, linestyle=":", linewidth=1.5, alpha=alpha * 0.7)
             self.artists.append(thresh_10_line)
 
-            thresh_90_line = self.ax.axhline(
-                self.threshold_90,
-                xmin=x_start_norm,
-                xmax=x_end_norm,
-                color=self.color,
-                linestyle=':',
-                linewidth=1.5,
-                alpha=alpha * 0.7
-            )
+            thresh_90_line = self.ax.axhline(self.threshold_90, xmin=x_start_norm, xmax=x_end_norm, color=self.color, linestyle=":", linewidth=1.5, alpha=alpha * 0.7)
             self.artists.append(thresh_90_line)
 
-        elif self.measurement_type in ['WID', 'NWID', 'DUTY']:
+        elif self.measurement_type in ["WID", "NWID", "DUTY"]:
             # Draw shaded region between gates
             ylim = self.ax.get_ylim()
-            fill = self.ax.fill_between(
-                [start_x, end_x],
-                ylim[0],
-                ylim[1],
-                color=self.color,
-                alpha=0.15
-            )
+            fill = self.ax.fill_between([start_x, end_x], ylim[0], ylim[1], color=self.color, alpha=0.15)
             self.artists.append(fill)
 
         # Draw label
@@ -150,16 +114,16 @@ class TimingMarker(MeasurementMarker):
         Args:
             **kwargs: Can include 'start_x', 'end_x', or 'center_x' with 'width'
         """
-        if 'start_x' in kwargs:
-            self.gates['start_x'] = kwargs['start_x']
-        if 'end_x' in kwargs:
-            self.gates['end_x'] = kwargs['end_x']
+        if "start_x" in kwargs:
+            self.gates["start_x"] = kwargs["start_x"]
+        if "end_x" in kwargs:
+            self.gates["end_x"] = kwargs["end_x"]
 
-        if 'center_x' in kwargs and 'width' in kwargs:
-            center = kwargs['center_x']
-            width = kwargs['width']
-            self.gates['start_x'] = center - width / 2
-            self.gates['end_x'] = center + width / 2
+        if "center_x" in kwargs and "width" in kwargs:
+            center = kwargs["center_x"]
+            width = kwargs["width"]
+            self.gates["start_x"] = center - width / 2
+            self.gates["end_x"] = center + width / 2
 
         self.is_dirty = True
         self.last_waveform_hash = None
@@ -179,19 +143,19 @@ class TimingMarker(MeasurementMarker):
             if len(gate_time) < 5:
                 return None
 
-            if self.measurement_type == 'RISE':
+            if self.measurement_type == "RISE":
                 return self._calculate_rise_time(gate_time, gate_voltage)
 
-            elif self.measurement_type == 'FALL':
+            elif self.measurement_type == "FALL":
                 return self._calculate_fall_time(gate_time, gate_voltage)
 
-            elif self.measurement_type == 'WID':
+            elif self.measurement_type == "WID":
                 return self._calculate_positive_width(gate_time, gate_voltage)
 
-            elif self.measurement_type == 'NWID':
+            elif self.measurement_type == "NWID":
                 return self._calculate_negative_width(gate_time, gate_voltage)
 
-            elif self.measurement_type == 'DUTY':
+            elif self.measurement_type == "DUTY":
                 return self._calculate_duty_cycle(gate_time, gate_voltage)
 
             else:
@@ -302,9 +266,7 @@ class TimingMarker(MeasurementMarker):
 
         # Find falling and rising edges
         t_falling = self._find_threshold_crossing(time, voltage, threshold, rising=False)
-        t_rising_next = self._find_threshold_crossing(time[time > t_falling] if t_falling else time,
-                                                       voltage[time > t_falling] if t_falling else voltage,
-                                                       threshold, rising=True)
+        t_rising_next = self._find_threshold_crossing(time[time > t_falling] if t_falling else time, voltage[time > t_falling] if t_falling else voltage, threshold, rising=True)
 
         if t_falling is None or t_rising_next is None or t_rising_next <= t_falling:
             return None
@@ -337,8 +299,7 @@ class TimingMarker(MeasurementMarker):
 
         return float(duty_cycle)
 
-    def _find_threshold_crossing(self, time: np.ndarray, voltage: np.ndarray,
-                                  threshold: float, rising: bool = True) -> Optional[float]:
+    def _find_threshold_crossing(self, time: np.ndarray, voltage: np.ndarray, threshold: float, rising: bool = True) -> Optional[float]:
         """Find time when waveform crosses threshold.
 
         Args:
@@ -372,7 +333,7 @@ class TimingMarker(MeasurementMarker):
             x_hint: Optional X position hint
         """
         try:
-            if self.measurement_type in ['RISE', 'FALL']:
+            if self.measurement_type in ["RISE", "FALL"]:
                 # Find edge near hint or in middle
                 if x_hint is not None:
                     center = x_hint
@@ -383,8 +344,8 @@ class TimingMarker(MeasurementMarker):
                 time_span = waveform.time[-1] - waveform.time[0]
                 margin = time_span * 0.05  # 5% margin
 
-                self.gates['start_x'] = center - margin
-                self.gates['end_x'] = center + margin
+                self.gates["start_x"] = center - margin
+                self.gates["end_x"] = center + margin
 
             else:  # WID, NWID, DUTY
                 # Use a reasonable portion of waveform
@@ -397,8 +358,8 @@ class TimingMarker(MeasurementMarker):
 
                 width = time_span * 0.3  # 30% of visible timespan
 
-                self.gates['start_x'] = center - width / 2
-                self.gates['end_x'] = center + width / 2
+                self.gates["start_x"] = center - width / 2
+                self.gates["end_x"] = center + width / 2
 
             logger.debug(f"Auto-placed timing marker")
             self.is_dirty = True

--- a/siglent/gui/widgets/measurement_markers/voltage_marker.py
+++ b/siglent/gui/widgets/measurement_markers/voltage_marker.py
@@ -34,12 +34,12 @@ class VoltageMarker(MeasurementMarker):
             canvas: Qt canvas
             color: Marker color (defaults to yellow/gold)
         """
-        super().__init__(marker_id, measurement_type, channel, ax, canvas, color or '#FFD700')
+        super().__init__(marker_id, measurement_type, channel, ax, canvas, color or "#FFD700")
 
-        self.unit = 'V'
+        self.unit = "V"
 
         # Initialize gates
-        self.gates = {'start_x': 0.0, 'end_x': 0.0}
+        self.gates = {"start_x": 0.0, "end_x": 0.0}
 
         # Store intermediate values for display
         self.max_value: Optional[float] = None
@@ -55,87 +55,40 @@ class VoltageMarker(MeasurementMarker):
                 pass
         self.artists.clear()
 
-        if not self.gates.get('start_x') or not self.gates.get('end_x'):
+        if not self.gates.get("start_x") or not self.gates.get("end_x"):
             return
 
-        start_x = self.gates['start_x']
-        end_x = self.gates['end_x']
+        start_x = self.gates["start_x"]
+        end_x = self.gates["end_x"]
 
         alpha = self.DEFAULT_SELECTED_ALPHA if self.selected else self.DEFAULT_ALPHA
 
         # Draw vertical gates
         ylim = self.ax.get_ylim()
 
-        line1 = self.ax.axvline(
-            start_x,
-            color=self.color,
-            linestyle=self.DEFAULT_LINE_STYLE,
-            linewidth=self.DEFAULT_LINE_WIDTH,
-            alpha=alpha,
-            picker=5
-        )
+        line1 = self.ax.axvline(start_x, color=self.color, linestyle=self.DEFAULT_LINE_STYLE, linewidth=self.DEFAULT_LINE_WIDTH, alpha=alpha, picker=5)
         self.artists.append(line1)
 
-        line2 = self.ax.axvline(
-            end_x,
-            color=self.color,
-            linestyle=self.DEFAULT_LINE_STYLE,
-            linewidth=self.DEFAULT_LINE_WIDTH,
-            alpha=alpha,
-            picker=5
-        )
+        line2 = self.ax.axvline(end_x, color=self.color, linestyle=self.DEFAULT_LINE_STYLE, linewidth=self.DEFAULT_LINE_WIDTH, alpha=alpha, picker=5)
         self.artists.append(line2)
 
         # Draw horizontal lines and brackets based on measurement type
-        if self.measurement_type in ['PKPK', 'AMPL'] and self.max_value is not None and self.min_value is not None:
+        if self.measurement_type in ["PKPK", "AMPL"] and self.max_value is not None and self.min_value is not None:
             # Draw lines at max and min
-            max_line = self.ax.axhline(
-                self.max_value,
-                xmin=(start_x - self.ax.get_xlim()[0]) / (self.ax.get_xlim()[1] - self.ax.get_xlim()[0]),
-                xmax=(end_x - self.ax.get_xlim()[0]) / (self.ax.get_xlim()[1] - self.ax.get_xlim()[0]),
-                color=self.color,
-                linestyle='-',
-                linewidth=1.5,
-                alpha=alpha
-            )
+            max_line = self.ax.axhline(self.max_value, xmin=(start_x - self.ax.get_xlim()[0]) / (self.ax.get_xlim()[1] - self.ax.get_xlim()[0]), xmax=(end_x - self.ax.get_xlim()[0]) / (self.ax.get_xlim()[1] - self.ax.get_xlim()[0]), color=self.color, linestyle="-", linewidth=1.5, alpha=alpha)
             self.artists.append(max_line)
 
-            min_line = self.ax.axhline(
-                self.min_value,
-                xmin=(start_x - self.ax.get_xlim()[0]) / (self.ax.get_xlim()[1] - self.ax.get_xlim()[0]),
-                xmax=(end_x - self.ax.get_xlim()[0]) / (self.ax.get_xlim()[1] - self.ax.get_xlim()[0]),
-                color=self.color,
-                linestyle='-',
-                linewidth=1.5,
-                alpha=alpha
-            )
+            min_line = self.ax.axhline(self.min_value, xmin=(start_x - self.ax.get_xlim()[0]) / (self.ax.get_xlim()[1] - self.ax.get_xlim()[0]), xmax=(end_x - self.ax.get_xlim()[0]) / (self.ax.get_xlim()[1] - self.ax.get_xlim()[0]), color=self.color, linestyle="-", linewidth=1.5, alpha=alpha)
             self.artists.append(min_line)
 
             # Draw vertical bracket on left side
             bracket_x = start_x - (end_x - start_x) * 0.05
-            bracket = self.ax.plot(
-                [bracket_x, bracket_x],
-                [self.min_value, self.max_value],
-                color=self.color,
-                linestyle='-',
-                linewidth=2,
-                alpha=alpha,
-                marker='|',
-                markersize=8
-            )[0]
+            bracket = self.ax.plot([bracket_x, bracket_x], [self.min_value, self.max_value], color=self.color, linestyle="-", linewidth=2, alpha=alpha, marker="|", markersize=8)[0]
             self.artists.append(bracket)
 
         elif self.result is not None:
             # Single horizontal line for other voltage measurements
-            h_line = self.ax.axhline(
-                self.result,
-                xmin=(start_x - self.ax.get_xlim()[0]) / (self.ax.get_xlim()[1] - self.ax.get_xlim()[0]),
-                xmax=(end_x - self.ax.get_xlim()[0]) / (self.ax.get_xlim()[1] - self.ax.get_xlim()[0]),
-                color=self.color,
-                linestyle='-',
-                linewidth=2,
-                alpha=alpha
-            )
+            h_line = self.ax.axhline(self.result, xmin=(start_x - self.ax.get_xlim()[0]) / (self.ax.get_xlim()[1] - self.ax.get_xlim()[0]), xmax=(end_x - self.ax.get_xlim()[0]) / (self.ax.get_xlim()[1] - self.ax.get_xlim()[0]), color=self.color, linestyle="-", linewidth=2, alpha=alpha)
             self.artists.append(h_line)
 
         # Draw label
@@ -153,16 +106,16 @@ class VoltageMarker(MeasurementMarker):
         Args:
             **kwargs: Can include 'start_x', 'end_x', or 'center_x' with 'width'
         """
-        if 'start_x' in kwargs:
-            self.gates['start_x'] = kwargs['start_x']
-        if 'end_x' in kwargs:
-            self.gates['end_x'] = kwargs['end_x']
+        if "start_x" in kwargs:
+            self.gates["start_x"] = kwargs["start_x"]
+        if "end_x" in kwargs:
+            self.gates["end_x"] = kwargs["end_x"]
 
-        if 'center_x' in kwargs and 'width' in kwargs:
-            center = kwargs['center_x']
-            width = kwargs['width']
-            self.gates['start_x'] = center - width / 2
-            self.gates['end_x'] = center + width / 2
+        if "center_x" in kwargs and "width" in kwargs:
+            center = kwargs["center_x"]
+            width = kwargs["width"]
+            self.gates["start_x"] = center - width / 2
+            self.gates["end_x"] = center + width / 2
 
         self.is_dirty = True
         self.last_waveform_hash = None
@@ -184,45 +137,45 @@ class VoltageMarker(MeasurementMarker):
                 return None
 
             # Calculate based on measurement type
-            if self.measurement_type == 'PKPK':
+            if self.measurement_type == "PKPK":
                 self.max_value = float(np.max(gate_voltage))
                 self.min_value = float(np.min(gate_voltage))
                 return self.max_value - self.min_value
 
-            elif self.measurement_type == 'AMPL':
+            elif self.measurement_type == "AMPL":
                 self.max_value = float(np.max(gate_voltage))
                 self.min_value = float(np.min(gate_voltage))
                 return (self.max_value - self.min_value) / 2
 
-            elif self.measurement_type == 'MAX':
+            elif self.measurement_type == "MAX":
                 return float(np.max(gate_voltage))
 
-            elif self.measurement_type == 'MIN':
+            elif self.measurement_type == "MIN":
                 return float(np.min(gate_voltage))
 
-            elif self.measurement_type == 'TOP':
+            elif self.measurement_type == "TOP":
                 # Top value (typically 90% percentile)
                 return float(np.percentile(gate_voltage, 90))
 
-            elif self.measurement_type == 'BASE':
+            elif self.measurement_type == "BASE":
                 # Base value (typically 10% percentile)
                 return float(np.percentile(gate_voltage, 10))
 
-            elif self.measurement_type == 'MEAN':
+            elif self.measurement_type == "MEAN":
                 return float(np.mean(gate_voltage))
 
-            elif self.measurement_type == 'CMEAN':
+            elif self.measurement_type == "CMEAN":
                 # Cycle mean - same as mean for our purposes
                 return float(np.mean(gate_voltage))
 
-            elif self.measurement_type == 'RMS':
-                return float(np.sqrt(np.mean(gate_voltage ** 2)))
+            elif self.measurement_type == "RMS":
+                return float(np.sqrt(np.mean(gate_voltage**2)))
 
-            elif self.measurement_type == 'CRMS':
+            elif self.measurement_type == "CRMS":
                 # Cycle RMS
                 # Remove DC component for true AC RMS
                 ac_voltage = gate_voltage - np.mean(gate_voltage)
-                return float(np.sqrt(np.mean(ac_voltage ** 2)))
+                return float(np.sqrt(np.mean(ac_voltage**2)))
 
             else:
                 logger.warning(f"Unknown voltage measurement type: {self.measurement_type}")
@@ -253,8 +206,8 @@ class VoltageMarker(MeasurementMarker):
             # Default gate width: 20% of visible timespan
             width = time_span * 0.2
 
-            self.gates['start_x'] = center - width / 2
-            self.gates['end_x'] = center + width / 2
+            self.gates["start_x"] = center - width / 2
+            self.gates["end_x"] = center + width / 2
 
             logger.debug(f"Auto-placed voltage marker at center={center:.6e}, width={width:.6e}")
             self.is_dirty = True

--- a/siglent/gui/widgets/visual_measurement_panel.py
+++ b/siglent/gui/widgets/visual_measurement_panel.py
@@ -33,11 +33,7 @@ import logging
 from typing import Optional, TYPE_CHECKING
 from pathlib import Path
 
-from PyQt6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QPushButton,
-    QComboBox, QLabel, QListWidget, QListWidgetItem, QCheckBox,
-    QFileDialog, QMessageBox
-)
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QPushButton, QComboBox, QLabel, QListWidget, QListWidgetItem, QCheckBox, QFileDialog, QMessageBox
 from PyQt6.QtCore import Qt, pyqtSignal, QTimer
 
 from siglent.gui.widgets.measurement_markers import FrequencyMarker, VoltageMarker, TimingMarker
@@ -72,24 +68,24 @@ class VisualMeasurementPanel(QWidget):
 
     # Measurement type options
     MEASUREMENT_TYPES = {
-        'Frequency': ('FREQ', FrequencyMarker),
-        'Period': ('PER', FrequencyMarker),
-        'Peak-to-Peak': ('PKPK', VoltageMarker),
-        'Amplitude': ('AMPL', VoltageMarker),
-        'Maximum': ('MAX', VoltageMarker),
-        'Minimum': ('MIN', VoltageMarker),
-        'RMS': ('RMS', VoltageMarker),
-        'Mean': ('MEAN', VoltageMarker),
-        'Top': ('TOP', VoltageMarker),
-        'Base': ('BASE', VoltageMarker),
-        'Rise Time': ('RISE', TimingMarker),
-        'Fall Time': ('FALL', TimingMarker),
-        'Positive Width': ('WID', TimingMarker),
-        'Negative Width': ('NWID', TimingMarker),
-        'Duty Cycle': ('DUTY', TimingMarker),
+        "Frequency": ("FREQ", FrequencyMarker),
+        "Period": ("PER", FrequencyMarker),
+        "Peak-to-Peak": ("PKPK", VoltageMarker),
+        "Amplitude": ("AMPL", VoltageMarker),
+        "Maximum": ("MAX", VoltageMarker),
+        "Minimum": ("MIN", VoltageMarker),
+        "RMS": ("RMS", VoltageMarker),
+        "Mean": ("MEAN", VoltageMarker),
+        "Top": ("TOP", VoltageMarker),
+        "Base": ("BASE", VoltageMarker),
+        "Rise Time": ("RISE", TimingMarker),
+        "Fall Time": ("FALL", TimingMarker),
+        "Positive Width": ("WID", TimingMarker),
+        "Negative Width": ("NWID", TimingMarker),
+        "Duty Cycle": ("DUTY", TimingMarker),
     }
 
-    def __init__(self, waveform_display: 'WaveformDisplay', parent: Optional[QWidget] = None):
+    def __init__(self, waveform_display: "WaveformDisplay", parent: Optional[QWidget] = None):
         """Initialize visual measurement panel.
 
         Args:
@@ -157,7 +153,7 @@ class VisualMeasurementPanel(QWidget):
         channel_layout.addWidget(QLabel("Channel:"))
 
         self.channel_combo = QComboBox()
-        self.channel_combo.addItems(['CH1', 'CH2', 'CH3', 'CH4'])
+        self.channel_combo.addItems(["CH1", "CH2", "CH3", "CH4"])
         channel_layout.addWidget(self.channel_combo, stretch=1)
 
         layout.addLayout(channel_layout)
@@ -260,20 +256,11 @@ class VisualMeasurementPanel(QWidget):
             marker_id = f"M{self.marker_counter}"
 
             # Create marker
-            marker = marker_class(
-                marker_id=marker_id,
-                measurement_type=mtype,
-                channel=channel,
-                ax=self.waveform_display.ax,
-                canvas=self.waveform_display.canvas
-            )
+            marker = marker_class(marker_id=marker_id, measurement_type=mtype, channel=channel, ax=self.waveform_display.ax, canvas=self.waveform_display.canvas)
 
             # Auto-place marker if waveform data available
             if self.waveform_display.current_waveforms:
-                waveform = next(
-                    (w for w in self.waveform_display.current_waveforms if w.channel == channel),
-                    None
-                )
+                waveform = next((w for w in self.waveform_display.current_waveforms if w.channel == channel), None)
                 if waveform:
                     marker.auto_place(waveform)
                     marker.update_measurement(waveform)
@@ -285,7 +272,7 @@ class VisualMeasurementPanel(QWidget):
             self._add_marker_to_list(marker)
 
             # Enable edit mode
-            self.waveform_display.set_marker_mode('edit')
+            self.waveform_display.set_marker_mode("edit")
 
             # Emit signal
             self.marker_added.emit(marker)
@@ -340,7 +327,7 @@ class VisualMeasurementPanel(QWidget):
         marker = item.data(Qt.ItemDataRole.UserRole)
         if marker:
             # Update marker enabled state
-            marker.enabled = (item.checkState() == Qt.CheckState.Checked)
+            marker.enabled = item.checkState() == Qt.CheckState.Checked
             marker.set_visible(marker.enabled)
             self.waveform_display.canvas.draw()
 
@@ -402,13 +389,7 @@ class VisualMeasurementPanel(QWidget):
     def _on_clear_all(self):
         """Handle clear all markers button click."""
         # Confirm with user
-        reply = QMessageBox.question(
-            self,
-            'Clear All Markers',
-            'Are you sure you want to remove all markers?',
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-            QMessageBox.StandardButton.No
-        )
+        reply = QMessageBox.question(self, "Clear All Markers", "Are you sure you want to remove all markers?", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No)
 
         if reply == QMessageBox.StandardButton.Yes:
             self.waveform_display.clear_all_markers()
@@ -423,19 +404,14 @@ class VisualMeasurementPanel(QWidget):
             default_dir = str(config_set.get_default_config_dir())
 
             # Show file dialog
-            filename, _ = QFileDialog.getSaveFileName(
-                self,
-                "Save Measurement Configuration",
-                default_dir,
-                "JSON Files (*.json)"
-            )
+            filename, _ = QFileDialog.getSaveFileName(self, "Save Measurement Configuration", default_dir, "JSON Files (*.json)")
 
             if not filename:
                 return
 
             # Ensure .json extension
-            if not filename.endswith('.json'):
-                filename += '.json'
+            if not filename.endswith(".json"):
+                filename += ".json"
 
             # Create configuration from current markers
             markers = []
@@ -444,24 +420,11 @@ class VisualMeasurementPanel(QWidget):
                 marker = item.data(Qt.ItemDataRole.UserRole)
                 if marker:
                     config = marker.get_config()
-                    markers.append(MeasurementMarkerConfig(
-                        id=config['id'],
-                        measurement_type=config['type'],
-                        channel=config['channel'],
-                        enabled=config['enabled'],
-                        gates=config['gates'],
-                        visual_style={'color': config['color']},
-                        result=config['result'],
-                        unit=config['unit']
-                    ))
+                    markers.append(MeasurementMarkerConfig(id=config["id"], measurement_type=config["type"], channel=config["channel"], enabled=config["enabled"], gates=config["gates"], visual_style={"color": config["color"]}, result=config["result"], unit=config["unit"]))
 
             # Create config set
             config_name = Path(filename).stem
-            config_set = MeasurementConfigSet(
-                name=config_name,
-                created_at=datetime.now(),
-                markers=markers
-            )
+            config_set = MeasurementConfigSet(name=config_name, created_at=datetime.now(), markers=markers)
 
             # Save to file
             config_set.save_to_file(filename)
@@ -481,12 +444,7 @@ class VisualMeasurementPanel(QWidget):
             default_dir = str(config_set.get_default_config_dir())
 
             # Show file dialog
-            filename, _ = QFileDialog.getOpenFileName(
-                self,
-                "Load Measurement Configuration",
-                default_dir,
-                "JSON Files (*.json)"
-            )
+            filename, _ = QFileDialog.getOpenFileName(self, "Load Measurement Configuration", default_dir, "JSON Files (*.json)")
 
             if not filename:
                 return
@@ -511,23 +469,10 @@ class VisualMeasurementPanel(QWidget):
                     continue
 
                 # Create marker
-                marker = marker_class(
-                    marker_id=marker_config.id,
-                    measurement_type=marker_config.measurement_type,
-                    channel=marker_config.channel,
-                    ax=self.waveform_display.ax,
-                    canvas=self.waveform_display.canvas,
-                    color=marker_config.visual_style.get('color')
-                )
+                marker = marker_class(marker_id=marker_config.id, measurement_type=marker_config.measurement_type, channel=marker_config.channel, ax=self.waveform_display.ax, canvas=self.waveform_display.canvas, color=marker_config.visual_style.get("color"))
 
                 # Set configuration
-                marker.set_config({
-                    'enabled': marker_config.enabled,
-                    'gates': marker_config.gates,
-                    'color': marker_config.visual_style.get('color'),
-                    'result': marker_config.result,
-                    'unit': marker_config.unit
-                })
+                marker.set_config({"enabled": marker_config.enabled, "gates": marker_config.gates, "color": marker_config.visual_style.get("color"), "result": marker_config.result, "unit": marker_config.unit})
 
                 # Add to display
                 self.waveform_display.add_measurement_marker(marker)
@@ -536,7 +481,7 @@ class VisualMeasurementPanel(QWidget):
                 self._add_marker_to_list(marker)
 
             # Update marker counter
-            max_id = max([int(m.id[1:]) for m in config_set.markers if m.id.startswith('M')], default=0)
+            max_id = max([int(m.id[1:]) for m in config_set.markers if m.id.startswith("M")], default=0)
             self.marker_counter = max_id
 
             QMessageBox.information(self, "Success", f"Loaded {len(config_set.markers)} markers from {filename}")
@@ -550,24 +495,19 @@ class VisualMeasurementPanel(QWidget):
         """Handle export results button click."""
         try:
             # Show file dialog
-            filename, _ = QFileDialog.getSaveFileName(
-                self,
-                "Export Measurement Results",
-                "",
-                "CSV Files (*.csv);;JSON Files (*.json)"
-            )
+            filename, _ = QFileDialog.getSaveFileName(self, "Export Measurement Results", "", "CSV Files (*.csv);;JSON Files (*.json)")
 
             if not filename:
                 return
 
             # Determine format from extension
-            if filename.endswith('.csv'):
+            if filename.endswith(".csv"):
                 self._export_csv(filename)
-            elif filename.endswith('.json'):
+            elif filename.endswith(".json"):
                 self._export_json(filename)
             else:
                 # Default to CSV
-                filename += '.csv'
+                filename += ".csv"
                 self._export_csv(filename)
 
             QMessageBox.information(self, "Success", f"Results exported to {filename}")
@@ -585,22 +525,15 @@ class VisualMeasurementPanel(QWidget):
         """
         import csv
 
-        with open(filename, 'w', newline='') as f:
+        with open(filename, "w", newline="") as f:
             writer = csv.writer(f)
-            writer.writerow(['Marker ID', 'Type', 'Channel', 'Value', 'Unit', 'Enabled'])
+            writer.writerow(["Marker ID", "Type", "Channel", "Value", "Unit", "Enabled"])
 
             for i in range(self.markers_list.count()):
                 item = self.markers_list.item(i)
                 marker = item.data(Qt.ItemDataRole.UserRole)
                 if marker:
-                    writer.writerow([
-                        marker.marker_id,
-                        marker.measurement_type,
-                        marker.channel,
-                        marker.result if marker.result is not None else '',
-                        marker.unit or '',
-                        'Yes' if marker.enabled else 'No'
-                    ])
+                    writer.writerow([marker.marker_id, marker.measurement_type, marker.channel, marker.result if marker.result is not None else "", marker.unit or "", "Yes" if marker.enabled else "No"])
 
     def _export_json(self, filename: str):
         """Export results to JSON file.
@@ -610,23 +543,13 @@ class VisualMeasurementPanel(QWidget):
         """
         import json
 
-        results = {
-            'timestamp': datetime.now().isoformat(),
-            'measurements': []
-        }
+        results = {"timestamp": datetime.now().isoformat(), "measurements": []}
 
         for i in range(self.markers_list.count()):
             item = self.markers_list.item(i)
             marker = item.data(Qt.ItemDataRole.UserRole)
             if marker:
-                results['measurements'].append({
-                    'marker_id': marker.marker_id,
-                    'type': marker.measurement_type,
-                    'channel': marker.channel,
-                    'value': marker.result,
-                    'unit': marker.unit,
-                    'enabled': marker.enabled
-                })
+                results["measurements"].append({"marker_id": marker.marker_id, "type": marker.measurement_type, "channel": marker.channel, "value": marker.result, "unit": marker.unit, "enabled": marker.enabled})
 
-        with open(filename, 'w') as f:
+        with open(filename, "w") as f:
             json.dump(results, f, indent=2)

--- a/siglent/gui/widgets/waveform_display.py
+++ b/siglent/gui/widgets/waveform_display.py
@@ -261,8 +261,7 @@ class WaveformDisplay(QWidget):
 
             if not line_found:
                 # Create new line
-                self.ax.plot(time_data, waveform.voltage, color=color, linewidth=1.0,
-                           label=f"CH{channel}", alpha=0.9)
+                self.ax.plot(time_data, waveform.voltage, color=color, linewidth=1.0, label=f"CH{channel}", alpha=0.9)
 
         # Update axis limits
         self.ax.relim()
@@ -963,16 +962,7 @@ class WaveformDisplay(QWidget):
         Returns:
             Dictionary mapping marker IDs to results
         """
-        return {
-            marker.marker_id: {
-                'type': marker.measurement_type,
-                'channel': marker.channel,
-                'result': marker.result,
-                'unit': marker.unit,
-                'enabled': marker.enabled
-            }
-            for marker in self.measurement_markers
-        }
+        return {marker.marker_id: {"type": marker.measurement_type, "channel": marker.channel, "result": marker.result, "unit": marker.unit, "enabled": marker.enabled} for marker in self.measurement_markers}
 
     def update_all_markers(self) -> None:
         """Update all enabled markers with current waveform data."""
@@ -982,10 +972,7 @@ class WaveformDisplay(QWidget):
         for marker in self.measurement_markers:
             if marker.enabled:
                 # Find waveform for marker's channel
-                waveform = next(
-                    (w for w in self.current_waveforms if w.channel == marker.channel),
-                    None
-                )
+                waveform = next((w for w in self.current_waveforms if w.channel == marker.channel), None)
 
                 if waveform:
                     marker.update_measurement(waveform)

--- a/siglent/gui/widgets/waveform_display_pg.py
+++ b/siglent/gui/widgets/waveform_display_pg.py
@@ -59,10 +59,10 @@ class WaveformDisplayPG(QWidget):
 
     # Channel colors (matching oscilloscope colors)
     CHANNEL_COLORS = {
-        1: (255, 215, 0),    # Yellow/Gold
-        2: (0, 206, 209),    # Cyan
-        3: (255, 20, 147),   # Deep Pink/Magenta
-        4: (0, 255, 0),      # Green
+        1: (255, 215, 0),  # Yellow/Gold
+        2: (0, 206, 209),  # Cyan
+        3: (255, 20, 147),  # Deep Pink/Magenta
+        4: (0, 255, 0),  # Green
     }
 
     def __init__(self, parent=None):
@@ -111,7 +111,7 @@ class WaveformDisplayPG(QWidget):
         # Create PyQtGraph plot widget
         pg.setConfigOptions(antialias=True)  # Enable antialiasing for smoother lines
         self.plot_widget = pg.PlotWidget()
-        self.plot_widget.setBackground('#1a1a1a')
+        self.plot_widget.setBackground("#1a1a1a")
 
         # Get plot item
         self.plot_item = self.plot_widget.getPlotItem()
@@ -133,9 +133,9 @@ class WaveformDisplayPG(QWidget):
     def _configure_axes(self):
         """Configure plot axes appearance."""
         # Set labels
-        self.plot_item.setLabel('bottom', 'Time', units='s', color='#cccccc')
-        self.plot_item.setLabel('left', 'Voltage', units='V', color='#cccccc')
-        self.plot_item.setTitle('Waveform Display', color='#cccccc')
+        self.plot_item.setLabel("bottom", "Time", units="s", color="#cccccc")
+        self.plot_item.setLabel("left", "Voltage", units="V", color="#cccccc")
+        self.plot_item.setTitle("Waveform Display", color="#cccccc")
 
         # Configure grid
         self.plot_item.showGrid(x=self.show_grid, y=self.show_grid, alpha=0.3)
@@ -145,7 +145,7 @@ class WaveformDisplayPG(QWidget):
 
         # Set axis colors
         axis_color = (136, 136, 136)  # #888888
-        for axis in ['bottom', 'left', 'top', 'right']:
+        for axis in ["bottom", "left", "top", "right"]:
             ax = self.plot_item.getAxis(axis)
             ax.setPen(pg.mkPen(color=axis_color))
             ax.setTextPen(pg.mkPen(color=(204, 204, 204)))  # #cccccc
@@ -289,12 +289,7 @@ class WaveformDisplayPG(QWidget):
                 # Create new plot item
                 logger.info(f"    Creating NEW plot item for CH{channel}")
                 pen = pg.mkPen(color=color, width=1.5)
-                plot_item = self.plot_item.plot(
-                    waveform.time,
-                    waveform.voltage,
-                    pen=pen,
-                    name=f"CH{channel}"
-                )
+                plot_item = self.plot_item.plot(waveform.time, waveform.voltage, pen=pen, name=f"CH{channel}")
                 self.plot_items[channel] = plot_item
                 logger.info(f"    Plot item created successfully")
 
@@ -332,12 +327,7 @@ class WaveformDisplayPG(QWidget):
             return
 
         # Get filename from user
-        filename, _ = QFileDialog.getSaveFileName(
-            self,
-            "Export Waveform Image",
-            "waveform.png",
-            "PNG Image (*.png);;PDF Document (*.pdf);;SVG Image (*.svg)"
-        )
+        filename, _ = QFileDialog.getSaveFileName(self, "Export Waveform Image", "waveform.png", "PNG Image (*.png);;PDF Document (*.pdf);;SVG Image (*.svg)")
 
         if filename:
             try:
@@ -457,16 +447,7 @@ class WaveformDisplayPG(QWidget):
         Returns:
             Dictionary mapping marker IDs to results
         """
-        return {
-            marker.marker_id: {
-                'type': marker.measurement_type,
-                'channel': marker.channel,
-                'result': marker.result,
-                'unit': marker.unit,
-                'enabled': marker.enabled
-            }
-            for marker in self.measurement_markers
-        }
+        return {marker.marker_id: {"type": marker.measurement_type, "channel": marker.channel, "result": marker.result, "unit": marker.unit, "enabled": marker.enabled} for marker in self.measurement_markers}
 
     def update_all_markers(self) -> None:
         """Update all enabled markers with current waveform data."""
@@ -475,10 +456,7 @@ class WaveformDisplayPG(QWidget):
 
         for marker in self.measurement_markers:
             if marker.enabled:
-                waveform = next(
-                    (w for w in self.current_waveforms if w.channel == marker.channel),
-                    None
-                )
+                waveform = next((w for w in self.current_waveforms if w.channel == marker.channel), None)
 
                 if waveform:
                     marker.update_measurement(waveform)
@@ -575,24 +553,14 @@ class WaveformDisplayPG(QWidget):
                     self.plot_item.removeItem(self.reference_item)
 
                 pen = pg.mkPen(color=(255, 20, 147), width=1.5, style=Qt.PenStyle.SolidLine)
-                self.reference_item = self.plot_item.plot(
-                    first_waveform.time,
-                    difference,
-                    pen=pen,
-                    name="Difference"
-                )
+                self.reference_item = self.plot_item.plot(first_waveform.time, difference, pen=pen, name="Difference")
             else:
                 # Show reference as overlay
                 if self.reference_item:
                     self.plot_item.removeItem(self.reference_item)
 
                 pen = pg.mkPen(color=(255, 165, 0), width=1.5, style=Qt.PenStyle.DashLine)
-                self.reference_item = self.plot_item.plot(
-                    ref_time,
-                    ref_voltage,
-                    pen=pen,
-                    name="Reference"
-                )
+                self.reference_item = self.plot_item.plot(ref_time, ref_voltage, pen=pen, name="Reference")
 
         except Exception as e:
             logger.error(f"Failed to plot reference overlay: {e}")

--- a/siglent/measurement_config.py
+++ b/siglent/measurement_config.py
@@ -72,7 +72,7 @@ class MeasurementMarkerConfig:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'MeasurementMarkerConfig':
+    def from_dict(cls, data: Dict[str, Any]) -> "MeasurementMarkerConfig":
         """Create instance from dictionary.
 
         Args:
@@ -114,16 +114,10 @@ class MeasurementConfigSet:
             Path(filepath).parent.mkdir(parents=True, exist_ok=True)
 
             # Build data dictionary
-            data = {
-                'name': self.name,
-                'version': '1.0',
-                'created_at': self.created_at.isoformat(),
-                'metadata': self.metadata,
-                'markers': [marker.to_dict() for marker in self.markers]
-            }
+            data = {"name": self.name, "version": "1.0", "created_at": self.created_at.isoformat(), "metadata": self.metadata, "markers": [marker.to_dict() for marker in self.markers]}
 
             # Write to file
-            with open(filepath, 'w') as f:
+            with open(filepath, "w") as f:
                 json.dump(data, f, indent=2)
 
             logger.info(f"Saved measurement configuration to {filepath}")
@@ -133,7 +127,7 @@ class MeasurementConfigSet:
             raise IOError(f"Failed to save configuration to {filepath}: {e}")
 
     @classmethod
-    def load_from_file(cls, filepath: str) -> 'MeasurementConfigSet':
+    def load_from_file(cls, filepath: str) -> "MeasurementConfigSet":
         """Load configuration from JSON file.
 
         Args:
@@ -147,27 +141,19 @@ class MeasurementConfigSet:
             ValueError: If file format is invalid
         """
         try:
-            with open(filepath, 'r') as f:
+            with open(filepath, "r") as f:
                 data = json.load(f)
 
             # Validate version
-            version = data.get('version', '1.0')
-            if version != '1.0':
+            version = data.get("version", "1.0")
+            if version != "1.0":
                 logger.warning(f"Loading configuration with version {version}, expected 1.0")
 
             # Parse markers
-            markers = [
-                MeasurementMarkerConfig.from_dict(m)
-                for m in data.get('markers', [])
-            ]
+            markers = [MeasurementMarkerConfig.from_dict(m) for m in data.get("markers", [])]
 
             # Create config set
-            config_set = cls(
-                name=data['name'],
-                created_at=datetime.fromisoformat(data['created_at']),
-                markers=markers,
-                metadata=data.get('metadata', {})
-            )
+            config_set = cls(name=data["name"], created_at=datetime.fromisoformat(data["created_at"]), markers=markers, metadata=data.get("metadata", {}))
 
             logger.info(f"Loaded measurement configuration from {filepath} ({len(markers)} markers)")
             return config_set
@@ -232,14 +218,15 @@ class MeasurementConfigSet:
         """
         # Use platform-appropriate config directory
         import platform
+
         system = platform.system()
 
-        if system == 'Windows':
-            config_dir = Path.home() / 'AppData' / 'Local' / 'siglent' / 'measurement_configs'
-        elif system == 'Darwin':  # macOS
-            config_dir = Path.home() / 'Library' / 'Application Support' / 'siglent' / 'measurement_configs'
+        if system == "Windows":
+            config_dir = Path.home() / "AppData" / "Local" / "siglent" / "measurement_configs"
+        elif system == "Darwin":  # macOS
+            config_dir = Path.home() / "Library" / "Application Support" / "siglent" / "measurement_configs"
         else:  # Linux and others
-            config_dir = Path.home() / '.config' / 'siglent' / 'measurement_configs'
+            config_dir = Path.home() / ".config" / "siglent" / "measurement_configs"
 
         # Ensure directory exists
         config_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
# Pull Request

## Description

Align GUI and measurement configuration modules with the repository Black configuration so the CI lint job passes.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Related Issues

Fixes #(issue number)
Relates to #(issue number)

## Changes Made

- Formatted GUI entry point and widgets with Black using the CI-specified line length so lint checks succeed.
- Reformatted measurement configuration data classes for consistent style.

## Testing

Describe how you tested your changes:

- [ ] Tested with actual hardware (SDS824X HD)
- [ ] Tested programmatic API
- [ ] Tested GUI application
- [ ] Ran existing examples
- [ ] Added new example (if applicable)

Commands:
- `black --check --line-length 1000 siglent/ examples/`
- `flake8 siglent/ --count --select=E9,F63,F7,F82 --show-source --statistics`

### Test Environment

- **OS**: Ubuntu 22.04 (GitHub Actions runner equivalent)
- **Python version**: 3.12.12
- **Oscilloscope model**: N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `black` for code formatting
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if needed)
- [ ] I have added examples (if adding new features)
- [x] I have tested my changes
- [ ] All existing examples still work

## Screenshots (if applicable)

N/A

## Additional Notes

Formatting-only change to satisfy automated workflow linting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530e4317c8832c81177d7dcb73557d)