### PR TITLE
Clarify local install instructions and glob errors

### DIFF
--- a/docs/development/BUILD.md
+++ b/docs/development/BUILD.md
@@ -28,8 +28,12 @@ twine upload dist/*
 # Install in editable mode for development
 pip install -e .
 
-# Or install the built package locally
-pip install dist/siglent_oscilloscope-0.1.0-py3-none-any.whl
+# Or install the built package locally (after running `python -m build`)
+# Bash / WSL
+pip install dist/*.whl
+
+# PowerShell (globbing is different, so use Get-ChildItem)
+pip install (Get-ChildItem dist\*.whl)
 ```
 
 ## Expected Output
@@ -40,6 +44,14 @@ dist/
 ├── siglent_oscilloscope-0.1.0.tar.gz
 └── siglent_oscilloscope-0.1.0-py3-none-any.whl
 ```
+
+If you see an error like `Invalid wheel filename (wrong number of parts): '*'` or
+`Requirement 'dist/*.whl' looks like a filename, but the file does not exist`, it
+usually means:
+
+1. The `dist/` directory is empty because `python -m build` has not been run.
+2. The shell (especially PowerShell) did not expand the `dist/*.whl` glob. Use the
+   PowerShell example above so pip receives the actual wheel file path.
 
 Note: PyPI normalizes "Siglent-Oscilloscope" to "siglent_oscilloscope" in filenames.
 


### PR DESCRIPTION
## Summary
- document platform-specific commands for installing locally built wheels
- add troubleshooting notes for missing dist files and glob expansion errors

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530f8d541c832cb0bfb799b619f44d)