### PR TITLE
Improve Windows wheel installation instructions

### DIFF
--- a/docs/development/BUILD.md
+++ b/docs/development/BUILD.md
@@ -32,8 +32,12 @@ pip install -e .
 # Bash / WSL
 pip install dist/*.whl
 
-# PowerShell (globbing is different, so use Get-ChildItem)
-pip install (Get-ChildItem dist\*.whl)
+# Windows PowerShell (keep the pip upgrade separate so globbing works)
+python -m pip install --upgrade pip
+python -m pip install (Get-ChildItem dist\*.whl)
+
+# Windows Command Prompt (cmd.exe)
+for %f in (dist\*.whl) do python -m pip install --upgrade pip "%f"
 ```
 
 ## Expected Output

--- a/docs/development/PROJECT_STRUCTURE.md
+++ b/docs/development/PROJECT_STRUCTURE.md
@@ -190,7 +190,10 @@ Controls what files are included in source distributions:
 5. **Update `CHANGELOG.md`** with changes
 6. **Build package:** `python -m build`
 7. **Check package:** `twine check dist/*`
-8. **Test install:** `pip install dist/*.whl`
+8. **Test install:**
+   - Bash/WSL: `pip install dist/*.whl`
+   - PowerShell: run `python -m pip install --upgrade pip` first, then `python -m pip install (Get-ChildItem dist\*.whl)` so globbing resolves the wheel path
+   - cmd.exe: `for %f in (dist\*.whl) do python -m pip install --upgrade pip "%f"`
 9. **Deploy to PyPI:** `twine upload dist/*`
 
 See `docs/development/BUILD.md` and `docs/development/PYPI_DEPLOYMENT.md` for detailed instructions.


### PR DESCRIPTION
## Summary
- Clarify Windows instructions for installing built wheels when pip upgrade is required
- Add PowerShell steps that separate pip upgrade from wheel installation to avoid globbing errors
- Provide cmd.exe example for iterating over wheel files on Windows

## Testing
- Not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695310aaff2c832cb821494adf206c90)