### PR TITLE
fix: honor user-configured NORMAL trigger mode in wait_for_trigger

### DIFF
--- a/scpi_control/automation.py
+++ b/scpi_control/automation.py
@@ -505,6 +505,11 @@ class TriggerWaitCollector:
     ) -> Optional[Dict[int, WaveformData]]:
         """Wait for a trigger event and capture waveform.
 
+        If the trigger mode has been set to NORMAL beforehand (e.g. via
+        ``trigger.set_mode('NORMAL')``), that mode is preserved and the wait
+        completes on the first trigger event. In any other mode, the scope is
+        switched to SINGLE and armed for a one-shot acquisition.
+
         Args:
             channels: List of channel numbers to capture
             max_wait: Maximum time to wait for trigger in seconds
@@ -526,16 +531,25 @@ class TriggerWaitCollector:
             ...     if data:
             ...         print("Trigger captured!")
         """
-        # Set to NORMAL trigger mode
-        self.collector.scope.trigger.mode = "NORM"
-        self.collector.scope.trigger_single()
+        # Honor a user-configured NORMAL trigger mode; otherwise arm a
+        # one-shot SINGLE acquisition.
+        mode_response = self.collector.scope.trigger.mode
+        current_mode = mode_response.split()[-1] if mode_response.split() else ""
+
+        if current_mode == "NORM":
+            # NORMAL mode re-arms after every trigger and never reports
+            # "Stop", so watch for the trigger event itself.
+            done_states = {"TRIG'D", "STOP"}
+        else:
+            self.collector.scope.trigger_single()
+            done_states = {"STOP"}
 
         start_time = time.time()
         while (time.time() - start_time) < max_wait:
             # Check trigger status
             status = self.collector.scope.query(":TRIG:STAT?").strip()
 
-            if status == "Stop":
+            if status.upper() in done_states:
                 # Trigger occurred, capture waveform
                 logger.info("Trigger detected!")
                 waveforms = {}

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -85,6 +85,34 @@ def test_start_continuous_capture_uses_trigger_mode(monkeypatch, collector):
     assert connection.waveform_requests == [1] * len(captures)
 
 
+def test_wait_for_trigger_honors_user_configured_normal_mode(monkeypatch):
+    # In NORMAL mode the scope re-arms after every trigger and reports
+    # "Trig'd" rather than "Stop", so the status sequence never contains "Stop"
+    connection = MockConnection(
+        channel_states={1: True},
+        trigger_status=["Ready", "Ready", "Trig'd"],
+        sample_rate=1_000.0,
+    )
+    collector = TriggerWaitCollector("mock", connection=connection)
+    collector.collector.connect()
+
+    fake_time = FakeTime()
+    monkeypatch.setattr("scpi_control.automation.time", fake_time)
+
+    # Reproduce issue: configure NORMAL trigger before waiting
+    collector.collector.scope.trigger.set_mode("NORMAL")
+    collector.collector.scope.trigger.set_source("C1")
+    collector.collector.scope.trigger.set_slope("NEG")
+
+    waveforms = collector.wait_for_trigger([1], max_wait=0.5, save_on_trigger=False)
+
+    collector.collector.disconnect()
+
+    assert waveforms is not None
+    assert connection.trigger_mode == "NORM"
+    assert "TRIG_MODE SINGLE" not in connection.writes
+
+
 def test_trigger_wait_collector_waits_for_stop(monkeypatch):
     connection = MockConnection(
         channel_states={1: True},


### PR DESCRIPTION
## Description

`TriggerWaitCollector.wait_for_trigger()` set `TRIG_MODE NORM` and then immediately called `trigger_single()`, which writes `TRIG_MODE SINGLE` + `ARM` — clobbering NORMAL mode (or any mode the caller configured beforehand). The wait loop also only accepted the `"Stop"` status, which is SINGLE-mode semantics: in NORMAL mode Siglent scopes re-arm after each trigger and report `Trig'd`, never `Stop`, so normal mode could never complete even without the override.

Now a pre-configured NORMAL mode is preserved and the wait completes on `Trig'd`/`Stop`; any other mode keeps the previous one-shot SINGLE+ARM behavior.

## Related Issues

Fixes #41

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test coverage improvement
- [ ] CI/CD improvement

## Changes Made

- `scpi_control/automation.py`: `wait_for_trigger()` now reads the current trigger mode first; if it is `NORM`, the mode is left untouched and the poll loop watches for `Trig'd`/`Stop`; otherwise it arms a one-shot SINGLE acquisition as before. Status comparison is case-insensitive, and the mode read tolerates command-header echo.
- `scpi_control/automation.py`: docstring documents the new NORMAL-mode behavior.
- `tests/test_automation.py`: regression test reproducing the issue's exact scenario (`set_mode('NORMAL')` → `wait_for_trigger`), asserting the mode is not clobbered to SINGLE and the wait completes on `Trig'd`.

## Testing

- [x] Tests pass locally (`make test` or `pytest tests/`)
- [x] Added tests for new functionality
- [ ] Tested with real hardware (if applicable)
- [ ] All CI checks pass

### Test Details

**Test environment:**

- OS: Windows 11 Pro
- Python version: 3.12.7
- Oscilloscope model (if applicable): MockConnection only — no hardware available

**Test results:**

```
tests/test_automation.py ......                    (incl. new regression test)
377 passed, 19 skipped in 4.52s
```

## Code Quality

- [x] Code follows the project style guidelines (`make lint` passes)
- [x] Code is formatted with Black (`make format`)
- [x] Self-reviewed the code
- [ ] Commented complex code sections
- [x] Updated docstrings for modified functions/classes
- [x] No new linting warnings introduced

## Documentation

- [ ] Updated README.md (if needed)
- [ ] Updated CHANGELOG.md with changes
- [x] Added/updated docstrings
- [ ] Added/updated examples (if applicable)
- [ ] Updated type hints

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation

## Additional Notes

Verified with the mock connection only (no hardware on hand). One related but separate concern: the poll uses `:TRIG:STAT?`, which belongs to the newer SCPI dialect — on legacy X-E firmware the equivalent is `SAST?`. That pre-existing dialect mismatch is out of scope here and tracked separately.
