### PR TITLE
fix: connection-layer hardening — thread safety, exact-length binary reads, port 5025

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -245,7 +245,7 @@ with DataCollector('192.168.1.100') as collector:
 ## Tips
 
 - Make sure your oscilloscope is connected to the same network as your computer
-- Ensure the SCPI port (5024) is accessible
+- Ensure the SCPI port (5025) is accessible
 - Some commands may vary slightly between oscilloscope models - refer to your programming manual
 - Enable at least one channel before capturing waveforms
 - Use AUTO trigger mode for continuous acquisition

--- a/examples/function_generator_basic.py
+++ b/examples/function_generator_basic.py
@@ -11,7 +11,7 @@ Supported models:
 Requirements:
 - Function generator connected to network
 - IP address configured on generator
-- Default SCPI port: 5024
+- Default SCPI port: 5025
 
 Usage:
     python function_generator_basic.py --ip 192.168.1.100
@@ -32,7 +32,7 @@ def main():
     """Main function to demonstrate AWG control."""
     parser = argparse.ArgumentParser(description="Control Siglent Function Generator")
     parser.add_argument("--ip", type=str, default="192.168.1.100", help="Function generator IP address")
-    parser.add_argument("--port", type=int, default=5024, help="SCPI port (default: 5024)")
+    parser.add_argument("--port", type=int, default=5025, help="SCPI port (default: 5025)")
     args = parser.parse_args()
 
     logger.info(f"Connecting to function generator at {args.ip}:{args.port}")

--- a/scpi_control/automation.py
+++ b/scpi_control/automation.py
@@ -63,7 +63,7 @@ class DataCollector:
     def __init__(
         self,
         host: str,
-        port: int = 5024,
+        port: int = 5025,
         timeout: float = 5.0,
         connection: Optional[BaseConnection] = None,
     ):
@@ -71,7 +71,7 @@ class DataCollector:
 
         Args:
             host: IP address or hostname of the oscilloscope
-            port: TCP port for SCPI communication (default: 5024)
+            port: TCP port for SCPI communication (default: 5025, the Siglent raw SCPI socket; 5024 is the telnet-style port with prompts and is not recommended)
             timeout: Command timeout in seconds (default: 5.0)
             connection: Optional connection implementation (e.g., MockConnection for offline tests)
         """
@@ -472,7 +472,7 @@ class TriggerWaitCollector:
     def __init__(
         self,
         host: str,
-        port: int = 5024,
+        port: int = 5025,
         timeout: float = 5.0,
         connection: Optional[BaseConnection] = None,
     ):
@@ -480,7 +480,7 @@ class TriggerWaitCollector:
 
         Args:
             host: IP address or hostname of the oscilloscope
-            port: TCP port for SCPI communication
+            port: TCP port for SCPI communication (default: 5025, the Siglent raw SCPI socket; 5024 is the telnet-style port with prompts and is not recommended)
             timeout: Command timeout in seconds
             connection: Optional connection implementation (e.g., MockConnection for offline tests)
         """

--- a/scpi_control/connection/base.py
+++ b/scpi_control/connection/base.py
@@ -1,5 +1,6 @@
 """Abstract base class for oscilloscope connections."""
 
+import threading
 from abc import ABC, abstractmethod
 from typing import Optional, Union
 
@@ -19,6 +20,9 @@ class BaseConnection(ABC):
         self.port = port
         self.timeout = timeout
         self._connected = False
+        # Reentrant so query() can hold it across its own write()/read() calls.
+        # Callers doing compound exchanges (write + read_raw) must hold it too.
+        self.lock = threading.RLock()
 
     @abstractmethod
     def connect(self) -> None:

--- a/scpi_control/connection/socket.py
+++ b/scpi_control/connection/socket.py
@@ -11,12 +11,12 @@ from scpi_control.connection.base import BaseConnection
 class SocketConnection(BaseConnection):
     """TCP socket connection for SCPI commands over Ethernet."""
 
-    def __init__(self, host: str, port: int = 5024, timeout: float = 5.0):
+    def __init__(self, host: str, port: int = 5025, timeout: float = 5.0):
         """Initialize socket connection.
 
         Args:
             host: IP address or hostname of the oscilloscope
-            port: TCP port number (default: 5024 for Siglent SCPI)
+            port: TCP port number (default: 5025, the Siglent raw SCPI socket; 5024 is the telnet-style port with prompts and is not recommended)
             timeout: Command timeout in seconds (default: 5.0)
         """
         super().__init__(host, port, timeout)

--- a/scpi_control/connection/socket.py
+++ b/scpi_control/connection/socket.py
@@ -202,7 +202,11 @@ class SocketConnection(BaseConnection):
         Once a '#<n><length>' header is seen, reads exactly the declared
         number of bytes (plus the trailing terminator when present) instead
         of draining until the line goes idle. Responses without a block
-        header keep the legacy idle-drain behavior.
+        header keep the legacy idle-drain behavior. A headerless response
+        shorter than 128 bytes is indistinguishable from a block header that
+        has not arrived yet, so it is returned only after the full connection
+        timeout elapses - an accepted trade-off so slow scopes that pause
+        between the command echo and the block header are not truncated.
 
         Raises:
             SiglentTimeoutError: If no data arrives at all, or the line
@@ -237,7 +241,11 @@ class SocketConnection(BaseConnection):
                         self._socket.settimeout(0.5)
 
                 if expected_total is not None and len(data) >= expected_total:
-                    data += self._drain_terminator()
+                    if len(data) == expected_total:
+                        # Terminator not seen yet; grab it so callers get the same
+                        # trailing bytes the legacy drain produced. When surplus
+                        # already arrived, skip the extra recv entirely.
+                        data += self._drain_terminator()
                     return data
         except socket.error as e:
             if not isinstance(e, socket.timeout):
@@ -259,7 +267,9 @@ class SocketConnection(BaseConnection):
         """
         idx = data.find(b"#")
         if idx == -1:
-            # Command echo prefixes are short; if no '#' this deep in, there is no block
+            # Command echo prefixes are short; if no '#' this deep in, there is no block.
+            # Below 128 bytes we keep waiting on the full timeout rather than risk
+            # truncating a split header.
             return None, len(data) >= 128
         if len(data) < idx + 2:
             return None, False  # '#' seen, digit count not yet arrived

--- a/scpi_control/connection/socket.py
+++ b/scpi_control/connection/socket.py
@@ -69,26 +69,27 @@ class SocketConnection(BaseConnection):
         if not self._connected or not self._socket:
             raise exceptions.SiglentConnectionError(f"Not connected to oscilloscope at {self.host}:{self.port}")
 
-        try:
-            # Ensure command ends with newline
-            if not command.endswith("\n"):
-                command += "\n"
-
-            # Track the most recent command for better error reporting
-            self._last_command = command.strip()
-
-            # Validate ASCII encoding before sending
+        with self.lock:
             try:
-                encoded_cmd = command.encode("ascii")
-            except UnicodeEncodeError as e:
-                raise exceptions.CommandError(f"SCPI command contains non-ASCII characters: {command!r}") from e
+                # Ensure command ends with newline
+                if not command.endswith("\n"):
+                    command += "\n"
 
-            self._socket.sendall(encoded_cmd)
-        except socket.timeout:
-            raise exceptions.SiglentTimeoutError(f"Command timeout for '{self._last_command}' on {self.host}:{self.port}")
-        except socket.error as e:
-            self._connected = False
-            raise exceptions.SiglentConnectionError(f"Write error to {self.host}:{self.port} for command '{self._last_command}': {e}")
+                # Track the most recent command for better error reporting
+                self._last_command = command.strip()
+
+                # Validate ASCII encoding before sending
+                try:
+                    encoded_cmd = command.encode("ascii")
+                except UnicodeEncodeError as e:
+                    raise exceptions.CommandError(f"SCPI command contains non-ASCII characters: {command!r}") from e
+
+                self._socket.sendall(encoded_cmd)
+            except socket.timeout:
+                raise exceptions.SiglentTimeoutError(f"Command timeout for '{self._last_command}' on {self.host}:{self.port}")
+            except socket.error as e:
+                self._connected = False
+                raise exceptions.SiglentConnectionError(f"Write error to {self.host}:{self.port} for command '{self._last_command}': {e}")
 
     def read(self) -> str:
         """Read response from the oscilloscope.
@@ -103,38 +104,39 @@ class SocketConnection(BaseConnection):
         if not self._connected or not self._socket:
             raise exceptions.SiglentConnectionError(f"Not connected to oscilloscope at {self.host}:{self.port}")
 
-        try:
-            data = b""
-            start_time = time.time()
+        with self.lock:
+            try:
+                data = b""
+                start_time = time.time()
 
-            while True:
-                # Check for timeout in the read loop
-                if time.time() - start_time > self.timeout:
-                    command_context = f"for '{self._last_command}' " if self._last_command else ""
-                    raise exceptions.SiglentTimeoutError(
-                        f"Read timeout {command_context}after {self.timeout}s waiting for newline terminator " f"(received {len(data)} bytes so far) from {self.host}:{self.port}"
-                    )
+                while True:
+                    # Check for timeout in the read loop
+                    if time.time() - start_time > self.timeout:
+                        command_context = f"for '{self._last_command}' " if self._last_command else ""
+                        raise exceptions.SiglentTimeoutError(
+                            f"Read timeout {command_context}after {self.timeout}s waiting for newline terminator " f"(received {len(data)} bytes so far) from {self.host}:{self.port}"
+                        )
 
-                chunk = self._socket.recv(self._buffer_size)
-                if not chunk:
-                    break
-                data += chunk
-                # Check if we received a complete response (ends with newline)
-                if data.endswith(b"\n"):
-                    break
+                    chunk = self._socket.recv(self._buffer_size)
+                    if not chunk:
+                        break
+                    data += chunk
+                    # Check if we received a complete response (ends with newline)
+                    if data.endswith(b"\n"):
+                        break
 
-            # Decode and strip whitespace and null bytes
-            response = data.decode("ascii").strip()
-            # Remove null bytes that some oscilloscopes prepend to responses
-            response = response.lstrip("\x00")
-            return response
-        except socket.timeout:
-            command_context = f"for '{self._last_command}' " if self._last_command else ""
-            raise exceptions.SiglentTimeoutError(f"Read timeout {command_context}from {self.host}:{self.port}")
-        except socket.error as e:
-            self._connected = False
-            command_context = f" while waiting for '{self._last_command}'" if self._last_command else ""
-            raise exceptions.SiglentConnectionError(f"Read error from {self.host}:{self.port}{command_context}: {e}")
+                # Decode and strip whitespace and null bytes
+                response = data.decode("ascii").strip()
+                # Remove null bytes that some oscilloscopes prepend to responses
+                response = response.lstrip("\x00")
+                return response
+            except socket.timeout:
+                command_context = f"for '{self._last_command}' " if self._last_command else ""
+                raise exceptions.SiglentTimeoutError(f"Read timeout {command_context}from {self.host}:{self.port}")
+            except socket.error as e:
+                self._connected = False
+                command_context = f" while waiting for '{self._last_command}'" if self._last_command else ""
+                raise exceptions.SiglentConnectionError(f"Read error from {self.host}:{self.port}{command_context}: {e}")
 
     def query(self, command: str) -> str:
         """Send a command and read the response.
@@ -150,10 +152,11 @@ class SocketConnection(BaseConnection):
             SiglentTimeoutError: If command times out
             CommandError: If command fails
         """
-        self.write(command)
-        # Small delay to allow oscilloscope to process
-        time.sleep(0.01)
-        return self.read()
+        with self.lock:
+            self.write(command)
+            # Small delay to allow oscilloscope to process
+            time.sleep(0.01)
+            return self.read()
 
     def read_raw(self, size: Optional[int] = None) -> bytes:
         """Read raw binary data from oscilloscope.
@@ -173,37 +176,38 @@ class SocketConnection(BaseConnection):
         if not self._connected or not self._socket:
             raise exceptions.SiglentConnectionError(f"Not connected to oscilloscope at {self.host}:{self.port}")
 
-        try:
-            if size is not None:
-                # Read exact number of bytes
-                data = b""
-                remaining = size
-                while remaining > 0:
-                    chunk = self._socket.recv(min(remaining, self._buffer_size))
-                    if not chunk:
-                        break
-                    data += chunk
-                    remaining -= len(chunk)
-                return data
-            else:
-                # Read all available data
-                data = b""
-                self._socket.settimeout(0.5)  # Short timeout for binary reads
-                try:
-                    while True:
-                        chunk = self._socket.recv(self._buffer_size)
+        with self.lock:
+            try:
+                if size is not None:
+                    # Read exact number of bytes
+                    data = b""
+                    remaining = size
+                    while remaining > 0:
+                        chunk = self._socket.recv(min(remaining, self._buffer_size))
                         if not chunk:
                             break
                         data += chunk
-                except socket.timeout:
-                    pass  # Expected when no more data
-                finally:
-                    self._socket.settimeout(self.timeout)  # Restore timeout
-                return data
-        except socket.error as e:
-            self._connected = False
-            command_context = f" after '{self._last_command}'" if self._last_command else ""
-            raise exceptions.SiglentConnectionError(f"Read error from {self.host}:{self.port}{command_context}: {e}")
+                        remaining -= len(chunk)
+                    return data
+                else:
+                    # Read all available data
+                    data = b""
+                    self._socket.settimeout(0.5)  # Short timeout for binary reads
+                    try:
+                        while True:
+                            chunk = self._socket.recv(self._buffer_size)
+                            if not chunk:
+                                break
+                            data += chunk
+                    except socket.timeout:
+                        pass  # Expected when no more data
+                    finally:
+                        self._socket.settimeout(self.timeout)  # Restore timeout
+                    return data
+            except socket.error as e:
+                self._connected = False
+                command_context = f" after '{self._last_command}'" if self._last_command else ""
+                raise exceptions.SiglentConnectionError(f"Read error from {self.host}:{self.port}{command_context}: {e}")
 
     def __repr__(self) -> str:
         """String representation of connection."""

--- a/scpi_control/connection/socket.py
+++ b/scpi_control/connection/socket.py
@@ -2,7 +2,7 @@
 
 import socket
 import time
-from typing import Optional
+from typing import Optional, Tuple
 
 from scpi_control import exceptions
 from scpi_control.connection.base import BaseConnection
@@ -190,24 +190,101 @@ class SocketConnection(BaseConnection):
                         remaining -= len(chunk)
                     return data
                 else:
-                    # Read all available data
-                    data = b""
-                    self._socket.settimeout(0.5)  # Short timeout for binary reads
-                    try:
-                        while True:
-                            chunk = self._socket.recv(self._buffer_size)
-                            if not chunk:
-                                break
-                            data += chunk
-                    except socket.timeout:
-                        pass  # Expected when no more data
-                    finally:
-                        self._socket.settimeout(self.timeout)  # Restore timeout
-                    return data
+                    return self._read_ieee_block()
             except socket.error as e:
                 self._connected = False
                 command_context = f" after '{self._last_command}'" if self._last_command else ""
                 raise exceptions.SiglentConnectionError(f"Read error from {self.host}:{self.port}{command_context}: {e}")
+
+    def _read_ieee_block(self) -> bytes:
+        """Read a response that may carry an IEEE 488.2 definite-length block.
+
+        Once a '#<n><length>' header is seen, reads exactly the declared
+        number of bytes (plus the trailing terminator when present) instead
+        of draining until the line goes idle. Responses without a block
+        header keep the legacy idle-drain behavior.
+
+        Raises:
+            SiglentTimeoutError: If no data arrives at all, or the line
+                stalls before the declared byte count is received.
+        """
+        data = b""
+        expected_total: Optional[int] = None
+        header_absent = False
+
+        try:
+            while True:
+                try:
+                    chunk = self._socket.recv(self._buffer_size)
+                except socket.timeout:
+                    command_context = f"for '{self._last_command}' " if self._last_command else ""
+                    if expected_total is not None:
+                        raise exceptions.SiglentTimeoutError(f"Binary read stalled {command_context}(received {len(data)} of {expected_total} declared bytes) from {self.host}:{self.port}")
+                    if data:
+                        # Headerless response finished (line went idle)
+                        return data
+                    raise exceptions.SiglentTimeoutError(f"Binary read timeout {command_context}- no data received from {self.host}:{self.port}")
+
+                if not chunk:
+                    return data  # Peer closed the connection
+
+                data += chunk
+
+                if expected_total is None and not header_absent:
+                    expected_total, header_absent = self._parse_block_total(data)
+                    if header_absent:
+                        # Legacy path: no way to know the length, drain until idle
+                        self._socket.settimeout(0.5)
+
+                if expected_total is not None and len(data) >= expected_total:
+                    data += self._drain_terminator()
+                    return data
+        except socket.error as e:
+            if not isinstance(e, socket.timeout):
+                self._connected = False
+                command_context = f" after '{self._last_command}'" if self._last_command else ""
+                raise exceptions.SiglentConnectionError(f"Read error from {self.host}:{self.port}{command_context}: {e}")
+            raise
+        finally:
+            self._socket.settimeout(self.timeout)
+
+    def _parse_block_total(self, data: bytes) -> Tuple[Optional[int], bool]:
+        """Locate an IEEE 488.2 block header and compute the total response size.
+
+        Returns:
+            (total_bytes, header_absent): total_bytes is prefix + '#' + digit
+            count + length digits + payload, or None if the header has not
+            fully arrived yet. header_absent is True when the response is
+            judged to have no definite-length block at all.
+        """
+        idx = data.find(b"#")
+        if idx == -1:
+            # Command echo prefixes are short; if no '#' this deep in, there is no block
+            return None, len(data) >= 128
+        if len(data) < idx + 2:
+            return None, False  # '#' seen, digit count not yet arrived
+        digit_char = data[idx + 1 : idx + 2]
+        if not digit_char.isdigit() or digit_char == b"0":
+            # '#0' (indefinite length) or stray '#': not a definite-length block
+            return None, True
+        num_digits = int(digit_char)
+        if len(data) < idx + 2 + num_digits:
+            return None, False  # Length field not yet complete
+        length_field = data[idx + 2 : idx + 2 + num_digits]
+        if not length_field.isdigit():
+            return None, True
+        payload_length = int(length_field)
+        return idx + 2 + num_digits + payload_length, False
+
+    def _drain_terminator(self) -> bytes:
+        """Opportunistically read the trailing terminator ("\\n\\n") after a block."""
+        self._socket.settimeout(0.05)
+        try:
+            return self._socket.recv(2)
+        except socket.timeout:
+            return b""
+        finally:
+            self._socket.settimeout(self.timeout)
 
     def __repr__(self) -> str:
         """String representation of connection."""

--- a/scpi_control/function_generator.py
+++ b/scpi_control/function_generator.py
@@ -57,7 +57,7 @@ class FunctionGenerator:
     def __init__(
         self,
         host: str,
-        port: int = 5024,
+        port: int = 5025,
         timeout: float = 5.0,
         connection: Optional[BaseConnection] = None,
     ):
@@ -65,7 +65,7 @@ class FunctionGenerator:
 
         Args:
             host: IP address or hostname of the function generator
-            port: TCP port for SCPI communication (default: 5024)
+            port: TCP port for SCPI communication (default: 5025, the Siglent raw SCPI socket; 5024 is the telnet-style port with prompts and is not recommended)
             timeout: Command timeout in seconds (default: 5.0)
             connection: Optional custom connection object (uses SocketConnection if None)
 

--- a/scpi_control/gui/connection_manager.py
+++ b/scpi_control/gui/connection_manager.py
@@ -23,12 +23,12 @@ class ConnectionManager:
         self.settings = QSettings("Siglent", "OscilloscopeControl")
         logger.info("Connection manager initialized")
 
-    def add_connection(self, host: str, port: int = 5024, model_name: Optional[str] = None) -> None:
+    def add_connection(self, host: str, port: int = 5025, model_name: Optional[str] = None) -> None:
         """Add a connection to the recent connections list.
 
         Args:
             host: IP address or hostname
-            port: TCP port (default: 5024)
+            port: TCP port (default: 5025, the Siglent raw SCPI socket; 5024 is the telnet-style port with prompts and is not recommended)
             model_name: Optional model name (e.g., "SDS824X HD")
         """
         # Get existing connections
@@ -77,12 +77,12 @@ class ConnectionManager:
         self.settings.setValue("recent_connections", [])
         logger.info("Cleared all recent connections")
 
-    def remove_connection(self, host: str, port: int = 5024) -> None:
+    def remove_connection(self, host: str, port: int = 5025) -> None:
         """Remove a specific connection from recent list.
 
         Args:
             host: IP address or hostname
-            port: TCP port
+            port: TCP port (default: 5025, the Siglent raw SCPI socket; 5024 is the telnet-style port with prompts and is not recommended)
         """
         recent = self.get_recent_connections()
         recent = [conn for conn in recent if not (conn["host"] == host and conn["port"] == port)]
@@ -102,7 +102,7 @@ class ConnectionManager:
         self,
         name: str,
         host: str,
-        port: int = 5024,
+        port: int = 5025,
         model_name: Optional[str] = None,
         notes: Optional[str] = None,
     ) -> None:
@@ -111,7 +111,7 @@ class ConnectionManager:
         Args:
             name: Profile name
             host: IP address or hostname
-            port: TCP port
+            port: TCP port (default: 5025, the Siglent raw SCPI socket; 5024 is the telnet-style port with prompts and is not recommended)
             model_name: Optional model name
             notes: Optional notes about this connection
         """
@@ -181,7 +181,7 @@ class ConnectionManager:
             Formatted string for display
         """
         host = connection.get("host", "Unknown")
-        port = connection.get("port", 5024)
+        port = connection.get("port", 5025)
         model = connection.get("model_name", "Unknown")
 
         # Parse timestamp if available

--- a/scpi_control/gui/main_window.py
+++ b/scpi_control/gui/main_window.py
@@ -527,7 +527,7 @@ class MainWindow(QMainWindow):
             connection: Connection dictionary with host and port
         """
         host = connection.get("host")
-        port = connection.get("port", 5024)
+        port = connection.get("port", 5025)
 
         if host:
             self._connect_to_scope(host, port)
@@ -558,12 +558,12 @@ class MainWindow(QMainWindow):
         if ok and ip:
             self._connect_to_scope(ip)
 
-    def _connect_to_scope(self, ip: str, port: int = 5024):
+    def _connect_to_scope(self, ip: str, port: int = 5025):
         """Connect to oscilloscope at specified IP and port.
 
         Args:
             ip: IP address or hostname
-            port: TCP port (default: 5024)
+            port: TCP port (default: 5025, the Siglent raw SCPI socket; 5024 is the telnet-style port with prompts and is not recommended)
         """
         try:
             self.statusBar().showMessage(f"Connecting to {ip}...")
@@ -647,12 +647,12 @@ class MainWindow(QMainWindow):
         if ok and ip:
             self._connect_to_psu(ip)
 
-    def _connect_to_psu(self, ip: str, port: int = 5024):
+    def _connect_to_psu(self, ip: str, port: int = 5025):
         """Connect to power supply at specified IP and port.
 
         Args:
             ip: IP address or hostname
-            port: TCP port (default: 5024)
+            port: TCP port (default: 5025, the Siglent raw SCPI socket; 5024 is the telnet-style port with prompts and is not recommended)
         """
         try:
             self.statusBar().showMessage(f"Connecting to PSU at {ip}...")
@@ -725,12 +725,12 @@ class MainWindow(QMainWindow):
         if ok and ip:
             self._connect_to_daq(ip)
 
-    def _connect_to_daq(self, ip: str, port: int = 5024):
+    def _connect_to_daq(self, ip: str, port: int = 5025):
         """Connect to data logger at specified IP and port.
 
         Args:
             ip: IP address or hostname
-            port: TCP port (default: 5024)
+            port: TCP port (default: 5025, the Siglent raw SCPI socket; 5024 is the telnet-style port with prompts and is not recommended)
         """
         try:
             self.statusBar().showMessage(f"Connecting to DAQ at {ip}...")

--- a/scpi_control/oscilloscope.py
+++ b/scpi_control/oscilloscope.py
@@ -47,7 +47,7 @@ class Oscilloscope:
     def __init__(
         self,
         host: str,
-        port: int = 5024,
+        port: int = 5025,
         timeout: float = 5.0,
         connection: Optional[BaseConnection] = None,
     ):
@@ -55,7 +55,7 @@ class Oscilloscope:
 
         Args:
             host: IP address or hostname of the oscilloscope
-            port: TCP port for SCPI communication (default: 5024)
+            port: TCP port for SCPI communication (default: 5025, the Siglent raw SCPI socket; 5024 is the telnet-style port with prompts and is not recommended)
             timeout: Command timeout in seconds (default: 5.0)
             connection: Optional custom connection object (uses SocketConnection if None)
 

--- a/scpi_control/power_supply.py
+++ b/scpi_control/power_supply.py
@@ -61,7 +61,7 @@ class PowerSupply:
     def __init__(
         self,
         host: str,
-        port: int = 5024,
+        port: int = 5025,
         timeout: float = 5.0,
         connection: Optional[BaseConnection] = None,
     ):
@@ -69,7 +69,7 @@ class PowerSupply:
 
         Args:
             host: IP address or hostname of the power supply
-            port: TCP port for SCPI communication (default: 5024)
+            port: TCP port for SCPI communication (default: 5025, the Siglent raw SCPI socket; 5024 is the telnet-style port with prompts and is not recommended)
             timeout: Command timeout in seconds (default: 5.0)
             connection: Optional custom connection object (uses SocketConnection if None)
 

--- a/scpi_control/waveform.py
+++ b/scpi_control/waveform.py
@@ -123,12 +123,12 @@ class Waveform:
         timebase = self._get_timebase()
         sample_rate = self._get_sample_rate()
 
-        # Request waveform data
+        # Request waveform data; hold the connection lock so no other thread
+        # can slip a query between the command and its binary response
         waveform_command = f"{ch}:WF? DAT2"  # DAT2 is binary format
-        self._scope.write(waveform_command)
-
-        # Read waveform data header and data
-        raw_data = self._scope.read_raw()
+        with self._scope._connection.lock:
+            self._scope.write(waveform_command)
+            raw_data = self._scope.read_raw()
 
         # Parse waveform data
         voltage_data = self._parse_waveform(raw_data, format, waveform_command)

--- a/tests/test_socket_connection.py
+++ b/tests/test_socket_connection.py
@@ -419,3 +419,62 @@ class TestSocketThreadSafety:
         t2.join()
 
         assert results == {"Q1?": "R1", "Q2?": "R2"}
+
+
+class TestReadRawIeeeBlock:
+    """read_raw(None) must honor the IEEE 488.2 definite-length header."""
+
+    def test_reads_exactly_declared_block_length(self, mock_socket):
+        # "C1:WF DAT2," prefix (11 bytes) + "#9" + 9-digit length (20) + payload
+        part1 = b"C1:WF DAT2,#9000000020" + b"A" * 10
+        part2 = b"B" * 10
+        mock_socket.recv.side_effect = [part1, part2, b"\n\n", socket.timeout()]
+
+        conn = SocketConnection("192.168.1.100")
+        conn.connect()
+        data = conn.read_raw()
+
+        assert data == part1 + part2 + b"\n\n"
+        # The block path must never fall back to the legacy 0.5s idle drain
+        assert call(0.5) not in mock_socket.settimeout.call_args_list
+
+    def test_header_split_across_chunks(self, mock_socket):
+        part1 = b"C1:WF DAT2,#"
+        part2 = b"9000000005HELLO\n\n"
+        mock_socket.recv.side_effect = [part1, part2, socket.timeout()]
+
+        conn = SocketConnection("192.168.1.100")
+        conn.connect()
+        data = conn.read_raw()
+
+        assert data == part1 + part2
+
+    def test_stall_mid_block_raises_timeout(self, mock_socket):
+        # Header declares 100 bytes but the line goes silent after 10
+        mock_socket.recv.side_effect = [b"C1:WF DAT2,#9000000100" + b"A" * 10, socket.timeout()]
+
+        conn = SocketConnection("192.168.1.100")
+        conn.connect()
+
+        with pytest.raises(TimeoutError):
+            conn.read_raw()
+
+    def test_no_data_at_all_raises_timeout(self, mock_socket):
+        # Previously returned b"" silently; an empty line is now an error
+        mock_socket.recv.side_effect = [socket.timeout()]
+
+        conn = SocketConnection("192.168.1.100")
+        conn.connect()
+
+        with pytest.raises(TimeoutError):
+            conn.read_raw()
+
+    def test_headerless_response_still_drains_on_idle(self, mock_socket):
+        # Responses without a '#' block keep the legacy idle-drain behavior
+        blob = bytes([0, 127, 255, 128, 64] * 200)  # 1000 bytes, no b"#"
+        mock_socket.recv.side_effect = [blob, socket.timeout()]
+
+        conn = SocketConnection("192.168.1.100")
+        conn.connect()
+
+        assert conn.read_raw() == blob

--- a/tests/test_socket_connection.py
+++ b/tests/test_socket_connection.py
@@ -27,7 +27,7 @@ class TestSocketConnectionInit:
         """Test initialization with default port."""
         conn = SocketConnection("192.168.1.100")
         assert conn.host == "192.168.1.100"
-        assert conn.port == 5024
+        assert conn.port == 5025
         assert conn.timeout == 5.0
 
     def test_init_custom_port(self):
@@ -50,7 +50,7 @@ class TestSocketConnect:
         conn.connect()
 
         assert conn._connected is True
-        mock_socket.connect.assert_called_once_with(("192.168.1.100", 5024))
+        mock_socket.connect.assert_called_once_with(("192.168.1.100", 5025))
         mock_socket.settimeout.assert_called()
 
     def test_connect_failure(self, mock_socket):

--- a/tests/test_socket_connection.py
+++ b/tests/test_socket_connection.py
@@ -478,3 +478,14 @@ class TestReadRawIeeeBlock:
         conn.connect()
 
         assert conn.read_raw() == blob
+
+    def test_no_extra_recv_when_terminator_arrives_with_payload(self, mock_socket):
+        # Payload and trailing terminator arrive in one chunk: no extra recv
+        blob = b"C1:WF DAT2,#9000000020" + b"A" * 20 + b"\n\n"
+        mock_socket.recv.side_effect = [blob]
+
+        conn = SocketConnection("192.168.1.100")
+        conn.connect()
+
+        assert conn.read_raw() == blob
+        assert mock_socket.recv.call_count == 1

--- a/tests/test_socket_connection.py
+++ b/tests/test_socket_connection.py
@@ -1,6 +1,8 @@
 """Tests for socket connection module."""
 
 import socket
+import threading
+import time
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
@@ -370,3 +372,50 @@ class TestSocketStringRepresentation:
         conn = SocketConnection("192.168.1.100")
         assert "SocketConnection" in repr(conn)
         assert "192.168.1.100" in repr(conn)
+
+
+class TestSocketThreadSafety:
+    """Test that concurrent SCPI exchanges cannot interleave."""
+
+    def test_connection_exposes_reentrant_lock(self, mock_socket):
+        conn = SocketConnection("192.168.1.100")
+        # Reentrant: acquiring twice from the same thread must not deadlock
+        with conn.lock:
+            with conn.lock:
+                pass
+
+    def test_query_is_atomic_under_concurrency(self, mock_socket):
+        # Q1's send is slow; without a lock, thread 2 completes its write and
+        # steals Q1's response off the wire. With the lock, each query's
+        # write+read pair is atomic and both threads get their own response.
+        responses = {b"Q1?\n": b"R1\n", b"Q2?\n": b"R2\n"}
+        pending = []
+
+        def fake_sendall(data):
+            pending.append(data)
+            if data == b"Q1?\n":
+                time.sleep(0.1)
+
+        def fake_recv(size):
+            return responses[pending.pop(0)]
+
+        mock_socket.sendall.side_effect = fake_sendall
+        mock_socket.recv.side_effect = fake_recv
+
+        conn = SocketConnection("192.168.1.100")
+        conn.connect()
+
+        results = {}
+
+        def do_query(cmd):
+            results[cmd] = conn.query(cmd)
+
+        t1 = threading.Thread(target=do_query, args=("Q1?",))
+        t2 = threading.Thread(target=do_query, args=("Q2?",))
+        t1.start()
+        time.sleep(0.02)  # ensure t1 is inside its slow sendall first
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert results == {"Q1?": "R1", "Q2?": "R2"}

--- a/tests/test_waveform_comprehensive.py
+++ b/tests/test_waveform_comprehensive.py
@@ -58,6 +58,9 @@ def mock_scope():
     scope.send_command = Mock()
     scope.query = Mock()
     scope.query_binary = Mock()
+    # Configure the lock to support context manager protocol
+    scope._connection.lock.__enter__ = Mock(return_value=None)
+    scope._connection.lock.__exit__ = Mock(return_value=None)
     return scope
 
 


### PR DESCRIPTION
## Description

Hardens the socket connection layer — groundwork for the upcoming web GUI server, and immediate fixes for the desktop GUI's shared-connection behavior:

1. **Thread safety.** `SocketConnection` had no synchronization, so concurrent callers (GUI worker threads, poll timers) could interleave write/read pairs and consume each other's responses. A reentrant lock now lives on `BaseConnection`; `query()` and the waveform command+binary-read pair hold it across the full exchange.
2. **Exact-length binary reads.** `read_raw()` drained the socket until 0.5 s of silence, which truncated deep-memory transfers on any mid-stream stall, returned empty data when the scope took longer than 0.5 s to start sending, and added a mandatory 0.5 s stall to every acquisition. It now parses the IEEE 488.2 `#<n><length>` header and reads exactly the declared byte count, waiting up to the full connection timeout between chunks. Headerless responses keep the legacy idle-drain; stalls raise `SiglentTimeoutError` instead of silently returning short data.
3. **Default port 5025.** Port 5024 is Siglent's interactive telnet service (welcome banner, `>>` prompts, IAC negotiation bytes) which the connection layer never handled; 5025 speaks the clean newline-terminated protocol the code assumes. Explicit `port=` arguments still work for either.

## Related Issues

None — foundation work for the planned web GUI.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [x] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test coverage improvement
- [ ] CI/CD improvement

> Breaking note: anyone relying on the implicit default port 5024 must now pass `port=5024` explicitly (or use the recommended 5025).

## Changes Made

- `scpi_control/connection/base.py`: `threading.RLock` created in `BaseConnection.__init__`, reaching every connection class.
- `scpi_control/connection/socket.py`: `write`/`read`/`read_raw` acquire the lock; `query()` holds it across write+read; new `_read_ieee_block`, `_parse_block_total`, `_drain_terminator` helpers implement declared-length reads with a documented 128-byte no-header heuristic; default port 5025.
- `scpi_control/waveform.py`: waveform command + binary read wrapped in the connection lock.
- Default-port and docstring updates in `oscilloscope.py`, `automation.py`, `function_generator.py`, `power_supply.py`, `gui/connection_manager.py`, `gui/main_window.py`, `examples/function_generator_basic.py`, `examples/README.md`.
- Tests: new `TestSocketThreadSafety` (incl. a deterministic two-thread interleaving test) and `TestReadRawIeeeBlock` (six cases: exact-length, split header, mid-block stall, empty line, headerless drain, no-extra-recv-on-surplus); two default-port expectations updated.

## Testing

- [x] Tests pass locally (`make test` or `pytest tests/`)
- [x] Added tests for new functionality
- [ ] Tested with real hardware (if applicable)
- [ ] All CI checks pass

### Test Details

**Test environment:**

- OS: Windows 11 Pro
- Python version: 3.12.7
- Oscilloscope model (if applicable): MockConnection only — no hardware available

**Test results:**

```
384 passed, 19 skipped in 2.83s
```

## Code Quality

- [x] Code follows the project style guidelines (`make lint` passes)
- [x] Code is formatted with Black (`make format`)
- [x] Self-reviewed the code
- [x] Commented complex code sections
- [x] Updated docstrings for modified functions/classes
- [x] No new linting warnings introduced

## Documentation

- [ ] Updated README.md (if needed)
- [ ] Updated CHANGELOG.md with changes
- [x] Added/updated docstrings
- [x] Added/updated examples (if applicable)
- [ ] Updated type hints

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation

## Additional Notes

Verified against the mock connection only (no hardware on hand). Known accepted trade-offs, documented in code: headerless binary responses shorter than 128 bytes wait out the full connection timeout (so split block headers from slow scopes are never truncated), and `query()` holds the connection lock for up to the full timeout — one slow query serializes other callers on the same connection, which is the intended semantics for a single physical instrument. CHANGELOG entry for the port-default change should land with the next release-notes update.