### PR TITLE
fix: adopt Black 26 stable style and pin the formatter across configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black flake8
+          pip install black==26.5.1 flake8
 
       - name: Check code formatting with Black
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 repos:
   # Black - Python code formatter
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.5.1
     hooks:
       - id: black
         language_version: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ where = ["."]
 include = ["siglent*", "scpi_control*"]
 
 [tool.black]
-line-length = 100
+line-length = 200
 target-version = ['py38', 'py39', 'py310', 'py311', "py312"]
 
 [tool.pytest.ini_options]

--- a/scpi_control/gui/main_window.py
+++ b/scpi_control/gui/main_window.py
@@ -417,8 +417,7 @@ class MainWindow(QMainWindow):
 
         # Add styled connect/disconnect buttons that stand out
         connect_btn = QPushButton("Connect")
-        connect_btn.setStyleSheet(
-            """
+        connect_btn.setStyleSheet("""
             QPushButton {
                 background-color: #4CAF50;
                 color: white;
@@ -434,14 +433,12 @@ class MainWindow(QMainWindow):
             QPushButton:pressed {
                 background-color: #3d8b40;
             }
-        """
-        )
+        """)
         connect_btn.clicked.connect(self._on_connect)
         toolbar.addWidget(connect_btn)
 
         disconnect_btn = QPushButton("Disconnect")
-        disconnect_btn.setStyleSheet(
-            """
+        disconnect_btn.setStyleSheet("""
             QPushButton {
                 background-color: #f44336;
                 color: white;
@@ -457,8 +454,7 @@ class MainWindow(QMainWindow):
             QPushButton:pressed {
                 background-color: #c1170a;
             }
-        """
-        )
+        """)
         disconnect_btn.clicked.connect(self._on_disconnect)
         toolbar.addWidget(disconnect_btn)
 

--- a/scpi_control/gui/widgets/daq_ai_panel.py
+++ b/scpi_control/gui/widgets/daq_ai_panel.py
@@ -142,8 +142,7 @@ class DAQAIPanel(QWidget):
         self.response_text = QTextEdit()
         self.response_text.setReadOnly(True)
         self.response_text.setPlaceholderText("AI analysis results will appear here...\n\n" "Connect to an AI provider and collect some data to get started.")
-        self.response_text.setStyleSheet(
-            """
+        self.response_text.setStyleSheet("""
             QTextEdit {
                 background-color: #1e1e1e;
                 color: #d4d4d4;
@@ -152,8 +151,7 @@ class DAQAIPanel(QWidget):
                 font-family: monospace;
                 font-size: 11px;
             }
-        """
-        )
+        """)
         layout.addWidget(self.response_text, stretch=1)
 
         # Chat input

--- a/scpi_control/gui/widgets/daq_data_view.py
+++ b/scpi_control/gui/widgets/daq_data_view.py
@@ -126,8 +126,7 @@ class DAQDataView(QWidget):
         # Data table
         self.data_table = QTableWidget()
         self.data_table.setAlternatingRowColors(True)
-        self.data_table.setStyleSheet(
-            """
+        self.data_table.setStyleSheet("""
             QTableWidget {
                 background-color: #2d2d2d;
                 alternate-background-color: #353535;
@@ -140,8 +139,7 @@ class DAQDataView(QWidget):
                 padding: 4px;
                 border: 1px solid #505050;
             }
-        """
-        )
+        """)
         splitter.addWidget(self.data_table)
 
         # Set splitter sizes (70% chart, 30% table)

--- a/scpi_control/gui/widgets/daq_scan_config.py
+++ b/scpi_control/gui/widgets/daq_scan_config.py
@@ -130,8 +130,7 @@ class DAQScanConfig(QWidget):
 
         self.start_btn = QPushButton("Start Logging")
         self.start_btn.setMinimumHeight(40)
-        self.start_btn.setStyleSheet(
-            """
+        self.start_btn.setStyleSheet("""
             QPushButton {
                 background-color: #2e7d32;
                 color: white;
@@ -144,16 +143,14 @@ class DAQScanConfig(QWidget):
             QPushButton:disabled {
                 background-color: #555555;
             }
-        """
-        )
+        """)
         self.start_btn.clicked.connect(self._on_start_clicked)
         button_layout.addWidget(self.start_btn)
 
         self.stop_btn = QPushButton("Stop")
         self.stop_btn.setMinimumHeight(40)
         self.stop_btn.setEnabled(False)
-        self.stop_btn.setStyleSheet(
-            """
+        self.stop_btn.setStyleSheet("""
             QPushButton {
                 background-color: #c62828;
                 color: white;
@@ -166,8 +163,7 @@ class DAQScanConfig(QWidget):
             QPushButton:disabled {
                 background-color: #555555;
             }
-        """
-        )
+        """)
         self.stop_btn.clicked.connect(self._on_stop_clicked)
         button_layout.addWidget(self.stop_btn)
 

--- a/scpi_control/gui/widgets/math_panel.py
+++ b/scpi_control/gui/widgets/math_panel.py
@@ -173,8 +173,7 @@ class MathPanel(QWidget):
         help_text = QTextEdit()
         help_text.setReadOnly(True)
         help_text.setMaximumHeight(150)
-        help_text.setHtml(
-            """
+        help_text.setHtml("""
 <b>Supported Operations:</b><br>
 <ul>
 <li><b>Basic:</b> C1 + C2, C1 - C2, C1 * C2, C1 / C2</li>
@@ -194,8 +193,7 @@ class MathPanel(QWidget):
 • Scaled sum: 2 * C1 + C2<br>
 • Power: C1 * C2 (voltage × current)<br>
 • Average: (C1 + C2) / 2 (not yet supported - use two steps)
-        """
-        )
+        """)
         layout.addWidget(help_text)
 
         return group

--- a/scpi_control/gui/widgets/psu_control.py
+++ b/scpi_control/gui/widgets/psu_control.py
@@ -41,8 +41,7 @@ class PSUControl(QWidget):
 
         # Safety: All Outputs OFF button
         all_off_btn = QPushButton("⚠ All Outputs OFF (Safety)")
-        all_off_btn.setStyleSheet(
-            """
+        all_off_btn.setStyleSheet("""
             QPushButton {
                 background-color: #DC143C;
                 color: white;
@@ -53,8 +52,7 @@ class PSUControl(QWidget):
             QPushButton:hover {
                 background-color: #B22222;
             }
-        """
-        )
+        """)
         all_off_btn.clicked.connect(self._on_all_off)
         layout.addWidget(all_off_btn)
 

--- a/scpi_control/gui/widgets/terminal_widget.py
+++ b/scpi_control/gui/widgets/terminal_widget.py
@@ -57,8 +57,7 @@ class TerminalWidget(QWidget):
         self.output_display = QTextEdit()
         self.output_display.setReadOnly(True)
         self.output_display.setFont(QFont("Courier New", 9))
-        self.output_display.setStyleSheet(
-            """
+        self.output_display.setStyleSheet("""
             QTextEdit {
                 background-color: #1e1e1e;
                 color: #d4d4d4;
@@ -66,8 +65,7 @@ class TerminalWidget(QWidget):
                 border-radius: 3px;
                 padding: 5px;
             }
-        """
-        )
+        """)
         output_layout.addWidget(self.output_display)
 
         splitter.addWidget(output_widget)
@@ -85,8 +83,7 @@ class TerminalWidget(QWidget):
         self.examples_display.setReadOnly(True)
         self.examples_display.setFont(QFont("Courier New", 8))
         self.examples_display.setMaximumHeight(150)
-        self.examples_display.setHtml(
-            """
+        self.examples_display.setHtml("""
         <style>
             body { font-family: 'Courier New'; font-size: 9pt; }
             .cmd { color: #4ec9b0; font-weight: bold; }
@@ -100,8 +97,7 @@ class TerminalWidget(QWidget):
         <p><span class="cmd">TRIG_MODE AUTO</span> <span class="desc">- Set trigger to AUTO mode</span></p>
         <p><span class="cmd">C1:TRA?</span> <span class="desc">- Get channel 1 trace on/off</span></p>
         <p><span class="cmd">C1:TRA ON</span> <span class="desc">- Enable channel 1</span></p>
-        """
-        )
+        """)
         examples_layout.addWidget(self.examples_display)
 
         splitter.addWidget(examples_widget)
@@ -122,8 +118,7 @@ class TerminalWidget(QWidget):
         self.command_input.setPlaceholderText("Enter SCPI command here (e.g., *IDN?)")
         self.command_input.returnPressed.connect(self._on_send_command)
         self.command_input.setFont(QFont("Courier New", 10))
-        self.command_input.setStyleSheet(
-            """
+        self.command_input.setStyleSheet("""
             QLineEdit {
                 padding: 6px;
                 border: 2px solid #4CAF50;
@@ -133,8 +128,7 @@ class TerminalWidget(QWidget):
             QLineEdit:focus {
                 border-color: #45a049;
             }
-        """
-        )
+        """)
 
         # Enable Up/Down arrow keys for history
         self.command_input.keyPressEvent = self._handle_key_press
@@ -144,8 +138,7 @@ class TerminalWidget(QWidget):
         # Send button
         send_button = QPushButton("Send")
         send_button.clicked.connect(self._on_send_command)
-        send_button.setStyleSheet(
-            """
+        send_button.setStyleSheet("""
             QPushButton {
                 background-color: #4CAF50;
                 color: white;
@@ -160,15 +153,13 @@ class TerminalWidget(QWidget):
             QPushButton:pressed {
                 background-color: #3d8b40;
             }
-        """
-        )
+        """)
         input_layout.addWidget(send_button)
 
         # Clear button
         clear_button = QPushButton("Clear")
         clear_button.clicked.connect(self._on_clear_output)
-        clear_button.setStyleSheet(
-            """
+        clear_button.setStyleSheet("""
             QPushButton {
                 background-color: #f44336;
                 color: white;
@@ -183,8 +174,7 @@ class TerminalWidget(QWidget):
             QPushButton:pressed {
                 background-color: #c1170a;
             }
-        """
-        )
+        """)
         input_layout.addWidget(clear_button)
 
         layout.addLayout(input_layout)

--- a/tests/test_function_generator.py
+++ b/tests/test_function_generator.py
@@ -64,28 +64,16 @@ class TestAWGSCPICommandSet:
 
         assert cmd_set.get_command("identify") == "*IDN?"
         assert cmd_set.get_command("reset") == "*RST"
-        assert (
-            cmd_set.get_command("set_frequency", ch=1, frequency=1000.0)
-            == "SOUR1:FREQ 1000.0"
-        )
+        assert cmd_set.get_command("set_frequency", ch=1, frequency=1000.0) == "SOUR1:FREQ 1000.0"
         assert cmd_set.get_command("get_frequency", ch=1) == "SOUR1:FREQ?"
 
     def test_siglent_sdg_commands(self):
         """Test Siglent SDG command overrides."""
         cmd_set = AWGSCPICommandSet("siglent_sdg")
 
-        assert (
-            cmd_set.get_command("set_function", ch=1, function="SINE")
-            == "C1:BSWV WVTP,SINE"
-        )
-        assert (
-            cmd_set.get_command("set_frequency", ch=1, frequency=1000.0)
-            == "C1:BSWV FRQ,1000.0"
-        )
-        assert (
-            cmd_set.get_command("set_amplitude", ch=1, amplitude=5.0)
-            == "C1:BSWV AMP,5.0"
-        )
+        assert cmd_set.get_command("set_function", ch=1, function="SINE") == "C1:BSWV WVTP,SINE"
+        assert cmd_set.get_command("set_frequency", ch=1, frequency=1000.0) == "C1:BSWV FRQ,1000.0"
+        assert cmd_set.get_command("set_amplitude", ch=1, amplitude=5.0) == "C1:BSWV AMP,5.0"
         assert cmd_set.get_command("set_output", ch=1, state="ON") == "C1:OUTP ON"
 
     def test_fallback_to_generic(self):
@@ -266,9 +254,7 @@ class TestAWGOutput:
 
     def test_configure_pulse(self, mock_awg):
         """Test pulse wave configuration."""
-        mock_awg.channel1.configure_pulse(
-            frequency=1000.0, amplitude=5.0, duty_cycle=25.0
-        )
+        mock_awg.channel1.configure_pulse(frequency=1000.0, amplitude=5.0, duty_cycle=25.0)
 
         assert mock_awg.channel1.function == "PULSE"
         assert mock_awg.channel1.frequency == 1000.0
@@ -277,9 +263,7 @@ class TestAWGOutput:
 
     def test_configure_ramp(self, mock_awg):
         """Test ramp wave configuration."""
-        mock_awg.channel1.configure_ramp(
-            frequency=500.0, amplitude=2.0, symmetry=50.0
-        )
+        mock_awg.channel1.configure_ramp(frequency=500.0, amplitude=2.0, symmetry=50.0)
 
         assert mock_awg.channel1.function == "RAMP"
         assert mock_awg.channel1.frequency == 500.0
@@ -396,9 +380,7 @@ class TestGenericAWG:
 
     def test_generic_awg_basic_control(self):
         """Test basic control of generic AWG."""
-        conn = MockConnection(
-            awg_mode=True, awg_idn="Generic,AWG-1000,SERIAL,1.0"
-        )
+        conn = MockConnection(awg_mode=True, awg_idn="Generic,AWG-1000,SERIAL,1.0")
         awg = FunctionGenerator("mock", connection=conn)
         awg.connect()
 


### PR DESCRIPTION
## Description

Fixes the failing Code Quality CI job. CI installs Black unpinned, so it picked up Black 26.x whose 2026 stable style hugs multiline strings against their enclosing parentheses (`setStyleSheet("""` instead of breaking the line). Seven GUI files formatted under the previous style were flagged with "would reformat". The Python 3.11 safety-check warning in the log was a red herring — the failure reproduces on Python 3.12 with Black 26.5.1 and disappears with Black 25.12.0.

Root cause: the repo had four disagreeing Black configurations — CI (unpinned latest, line length 200), Makefile (local version, 200), pre-commit (pinned 24.10.0, 200), and pyproject.toml (100). Any yearly Black style release could break CI with no code change.

## Related Issues

None

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Test coverage improvement
- [x] CI/CD improvement

## Changes Made

- Reformatted the 7 flagged GUI files (plus `tests/test_function_generator.py`, which `make lint` covers) with `black==26.5.1 --line-length 200` — whitespace-only, AST-safe changes
- Pinned `black==26.5.1` in the CI lint job so future yearly style bumps can't break CI silently
- Bumped the pre-commit Black hook from 24.10.0 to 26.5.1 so local hooks produce what CI checks
- Aligned `pyproject.toml` `[tool.black]` line-length (100 → 200) with the value CI, the Makefile, and pre-commit already use
- Bumped the lint job to Python 3.12 so Black's AST safety check can parse py312-target code (removes the warning in the CI log)

## Testing

- [x] Tests pass locally (`make test` or `pytest tests/`)
- [ ] Added tests for new functionality
- [ ] Tested with real hardware (if applicable)
- [ ] All CI checks pass

### Test Details

**Test environment:**

- OS: Windows 11 Pro
- Python version: 3.12.7 (Black run in an isolated venv with black==26.5.1, matching what CI installs)
- Oscilloscope model (if applicable): N/A — formatting/CI change only

**Test results:**

```
black --check --line-length 200 scpi_control/ examples/   -> 128 files would be left unchanged
black --check --line-length 200 scpi_control/ tests/ examples/ -> 155 files would be left unchanged
flake8 scpi_control/ --count --select=E9,F63,F7,F82        -> 0
pytest tests/ -> 466 passed, 19 skipped in 7.86s
```

## Code Quality

- [x] Code follows the project style guidelines (`make lint` passes)
- [x] Code is formatted with Black (`make format`)
- [x] Self-reviewed the code
- [ ] Commented complex code sections
- [ ] Updated docstrings for modified functions/classes
- [x] No new linting warnings introduced

## Documentation

- [ ] Updated README.md (if needed)
- [ ] Updated CHANGELOG.md with changes
- [ ] Added/updated docstrings
- [ ] Added/updated examples (if applicable)
- [ ] Updated type hints

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation

## Additional Notes

The source-file diffs are purely formatting (Black verifies AST equivalence before writing). Contributors with the old pre-commit hook cached should run `pre-commit autoupdate` or `pre-commit install --install-hooks` after pulling to pick up the 26.5.1 hook.