### PR TITLE
feat: web gateway server with multi-session API, streaming, and LAN discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,10 @@ jobs:
           pip install -e ".[dev]"
           pip install pytest pytest-cov pytest-xdist
 
+      - name: Install web extra (Python >= 3.9)
+        if: matrix.python-version != '3.8'
+        run: pip install -e ".[web]"
+
       - name: Run tests with coverage
         run: |
           pytest tests/ --cov=scpi_control --cov-report=xml --cov-report=term-missing -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Install web extra (Python >= 3.9)
         if: matrix.python-version != '3.8'
-        run: pip install -e ".[web]"
+        run: pip install -e ".[web]" httpx  # httpx: required by fastapi.testclient
 
       - name: Run tests with coverage
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ node_modules/
 
 # Documentation
 site/
+
+# Web gateway frontend build output
+scpi_control/server/static/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,9 @@ include docs/SDS800XHD_Series_ProgrammingGuide_EN11G.pdf
 # Include resources (logos, icons)
 recursive-include resources *.png *.ico *.icns
 
+# Include web gateway frontend build output (when present)
+recursive-include scpi_control/server/static *
+
 # Include examples
 recursive-include examples *.py
 recursive-include examples *.md

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,9 @@ pre-pr-fix:  ## Run pre-PR validation with auto-fix
 gui:  ## Launch the GUI application
 	siglent-gui
 
+web-server:  ## Run the web gateway (dev, mock-friendly)
+	python -m scpi_control.server --port 8765
+
 version:  ## Show package version
 	@python -c "import scpi_control; print(f'SCPI-Instrument-Control v{scpi_control.__version__}')"
 

--- a/README.md
+++ b/README.md
@@ -605,6 +605,10 @@ built-in mock (`mock: true`) for hardware-free use. The API is documented at
 `/docs` (OpenAPI). No authentication in this release — bind to `127.0.0.1`
 (the default) unless your LAN is trusted.
 
+- `GET /api/discover` scans the gateway's subnet (or `?cidr=…`) for SCPI
+  instruments on port 5025 and lists them with model and dialect — handy when
+  DHCP moves your instruments around.
+
 ## API Documentation
 
 ### Oscilloscope

--- a/README.md
+++ b/README.md
@@ -591,6 +591,20 @@ See `examples/vector_graphics_xy_mode.py` for programmatic usage and animation e
 - I2C, SPI, UART, CAN, LIN decoding
 - Packet analysis and export
 
+## Web Gateway (beta)
+
+Control instruments from any browser on your LAN:
+
+```bash
+pip install scpi-instrument-control[web]   # Python 3.9+
+scpi-web --host 0.0.0.0 --port 8765
+```
+
+Open `http://<gateway-pc>:8765`. Sessions can target real scopes by IP or a
+built-in mock (`mock: true`) for hardware-free use. The API is documented at
+`/docs` (OpenAPI). No authentication in this release — bind to `127.0.0.1`
+(the default) unless your LAN is trusted.
+
 ## API Documentation
 
 ### Oscilloscope

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,10 @@ gui = [
     "PyQt6-WebEngine>=6.6.0",
     "pyqtgraph>=0.13.0",
 ]
+web = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.30",
+]
 fun = [
     "shapely>=2.0.0",
     "Pillow>=10.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ all = [
 [project.scripts]
 siglent-gui = "scpi_control.gui.app:main"
 siglent-report-generator = "scpi_control.report_generator.app:main"
+scpi-web = "scpi_control.server.__main__:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/scpi_control/connection/mock.py
+++ b/scpi_control/connection/mock.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 from scpi_control import exceptions
 from scpi_control.connection.base import BaseConnection
@@ -18,6 +18,29 @@ def _format_scientific(value: float, unit: str) -> str:
 def _format_nr3(value: float) -> str:
     """Format a bare NR3 numeric value (no unit) as used by modern-dialect queries."""
     return f"{value:.2E}"
+
+
+# Canonical PAVA? measurement values for the legacy dialect (mirrors real
+# hardware where PAVA? is legacy-only; the modern dialect has no equivalent).
+_MOCK_PAVA_VALUES: Dict[str, Tuple[str, str]] = {
+    "PKPK": ("2.000E+00", "V"),
+    "MAX": ("1.000E+00", "V"),
+    "MIN": ("-1.000E+00", "V"),
+    "AMPL": ("2.000E+00", "V"),
+    "TOP": ("1.000E+00", "V"),
+    "BASE": ("-1.000E+00", "V"),
+    "CMEAN": ("0.000E+00", "V"),
+    "MEAN": ("0.000E+00", "V"),
+    "RMS": ("7.070E-01", "V"),
+    "CRMS": ("7.070E-01", "V"),
+    "FREQ": ("1.000E+03", "HZ"),
+    "PER": ("1.000E-03", "S"),
+    "RISE": ("3.500E-05", "S"),
+    "FALL": ("3.500E-05", "S"),
+    "WID": ("5.000E-04", "S"),
+    "NWID": ("5.000E-04", "S"),
+    "DUTY": ("5.000E+01", "%"),
+}
 
 
 class MockConnection(BaseConnection):
@@ -734,6 +757,14 @@ class MockConnection(BaseConnection):
 
             if upper == "TRIG_SELECT?":
                 return f"{self.trigger_type},SR,{self.trigger_source}"
+
+            if match := re.match(r"PAVA\?\s*(\w+)\s*,\s*C?(\d+)", command, re.IGNORECASE):
+                mtype = match.group(1).upper()
+                channel = match.group(2)
+                entry = _MOCK_PAVA_VALUES.get(mtype)
+                if entry is not None:
+                    value, unit = entry
+                    return f"PAVA {mtype},C{channel},{value}{unit}"
 
         if self.psu_mode or self.awg_mode or self.daq_mode:
             return ""

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -1,0 +1,19 @@
+"""Lab gateway entry point: python -m scpi_control.server / scpi-web."""
+
+import argparse
+
+import uvicorn
+
+from scpi_control.server.app import create_app
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(prog="scpi-web", description="SCPI Instrument Control web gateway")
+    parser.add_argument("--host", default="127.0.0.1", help="bind address (use 0.0.0.0 to expose on the LAN)")
+    parser.add_argument("--port", type=int, default=8765)
+    args = parser.parse_args(argv)
+    uvicorn.run(create_app(), host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/scpi_control/server/api/discovery.py
+++ b/scpi_control/server/api/discovery.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from fastapi import APIRouter, Request
+from fastapi.concurrency import run_in_threadpool
+
+from scpi_control.server import discovery
+
+router = APIRouter(tags=["discovery"])
+
+
+@router.get("/discover")
+async def discover_instruments(request: Request, cidr: Optional[str] = None):
+    manager = request.app.state.manager
+    sessions = [s for s in manager.list() if s.address and s.state == "connected"]
+    skip = frozenset(s.address for s in sessions)
+    found = await run_in_threadpool(discovery.discover, cidr=cidr, port=discovery.SCPI_PORT, skip=skip)
+    for entry in found:
+        entry["connected"] = False
+    connected = [
+        {
+            "address": s.address,
+            "idn": s.idn,
+            "manufacturer": s.idn.split(",")[0].strip() if s.idn else "",
+            "model": s.model,
+            "dialect": s.dialect,
+            "kind": "scope",
+            "connected": True,
+            "session_id": s.id,
+        }
+        for s in sessions
+    ]
+    results = connected + found
+    results.sort(key=discovery._sort_key)
+    return results

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -1,4 +1,101 @@
 # scpi_control/server/api/scope.py
-from fastapi import APIRouter
+import asyncio
+from typing import Any, Callable
+
+from fastapi import APIRouter, Request
+
+from scpi_control.exceptions import InvalidParameterError
+from scpi_control.server.api.sessions import require_session
+from scpi_control.server.schemas import ALLOWED_COUPLING, ChannelPatch, TimebasePatch, TriggerPatch
+from scpi_control.server.sessions import InstrumentSession, read_state
 
 router = APIRouter(tags=["scope"])
+
+
+async def run_job(session: InstrumentSession, fn: Callable) -> Any:
+    return await asyncio.wrap_future(session.submit(fn))
+
+
+async def mutate(session: InstrumentSession, fn: Callable) -> dict:
+    """Run a mutation, then read + broadcast + return the fresh state."""
+    await run_job(session, fn)
+    state = await run_job(session, read_state)
+    session.publish({"type": "state", "state": state})
+    return state
+
+
+@router.get("/sessions/{session_id}/scope/state")
+async def get_state(session_id: str, request: Request):
+    session = require_session(request, session_id)
+    return await run_job(session, read_state)
+
+
+@router.patch("/sessions/{session_id}/scope/channels/{channel}")
+async def patch_channel(session_id: str, channel: int, body: ChannelPatch, request: Request):
+    session = require_session(request, session_id)
+    if body.coupling is not None and body.coupling.upper() not in ALLOWED_COUPLING:
+        raise InvalidParameterError("invalid coupling: {0}".format(body.coupling))
+
+    def apply(scope):
+        ch = scope.get_channel(channel)
+        if ch is None:
+            raise InvalidParameterError("channel {0} not available".format(channel))
+        if body.enabled is not None:
+            ch.enabled = body.enabled
+        if body.voltage_scale is not None:
+            ch.voltage_scale = body.voltage_scale
+        if body.voltage_offset is not None:
+            ch.voltage_offset = body.voltage_offset
+        if body.coupling is not None:
+            ch.coupling = body.coupling.upper()
+        if body.probe_ratio is not None:
+            ch.probe_ratio = body.probe_ratio
+
+    return await mutate(session, apply)
+
+
+@router.patch("/sessions/{session_id}/scope/timebase")
+async def patch_timebase(session_id: str, body: TimebasePatch, request: Request):
+    session = require_session(request, session_id)
+
+    def apply(scope):
+        scope.timebase = body.timebase
+
+    return await mutate(session, apply)
+
+
+@router.patch("/sessions/{session_id}/scope/trigger")
+async def patch_trigger(session_id: str, body: TriggerPatch, request: Request):
+    session = require_session(request, session_id)
+
+    def apply(scope):
+        trig = scope.trigger
+        if body.mode is not None:
+            trig.mode = body.mode.upper()
+        if body.source is not None:
+            trig.source = body.source
+        if body.level is not None:
+            trig.level = body.level
+        if body.slope is not None:
+            trig.slope = body.slope.upper()
+        if body.coupling is not None:
+            trig.coupling = body.coupling.upper()
+
+    return await mutate(session, apply)
+
+
+_RUN_OPS = {
+    "run": lambda scope: scope.run(),
+    "stop": lambda scope: scope.stop(),
+    "single": lambda scope: scope.trigger_single(),
+    "auto": lambda scope: scope.auto_setup(),
+}
+
+
+@router.post("/sessions/{session_id}/scope/{op}")
+async def run_op(session_id: str, op: str, request: Request):
+    session = require_session(request, session_id)
+    fn = _RUN_OPS.get(op)
+    if fn is None:
+        raise InvalidParameterError("unknown operation: {0}".format(op))
+    return await mutate(session, fn)

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -1,12 +1,12 @@
 # scpi_control/server/api/scope.py
 import asyncio
-from typing import Any, Callable
+from typing import Any, Callable, List
 
 from fastapi import APIRouter, Request
 
 from scpi_control.exceptions import InvalidParameterError
 from scpi_control.server.api.sessions import require_session
-from scpi_control.server.schemas import ALLOWED_COUPLING, ChannelPatch, TimebasePatch, TriggerPatch
+from scpi_control.server.schemas import ALLOWED_COUPLING, ALLOWED_MEASUREMENTS, ChannelPatch, CommandIn, MeasurementItem, TimebasePatch, TriggerPatch
 from scpi_control.server.sessions import InstrumentSession, read_state
 
 router = APIRouter(tags=["scope"])
@@ -84,6 +84,37 @@ async def patch_trigger(session_id: str, body: TriggerPatch, request: Request):
     return await mutate(session, apply)
 
 
+@router.post("/sessions/{session_id}/scope/command")
+async def send_command(session_id: str, body: CommandIn, request: Request):
+    session = require_session(request, session_id)
+    command = body.command.strip()
+    if not command:
+        raise InvalidParameterError("empty command")
+
+    def run(scope):
+        if command.endswith("?"):
+            return scope.query(command)
+        scope.write(command)
+        return None
+
+    response = await run_job(session, run)
+    return {"command": command, "response": response}
+
+
+@router.put("/sessions/{session_id}/scope/measurements")
+async def put_measurements(session_id: str, body: List[MeasurementItem], request: Request):
+    session = require_session(request, session_id)
+    for item in body:
+        if item.mtype.upper() not in ALLOWED_MEASUREMENTS:
+            raise InvalidParameterError("unknown measurement type: {0}".format(item.mtype))
+        if not 1 <= item.channel <= max(1, session.num_channels):
+            raise InvalidParameterError("channel {0} out of range".format(item.channel))
+    session.set_measurements([(item.channel, item.mtype.upper()) for item in body])
+    return {"measurements": [{"channel": c, "mtype": m} for c, m in session.measurements]}
+
+
+# NOTE: run_op's {op} path is a catch-all for POST /scope/*; any new specific
+# POST route under /scope must be registered ABOVE it or it will be shadowed.
 _RUN_OPS = {
     "run": lambda scope: scope.run(),
     "stop": lambda scope: scope.stop(),

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -3,6 +3,7 @@ import asyncio
 from typing import Any, Callable, List
 
 from fastapi import APIRouter, Request
+from fastapi.responses import PlainTextResponse
 
 from scpi_control.exceptions import InvalidParameterError
 from scpi_control.server.api.sessions import require_session
@@ -111,6 +112,36 @@ async def put_measurements(session_id: str, body: List[MeasurementItem], request
             raise InvalidParameterError("channel {0} out of range".format(item.channel))
     session.set_measurements([(item.channel, item.mtype.upper()) for item in body])
     return {"measurements": [{"channel": c, "mtype": m} for c, m in session.measurements]}
+
+
+def _build_csv(captures) -> str:
+    """captures: list of (channel:int, WaveformData). Align to the shortest."""
+    n = min(len(w.voltage) for _, w in captures)
+    time_axis = captures[0][1].time
+    header = "time_s," + ",".join("C{0}_V".format(c) for c, _ in captures)
+    rows = [header]
+    for i in range(n):
+        rows.append("{0:.9g},{1}".format(float(time_axis[i]), ",".join("{0:.9g}".format(float(w.voltage[i])) for _, w in captures)))
+    return "\n".join(rows) + "\n"
+
+
+@router.get("/sessions/{session_id}/scope/capture.csv")
+async def capture_csv(session_id: str, request: Request, channels: str = "1"):
+    session = require_session(request, session_id)
+    try:
+        channel_list = sorted({int(c) for c in channels.split(",") if c.strip()})
+    except ValueError:
+        raise InvalidParameterError("channels must be a comma-separated list of integers")
+    if not channel_list:
+        raise InvalidParameterError("no channels requested")
+
+    def capture(scope):
+        return [(c, scope.get_waveform(c)) for c in channel_list]
+
+    captures = await run_job(session, capture)
+    csv_text = _build_csv(captures)
+    filename = "capture_{0}_C{1}.csv".format(session.id, "-".join(str(c) for c in channel_list))
+    return PlainTextResponse(csv_text, media_type="text/csv", headers={"Content-Disposition": 'attachment; filename="{0}"'.format(filename)})
 
 
 # NOTE: run_op's {op} path is a catch-all for POST /scope/*; any new specific

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -1,0 +1,4 @@
+# scpi_control/server/api/scope.py
+from fastapi import APIRouter
+
+router = APIRouter(tags=["scope"])

--- a/scpi_control/server/api/sessions.py
+++ b/scpi_control/server/api/sessions.py
@@ -1,0 +1,25 @@
+# scpi_control/server/api/sessions.py
+from fastapi import APIRouter, HTTPException, Request
+
+router = APIRouter(tags=["sessions"])
+
+
+def get_manager(request: Request):
+    return request.app.state.manager
+
+
+@router.get("/sessions")
+def list_sessions(request: Request):
+    from scpi_control.server.schemas import session_out
+
+    return [session_out(s) for s in get_manager(request).list()]
+
+
+@router.get("/sessions/{session_id}")
+def get_session(session_id: str, request: Request):
+    from scpi_control.server.schemas import session_out
+
+    session = get_manager(request).get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="unknown session {0}".format(session_id))
+    return session_out(session)

--- a/scpi_control/server/api/sessions.py
+++ b/scpi_control/server/api/sessions.py
@@ -1,5 +1,9 @@
 # scpi_control/server/api/sessions.py
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi.concurrency import run_in_threadpool
+
+from scpi_control.models import MODEL_REGISTRY
+from scpi_control.server.schemas import ModelOut, SessionCreate, session_out
 
 router = APIRouter(tags=["sessions"])
 
@@ -8,18 +12,39 @@ def get_manager(request: Request):
     return request.app.state.manager
 
 
+def require_session(request: Request, session_id: str):
+    session = get_manager(request).get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="unknown session {0}".format(session_id))
+    return session
+
+
+@router.get("/models")
+def list_models():
+    caps = sorted(MODEL_REGISTRY.values(), key=lambda c: c.model_name)
+    return [ModelOut(model_name=c.model_name, series=c.series, num_channels=c.num_channels, bandwidth_mhz=c.bandwidth_mhz, dialect=c.dialect) for c in caps]
+
+
 @router.get("/sessions")
 def list_sessions(request: Request):
-    from scpi_control.server.schemas import session_out
-
     return [session_out(s) for s in get_manager(request).list()]
 
 
 @router.get("/sessions/{session_id}")
 def get_session(session_id: str, request: Request):
-    from scpi_control.server.schemas import session_out
+    return session_out(require_session(request, session_id))
 
-    session = get_manager(request).get(session_id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="unknown session {0}".format(session_id))
+
+@router.post("/sessions", status_code=201)
+async def create_session(body: SessionCreate, request: Request):
+    label = body.label or (body.model or ("Mock scope" if body.mock else body.address or ""))
+    # InstrumentSession.open blocks on connect; keep the event loop free.
+    session = await run_in_threadpool(get_manager(request).create, label, address=body.address, port=body.port, mock=body.mock, model=body.model)
     return session_out(session)
+
+
+@router.delete("/sessions/{session_id}", status_code=204)
+async def delete_session(session_id: str, request: Request):
+    require_session(request, session_id)
+    await run_in_threadpool(get_manager(request).delete, session_id)
+    return Response(status_code=204)

--- a/scpi_control/server/api/stream.py
+++ b/scpi_control/server/api/stream.py
@@ -1,0 +1,4 @@
+# scpi_control/server/api/stream.py
+from fastapi import APIRouter
+
+router = APIRouter(tags=["stream"])

--- a/scpi_control/server/api/stream.py
+++ b/scpi_control/server/api/stream.py
@@ -1,11 +1,67 @@
 # scpi_control/server/api/stream.py
 import asyncio
+import contextlib
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from scpi_control.server.sessions import read_state
 
 router = APIRouter(tags=["stream"])
+
+# Cap the per-connection outbox so a slow/paused client cannot make the event
+# loop buffer waveform frames without bound. 256 frames ~= a minute at 4 Hz.
+OUTBOX_MAXSIZE = 256
+
+
+def _enqueue(outbox: "asyncio.Queue", message) -> None:
+    """Put ``message`` on ``outbox``, dropping the oldest waveform under backpressure.
+
+    Runs on the event-loop thread (scheduled via ``call_soon_threadsafe``), so no
+    other producer touches the queue concurrently and this stays race-free. When the
+    queue is full we evict the oldest ``waveform`` frame to make room; ``state`` /
+    ``error`` / ``closed`` control frames are never dropped. If a single scan finds no
+    waveform to evict, we drop the incoming frame instead of a control frame.
+    """
+    if not outbox.full():
+        outbox.put_nowait(message)
+        return
+    dropped_waveform = False
+    for _ in range(outbox.qsize()):
+        try:
+            item = outbox.get_nowait()
+        except asyncio.QueueEmpty:
+            break
+        if not dropped_waveform and isinstance(item, dict) and item.get("type") == "waveform":
+            dropped_waveform = True
+            continue  # evict this oldest waveform frame
+        outbox.put_nowait(item)  # rotate everything else back in order
+    if dropped_waveform:
+        outbox.put_nowait(message)
+    # else: only control frames present -> drop the incoming frame, keep controls
+
+
+async def _receive_until_disconnect(websocket: WebSocket) -> None:
+    """Park on the receive side so a client disconnect is noticed even when idle."""
+    try:
+        while True:
+            message = await websocket.receive()
+            if message.get("type") == "websocket.disconnect":
+                return
+    except Exception:
+        return
+
+
+async def _send_from_outbox(websocket: WebSocket, outbox: "asyncio.Queue") -> None:
+    """Forward queued messages until the session closes or the socket errors."""
+    try:
+        while True:
+            message = await outbox.get()
+            await websocket.send_json(message)
+            if isinstance(message, dict) and message.get("type") == "closed":
+                await websocket.close(code=4410)
+                return
+    except Exception:
+        return
 
 
 @router.websocket("/sessions/{session_id}/stream")
@@ -17,19 +73,31 @@ async def stream(websocket: WebSocket, session_id: str):
     await websocket.accept()
 
     loop = asyncio.get_running_loop()
-    outbox: "asyncio.Queue" = asyncio.Queue()
+    outbox: "asyncio.Queue" = asyncio.Queue(maxsize=OUTBOX_MAXSIZE)
 
     def on_message(message):
-        loop.call_soon_threadsafe(outbox.put_nowait, message)
+        loop.call_soon_threadsafe(_enqueue, outbox, message)
 
     unsubscribe = session.subscribe(on_message)
+    receiver = None
+    sender = None
     try:
         initial = await asyncio.wrap_future(session.submit(read_state))
         await websocket.send_json({"type": "state", "state": initial})
-        while True:
-            message = await outbox.get()
-            await websocket.send_json(message)
+        # Run the receiver (disconnect detection) and sender concurrently; whichever
+        # finishes first tears the connection down.
+        receiver = asyncio.ensure_future(_receive_until_disconnect(websocket))
+        sender = asyncio.ensure_future(_send_from_outbox(websocket, outbox))
+        await asyncio.wait({receiver, sender}, return_when=asyncio.FIRST_COMPLETED)
     except WebSocketDisconnect:
+        pass
+    except Exception:
+        # Any failure on the send/receive path tears down quietly (no ASGI noise).
         pass
     finally:
         unsubscribe()
+        for task in (receiver, sender):
+            if task is not None:
+                task.cancel()
+                with contextlib.suppress(Exception, asyncio.CancelledError):
+                    await task

--- a/scpi_control/server/api/stream.py
+++ b/scpi_control/server/api/stream.py
@@ -1,4 +1,35 @@
 # scpi_control/server/api/stream.py
-from fastapi import APIRouter
+import asyncio
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from scpi_control.server.sessions import read_state
 
 router = APIRouter(tags=["stream"])
+
+
+@router.websocket("/sessions/{session_id}/stream")
+async def stream(websocket: WebSocket, session_id: str):
+    session = websocket.app.state.manager.get(session_id)
+    if session is None:
+        await websocket.close(code=4404)
+        return
+    await websocket.accept()
+
+    loop = asyncio.get_running_loop()
+    outbox: "asyncio.Queue" = asyncio.Queue()
+
+    def on_message(message):
+        loop.call_soon_threadsafe(outbox.put_nowait, message)
+
+    unsubscribe = session.subscribe(on_message)
+    try:
+        initial = await asyncio.wrap_future(session.submit(read_state))
+        await websocket.send_json({"type": "state", "state": initial})
+        while True:
+            message = await outbox.get()
+            await websocket.send_json(message)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        unsubscribe()

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -1,9 +1,11 @@
 """FastAPI app factory (requires the [web] extra; Python >= 3.9)."""
 
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Optional
 
 from fastapi import FastAPI, Request
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -19,8 +21,16 @@ def _error_response(status: int, exc: BaseException) -> JSONResponse:
 
 
 def create_app(manager: Optional[SessionManager] = None) -> FastAPI:
-    app = FastAPI(title="SCPI Instrument Control Gateway")
-    app.state.manager = manager if manager is not None else SessionManager()
+    manager = manager if manager is not None else SessionManager()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        yield
+        # close_all() joins worker threads, so keep it off the event loop.
+        await run_in_threadpool(app.state.manager.close_all)
+
+    app = FastAPI(title="SCPI Instrument Control Gateway", lifespan=lifespan)
+    app.state.manager = manager
 
     from scpi_control.server.api import scope as scope_api
     from scpi_control.server.api import sessions as sessions_api
@@ -52,7 +62,8 @@ def create_app(manager: Optional[SessionManager] = None) -> FastAPI:
 
     @app.exception_handler(StarletteHTTPException)
     async def _http_error(request: Request, exc: StarletteHTTPException):
-        return JSONResponse(status_code=exc.status_code, content={"error": "HTTPException", "detail": exc.detail})
+        # Preserve headers Starlette attaches (e.g. Allow on a 405).
+        return JSONResponse(status_code=exc.status_code, content={"error": "HTTPException", "detail": exc.detail}, headers=getattr(exc, "headers", None))
 
     if STATIC_DIR.is_dir():
         app.mount("/", StaticFiles(directory=str(STATIC_DIR), html=True), name="frontend")

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -1,0 +1,59 @@
+"""FastAPI app factory (requires the [web] extra; Python >= 3.9)."""
+
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+from scpi_control.exceptions import InvalidParameterError, SiglentError, SiglentTimeoutError
+from scpi_control.server.sessions import SessionError, SessionManager
+
+STATIC_DIR = Path(__file__).parent / "static"
+
+
+def _error_response(status: int, exc: BaseException) -> JSONResponse:
+    return JSONResponse(status_code=status, content={"error": type(exc).__name__, "detail": str(exc)})
+
+
+def create_app(manager: Optional[SessionManager] = None) -> FastAPI:
+    app = FastAPI(title="SCPI Instrument Control Gateway")
+    app.state.manager = manager if manager is not None else SessionManager()
+
+    from scpi_control.server.api import scope as scope_api
+    from scpi_control.server.api import sessions as sessions_api
+    from scpi_control.server.api import stream as stream_api
+
+    app.include_router(sessions_api.router, prefix="/api")
+    app.include_router(scope_api.router, prefix="/api")
+    app.include_router(stream_api.router, prefix="/api")
+
+    @app.exception_handler(InvalidParameterError)
+    async def _invalid_parameter(request: Request, exc: InvalidParameterError):
+        return _error_response(400, exc)
+
+    @app.exception_handler(ValueError)
+    async def _value_error(request: Request, exc: ValueError):
+        return _error_response(400, exc)
+
+    @app.exception_handler(SessionError)
+    async def _session_error(request: Request, exc: SessionError):
+        return _error_response(409, exc)
+
+    @app.exception_handler(SiglentTimeoutError)
+    async def _timeout(request: Request, exc: SiglentTimeoutError):
+        return _error_response(504, exc)
+
+    @app.exception_handler(SiglentError)
+    async def _siglent(request: Request, exc: SiglentError):
+        return _error_response(500, exc)
+
+    @app.exception_handler(HTTPException)
+    async def _http_error(request: Request, exc: HTTPException):
+        return JSONResponse(status_code=exc.status_code, content={"error": "HTTPException", "detail": exc.detail})
+
+    if STATIC_DIR.is_dir():
+        app.mount("/", StaticFiles(directory=str(STATIC_DIR), html=True), name="frontend")
+
+    return app

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -32,6 +32,7 @@ def create_app(manager: Optional[SessionManager] = None) -> FastAPI:
     app = FastAPI(title="SCPI Instrument Control Gateway", lifespan=lifespan)
     app.state.manager = manager
 
+    from scpi_control.server.api import discovery as discovery_api
     from scpi_control.server.api import scope as scope_api
     from scpi_control.server.api import sessions as sessions_api
     from scpi_control.server.api import stream as stream_api
@@ -39,6 +40,7 @@ def create_app(manager: Optional[SessionManager] = None) -> FastAPI:
     app.include_router(sessions_api.router, prefix="/api")
     app.include_router(scope_api.router, prefix="/api")
     app.include_router(stream_api.router, prefix="/api")
+    app.include_router(discovery_api.router, prefix="/api")
 
     @app.exception_handler(InvalidParameterError)
     async def _invalid_parameter(request: Request, exc: InvalidParameterError):

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -3,9 +3,10 @@
 from pathlib import Path
 from typing import Optional
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from scpi_control.exceptions import InvalidParameterError, SiglentError, SiglentTimeoutError
 from scpi_control.server.sessions import SessionError, SessionManager
@@ -49,8 +50,8 @@ def create_app(manager: Optional[SessionManager] = None) -> FastAPI:
     async def _siglent(request: Request, exc: SiglentError):
         return _error_response(500, exc)
 
-    @app.exception_handler(HTTPException)
-    async def _http_error(request: Request, exc: HTTPException):
+    @app.exception_handler(StarletteHTTPException)
+    async def _http_error(request: Request, exc: StarletteHTTPException):
         return JSONResponse(status_code=exc.status_code, content={"error": "HTTPException", "detail": exc.detail})
 
     if STATIC_DIR.is_dir():

--- a/scpi_control/server/discovery.py
+++ b/scpi_control/server/discovery.py
@@ -96,7 +96,13 @@ def _probe(address: str, port: int, connect_timeout: float, probe_timeout: float
 
 
 def _sort_key(entry):
-    return (entry["kind"] != "scope", ipaddress.ip_address(str(entry["address"])))
+    address = str(entry["address"])
+    try:
+        numeric = int(ipaddress.ip_address(address))
+        return (entry["kind"] != "scope", 0, numeric, "")
+    except ValueError:
+        # hostname-addressed entries (connected sessions) sort after IP literals
+        return (entry["kind"] != "scope", 1, 0, address)
 
 
 def discover(

--- a/scpi_control/server/discovery.py
+++ b/scpi_control/server/discovery.py
@@ -95,6 +95,10 @@ def _probe(address: str, port: int, connect_timeout: float, probe_timeout: float
     return {"address": address, "idn": idn, "manufacturer": manufacturer, "model": model, "dialect": dialect, "kind": kind}
 
 
+def _sort_key(entry):
+    return (entry["kind"] != "scope", ipaddress.ip_address(str(entry["address"])))
+
+
 def discover(
     cidr: Optional[str] = None,
     port: int = SCPI_PORT,
@@ -112,5 +116,5 @@ def discover(
         for found in pool.map(lambda address: _probe(address, port, connect_timeout, probe_timeout), targets):
             if found is not None:
                 results.append(found)
-    results.sort(key=lambda entry: (entry["kind"] != "scope", str(entry["address"])))
+    results.sort(key=_sort_key)
     return results

--- a/scpi_control/server/discovery.py
+++ b/scpi_control/server/discovery.py
@@ -1,0 +1,116 @@
+"""LAN discovery of SCPI instruments: TCP port scan + *IDN? probe.
+
+FastAPI-free (stdlib + scpi_control only; Python 3.8-clean), mirroring
+sessions.py. The scan runs on the caller's thread; instrument session worker
+threads are never involved. Callers must pass already-held addresses in
+`skip` — Siglent raw sockets allow one client, so probing a live session's
+instrument could disturb it.
+"""
+
+import ipaddress
+import socket
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, FrozenSet, List, Optional
+
+from scpi_control.exceptions import InvalidParameterError
+from scpi_control.models import MODEL_REGISTRY, detect_model_from_idn
+
+SCPI_PORT = 5025
+MAX_HOSTS = 1024  # /22
+
+_KIND_PREFIXES = (("SPD", "psu"), ("SDP", "psu"), ("SDG", "awg"), ("SDM", "daq"))
+
+
+def _classify(model: str) -> str:
+    upper = model.upper()
+    if model in MODEL_REGISTRY or upper.startswith("SDS"):
+        return "scope"
+    for prefix, kind in _KIND_PREFIXES:
+        if upper.startswith(prefix):
+            return kind
+    return "unknown"
+
+
+def _local_ip() -> Optional[str]:
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            sock.connect(("8.8.8.8", 80))  # UDP connect: routes, sends nothing
+            return sock.getsockname()[0]
+        finally:
+            sock.close()
+    except OSError:
+        return None
+
+
+def _local_network() -> "ipaddress.IPv4Network":
+    local = _local_ip()
+    if local is None:
+        raise InvalidParameterError("could not determine the local network; pass an explicit cidr")
+    return ipaddress.ip_network("{0}/24".format(local), strict=False)
+
+
+def _expand(cidr: Optional[str]) -> List[str]:
+    if cidr is None:
+        network = _local_network()
+    else:
+        try:
+            network = ipaddress.ip_network(cidr.strip(), strict=False)
+        except ValueError:
+            raise InvalidParameterError("invalid cidr: {0}".format(cidr))
+        if not isinstance(network, ipaddress.IPv4Network):
+            raise InvalidParameterError("only IPv4 ranges are supported")
+    if network.num_addresses > MAX_HOSTS:
+        raise InvalidParameterError("range too wide: {0} (maximum /22)".format(network))
+    if network.num_addresses <= 2:
+        return [str(network.network_address)]
+    return [str(host) for host in network.hosts()]
+
+
+def _probe(address: str, port: int, connect_timeout: float, probe_timeout: float) -> Optional[Dict[str, object]]:
+    try:
+        with socket.create_connection((address, port), timeout=connect_timeout) as sock:
+            sock.settimeout(probe_timeout)
+            sock.sendall(b"*IDN?\n")
+            raw = b""
+            while not raw.endswith(b"\n") and len(raw) < 4096:
+                chunk = sock.recv(1024)
+                if not chunk:
+                    break
+                raw += chunk
+    except OSError:
+        return None
+    idn = raw.decode("ascii", errors="replace").strip()
+    parts = [part.strip() for part in idn.split(",")]
+    if len(parts) < 2 or not parts[0] or not parts[1]:
+        return None
+    manufacturer, model = parts[0], parts[1]
+    kind = _classify(model)
+    dialect = ""
+    if kind == "scope":
+        try:
+            dialect = detect_model_from_idn(idn).dialect
+        except ValueError:
+            pass
+    return {"address": address, "idn": idn, "manufacturer": manufacturer, "model": model, "dialect": dialect, "kind": kind}
+
+
+def discover(
+    cidr: Optional[str] = None,
+    port: int = SCPI_PORT,
+    connect_timeout: float = 0.4,
+    probe_timeout: float = 1.0,
+    skip: FrozenSet[str] = frozenset(),
+    max_workers: int = 128,
+) -> List[Dict[str, object]]:
+    own = _local_ip()
+    targets = [address for address in _expand(cidr) if address not in skip and address != own]
+    if not targets:
+        return []
+    results: List[Dict[str, object]] = []
+    with ThreadPoolExecutor(max_workers=min(max_workers, len(targets))) as pool:
+        for found in pool.map(lambda address: _probe(address, port, connect_timeout, probe_timeout), targets):
+            if found is not None:
+                results.append(found)
+    results.sort(key=lambda entry: (entry["kind"] != "scope", str(entry["address"])))
+    return results

--- a/scpi_control/server/schemas.py
+++ b/scpi_control/server/schemas.py
@@ -1,0 +1,79 @@
+"""Pydantic wire models (requires the [web] extra; Python >= 3.9)."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+ALLOWED_MEASUREMENTS = frozenset({"PKPK", "MAX", "MIN", "AMPL", "TOP", "BASE", "CMEAN", "MEAN", "RMS", "CRMS", "FREQ", "PER", "RISE", "FALL", "WID", "NWID", "DUTY"})
+ALLOWED_COUPLING = frozenset({"DC", "AC", "GND"})
+
+
+class SessionCreate(BaseModel):
+    label: str = ""
+    address: Optional[str] = None
+    port: int = 5025
+    mock: bool = False
+    model: Optional[str] = None
+
+
+class SessionOut(BaseModel):
+    id: str
+    label: str
+    mock: bool
+    address: Optional[str]
+    state: str
+    idn: str
+    model: str
+    dialect: str
+    num_channels: int
+
+
+class ChannelPatch(BaseModel):
+    enabled: Optional[bool] = None
+    voltage_scale: Optional[float] = None
+    voltage_offset: Optional[float] = None
+    coupling: Optional[str] = None
+    probe_ratio: Optional[float] = None
+
+
+class TimebasePatch(BaseModel):
+    timebase: float
+
+
+class TriggerPatch(BaseModel):
+    mode: Optional[str] = None
+    source: Optional[str] = None
+    level: Optional[float] = None
+    slope: Optional[str] = None
+    coupling: Optional[str] = None
+
+
+class MeasurementItem(BaseModel):
+    channel: int
+    mtype: str
+
+
+class CommandIn(BaseModel):
+    command: str
+
+
+class ModelOut(BaseModel):
+    model_name: str
+    series: str
+    num_channels: int
+    bandwidth_mhz: int
+    dialect: str
+
+
+def session_out(session) -> Dict[str, Any]:
+    return SessionOut(
+        id=session.id,
+        label=session.label,
+        mock=session.mock,
+        address=session.address,
+        state=session.state,
+        idn=session.idn,
+        model=session.model,
+        dialect=session.dialect,
+        num_channels=session.num_channels,
+    ).model_dump()

--- a/scpi_control/server/schemas.py
+++ b/scpi_control/server/schemas.py
@@ -1,6 +1,6 @@
 """Pydantic wire models (requires the [web] extra; Python >= 3.9)."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel
 

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -75,7 +75,7 @@ class SessionError(RuntimeError):
 def _make_mock_connection(model: Optional[str]) -> MockConnection:
     idn = DEFAULT_MOCK_IDN if model is None else "Siglent Technologies,{0},MOCK0001,1.0.0.0".format(model)
     waveform_payloads = {1: bytes(range(256)), 2: bytes(range(256)), 3: bytes(range(256)), 4: bytes(range(256))}
-    return MockConnection("mock", idn=idn, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3, waveform_payloads=waveform_payloads)
+    return MockConnection("mock", idn=idn, channel_states={1: True, 2: False, 3: False, 4: False}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3, waveform_payloads=waveform_payloads)
 
 
 class InstrumentSession:

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -16,6 +16,53 @@ from scpi_control import Oscilloscope
 from scpi_control.connection.mock import MockConnection
 from scpi_control.exceptions import SiglentError
 
+MAX_FRAME_POINTS = 2000
+MEASUREMENT_EVERY_N_POLLS = 4
+
+
+def _safe(fn, default=None):
+    try:
+        return fn()
+    except SiglentError:
+        return default
+
+
+def read_state(scope: Oscilloscope) -> Dict[str, Any]:
+    channels: Dict[int, Dict[str, Any]] = {}
+    for n in scope.supported_channels:
+        ch = scope.get_channel(n)
+        channels[n] = {
+            "enabled": ch.enabled,
+            "voltage_scale": ch.voltage_scale,
+            "voltage_offset": ch.voltage_offset,
+            "coupling": ch.coupling,
+            "probe_ratio": _safe(lambda: ch.probe_ratio),
+        }
+    trig = scope.trigger
+    return {
+        "run_state": scope.acquisition_status(),
+        "timebase": scope.timebase,
+        "channels": channels,
+        "trigger": {
+            "mode": trig.mode,
+            "source": _safe(lambda: trig.source),
+            "level": _safe(lambda: trig.level),
+            "slope": _safe(lambda: trig.slope),
+            "coupling": _safe(lambda: trig.coupling),
+        },
+    }
+
+
+def _waveform_frame(scope: Oscilloscope, channel: int) -> Dict[str, Any]:
+    data = scope.get_waveform(channel)
+    voltage = data.voltage
+    step = max(1, len(voltage) // MAX_FRAME_POINTS)
+    points = voltage[::step]
+    t0 = float(data.time[0]) if len(data.time) else 0.0
+    dt = float(data.time[1] - data.time[0]) * step if len(data.time) > 1 else 1.0
+    return {"type": "waveform", "channel": channel, "t0": t0, "dt": dt, "points": [float(v) for v in points]}
+
+
 _STOP = object()
 
 DEFAULT_MOCK_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
@@ -47,6 +94,10 @@ class InstrumentSession:
         self._queue: "queue.Queue" = queue.Queue()
         self._closed = threading.Event()
         self._thread = threading.Thread(target=self._worker, name="scpi-session-{0}".format(self.id), daemon=True)
+        self._subscribers: List[Callable[[Dict[str, Any]], None]] = []
+        self._subscribers_lock = threading.Lock()
+        self.measurements: List[Tuple[int, str]] = []
+        self._poll_count = 0
 
     @classmethod
     def open(
@@ -101,6 +152,26 @@ class InstrumentSession:
         self._thread.join(timeout=timeout)
         self.state = "closed"
 
+    def subscribe(self, callback: Callable[[Dict[str, Any]], None]) -> Callable[[], None]:
+        with self._subscribers_lock:
+            self._subscribers.append(callback)
+
+        def unsubscribe() -> None:
+            with self._subscribers_lock:
+                if callback in self._subscribers:
+                    self._subscribers.remove(callback)
+
+        return unsubscribe
+
+    def publish(self, message: Dict[str, Any]) -> None:
+        with self._subscribers_lock:
+            subscribers = list(self._subscribers)
+        for callback in subscribers:
+            callback(message)
+
+    def set_measurements(self, items: List[Tuple[int, str]]) -> None:
+        self.measurements = list(items)
+
     def _worker(self) -> None:
         while True:
             try:
@@ -123,4 +194,26 @@ class InstrumentSession:
             pass
 
     def _poll_tick(self) -> None:
-        """Streaming poll; implemented in Task 2."""
+        with self._subscribers_lock:
+            if not self._subscribers:
+                return
+        if self.state != "connected":
+            return
+        self._poll_count += 1
+        scope = self._scope
+        try:
+            for n in scope.supported_channels:
+                ch = scope.get_channel(n)
+                if ch is not None and _safe(lambda: ch.enabled, default=False):
+                    self.publish(_waveform_frame(scope, n))
+            if self.measurements and self._poll_count % MEASUREMENT_EVERY_N_POLLS == 0:
+                values = []
+                for channel, mtype in self.measurements:
+                    value = _safe(lambda: scope.measurement.measure(mtype, channel))
+                    values.append({"channel": channel, "mtype": mtype, "value": value})
+                self.publish({"type": "measurements", "values": values})
+        except SiglentError as exc:
+            self.error_detail = str(exc)
+            self.publish({"type": "error", "detail": str(exc)})
+            if not scope.is_connected:
+                self.state = "error"

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -1,0 +1,126 @@
+"""Instrument session layer: one worker thread per instrument.
+
+All SCPI I/O for a session happens on its single worker thread (FIFO job
+queue), so compound operations are atomic and the non-thread-safe connection
+is never shared across threads (AUDIT.md C2). This module is FastAPI-free:
+the API layer adapts the returned concurrent.futures.Future to asyncio.
+"""
+
+import queue
+import threading
+import uuid
+from concurrent.futures import Future
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from scpi_control import Oscilloscope
+from scpi_control.connection.mock import MockConnection
+from scpi_control.exceptions import SiglentError
+
+_STOP = object()
+
+DEFAULT_MOCK_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+
+
+class SessionError(RuntimeError):
+    """Session is not in a state that can accept jobs (maps to HTTP 409)."""
+
+
+def _make_mock_connection(model: Optional[str]) -> MockConnection:
+    idn = DEFAULT_MOCK_IDN if model is None else "Siglent Technologies,{0},MOCK0001,1.0.0.0".format(model)
+    return MockConnection("mock", idn=idn, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+
+
+class InstrumentSession:
+    def __init__(self, label: str, scope: Oscilloscope, mock: bool, address: Optional[str], poll_interval: float):
+        self.id = uuid.uuid4().hex[:8]
+        self.label = label
+        self.mock = mock
+        self.address = address
+        self.state = "connecting"
+        self.idn = ""
+        self.model = ""
+        self.dialect = ""
+        self.num_channels = 0
+        self.error_detail: Optional[str] = None
+        self._scope = scope
+        self._poll_interval = poll_interval
+        self._queue: "queue.Queue" = queue.Queue()
+        self._closed = threading.Event()
+        self._thread = threading.Thread(target=self._worker, name="scpi-session-{0}".format(self.id), daemon=True)
+
+    @classmethod
+    def open(
+        cls,
+        label: str,
+        *,
+        address: Optional[str] = None,
+        port: int = 5025,
+        mock: bool = False,
+        model: Optional[str] = None,
+        poll_interval: float = 0.25,
+        _connection=None,
+    ) -> "InstrumentSession":
+        if mock:
+            conn = _connection if _connection is not None else _make_mock_connection(model)
+            scope = Oscilloscope("mock", connection=conn)
+        else:
+            if not address:
+                raise ValueError("address is required for a non-mock session")
+            scope = Oscilloscope(address, port=port)
+        session = cls(label, scope, mock, address, poll_interval)
+        session._thread.start()
+        try:
+            session.submit(session._connect_job).result(timeout=30)
+        except BaseException:
+            session.close()
+            raise
+        return session
+
+    def _connect_job(self, scope: Oscilloscope) -> None:
+        scope.connect()
+        self.idn = scope.identify()
+        info = scope.device_info or {}
+        self.model = info.get("model", "")
+        self.dialect = scope.dialect or ""
+        self.num_channels = len(scope.supported_channels)
+        self.state = "connected"
+
+    def submit(self, fn: Callable[[Oscilloscope], Any]) -> "Future":
+        if self._closed.is_set() or self.state == "error":
+            # spec: mutations on a dead session are 409 until it is deleted
+            raise SessionError("session {0} is {1}".format(self.id, self.state))
+        future: Future = Future()
+        self._queue.put((fn, future))
+        return future
+
+    def close(self, timeout: float = 10.0) -> None:
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        self._queue.put(_STOP)
+        self._thread.join(timeout=timeout)
+        self.state = "closed"
+
+    def _worker(self) -> None:
+        while True:
+            try:
+                item = self._queue.get(timeout=self._poll_interval)
+            except queue.Empty:
+                self._poll_tick()
+                continue
+            if item is _STOP:
+                break
+            fn, future = item
+            if not future.set_running_or_notify_cancel():
+                continue
+            try:
+                future.set_result(fn(self._scope))
+            except BaseException as exc:  # propagate everything to the caller
+                future.set_exception(exc)
+        try:
+            self._scope.disconnect()
+        except SiglentError:
+            pass
+
+    def _poll_tick(self) -> None:
+        """Streaming poll; implemented in Task 2."""

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -56,7 +56,7 @@ def read_state(scope: Oscilloscope) -> Dict[str, Any]:
 def _waveform_frame(scope: Oscilloscope, channel: int) -> Dict[str, Any]:
     data = scope.get_waveform(channel)
     voltage = data.voltage
-    step = max(1, len(voltage) // MAX_FRAME_POINTS)
+    step = max(1, -(-len(voltage) // MAX_FRAME_POINTS))  # ceiling division keeps len(points) <= cap
     points = voltage[::step]
     t0 = float(data.time[0]) if len(data.time) else 0.0
     dt = float(data.time[1] - data.time[0]) * step if len(data.time) > 1 else 1.0
@@ -167,7 +167,10 @@ class InstrumentSession:
         with self._subscribers_lock:
             subscribers = list(self._subscribers)
         for callback in subscribers:
-            callback(message)
+            try:
+                callback(message)
+            except Exception:  # a broken subscriber must not kill the worker thread
+                continue
 
     def set_measurements(self, items: List[Tuple[int, str]]) -> None:
         self.measurements = list(items)

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -74,7 +74,8 @@ class SessionError(RuntimeError):
 
 def _make_mock_connection(model: Optional[str]) -> MockConnection:
     idn = DEFAULT_MOCK_IDN if model is None else "Siglent Technologies,{0},MOCK0001,1.0.0.0".format(model)
-    return MockConnection("mock", idn=idn, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+    waveform_payloads = {1: bytes(range(256)), 2: bytes(range(256)), 3: bytes(range(256)), 4: bytes(range(256))}
+    return MockConnection("mock", idn=idn, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3, waveform_payloads=waveform_payloads)
 
 
 class InstrumentSession:

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -10,11 +10,12 @@ import queue
 import threading
 import uuid
 from concurrent.futures import Future
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from scpi_control import Oscilloscope
 from scpi_control.connection.mock import MockConnection
-from scpi_control.exceptions import SiglentError
+from scpi_control.exceptions import SiglentConnectionError, SiglentError
 
 MAX_FRAME_POINTS = 2000
 MEASUREMENT_EVERY_N_POLLS = 4
@@ -123,6 +124,11 @@ class InstrumentSession:
         session._thread.start()
         try:
             session.submit(session._connect_job).result(timeout=30)
+        except FuturesTimeoutError:
+            # A hung connect leaves a worker parked on the socket; close then
+            # surface it as a domain error rather than a bare futures timeout.
+            session.close()
+            raise SiglentConnectionError("connect timed out")
         except BaseException:
             session.close()
             raise
@@ -152,6 +158,9 @@ class InstrumentSession:
         self._queue.put(_STOP)
         self._thread.join(timeout=timeout)
         self.state = "closed"
+        # Tell any live streams the session is gone. Publishing from the closing
+        # thread is safe: subscribers only schedule via call_soon_threadsafe.
+        self.publish({"type": "closed"})
 
     def subscribe(self, callback: Callable[[Dict[str, Any]], None]) -> Callable[[], None]:
         with self._subscribers_lock:
@@ -176,6 +185,12 @@ class InstrumentSession:
     def set_measurements(self, items: List[Tuple[int, str]]) -> None:
         self.measurements = list(items)
 
+    def _enter_error_state(self, detail: str) -> None:
+        """Flip to the terminal error state and tell the streams once."""
+        self.state = "error"
+        self.error_detail = detail
+        self.publish({"type": "error", "detail": detail})
+
     def _worker(self) -> None:
         while True:
             try:
@@ -192,6 +207,23 @@ class InstrumentSession:
                 future.set_result(fn(self._scope))
             except BaseException as exc:  # propagate everything to the caller
                 future.set_exception(exc)
+                # A SiglentError from a dropped wire is a session-fatal event:
+                # flip to "error" so REST mutations start returning 409.
+                if isinstance(exc, SiglentError) and not self._scope.is_connected:
+                    self._enter_error_state(str(exc))
+        # Drain jobs that raced in behind _STOP so their callers get a clean 409
+        # instead of an await that never resolves.
+        while True:
+            try:
+                item = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            if item is _STOP:
+                continue
+            fn, future = item
+            if not future.set_running_or_notify_cancel():
+                continue
+            future.set_exception(SessionError("session {0} is closed".format(self.id)))
         try:
             self._scope.disconnect()
         except SiglentError:
@@ -202,6 +234,10 @@ class InstrumentSession:
             if not self._subscribers:
                 return
         if self.state != "connected":
+            return
+        if not self._scope.is_connected:
+            # The wire dropped while idle (no job in flight to surface it).
+            self._enter_error_state("connection lost")
             return
         self._poll_count += 1
         scope = self._scope

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -220,3 +220,40 @@ class InstrumentSession:
             self.publish({"type": "error", "detail": str(exc)})
             if not scope.is_connected:
                 self.state = "error"
+
+
+class SessionManager:
+    """Registry of live sessions. create() connects before registering."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, InstrumentSession] = {}
+        self._lock = threading.Lock()
+
+    def create(self, label: str, *, address: Optional[str] = None, port: int = 5025, mock: bool = False, model: Optional[str] = None, _connection=None) -> InstrumentSession:
+        session = InstrumentSession.open(label, address=address, port=port, mock=mock, model=model, _connection=_connection)
+        with self._lock:
+            self._sessions[session.id] = session
+        return session
+
+    def list(self) -> List[InstrumentSession]:
+        with self._lock:
+            return list(self._sessions.values())
+
+    def get(self, session_id: str) -> Optional[InstrumentSession]:
+        with self._lock:
+            return self._sessions.get(session_id)
+
+    def delete(self, session_id: str) -> bool:
+        with self._lock:
+            session = self._sessions.pop(session_id, None)
+        if session is None:
+            return False
+        session.close()
+        return True
+
+    def close_all(self) -> None:
+        with self._lock:
+            sessions = list(self._sessions.values())
+            self._sessions.clear()
+        for session in sessions:
+            session.close()

--- a/tests/test_mock_dialects.py
+++ b/tests/test_mock_dialects.py
@@ -77,3 +77,35 @@ class TestLegacyResponses:
     def test_unknown_query_times_out(self):
         with pytest.raises(TimeoutError):
             self.conn.query("BOGUS:QUERY?")
+
+
+def test_legacy_mock_answers_pava_measurements():
+    from scpi_control import Oscilloscope
+    from scpi_control.connection.mock import MockConnection
+
+    conn = MockConnection("mock", idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0", channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    try:
+        for mtype in ("PKPK", "FREQ", "RMS", "MEAN", "PER", "MAX", "MIN"):
+            value = scope.measurement.measure(mtype, 1)
+            assert isinstance(value, float), mtype
+    finally:
+        scope.disconnect()
+
+
+def test_modern_mock_still_times_out_on_pava():
+    import pytest as _pytest
+
+    from scpi_control import Oscilloscope
+    from scpi_control.connection.mock import MockConnection
+    from scpi_control.exceptions import SiglentTimeoutError
+
+    conn = MockConnection("mock", idn="Siglent Technologies,SDS824X HD,MOCK0002,3.8.12", channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    try:
+        with _pytest.raises(SiglentTimeoutError):
+            scope.measurement.measure("PKPK", 1)
+    finally:
+        scope.disconnect()

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -29,3 +29,17 @@ def test_unknown_session_is_404(client):
     assert response.status_code == 404
     body = response.json()
     assert body["error"] and body["detail"]
+
+
+def test_unmatched_route_404_shares_error_shape(client):
+    response = client.get("/api/definitely-not-a-route")
+    assert response.status_code == 404
+    body = response.json()
+    assert set(body) == {"error", "detail"}
+
+
+def test_wrong_method_405_shares_error_shape(client):
+    response = client.delete("/api/sessions")  # only GET/POST exist on this path
+    assert response.status_code == 405
+    body = response.json()
+    assert set(body) == {"error", "detail"}

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -45,6 +45,24 @@ def test_wrong_method_405_shares_error_shape(client):
     assert set(body) == {"error", "detail"}
 
 
+def test_wrong_method_405_keeps_allow_header(client):
+    # Fix 7: the StarletteHTTPException handler must preserve the Allow header.
+    response = client.delete("/api/sessions")
+    assert response.status_code == 405
+    assert "allow" in {k.lower() for k in response.headers}
+
+
+def test_lifespan_shutdown_closes_sessions():
+    # Fix 6: leaving the app context (lifespan teardown) closes live sessions.
+    manager = SessionManager()
+    with TestClient(create_app(manager)) as client:
+        body = client.post("/api/sessions", json={"mock": True}).json()
+        session = manager.get(body["id"])
+        assert session.state == "connected"
+    # No explicit close_all() -> the lifespan teardown must have closed it.
+    assert session.state == "closed"
+
+
 def create_mock_session(client, model=None):
     payload = {"mock": True}
     if model:

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -134,3 +134,34 @@ class TestScopeEndpoints:
 
     def test_unknown_session_scope_call_is_404(self, client):
         assert client.get("/api/sessions/nope/scope/state").status_code == 404
+
+
+class TestTerminalAndMeasurements:
+    def test_command_query_returns_response(self, client):
+        sid = create_mock_session(client)["id"]
+        response = client.post("/api/sessions/{0}/scope/command".format(sid), json={"command": "*IDN?"})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["command"] == "*IDN?"
+        assert "SDS1104X-E" in body["response"]
+
+    def test_command_write_returns_null_response(self, client):
+        sid = create_mock_session(client)["id"]
+        response = client.post("/api/sessions/{0}/scope/command".format(sid), json={"command": "TRMD AUTO"})
+        assert response.status_code == 200
+        assert response.json()["response"] is None
+
+    def test_unknown_query_times_out_as_504(self, client):
+        sid = create_mock_session(client)["id"]
+        response = client.post("/api/sessions/{0}/scope/command".format(sid), json={"command": "BOGUS?"})
+        assert response.status_code == 504
+
+    def test_put_measurements_validates(self, client):
+        sid = create_mock_session(client)["id"]
+        ok = client.put("/api/sessions/{0}/scope/measurements".format(sid), json=[{"channel": 1, "mtype": "PKPK"}, {"channel": 2, "mtype": "FREQ"}])
+        assert ok.status_code == 200
+        assert ok.json()["measurements"] == [{"channel": 1, "mtype": "PKPK"}, {"channel": 2, "mtype": "FREQ"}]
+        bad_type = client.put("/api/sessions/{0}/scope/measurements".format(sid), json=[{"channel": 1, "mtype": "NOPE"}])
+        assert bad_type.status_code == 400
+        bad_channel = client.put("/api/sessions/{0}/scope/measurements".format(sid), json=[{"channel": 9, "mtype": "PKPK"}])
+        assert bad_channel.status_code == 400

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -192,3 +192,18 @@ class TestCapture:
     def test_capture_csv_bad_channels_param_is_400(self, client):
         sid = create_mock_session(client)["id"]
         assert client.get("/api/sessions/{0}/scope/capture.csv?channels=banana".format(sid)).status_code == 400
+
+
+def test_cli_parses_defaults(monkeypatch):
+    import scpi_control.server.__main__ as cli
+
+    captured = {}
+
+    def fake_run(app, host, port, **kwargs):
+        captured.update(host=host, port=port)
+
+    monkeypatch.setattr(cli.uvicorn, "run", fake_run)
+    cli.main([])
+    assert captured == {"host": "127.0.0.1", "port": 8765}
+    cli.main(["--host", "0.0.0.0", "--port", "9000"])
+    assert captured == {"host": "0.0.0.0", "port": 9000}

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -165,3 +165,22 @@ class TestTerminalAndMeasurements:
         assert bad_type.status_code == 400
         bad_channel = client.put("/api/sessions/{0}/scope/measurements".format(sid), json=[{"channel": 9, "mtype": "PKPK"}])
         assert bad_channel.status_code == 400
+
+
+class TestCapture:
+    def test_capture_csv_single_channel(self, client):
+        sid = create_mock_session(client)["id"]
+        response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert "attachment" in response.headers.get("content-disposition", "")
+        lines = response.text.strip().splitlines()
+        assert lines[0] == "time_s,C1_V"
+        assert len(lines) > 10
+        first = lines[1].split(",")
+        float(first[0])
+        float(first[1])  # parseable numbers
+
+    def test_capture_csv_bad_channels_param_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.get("/api/sessions/{0}/scope/capture.csv?channels=banana".format(sid)).status_code == 400

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -87,3 +87,50 @@ def test_models_endpoint_lists_registry(client):
     assert "SDS1104X-E" in names and "SDS824X HD" in names
     assert names == sorted(names)
     assert {"model_name", "series", "num_channels", "bandwidth_mhz", "dialect"} <= set(models[0])
+
+
+class TestScopeEndpoints:
+    def _session(self, client):
+        return create_mock_session(client)["id"]
+
+    def test_get_state(self, client):
+        sid = self._session(client)
+        state = client.get("/api/sessions/{0}/scope/state".format(sid)).json()
+        assert state["channels"]["1"]["enabled"] is True
+        assert state["trigger"]["mode"] in ("AUTO", "NORM", "SINGLE", "STOP")
+        assert isinstance(state["timebase"], float)
+
+    def test_patch_channel_applies_and_returns_state(self, client):
+        sid = self._session(client)
+        response = client.patch("/api/sessions/{0}/scope/channels/1".format(sid), json={"voltage_scale": 0.5, "coupling": "AC"})
+        assert response.status_code == 200
+        ch1 = response.json()["channels"]["1"]
+        assert ch1["voltage_scale"] == 0.5
+        assert ch1["coupling"] == "AC"
+
+    def test_patch_channel_invalid_coupling_is_400(self, client):
+        sid = self._session(client)
+        response = client.patch("/api/sessions/{0}/scope/channels/1".format(sid), json={"coupling": "BANANA"})
+        assert response.status_code == 400
+
+    def test_patch_timebase(self, client):
+        sid = self._session(client)
+        response = client.patch("/api/sessions/{0}/scope/timebase".format(sid), json={"timebase": 0.002})
+        assert response.status_code == 200
+        assert response.json()["timebase"] == 0.002
+
+    def test_patch_trigger_mode(self, client):
+        sid = self._session(client)
+        response = client.patch("/api/sessions/{0}/scope/trigger".format(sid), json={"mode": "SINGLE"})
+        assert response.status_code == 200
+        assert response.json()["trigger"]["mode"] == "SINGLE"
+
+    def test_run_stop_endpoints(self, client):
+        sid = self._session(client)
+        for op in ("run", "stop", "single", "auto"):
+            response = client.post("/api/sessions/{0}/scope/{1}".format(sid, op))
+            assert response.status_code == 200, (op, response.text)
+            assert "run_state" in response.json()
+
+    def test_unknown_session_scope_call_is_404(self, client):
+        assert client.get("/api/sessions/nope/scope/state").status_code == 404

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -251,6 +251,23 @@ class TestDiscoverEndpoint:
         assert entry["session_id"] == body["id"]
         assert entry["model"] == "SDS1104X-E"
 
+    def test_discover_tolerates_hostname_session(self, client, monkeypatch):
+        from scpi_control.server import discovery
+        from tests.test_server_discovery import FakeScpiServer
+
+        body = create_mock_session(client)
+        session = client.app.state.manager.get(body["id"])
+        session.address = "bench-scope.local"
+        with FakeScpiServer() as server:
+            monkeypatch.setattr(discovery, "SCPI_PORT", server.port)
+            response = client.get("/api/discover?cidr=127.0.0.1/32")
+        assert response.status_code == 200
+        entries = response.json()
+        addresses = [e["address"] for e in entries]
+        assert "bench-scope.local" in addresses  # merged session present
+        assert "127.0.0.1" in addresses  # scan result present
+        assert addresses.index("127.0.0.1") < addresses.index("bench-scope.local")
+
 
 def test_cli_parses_defaults(monkeypatch):
     import scpi_control.server.__main__ as cli

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -181,6 +181,14 @@ class TestCapture:
         float(first[0])
         float(first[1])  # parseable numbers
 
+    def test_capture_csv_multi_channel(self, client):
+        sid = create_mock_session(client)["id"]
+        response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1,2".format(sid))
+        assert response.status_code == 200
+        lines = response.text.strip().splitlines()
+        assert lines[0] == "time_s,C1_V,C2_V"
+        assert len(lines) > 10
+
     def test_capture_csv_bad_channels_param_is_400(self, client):
         sid = create_mock_session(client)["id"]
         assert client.get("/api/sessions/{0}/scope/capture.csv?channels=banana".format(sid)).status_code == 400

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1,0 +1,31 @@
+"""REST API tests. Skipped entirely when the [web] extra is not installed."""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scpi_control.server.app import create_app  # noqa: E402
+from scpi_control.server.sessions import SessionManager  # noqa: E402
+
+
+@pytest.fixture()
+def client():
+    manager = SessionManager()
+    app = create_app(manager)
+    with TestClient(app) as test_client:
+        yield test_client
+    manager.close_all()
+
+
+def test_lists_no_sessions_initially(client):
+    response = client.get("/api/sessions")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_unknown_session_is_404(client):
+    response = client.get("/api/sessions/deadbeef")
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error"] and body["detail"]

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -43,3 +43,47 @@ def test_wrong_method_405_shares_error_shape(client):
     assert response.status_code == 405
     body = response.json()
     assert set(body) == {"error", "detail"}
+
+
+def create_mock_session(client, model=None):
+    payload = {"mock": True}
+    if model:
+        payload["model"] = model
+    response = client.post("/api/sessions", json=payload)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+class TestSessionEndpoints:
+    def test_create_mock_session_returns_info(self, client):
+        body = create_mock_session(client)
+        assert body["state"] == "connected"
+        assert body["mock"] is True
+        assert body["model"] == "SDS1104X-E"
+        assert body["dialect"] == "legacy"
+        assert body["num_channels"] == 4
+
+    def test_create_modern_mock_by_model(self, client):
+        body = create_mock_session(client, model="SDS824X HD")
+        assert body["model"] == "SDS824X HD"
+        assert body["dialect"] == "modern"
+
+    def test_create_real_session_requires_address(self, client):
+        response = client.post("/api/sessions", json={"mock": False})
+        assert response.status_code == 400
+
+    def test_delete_session(self, client):
+        body = create_mock_session(client)
+        assert client.delete("/api/sessions/" + body["id"]).status_code == 204
+        assert client.delete("/api/sessions/" + body["id"]).status_code == 404
+        assert client.get("/api/sessions").json() == []
+
+
+def test_models_endpoint_lists_registry(client):
+    response = client.get("/api/models")
+    assert response.status_code == 200
+    models = response.json()
+    names = [m["model_name"] for m in models]
+    assert "SDS1104X-E" in names and "SDS824X HD" in names
+    assert names == sorted(names)
+    assert {"model_name", "series", "num_channels", "bandwidth_mhz", "dialect"} <= set(models[0])

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -212,6 +212,46 @@ class TestCapture:
         assert client.get("/api/sessions/{0}/scope/capture.csv?channels=banana".format(sid)).status_code == 400
 
 
+class TestDiscoverEndpoint:
+    def test_discover_finds_fake_instrument(self, client, monkeypatch):
+        from scpi_control.server import discovery
+        from tests.test_server_discovery import FakeScpiServer
+
+        with FakeScpiServer() as server:
+            monkeypatch.setattr(discovery, "SCPI_PORT", server.port)
+            response = client.get("/api/discover?cidr=127.0.0.1/32")
+        assert response.status_code == 200
+        entries = response.json()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["address"] == "127.0.0.1"
+        assert entry["model"] == "SDS1104X-E"
+        assert entry["kind"] == "scope"
+        assert entry["connected"] is False
+
+    def test_discover_invalid_cidr_is_400(self, client):
+        assert client.get("/api/discover?cidr=banana").status_code == 400
+        assert client.get("/api/discover?cidr=10.0.0.0/8").status_code == 400
+
+    def test_discover_merges_connected_session_without_probing(self, client, monkeypatch):
+        from scpi_control.server import discovery
+        from tests.test_server_discovery import FakeScpiServer
+
+        body = create_mock_session(client)
+        session = client.app.state.manager.get(body["id"])
+        session.address = "127.0.0.1"  # simulate a real networked instrument held by the gateway
+        with FakeScpiServer() as server:
+            monkeypatch.setattr(discovery, "SCPI_PORT", server.port)
+            response = client.get("/api/discover?cidr=127.0.0.1/32")
+            assert server.connections == 0  # held address must never be probed
+        entries = response.json()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["connected"] is True
+        assert entry["session_id"] == body["id"]
+        assert entry["model"] == "SDS1104X-E"
+
+
 def test_cli_parses_defaults(monkeypatch):
     import scpi_control.server.__main__ as cli
 

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -3,6 +3,7 @@
 import pytest
 
 fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")  # fastapi.testclient needs it; raises RuntimeError (not ImportError) without it
 from fastapi.testclient import TestClient  # noqa: E402
 
 from scpi_control.server.app import create_app  # noqa: E402

--- a/tests/test_server_discovery.py
+++ b/tests/test_server_discovery.py
@@ -142,3 +142,21 @@ class TestDiscover:
             results = discover(cidr="127.0.0.1/32", port=server.port, skip=frozenset({"127.0.0.1"}))
             assert results == []
             assert server.connections == 0
+
+
+def test_sort_key_orders_numerically_scopes_first():
+    from scpi_control.server.discovery import _sort_key
+
+    entries = [
+        {"address": "10.0.0.10", "kind": "psu"},
+        {"address": "10.0.0.9", "kind": "scope"},
+        {"address": "10.0.0.10", "kind": "scope"},
+        {"address": "10.0.0.2", "kind": "scope"},
+    ]
+    ordered = sorted(entries, key=_sort_key)
+    assert [(e["address"], e["kind"]) for e in ordered] == [
+        ("10.0.0.2", "scope"),
+        ("10.0.0.9", "scope"),
+        ("10.0.0.10", "scope"),
+        ("10.0.0.10", "psu"),
+    ]

--- a/tests/test_server_discovery.py
+++ b/tests/test_server_discovery.py
@@ -1,0 +1,144 @@
+"""LAN discovery core. Loopback-only; no fastapi dependency."""
+
+import socket
+import threading
+
+import pytest
+
+from scpi_control.exceptions import InvalidParameterError
+from scpi_control.server.discovery import _classify, _expand, _probe, discover
+
+LEGACY_IDN_LINE = b"Siglent Technologies,SDS1104X-E,FAKE0001,1.0.0.0\n"
+
+
+class FakeScpiServer:
+    """Threaded loopback server answering *IDN? once per connection.
+
+    response=None accepts the connection but never answers (silent device).
+    Tracks how many connections it accepted (used to prove skip behavior).
+    """
+
+    def __init__(self, response=LEGACY_IDN_LINE):
+        self.response = response
+        self.connections = 0
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(5)
+        self.port = self._sock.getsockname()[1]
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        self._sock.settimeout(0.2)
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            self.connections += 1
+            with conn:
+                try:
+                    conn.settimeout(1.0)
+                    data = conn.recv(1024)
+                    if data.strip() == b"*IDN?" and self.response is not None:
+                        conn.sendall(self.response)
+                except OSError:
+                    pass
+
+    def close(self):
+        self._stop.set()
+        self._sock.close()
+        self._thread.join(timeout=2)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+class TestClassify:
+    @pytest.mark.parametrize(
+        "model,kind",
+        [
+            ("SDS824X HD", "scope"),
+            ("SDS1104X-E", "scope"),
+            ("SDS9999X", "scope"),  # SDS prefix, not in registry
+            ("SPD3303X", "psu"),
+            ("SDP5081X", "psu"),
+            ("SDG2042X", "awg"),
+            ("SDM3055", "daq"),
+            ("DP832", "unknown"),
+        ],
+    )
+    def test_kinds(self, model, kind):
+        assert _classify(model) == kind
+
+
+class TestExpand:
+    def test_single_host_cidr(self):
+        assert _expand("127.0.0.1/32") == ["127.0.0.1"]
+
+    def test_malformed_cidr_raises(self):
+        with pytest.raises(InvalidParameterError):
+            _expand("not-a-network")
+
+    def test_too_wide_cidr_raises(self):
+        with pytest.raises(InvalidParameterError):
+            _expand("10.0.0.0/8")
+
+    def test_ipv6_raises(self):
+        with pytest.raises(InvalidParameterError):
+            _expand("::1/128")
+
+    def test_slash24_yields_254_hosts(self):
+        hosts = _expand("192.0.2.0/24")
+        assert len(hosts) == 254
+        assert hosts[0] == "192.0.2.1" and hosts[-1] == "192.0.2.254"
+
+
+class TestProbe:
+    def test_probe_parses_idn(self):
+        with FakeScpiServer() as server:
+            result = _probe("127.0.0.1", server.port, 0.5, 1.0)
+        assert result == {
+            "address": "127.0.0.1",
+            "idn": "Siglent Technologies,SDS1104X-E,FAKE0001,1.0.0.0",
+            "manufacturer": "Siglent Technologies",
+            "model": "SDS1104X-E",
+            "dialect": "legacy",
+            "kind": "scope",
+        }
+
+    def test_probe_garbage_banner_returns_none(self):
+        with FakeScpiServer(response=b"no commas here\n") as server:
+            assert _probe("127.0.0.1", server.port, 0.5, 1.0) is None
+
+    def test_probe_silent_device_returns_none(self):
+        with FakeScpiServer(response=None) as server:
+            assert _probe("127.0.0.1", server.port, 0.5, 0.3) is None
+
+    def test_probe_refused_port_returns_none(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        unused_port = sock.getsockname()[1]
+        sock.close()
+        assert _probe("127.0.0.1", unused_port, 0.3, 0.3) is None
+
+
+class TestDiscover:
+    def test_finds_fake_instrument_on_loopback(self):
+        with FakeScpiServer() as server:
+            results = discover(cidr="127.0.0.1/32", port=server.port, connect_timeout=0.5)
+        assert len(results) == 1
+        assert results[0]["model"] == "SDS1104X-E"
+        assert results[0]["kind"] == "scope"
+
+    def test_skip_prevents_probe(self):
+        with FakeScpiServer() as server:
+            results = discover(cidr="127.0.0.1/32", port=server.port, skip=frozenset({"127.0.0.1"}))
+            assert results == []
+            assert server.connections == 0

--- a/tests/test_server_discovery.py
+++ b/tests/test_server_discovery.py
@@ -160,3 +160,14 @@ def test_sort_key_orders_numerically_scopes_first():
         ("10.0.0.10", "scope"),
         ("10.0.0.10", "psu"),
     ]
+
+
+def test_sort_key_tolerates_hostnames():
+    from scpi_control.server.discovery import _sort_key
+
+    entries = [
+        {"address": "bench-scope.local", "kind": "scope"},
+        {"address": "10.0.0.2", "kind": "scope"},
+    ]
+    ordered = sorted(entries, key=_sort_key)
+    assert [e["address"] for e in ordered] == ["10.0.0.2", "bench-scope.local"]

--- a/tests/test_server_sessions.py
+++ b/tests/test_server_sessions.py
@@ -1,13 +1,15 @@
 """Worker-thread session core. No FastAPI dependency."""
 
+import concurrent.futures
 import threading
 import time
+from concurrent.futures import Future
 
 import pytest
 
 from scpi_control.connection.mock import MockConnection
-from scpi_control.exceptions import SiglentError
-from scpi_control.server.sessions import InstrumentSession, SessionError
+from scpi_control.exceptions import SiglentConnectionError, SiglentError
+from scpi_control.server.sessions import _STOP, InstrumentSession, SessionError
 
 LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
 
@@ -98,6 +100,106 @@ def test_open_failure_raises_and_leaves_no_thread():
         InstrumentSession.open("bad", mock=True, _connection=conn)
     time.sleep(0.1)
     assert threading.active_count() <= before + 1
+
+
+class KillableMock(MockConnection):
+    """A mock whose connection can be pulled mid-session, as if the wire dropped."""
+
+    def kill(self):
+        # Flip the connected flag; the base query()/write() then raise
+        # SiglentConnectionError for every subsequent call, like a dead socket.
+        self._connected = False
+
+
+def _killable_session():
+    conn = KillableMock("mock", idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+    return InstrumentSession.open("bench-1", mock=True, _connection=conn), conn
+
+
+def _wait_for(predicate, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return predicate()
+
+
+class TestErrorState:
+    def test_dropped_connection_flips_to_error_and_blocks_mutations(self):
+        # Fix 3: a job that fails because the wire dropped must flip the session
+        # to "error" and make further submits raise SessionError (-> HTTP 409).
+        session, conn = _killable_session()
+        try:
+            conn.kill()
+            with pytest.raises(SiglentError):
+                session.submit(lambda scope: scope.identify()).result(timeout=5)
+            assert _wait_for(lambda: session.state == "error")
+            assert session.state == "error"
+            with pytest.raises(SessionError):
+                session.submit(lambda scope: scope.identify())
+        finally:
+            session.close()
+
+    def test_idle_poll_detects_dropped_connection(self):
+        # Fix 3: even with no job in flight, the poll loop must notice the drop.
+        session, conn = _killable_session()
+        try:
+            unsubscribe = session.subscribe(lambda msg: None)
+            conn.kill()
+            assert _wait_for(lambda: session.state == "error")
+            assert session.state == "error"
+            unsubscribe()
+        finally:
+            session.close()
+
+
+class TestCloseDrain:
+    def test_close_drains_jobs_stuck_behind_stop(self):
+        # Fix 4: a job that lands behind _STOP (submit/close race) must be failed
+        # with SessionError on drain, not left to hang forever.
+        session, _ = make_mock_session()
+        gate = threading.Event()
+        started = threading.Event()
+
+        def slow(scope):
+            started.set()
+            gate.wait(3.0)
+
+        session.submit(slow)
+        assert started.wait(2.0)  # worker is now busy holding the slow job
+        # Reproduce the race deterministically: _STOP ahead of a still-queued job.
+        orphan = Future()
+        session._queue.put(_STOP)
+        session._queue.put((lambda scope: "never runs", orphan))
+        gate.set()  # release the slow job -> worker hits _STOP, then drains
+        done, _ = concurrent.futures.wait([orphan], timeout=5)
+        assert orphan in done, "orphaned future hung instead of being drained"
+        with pytest.raises(SessionError):
+            orphan.result()
+        session.close()
+
+
+class TestCloseNotifiesStreams:
+    def test_close_publishes_closed_message(self):
+        # Fix 5 (sessions half): close() tells subscribers the session is gone.
+        session, _ = make_mock_session()
+        seen = []
+        session.subscribe(seen.append)
+        session.close()
+        assert any(m.get("type") == "closed" for m in seen)
+
+
+def test_open_connect_timeout_raises_connection_error(monkeypatch):
+    # Fix 8: a connect that never completes surfaces as SiglentConnectionError.
+    conn = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+
+    def fake_result(self, timeout=None):
+        raise concurrent.futures.TimeoutError()
+
+    monkeypatch.setattr(concurrent.futures.Future, "result", fake_result)
+    with pytest.raises(SiglentConnectionError):
+        InstrumentSession.open("t", mock=True, _connection=conn)
 
 
 from scpi_control.server.sessions import SessionManager

--- a/tests/test_server_sessions.py
+++ b/tests/test_server_sessions.py
@@ -98,3 +98,36 @@ def test_open_failure_raises_and_leaves_no_thread():
         InstrumentSession.open("bad", mock=True, _connection=conn)
     time.sleep(0.1)
     assert threading.active_count() <= before + 1
+
+
+from scpi_control.server.sessions import SessionManager
+
+
+class TestSessionManager:
+    def _manager_with_one(self):
+        manager = SessionManager()
+        conn = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+        session = manager.create("bench-1", mock=True, _connection=conn)
+        return manager, session
+
+    def test_create_registers_and_get_returns_it(self):
+        manager, session = self._manager_with_one()
+        try:
+            assert manager.get(session.id) is session
+            assert manager.list() == [session]
+        finally:
+            manager.close_all()
+
+    def test_delete_closes_and_removes(self):
+        manager, session = self._manager_with_one()
+        assert manager.delete(session.id) is True
+        assert session.state == "closed"
+        assert manager.get(session.id) is None
+        assert manager.delete("nope") is False
+
+    def test_failed_create_registers_nothing(self):
+        manager = SessionManager()
+        conn = FailingMock("mock", idn=LEGACY_IDN)  # FailingMock defined above in this file
+        with pytest.raises(SiglentError):
+            manager.create("bad", mock=True, _connection=conn)
+        assert manager.list() == []

--- a/tests/test_server_sessions.py
+++ b/tests/test_server_sessions.py
@@ -1,0 +1,100 @@
+"""Worker-thread session core. No FastAPI dependency."""
+
+import threading
+import time
+
+import pytest
+
+from scpi_control.connection.mock import MockConnection
+from scpi_control.exceptions import SiglentError
+from scpi_control.server.sessions import InstrumentSession, SessionError
+
+LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+
+
+def make_mock_session(**kwargs):
+    conn = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+    return InstrumentSession.open("bench-1", mock=True, _connection=conn, **kwargs), conn
+
+
+class TestOpenClose:
+    def test_open_connects_and_populates_info(self):
+        session, _ = make_mock_session()
+        try:
+            assert session.state == "connected"
+            assert session.model == "SDS1104X-E"
+            assert session.dialect == "legacy"
+            assert session.num_channels == 4
+            assert "SDS1104X-E" in session.idn
+            assert session.id
+        finally:
+            session.close()
+
+    def test_close_is_idempotent_and_sets_state(self):
+        session, _ = make_mock_session()
+        session.close()
+        session.close()
+        assert session.state == "closed"
+
+    def test_submit_after_close_raises(self):
+        session, _ = make_mock_session()
+        session.close()
+        with pytest.raises(SessionError):
+            session.submit(lambda scope: scope.identify())
+
+
+class TestSerialization:
+    def test_jobs_run_on_one_thread_in_fifo_order(self):
+        session, _ = make_mock_session()
+        try:
+            seen_threads = set()
+            order = []
+
+            def job(tag):
+                def _run(scope):
+                    seen_threads.add(threading.current_thread().name)
+                    order.append(tag)
+                    return tag
+
+                return _run
+
+            futures = [session.submit(job(i)) for i in range(20)]
+            results = [f.result(timeout=5) for f in futures]
+            assert results == list(range(20))
+            assert order == list(range(20))
+            assert len(seen_threads) == 1
+            assert threading.current_thread().name not in seen_threads
+        finally:
+            session.close()
+
+    def test_job_exception_propagates_without_killing_worker(self):
+        session, _ = make_mock_session()
+        try:
+
+            def boom(scope):
+                raise ValueError("nope")
+
+            with pytest.raises(ValueError):
+                session.submit(boom).result(timeout=5)
+            # worker still alive afterwards:
+            assert session.submit(lambda s: s.identify()).result(timeout=5).startswith("Siglent")
+        finally:
+            session.close()
+
+
+class FailingMock(MockConnection):
+    """Constructs fine, fails at connect — models an unreachable instrument."""
+
+    def connect(self):
+        from scpi_control.exceptions import SiglentConnectionError
+
+        raise SiglentConnectionError("boom")
+
+
+def test_open_failure_raises_and_leaves_no_thread():
+    before = threading.active_count()
+    conn = FailingMock("mock", idn=LEGACY_IDN)
+    with pytest.raises(SiglentError):
+        InstrumentSession.open("bad", mock=True, _connection=conn)
+    time.sleep(0.1)
+    assert threading.active_count() <= before + 1

--- a/tests/test_server_stream_ws.py
+++ b/tests/test_server_stream_ws.py
@@ -1,0 +1,62 @@
+# tests/test_server_stream_ws.py
+"""WebSocket streaming tests. Skipped when the [web] extra is not installed."""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scpi_control.server.app import create_app  # noqa: E402
+from scpi_control.server.sessions import SessionManager  # noqa: E402
+
+
+@pytest.fixture()
+def client():
+    manager = SessionManager()
+    app = create_app(manager)
+    with TestClient(app) as test_client:
+        yield test_client
+    manager.close_all()
+
+
+def _create_mock(client):
+    response = client.post("/api/sessions", json={"mock": True})
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def test_stream_sends_initial_state_then_waveforms(client):
+    sid = _create_mock(client)
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid)) as ws:
+        first = ws.receive_json()
+        assert first["type"] == "state"
+        assert first["state"]["channels"]["1"]["enabled"] is True
+        # channel 1 is enabled on the default mock -> waveform frames flow
+        for _ in range(10):
+            msg = ws.receive_json()
+            if msg["type"] == "waveform":
+                assert msg["channel"] == 1
+                assert 0 < len(msg["points"]) <= 2000
+                break
+        else:
+            pytest.fail("no waveform frame received")
+
+
+def test_stream_relays_state_broadcast_after_mutation(client):
+    sid = _create_mock(client)
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid)) as ws:
+        assert ws.receive_json()["type"] == "state"
+        response = client.patch("/api/sessions/{0}/scope/timebase".format(sid), json={"timebase": 0.002})
+        assert response.status_code == 200
+        for _ in range(20):
+            msg = ws.receive_json()
+            if msg["type"] == "state" and msg["state"]["timebase"] == 0.002:
+                break
+        else:
+            pytest.fail("no state broadcast observed")
+
+
+def test_stream_unknown_session_closes(client):
+    with pytest.raises(Exception):
+        with client.websocket_connect("/api/sessions/nope/stream") as ws:
+            ws.receive_json()

--- a/tests/test_server_stream_ws.py
+++ b/tests/test_server_stream_ws.py
@@ -1,11 +1,16 @@
 # tests/test_server_stream_ws.py
 """WebSocket streaming tests. Skipped when the [web] extra is not installed."""
 
+import asyncio
+import time
+
 import pytest
 
 fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
+from starlette.websockets import WebSocketDisconnect  # noqa: E402
 
+from scpi_control.server.api.stream import _enqueue  # noqa: E402
 from scpi_control.server.app import create_app  # noqa: E402
 from scpi_control.server.sessions import SessionManager  # noqa: E402
 
@@ -16,6 +21,16 @@ def client():
     app = create_app(manager)
     with TestClient(app) as test_client:
         yield test_client
+    manager.close_all()
+
+
+@pytest.fixture()
+def client_manager():
+    """Like ``client`` but also hands back the manager for white-box assertions."""
+    manager = SessionManager()
+    app = create_app(manager)
+    with TestClient(app) as test_client:
+        yield test_client, manager
     manager.close_all()
 
 
@@ -60,3 +75,71 @@ def test_stream_unknown_session_closes(client):
     with pytest.raises(Exception):
         with client.websocket_connect("/api/sessions/nope/stream") as ws:
             ws.receive_json()
+
+
+# --- Fix 1: bounded outbox with drop-oldest --------------------------------
+
+
+def test_enqueue_appends_when_not_full():
+    q = asyncio.Queue(maxsize=4)
+    _enqueue(q, {"type": "state"})
+    assert q.qsize() == 1
+
+
+def test_enqueue_drops_oldest_waveform_when_full():
+    q = asyncio.Queue(maxsize=4)
+    for i in range(4):
+        q.put_nowait({"type": "waveform", "channel": 1, "seq": i})
+    _enqueue(q, {"type": "waveform", "channel": 1, "seq": 99})
+    items = [q.get_nowait() for _ in range(q.qsize())]
+    assert len(items) <= 4
+    seqs = [m["seq"] for m in items]
+    assert 99 in seqs  # newest frame present
+    assert 0 not in seqs  # oldest frame dropped
+
+
+def test_enqueue_preserves_control_and_drops_incoming_waveform():
+    q = asyncio.Queue(maxsize=4)
+    for i in range(4):
+        q.put_nowait({"type": "state", "n": i})
+    _enqueue(q, {"type": "waveform", "channel": 1})
+    items = [q.get_nowait() for _ in range(q.qsize())]
+    assert len(items) == 4
+    assert all(m["type"] == "state" for m in items)  # control frames preserved
+    assert [m["n"] for m in items] == [0, 1, 2, 3]  # order intact, waveform dropped
+
+
+# --- Fix 2: idle sessions still notice client disconnect -------------------
+
+
+def test_idle_stream_detects_disconnect_and_unsubscribes(client_manager):
+    client, manager = client_manager
+    sid = _create_mock(client)
+    session = manager.get(sid)
+    # Disable ch1 -> the session now publishes nothing, so the sender parks.
+    assert client.patch("/api/sessions/{0}/scope/channels/1".format(sid), json={"enabled": False}).status_code == 200
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid)) as ws:
+        assert ws.receive_json()["type"] == "state"
+    # Client context exited -> disconnect. The receiver must notice and unsubscribe.
+    deadline = time.time() + 5
+    while session._subscribers and time.time() < deadline:
+        time.sleep(0.05)
+    assert session._subscribers == []
+
+
+# --- Fix 5: deleting a session closes its streams --------------------------
+
+
+def test_delete_session_closes_stream(client):
+    sid = _create_mock(client)
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid)) as ws:
+        assert ws.receive_json()["type"] == "state"
+        assert client.delete("/api/sessions/{0}".format(sid)).status_code == 204
+        closed_seen = False
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            for _ in range(200):
+                msg = ws.receive_json()
+                if msg["type"] == "closed":
+                    closed_seen = True
+        assert closed_seen
+        assert exc_info.value.code == 4410

--- a/tests/test_server_stream_ws.py
+++ b/tests/test_server_stream_ws.py
@@ -7,6 +7,7 @@ import time
 import pytest
 
 fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")  # fastapi.testclient needs it; raises RuntimeError (not ImportError) without it
 from fastapi.testclient import TestClient  # noqa: E402
 from starlette.websockets import WebSocketDisconnect  # noqa: E402
 

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -11,6 +11,7 @@ from scpi_control.server.sessions import MAX_FRAME_POINTS, InstrumentSession, _w
 from scpi_control.waveform import WaveformData
 
 LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+MODERN_IDN = "Siglent Technologies,SDS824X HD,MOCK0002,3.8.12"
 
 
 def make_session(poll_interval=0.05, **conn_kwargs):
@@ -77,8 +78,10 @@ def test_no_poll_without_subscribers():
 
 
 def test_measurement_poll_reports_none_on_timeout():
-    # MockConnection has no PAVA? response by default -> SiglentTimeoutError -> value None
-    session = make_session()
+    # PAVA? is legacy-only; on a modern-dialect mock it still has no response ->
+    # SiglentTimeoutError -> value None. (The legacy mock now answers PAVA?, so a
+    # modern scope is used here to keep exercising the graceful-timeout path.)
+    session = make_session(idn=MODERN_IDN)
     try:
         session.set_measurements([(1, "PKPK")])
         msgs = collect(session, "measurements", n=1, timeout=8.0)

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -1,0 +1,98 @@
+"""Streaming poll + state snapshot. No FastAPI dependency."""
+
+import time
+
+from scpi_control import Oscilloscope
+from scpi_control.connection.mock import MockConnection
+from scpi_control.server.sessions import InstrumentSession, read_state
+
+LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+
+
+def make_session(poll_interval=0.05, **conn_kwargs):
+    defaults = dict(idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+    defaults.update(conn_kwargs)
+    conn = MockConnection("mock", **defaults)
+    return InstrumentSession.open("s", mock=True, _connection=conn, poll_interval=poll_interval)
+
+
+def collect(session, wanted_type, n=1, timeout=5.0):
+    got = []
+
+    def cb(msg):
+        if msg["type"] == wanted_type:
+            got.append(msg)
+
+    unsubscribe = session.subscribe(cb)
+    deadline = time.time() + timeout
+    while len(got) < n and time.time() < deadline:
+        time.sleep(0.02)
+    unsubscribe()
+    return got
+
+
+def test_read_state_snapshot_shape():
+    conn = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    try:
+        state = read_state(scope)
+        assert state["run_state"] in ("ARM", "READY", "AUTO", "TRIGD", "STOP", "ROLL")
+        assert isinstance(state["timebase"], float)
+        assert set(state["channels"]) == {1, 2, 3, 4}
+        ch1 = state["channels"][1]
+        assert ch1["enabled"] is True
+        assert isinstance(ch1["voltage_scale"], float)
+        assert state["trigger"]["mode"] in ("AUTO", "NORM", "SINGLE", "STOP")
+    finally:
+        scope.disconnect()
+
+
+def test_poll_publishes_waveform_frames_for_enabled_channels():
+    session = make_session()
+    try:
+        frames = collect(session, "waveform", n=2)
+        assert len(frames) >= 2
+        frame = frames[0]
+        assert frame["channel"] == 1
+        assert 0 < len(frame["points"]) <= 2000
+        assert isinstance(frame["points"][0], float)
+        assert frame["dt"] > 0
+    finally:
+        session.close()
+
+
+def test_no_poll_without_subscribers():
+    session = make_session()
+    try:
+        writes_before = len(session._scope._connection.queries)
+        time.sleep(0.3)
+        assert len(session._scope._connection.queries) == writes_before
+    finally:
+        session.close()
+
+
+def test_measurement_poll_reports_none_on_timeout():
+    # MockConnection has no PAVA? response by default -> SiglentTimeoutError -> value None
+    session = make_session()
+    try:
+        session.set_measurements([(1, "PKPK")])
+        msgs = collect(session, "measurements", n=1, timeout=8.0)
+        assert msgs, "expected a measurements message"
+        entry = msgs[0]["values"][0]
+        assert entry["channel"] == 1 and entry["mtype"] == "PKPK"
+        assert entry["value"] is None
+    finally:
+        session.close()
+
+
+def test_user_job_still_runs_promptly_while_streaming():
+    session = make_session()
+    try:
+        unsubscribe = session.subscribe(lambda m: None)
+        start = time.time()
+        assert session.submit(lambda s: s.identify()).result(timeout=5)
+        assert time.time() - start < 2.0
+        unsubscribe()
+    finally:
+        session.close()

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -2,9 +2,13 @@
 
 import time
 
+import numpy as np
+import pytest
+
 from scpi_control import Oscilloscope
 from scpi_control.connection.mock import MockConnection
-from scpi_control.server.sessions import InstrumentSession, read_state
+from scpi_control.server.sessions import MAX_FRAME_POINTS, InstrumentSession, _waveform_frame, read_state
+from scpi_control.waveform import WaveformData
 
 LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
 
@@ -94,5 +98,40 @@ def test_user_job_still_runs_promptly_while_streaming():
         assert session.submit(lambda s: s.identify()).result(timeout=5)
         assert time.time() - start < 2.0
         unsubscribe()
+    finally:
+        session.close()
+
+
+class _StubScope:
+    def __init__(self, n):
+        self._data = WaveformData(time=np.linspace(0.0, 1.0, n), voltage=np.zeros(n), channel=1)
+
+    def get_waveform(self, channel):
+        return self._data
+
+
+@pytest.mark.parametrize("n", [1999, 2000, 2001, 4001, 14001])
+def test_waveform_frame_never_exceeds_cap(n):
+    frame = _waveform_frame(_StubScope(n), 1)
+    assert len(frame["points"]) <= MAX_FRAME_POINTS
+
+
+def test_raising_subscriber_does_not_kill_worker():
+    session = make_session()
+    try:
+        good = []
+
+        def bad(msg):
+            raise RuntimeError("boom")
+
+        unsubscribe_bad = session.subscribe(bad)
+        unsubscribe_good = session.subscribe(good.append)
+        deadline = time.time() + 5
+        while not good and time.time() < deadline:
+            time.sleep(0.02)
+        assert good, "worker died or good subscriber starved"
+        assert session.submit(lambda s: s.identify()).result(timeout=5)
+        unsubscribe_bad()
+        unsubscribe_good()
     finally:
         session.close()


### PR DESCRIPTION
## Description

Adds the V1 backend of the browser lab gateway: `scpi_control/server/` — a FastAPI app that manages named instrument sessions, each owning one `Oscilloscope` and one worker thread with a FIFO job queue so all SCPI per instrument is serialized (fixes AUDIT.md C2 by construction). REST endpoints cover session CRUD, scope state/mutations/run-ops, a raw SCPI terminal, measurement config, full-resolution CSV capture, the model registry, and LAN discovery (`GET /api/discover`: subnet TCP scan on 5025 + `*IDN?` probe, classified scope/psu/awg/daq, merged with live sessions which are never probed). Each session exposes a WebSocket stream (initial state snapshot, waveform frames stride-decimated to ≤2000 points at ~4 Hz, measurements at ~1 Hz, state broadcasts after every mutation, terminal `closed` frame + 4410 close on session delete) with a bounded outbox and receive-side disconnect detection. Mock sessions (`mock: true`) run the identical code path and the legacy mock now answers `PAVA?` so the Measure flow works hardware-free.

## Related Issues

None

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test coverage improvement
- [ ] CI/CD improvement

## Changes Made

- New `scpi_control/server/` package: `sessions.py` (FastAPI-free session core: worker-thread job queue, streaming poll, error-state transitions, queue drain on close), `schemas.py`, `app.py` (factory, exact error mapping `{error, detail}` for 400/404/405/409/504/500, lifespan shutdown that disconnects instruments cleanly), `api/` routers (sessions, scope, stream, discovery), `discovery.py` (subnet scan + IDN probe, /22 cap, hostname-tolerant sorting), `__main__.py` CLI
- WebSocket stream hardening: bounded drop-oldest outbox, sender/receiver pair for disconnect detection, session-delete closes streams with code 4410
- `MockConnection`: legacy personality answers `PAVA?` for all 17 measurement types (modern still times out, mirroring hardware); mock waveform payloads for all four channels
- Packaging: `[web]` extra (`fastapi`, `uvicorn[standard]`; Python 3.9+ — core library stays 3.8+), `scpi-web` console script, static-dir hooks for the future frontend, `make web-server`, CI installs the extra on 3.9+, README "Web Gateway (beta)" section

## Testing

- [x] Tests pass locally (`make test` or `pytest tests/`)
- [x] Added tests for new functionality
- [ ] Tested with real hardware (if applicable)
- [ ] All CI checks pass

### Test Details

**Test environment:**

- OS: Windows 11 Pro
- Python version: 3.12.7
- Oscilloscope model (if applicable): mock sessions in CI; real-scope bench testing in progress

**Test results:**

```
552 passed, 19 skipped in 5.41s
```

86 new tests (session core, streaming, REST, WebSocket, discovery — loopback-only, no real network in CI). Skipped tests are the pre-existing VISA-hardware tests.

## Code Quality

- [x] Code follows the project style guidelines (`make lint` passes)
- [x] Code is formatted with Black (`make format`)
- [x] Self-reviewed the code
- [x] Commented complex code sections
- [x] Updated docstrings for modified functions/classes
- [x] No new linting warnings introduced

## Documentation

- [x] Updated README.md (if needed)
- [ ] Updated CHANGELOG.md with changes
- [x] Added/updated docstrings
- [ ] Added/updated examples (if applicable)
- [x] Updated type hints

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation

## Additional Notes

No authentication in V1 by design: the server binds `127.0.0.1` unless started with `--host 0.0.0.0`. The React frontend (`webapp/app/`) is the next milestone and will consume this API; the stream's `closed`/4410 contract and nullable `trigger.source` are the two wire details it must honor. `make lint`'s full flake8 pass has ~170 pre-existing warnings unrelated to this branch; the CI gate (Black 26.5.1 + flake8 E9/F63/F7/F82) is clean.