### PR TITLE
feat: browser UI for the SCPI gateway (React/Vite frontend served by FastAPI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,29 @@ jobs:
           # Exit-zero treats all errors as warnings
           flake8 scpi_control/ --count --exit-zero --max-line-length=200 --statistics
 
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: webapp/app
+
+      - name: Unit tests
+        run: npm test
+        working-directory: webapp/app
+
+      - name: Typecheck and build
+        run: npm run build
+        working-directory: webapp/app
+
   build:
     name: Build Package
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,11 @@ jobs:
           node-version: "24"
 
       - name: Install dependencies
-        run: npm ci
+        # npm install, not npm ci: the lockfile is generated on Windows and
+        # omits Linux-only optional dep nodes (@emnapi/*, WASM fallbacks), which
+        # makes strict `npm ci` fail on the Linux runner. `npm install` respects
+        # the lockfile and adds the platform's missing optional nodes.
+        run: npm install --no-audit --no-fund
         working-directory: webapp/app
 
       - name: Unit tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,18 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: webapp/app
+
+      - name: Build frontend
+        run: make webapp-build
+
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,9 @@ jobs:
           node-version: "24"
 
       - name: Install frontend dependencies
-        run: npm ci
+        # npm install (not ci): the Windows-generated lockfile omits Linux-only
+        # optional dep nodes, which makes strict `npm ci` fail on Linux runners.
+        run: npm install --no-audit --no-fund
         working-directory: webapp/app
 
       - name: Build frontend

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev install-all test test-cov test-fast test-exceptions codecov-install codecov-upload codecov-report lint format clean build publish build-exe build-exe-clean build-exe-test install-pyinstaller test-build-system docs docs-generate docs-examples docs-api docs-serve docs-deploy pre-commit pre-commit-branch pre-pr pre-pr-fast pre-pr-fix version-bump bump-major bump-minor bump-patch
+.PHONY: help install install-dev install-all test test-cov test-fast test-exceptions codecov-install codecov-upload codecov-report lint format clean build publish build-exe build-exe-clean build-exe-test install-pyinstaller test-build-system docs docs-generate docs-examples docs-api docs-serve docs-deploy pre-commit pre-commit-branch pre-pr pre-pr-fast pre-pr-fix version-bump bump-major bump-minor bump-patch webapp-install webapp-build
 
 help:  ## Show this help message
 	@echo "Available commands:"
@@ -195,6 +195,16 @@ gui:  ## Launch the GUI application
 
 web-server:  ## Run the web gateway (dev, mock-friendly)
 	python -m scpi_control.server --port 8765
+
+webapp-install:  ## Install webapp dependencies
+	cd webapp/app && npm install
+
+webapp-build:  ## Build the webapp into the server's static dir
+	cd webapp/app && npm run build
+	rm -rf scpi_control/server/static
+	mkdir -p scpi_control/server/static
+	cp -r webapp/app/dist/* scpi_control/server/static/
+	@echo "✓ Webapp built into scpi_control/server/static/"
 
 version:  ## Show package version
 	@python -c "import scpi_control; print(f'SCPI-Instrument-Control v{scpi_control.__version__}')"

--- a/README.md
+++ b/README.md
@@ -609,6 +609,18 @@ built-in mock (`mock: true`) for hardware-free use. The API is documented at
   instruments on port 5025 and lists them with model and dialect — handy when
   DHCP moves your instruments around.
 
+### Browser UI
+
+```bash
+make webapp-install       # once
+make webapp-build         # build the UI into the server
+scpi-web --host 0.0.0.0   # serve API + UI on one port
+```
+
+Open `http://<gateway-pc>:8765`. For UI development, run `scpi-web` in one
+terminal and `cd webapp/app && npm run dev` in another — Vite proxies `/api`
+(HTTP and WebSocket) to the gateway with hot reload.
+
 ## API Documentation
 
 ### Oscilloscope

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -4,10 +4,9 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Optional
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
-from fastapi.responses import JSONResponse
-from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse, JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from scpi_control.exceptions import InvalidParameterError, SiglentError, SiglentTimeoutError
@@ -68,6 +67,18 @@ def create_app(manager: Optional[SessionManager] = None) -> FastAPI:
         return JSONResponse(status_code=exc.status_code, content={"error": "HTTPException", "detail": exc.detail}, headers=getattr(exc, "headers", None))
 
     if STATIC_DIR.is_dir():
-        app.mount("/", StaticFiles(directory=str(STATIC_DIR), html=True), name="frontend")
+        index_file = STATIC_DIR / "index.html"
+
+        # Catch-all GET, registered LAST so every API route wins. Serves a real
+        # file when one exists (JS/CSS/assets), otherwise index.html so client
+        # routes deep-link. /api/* keeps the JSON {error, detail} 404 shape.
+        @app.get("/{full_path:path}", include_in_schema=False)
+        async def spa(full_path: str):
+            if full_path.startswith("api/"):
+                raise HTTPException(status_code=404, detail="unknown path /{0}".format(full_path))
+            candidate = STATIC_DIR / full_path
+            if full_path and candidate.is_file():
+                return FileResponse(str(candidate))
+            return FileResponse(str(index_file))
 
     return app

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -68,6 +68,7 @@ def create_app(manager: Optional[SessionManager] = None) -> FastAPI:
 
     if STATIC_DIR.is_dir():
         index_file = STATIC_DIR / "index.html"
+        static_root = STATIC_DIR.resolve()
 
         # Catch-all GET, registered LAST so every API route wins. Serves a real
         # file when one exists (JS/CSS/assets), otherwise index.html so client
@@ -76,8 +77,10 @@ def create_app(manager: Optional[SessionManager] = None) -> FastAPI:
         async def spa(full_path: str):
             if full_path.startswith("api/"):
                 raise HTTPException(status_code=404, detail="unknown path /{0}".format(full_path))
-            candidate = STATIC_DIR / full_path
-            if full_path and candidate.is_file():
+            candidate = (STATIC_DIR / full_path).resolve()
+            # Guard against path traversal (e.g. "%2e%2e/secret.txt") escaping
+            # STATIC_DIR: only serve the resolved candidate if it's still inside.
+            if full_path and candidate.is_file() and candidate.is_relative_to(static_root):
                 return FileResponse(str(candidate))
             return FileResponse(str(index_file))
 

--- a/tests/test_server_spa.py
+++ b/tests/test_server_spa.py
@@ -52,3 +52,21 @@ def test_no_static_build_still_boots():
     with TestClient(create_app(manager)) as client:
         assert client.get("/api/sessions").status_code == 200
     manager.close_all()
+
+
+def test_encoded_traversal_is_contained(tmp_path, monkeypatch):
+    # secret lives OUTSIDE the served static dir
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP SECRET", encoding="utf-8")
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "index.html").write_text("<!doctype html><title>gateway</title>", encoding="utf-8")
+    monkeypatch.setattr(app_module, "STATIC_DIR", static_dir)
+    manager = SessionManager()
+    with TestClient(create_app(manager)) as client:
+        # Starlette decodes %2e%2e -> .. before the path param reaches the handler
+        for payload in ("/%2e%2e/secret.txt", "/../secret.txt", "/%2e%2e%2fsecret.txt"):
+            response = client.get(payload)
+            assert response.status_code in (200, 404), payload
+            assert "TOP SECRET" not in response.text, payload
+    manager.close_all()

--- a/tests/test_server_spa.py
+++ b/tests/test_server_spa.py
@@ -1,0 +1,54 @@
+# tests/test_server_spa.py
+"""SPA fallback: client routes serve index.html; /api 404s stay JSON."""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scpi_control.server import app as app_module  # noqa: E402
+from scpi_control.server.app import create_app  # noqa: E402
+from scpi_control.server.sessions import SessionManager  # noqa: E402
+
+
+@pytest.fixture()
+def static_client(tmp_path, monkeypatch):
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "index.html").write_text("<!doctype html><title>gateway</title>", encoding="utf-8")
+    (static_dir / "app.js").write_text("console.log('x')", encoding="utf-8")
+    monkeypatch.setattr(app_module, "STATIC_DIR", static_dir)
+    manager = SessionManager()
+    with TestClient(create_app(manager)) as client:
+        yield client
+    manager.close_all()
+
+
+def test_root_serves_index(static_client):
+    response = static_client.get("/")
+    assert response.status_code == 200
+    assert "gateway" in response.text
+
+
+def test_client_route_falls_back_to_index(static_client):
+    response = static_client.get("/sessions/abc123")
+    assert response.status_code == 200
+    assert "gateway" in response.text
+
+
+def test_static_asset_is_served(static_client):
+    assert static_client.get("/app.js").status_code == 200
+
+
+def test_unknown_api_path_still_json_404(static_client):
+    response = static_client.get("/api/nope")
+    assert response.status_code == 404
+    assert set(response.json()) == {"error", "detail"}
+
+
+def test_no_static_build_still_boots():
+    manager = SessionManager()
+    with TestClient(create_app(manager)) as client:
+        assert client.get("/api/sessions").status_code == 200
+    manager.close_all()

--- a/webapp/app/.gitignore
+++ b/webapp/app/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SCPI Instrument Control</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/webapp/app/package-lock.json
+++ b/webapp/app/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.13.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -707,6 +708,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/webapp/app/package-lock.json
+++ b/webapp/app/package-lock.json
@@ -1,0 +1,2235 @@
+{
+  "name": "app",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "app",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "uplot": "^1.6.32",
+        "zustand": "^5.0.14"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@types/node": "^24.13.3",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.3",
+        "jsdom": "^29.1.1",
+        "typescript": "~6.0.2",
+        "vite": "^8.1.1",
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.8"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uplot": {
+      "version": "1.6.32",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
+      "integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/webapp/app/package.json
+++ b/webapp/app/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "uplot": "^1.6.32",
+    "zustand": "^5.0.14"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^24.13.3",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "jsdom": "^29.1.1",
+    "typescript": "~6.0.2",
+    "vite": "^8.1.1",
+    "vitest": "^4.1.10"
+  }
+}

--- a/webapp/app/package.json
+++ b/webapp/app/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc --noEmit && tsc --noEmit -p tsconfig.node.json && vite build",
     "preview": "vite preview",
     "test": "vitest run"
   },

--- a/webapp/app/package.json
+++ b/webapp/app/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -4,6 +4,7 @@ import { ChannelsPanel } from "./features/controls/ChannelsPanel";
 import { ScopeToolbar } from "./features/controls/ScopeToolbar";
 import { TriggerPanel } from "./features/controls/TriggerPanel";
 import { MeasurePanel } from "./features/measure/MeasurePanel";
+import { ReadoutStrip } from "./features/readout/ReadoutStrip";
 import { TerminalPanel } from "./features/terminal/TerminalPanel";
 import { WaveformCanvas } from "./features/waveform/WaveformCanvas";
 import { StatusIndicator } from "./ds/StatusIndicator";
@@ -27,8 +28,9 @@ export default function App() {
           <StatusIndicator state={status} />
         </span>
       </header>
-      <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)", display: "flex", flexDirection: "column" }}>
+      <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)", display: "flex", flexDirection: "column", gap: "var(--space-3)", minHeight: 0 }}>
         {session === null && <ConnectDialog onConnected={(s) => useSession.getState().setSession(s)} />}
+        {session !== null && <ReadoutStrip />}
         {session !== null && (
           <div style={{ flex: 1, display: "flex", gap: "var(--space-3)", minHeight: 0 }}>
             <div style={{ width: "280px", flexShrink: 0, overflowY: "auto" }}>

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -1,10 +1,13 @@
 import { ConnectDialog } from "./features/connect/ConnectDialog";
+import { WaveformCanvas } from "./features/waveform/WaveformCanvas";
 import { StatusIndicator } from "./ds/StatusIndicator";
+import { useStream } from "./stream/useStream";
 import { useSession } from "./store/session";
 
 export default function App() {
   const status = useSession((s) => s.status);
   const session = useSession((s) => s.session);
+  useStream(session?.id ?? null);
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100vh", background: "var(--lc-bg)", fontFamily: "var(--font-ui)" }}>
       <header style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", padding: "10px 14px", background: "var(--lc-panel)", borderBottom: "1px solid var(--lc-border)" }}>
@@ -14,8 +17,9 @@ export default function App() {
           <StatusIndicator state={status} />
         </span>
       </header>
-      <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)" }}>
+      <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)", display: "flex", flexDirection: "column" }}>
         {session === null && <ConnectDialog onConnected={(s) => useSession.getState().setSession(s)} />}
+        {session !== null && <WaveformCanvas />}
       </main>
     </div>
   );

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -1,0 +1,19 @@
+import { StatusIndicator } from "./ds/StatusIndicator";
+import { useSession } from "./store/session";
+
+export default function App() {
+  const status = useSession((s) => s.status);
+  const session = useSession((s) => s.session);
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100vh", background: "var(--lc-bg)", fontFamily: "var(--font-ui)" }}>
+      <header style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", padding: "10px 14px", background: "var(--lc-panel)", borderBottom: "1px solid var(--lc-border)" }}>
+        <strong style={{ color: "var(--lc-text)" }}>SCPI Instrument Control</strong>
+        <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-xs)", color: "var(--lc-muted)" }}>{session ? `${session.model} · ${session.address ?? "mock"}` : "no instrument"}</span>
+        <span style={{ marginLeft: "auto" }}>
+          <StatusIndicator state={status} />
+        </span>
+      </header>
+      <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)" }}>Connect an instrument to begin.</main>
+    </div>
+  );
+}

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -1,3 +1,4 @@
+import { ConnectDialog } from "./features/connect/ConnectDialog";
 import { StatusIndicator } from "./ds/StatusIndicator";
 import { useSession } from "./store/session";
 
@@ -13,7 +14,9 @@ export default function App() {
           <StatusIndicator state={status} />
         </span>
       </header>
-      <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)" }}>Connect an instrument to begin.</main>
+      <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)" }}>
+        {session === null && <ConnectDialog onConnected={(s) => useSession.getState().setSession(s)} />}
+      </main>
     </div>
   );
 }

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -1,12 +1,20 @@
+import { useState } from "react";
 import { ConnectDialog } from "./features/connect/ConnectDialog";
+import { ChannelsPanel } from "./features/controls/ChannelsPanel";
+import { ScopeToolbar } from "./features/controls/ScopeToolbar";
+import { TriggerPanel } from "./features/controls/TriggerPanel";
 import { WaveformCanvas } from "./features/waveform/WaveformCanvas";
 import { StatusIndicator } from "./ds/StatusIndicator";
+import { Tabs } from "./ds/Tabs";
 import { useStream } from "./stream/useStream";
 import { useSession } from "./store/session";
+
+const RAIL_TABS = ["Channels", "Trigger"];
 
 export default function App() {
   const status = useSession((s) => s.status);
   const session = useSession((s) => s.session);
+  const [railTab, setRailTab] = useState("Channels");
   useStream(session?.id ?? null);
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100vh", background: "var(--lc-bg)", fontFamily: "var(--font-ui)" }}>
@@ -19,7 +27,19 @@ export default function App() {
       </header>
       <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)", display: "flex", flexDirection: "column" }}>
         {session === null && <ConnectDialog onConnected={(s) => useSession.getState().setSession(s)} />}
-        {session !== null && <WaveformCanvas />}
+        {session !== null && (
+          <div style={{ flex: 1, display: "flex", gap: "var(--space-3)", minHeight: 0 }}>
+            <div style={{ width: "280px", flexShrink: 0, overflowY: "auto" }}>
+              <Tabs tabs={RAIL_TABS} value={railTab} onChange={setRailTab}>
+                {railTab === "Channels" ? <ChannelsPanel /> : <TriggerPanel />}
+              </Tabs>
+            </div>
+            <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "var(--space-3)", minWidth: 0 }}>
+              <WaveformCanvas />
+              <ScopeToolbar />
+            </div>
+          </div>
+        )}
       </main>
     </div>
   );

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -3,13 +3,15 @@ import { ConnectDialog } from "./features/connect/ConnectDialog";
 import { ChannelsPanel } from "./features/controls/ChannelsPanel";
 import { ScopeToolbar } from "./features/controls/ScopeToolbar";
 import { TriggerPanel } from "./features/controls/TriggerPanel";
+import { MeasurePanel } from "./features/measure/MeasurePanel";
+import { TerminalPanel } from "./features/terminal/TerminalPanel";
 import { WaveformCanvas } from "./features/waveform/WaveformCanvas";
 import { StatusIndicator } from "./ds/StatusIndicator";
 import { Tabs } from "./ds/Tabs";
 import { useStream } from "./stream/useStream";
 import { useSession } from "./store/session";
 
-const RAIL_TABS = ["Channels", "Trigger"];
+const RAIL_TABS = ["Channels", "Trigger", "Measure", "Terminal"];
 
 export default function App() {
   const status = useSession((s) => s.status);
@@ -31,7 +33,10 @@ export default function App() {
           <div style={{ flex: 1, display: "flex", gap: "var(--space-3)", minHeight: 0 }}>
             <div style={{ width: "280px", flexShrink: 0, overflowY: "auto" }}>
               <Tabs tabs={RAIL_TABS} value={railTab} onChange={setRailTab}>
-                {railTab === "Channels" ? <ChannelsPanel /> : <TriggerPanel />}
+                {railTab === "Channels" && <ChannelsPanel />}
+                {railTab === "Trigger" && <TriggerPanel />}
+                {railTab === "Measure" && <MeasurePanel />}
+                {railTab === "Terminal" && <TerminalPanel />}
               </Tabs>
             </div>
             <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "var(--space-3)", minWidth: 0 }}>

--- a/webapp/app/src/api/client.test.ts
+++ b/webapp/app/src/api/client.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError, api } from "./client";
+
+function mockFetch(body: unknown, init: { status?: number } = {}) {
+  const status = init.status ?? 200;
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status < 400,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("api client", () => {
+  it("creates a mock session", async () => {
+    const fetchMock = mockFetch({ id: "abc", label: "Mock scope", mock: true, address: null, state: "connected", idn: "x", model: "SDS1104X-E", dialect: "legacy", num_channels: 4 }, { status: 201 });
+    const session = await api.createSession({ mock: true });
+    expect(session.id).toBe("abc");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/sessions");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ mock: true });
+  });
+
+  it("throws ApiError carrying the server error shape", async () => {
+    mockFetch({ error: "InvalidParameterError", detail: "invalid coupling: BANANA" }, { status: 400 });
+    await expect(api.patchChannel("abc", 1, { coupling: "BANANA" })).rejects.toMatchObject({
+      status: 400,
+      error: "InvalidParameterError",
+      detail: "invalid coupling: BANANA",
+    });
+    await expect(api.patchChannel("abc", 1, { coupling: "BANANA" })).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("builds a capture URL with the channel list", () => {
+    expect(api.captureUrl("abc", [1, 2])).toBe("/api/sessions/abc/scope/capture.csv?channels=1,2");
+  });
+
+  it("sends run ops as POST", async () => {
+    const fetchMock = mockFetch({ run_state: "TRIGD", timebase: 0.001, channels: {}, trigger: { mode: "AUTO", source: null, level: null, slope: null, coupling: null } });
+    await api.runOp("abc", "single");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/sessions/abc/scope/single");
+    expect(init.method).toBe("POST");
+  });
+});

--- a/webapp/app/src/api/client.ts
+++ b/webapp/app/src/api/client.ts
@@ -1,0 +1,58 @@
+import type { ChannelPatch, DiscoveredDevice, MeasurementValue, ModelInfo, RunOp, ScopeState, SessionCreate, SessionInfo, TriggerPatch } from "./types";
+
+export class ApiError extends Error {
+  status: number;
+  error: string;
+  detail: string;
+
+  constructor(status: number, error: string, detail: string) {
+    super(detail || error);
+    this.name = "ApiError";
+    this.status = status;
+    this.error = error;
+    this.detail = detail;
+  }
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(path, init);
+  if (!response.ok) {
+    let error = "Error";
+    let detail = "request failed";
+    try {
+      const body = await response.json();
+      error = body.error ?? error;
+      detail = body.detail ?? detail;
+    } catch {
+      // non-JSON error body: keep defaults
+    }
+    throw new ApiError(response.status, error, detail);
+  }
+  if (response.status === 204) return undefined as T;
+  return (await response.json()) as T;
+}
+
+function json(method: string, body: unknown): RequestInit {
+  return { method, headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) };
+}
+
+const scope = (id: string) => `/api/sessions/${id}/scope`;
+
+export const api = {
+  models: () => request<ModelInfo[]>("/api/models"),
+  discover: (cidr?: string) => request<DiscoveredDevice[]>(cidr ? `/api/discover?cidr=${encodeURIComponent(cidr)}` : "/api/discover"),
+  createSession: (body: SessionCreate) => request<SessionInfo>("/api/sessions", json("POST", body)),
+  listSessions: () => request<SessionInfo[]>("/api/sessions"),
+  getSession: (id: string) => request<SessionInfo>(`/api/sessions/${id}`),
+  deleteSession: (id: string) => request<void>(`/api/sessions/${id}`, { method: "DELETE" }),
+  getState: (id: string) => request<ScopeState>(`${scope(id)}/state`),
+  patchChannel: (id: string, channel: number, body: ChannelPatch) => request<ScopeState>(`${scope(id)}/channels/${channel}`, json("PATCH", body)),
+  patchTimebase: (id: string, timebase: number) => request<ScopeState>(`${scope(id)}/timebase`, json("PATCH", { timebase })),
+  patchTrigger: (id: string, body: TriggerPatch) => request<ScopeState>(`${scope(id)}/trigger`, json("PATCH", body)),
+  runOp: (id: string, op: RunOp) => request<ScopeState>(`${scope(id)}/${op}`, { method: "POST" }),
+  command: (id: string, command: string) => request<{ command: string; response: string | null }>(`${scope(id)}/command`, json("POST", { command })),
+  setMeasurements: (id: string, items: { channel: number; mtype: string }[]) => request<{ measurements: { channel: number; mtype: string }[] }>(`${scope(id)}/measurements`, json("PUT", items)),
+  captureUrl: (id: string, channels: number[]) => `${scope(id)}/capture.csv?channels=${channels.join(",")}`,
+};
+
+export type { MeasurementValue };

--- a/webapp/app/src/api/types.ts
+++ b/webapp/app/src/api/types.ts
@@ -1,0 +1,68 @@
+export type ChannelState = {
+  enabled: boolean;
+  voltage_scale: number;
+  voltage_offset: number;
+  coupling: string;
+  probe_ratio: number | null;
+};
+
+export type TriggerState = {
+  mode: string;
+  source: string | null;
+  level: number | null;
+  slope: string | null;
+  coupling: string | null;
+};
+
+// NOTE: channel keys arrive as strings ("1".."4") — JSON object keys.
+export type ScopeState = {
+  run_state: string;
+  timebase: number;
+  channels: Record<string, ChannelState>;
+  trigger: TriggerState;
+};
+
+export type SessionInfo = {
+  id: string;
+  label: string;
+  mock: boolean;
+  address: string | null;
+  state: string;
+  idn: string;
+  model: string;
+  dialect: string;
+  num_channels: number;
+};
+
+export type DiscoveredDevice = {
+  address: string;
+  idn: string;
+  manufacturer: string;
+  model: string;
+  dialect: string;
+  kind: string;
+  connected: boolean;
+  session_id?: string;
+};
+
+export type ModelInfo = {
+  model_name: string;
+  series: string;
+  num_channels: number;
+  bandwidth_mhz: number;
+  dialect: string;
+};
+
+export type MeasurementValue = { channel: number; mtype: string; value: number | null };
+
+export type StreamMessage =
+  | { type: "state"; state: ScopeState }
+  | { type: "waveform"; channel: number; t0: number; dt: number; points: number[] }
+  | { type: "measurements"; values: MeasurementValue[] }
+  | { type: "error"; detail: string }
+  | { type: "closed" };
+
+export type SessionCreate = { label?: string; address?: string; port?: number; mock?: boolean; model?: string };
+export type ChannelPatch = Partial<{ enabled: boolean; voltage_scale: number; voltage_offset: number; coupling: string; probe_ratio: number }>;
+export type TriggerPatch = Partial<{ mode: string; source: string; level: number; slope: string; coupling: string }>;
+export type RunOp = "run" | "stop" | "single" | "auto";

--- a/webapp/app/src/ds/Button.tsx
+++ b/webapp/app/src/ds/Button.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+
+export type ButtonVariant = "default" | "primary" | "danger" | "critical" | "ghost";
+export type ButtonSize = "sm" | "md";
+
+export type ButtonProps = {
+  children?: React.ReactNode;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  icon?: React.ReactNode;
+  disabled?: boolean;
+  fullWidth?: boolean;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  type?: "button" | "submit" | "reset";
+  style?: React.CSSProperties;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type" | "onClick" | "style" | "disabled">;
+
+/**
+ * Button — the app's push button (QPushButton).
+ *
+ * Variants map to the real setStyleSheet blocks in the PyQt6 source:
+ *  - default  : native light Qt button (Auto Scale, Add, Update Now…)
+ *  - primary  : Connect / Send — success green (#4CAF50)
+ *  - danger   : Disconnect / Clear — red (#f44336)
+ *  - critical : "All Outputs OFF (Safety)" — crimson, larger radius/padding
+ *  - ghost    : flat toolbar text actions (Run, Stop, Single, Capture…)
+ */
+export function Button({
+  children,
+  variant = "default",
+  size = "md",
+  icon = null,
+  disabled = false,
+  fullWidth = false,
+  onClick,
+  type = "button",
+  style,
+  ...rest
+}: ButtonProps) {
+  const sizes: Record<ButtonSize, React.CSSProperties> = {
+    sm: { fontSize: "var(--text-xs)", padding: "4px 12px", height: "var(--control-height-sm)" },
+    md: { fontSize: "var(--text-sm)", padding: "7px 20px", height: "32px" },
+  };
+
+  const base: React.CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "6px",
+    fontFamily: "var(--font-ui)",
+    fontWeight: "var(--weight-medium)",
+    lineHeight: 1,
+    border: "1px solid transparent",
+    borderRadius: "var(--lc-radius-sm)",
+    cursor: disabled ? "not-allowed" : "pointer",
+    userSelect: "none",
+    whiteSpace: "nowrap",
+    transition: "background-color 90ms ease, border-color 90ms ease, filter 90ms ease",
+    width: fullWidth ? "100%" : "auto",
+    opacity: disabled ? 0.5 : 1,
+    ...sizes[size],
+  };
+
+  const variants: Record<ButtonVariant, React.CSSProperties> = {
+    default: {
+      background: "var(--lc-panel)",
+      borderColor: "var(--lc-border-strong)",
+      color: "var(--lc-text)",
+    },
+    primary: {
+      background: "var(--success)",
+      color: "#ffffff",
+      fontWeight: "var(--weight-bold)",
+      borderColor: "transparent",
+    },
+    danger: {
+      background: "var(--danger)",
+      color: "#ffffff",
+      fontWeight: "var(--weight-bold)",
+      borderColor: "transparent",
+    },
+    critical: {
+      background: "var(--critical)",
+      color: "#ffffff",
+      fontWeight: "var(--weight-bold)",
+      borderRadius: "var(--radius-md)",
+      padding: "10px 20px",
+      borderColor: "transparent",
+    },
+    ghost: {
+      background: "transparent",
+      color: "var(--text-primary)",
+      borderColor: "transparent",
+      padding: size === "sm" ? "4px 10px" : "6px 14px",
+    },
+  };
+
+  const hoverBg: Record<ButtonVariant, string> = {
+    default: "var(--lc-control-hover)",
+    primary: "var(--success-hover)",
+    danger: "var(--danger-hover)",
+    critical: "var(--critical-hover)",
+    ghost: "rgba(0,0,0,0.06)",
+  };
+  const pressBg: Record<ButtonVariant, string> = {
+    default: "var(--lc-panel-2)",
+    primary: "var(--success-pressed)",
+    danger: "var(--danger-pressed)",
+    critical: "var(--critical-hover)",
+    ghost: "rgba(0,0,0,0.11)",
+  };
+
+  const [state, setState] = React.useState<"rest" | "hover" | "active">("rest");
+  const dyn: React.CSSProperties =
+    !disabled && state === "hover" ? { background: hoverBg[variant] } :
+    !disabled && state === "active" ? { background: pressBg[variant] } : {};
+
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      onClick={onClick}
+      onMouseEnter={() => setState("hover")}
+      onMouseLeave={() => setState("rest")}
+      onMouseDown={() => setState("active")}
+      onMouseUp={() => setState("hover")}
+      style={{ ...base, ...variants[variant], ...dyn, ...style }}
+      {...rest}
+    >
+      {icon && <span style={{ display: "inline-flex", fontSize: "1.05em" }}>{icon}</span>}
+      {children}
+    </button>
+  );
+}

--- a/webapp/app/src/ds/Checkbox.tsx
+++ b/webapp/app/src/ds/Checkbox.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+
+export type CheckboxProps = {
+  label?: React.ReactNode;
+  checked?: boolean;
+  defaultChecked?: boolean;
+  disabled?: boolean;
+  bold?: boolean;
+  onChange?: (value: boolean) => void;
+  style?: React.CSSProperties;
+} & Omit<React.LabelHTMLAttributes<HTMLLabelElement>, "onChange" | "style">;
+
+/**
+ * Checkbox — QCheckBox. Square box with a check, label to the right.
+ * Used for Enable channel, Bandwidth Limit, Grid, Timestamp, Statistics…
+ */
+export function Checkbox({
+  label,
+  checked,
+  defaultChecked = false,
+  disabled = false,
+  bold = false,
+  onChange,
+  style,
+  ...rest
+}: CheckboxProps) {
+  const isControlled = checked !== undefined;
+  const [internal, setInternal] = React.useState(defaultChecked);
+  const value = isControlled ? checked : internal;
+
+  const toggle = () => {
+    if (disabled) return;
+    if (!isControlled) setInternal(!value);
+    onChange && onChange(!value);
+  };
+
+  return (
+    <label
+      onClick={toggle}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "8px",
+        fontFamily: "var(--font-ui)",
+        fontSize: "var(--text-sm)",
+        fontWeight: bold ? "var(--weight-bold)" : "var(--weight-normal)",
+        color: "var(--text-primary)",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+        userSelect: "none",
+        ...style,
+      }}
+      {...rest}
+    >
+      <span
+        style={{
+          width: "17px",
+          height: "17px",
+          flexShrink: 0,
+          borderRadius: "5px",
+          border: `1px solid ${value ? "var(--success)" : "var(--lc-border-strong)"}`,
+          background: value ? "var(--success)" : "var(--lc-control)",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          transition: "background-color 90ms ease, border-color 90ms ease",
+        }}
+      >
+        {value && (
+          <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+            <path d="M2.5 6.2L4.8 8.5L9.5 3.5" stroke="#fff" strokeWidth="1.8"
+              strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+      </span>
+      {label}
+    </label>
+  );
+}

--- a/webapp/app/src/ds/ComboBox.tsx
+++ b/webapp/app/src/ds/ComboBox.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+
+export type ComboBoxOption = string | { label: string; value: string };
+
+export type ComboBoxProps = {
+  options?: ComboBoxOption[];
+  value?: string;
+  defaultValue?: string;
+  disabled?: boolean;
+  onChange?: (value: string) => void;
+  width?: string | number;
+  style?: React.CSSProperties;
+} & Omit<React.SelectHTMLAttributes<HTMLSelectElement>, "value" | "defaultValue" | "onChange" | "style" | "disabled">;
+
+/**
+ * ComboBox — QComboBox dropdown. Native light Qt select with a chevron.
+ * Used for Coupling (DC/AC/GND), Probe ratio, Trigger Mode/Source/Slope,
+ * Channel pickers, Math operation, Window function…
+ */
+export function ComboBox({
+  options = [],
+  value,
+  defaultValue,
+  disabled = false,
+  onChange,
+  width,
+  style,
+  ...rest
+}: ComboBoxProps) {
+  const norm = options.map((o) =>
+    typeof o === "string" ? { label: o, value: o } : o
+  );
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = React.useState(
+    defaultValue ?? (norm[0] && norm[0].value)
+  );
+  const current = isControlled ? value : internal;
+
+  const [hover, setHover] = React.useState(false);
+  const [foc, setFoc] = React.useState(false);
+
+  const handle = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const v = e.target.value;
+    if (!isControlled) setInternal(v);
+    onChange && onChange(v);
+  };
+
+  return (
+    <div
+      style={{ position: "relative", display: "inline-block", width: width || "auto", ...style }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <select
+        value={current}
+        disabled={disabled}
+        onChange={handle}
+        style={{
+          appearance: "none",
+          WebkitAppearance: "none",
+          MozAppearance: "none",
+          width: "100%",
+          height: "32px",
+          padding: "0 28px 0 10px",
+          fontFamily: "var(--font-ui)",
+          fontSize: "var(--text-sm)",
+          color: "var(--lc-text)",
+          background: "var(--lc-control)",
+          border: `1px solid ${foc ? "var(--lc-accent)" : hover && !disabled ? "var(--lc-border-strong)" : "var(--lc-border-strong)"}`,
+          borderRadius: "var(--lc-radius-sm)",
+          boxShadow: foc ? "0 0 0 3px var(--lc-accent-soft)" : "none",
+          cursor: disabled ? "not-allowed" : "pointer",
+          opacity: disabled ? 0.5 : 1,
+          outline: "none",
+        }}
+        onFocus={() => setFoc(true)}
+        onBlur={() => setFoc(false)}
+        {...rest}
+      >
+        {norm.map((o) => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+      <span
+        aria-hidden
+        style={{
+          position: "absolute",
+          right: "9px",
+          top: "50%",
+          transform: "translateY(-50%)",
+          pointerEvents: "none",
+          color: "var(--lc-text-2)",
+          fontSize: "10px",
+          lineHeight: 1,
+        }}
+      >
+        ▾
+      </span>
+    </div>
+  );
+}

--- a/webapp/app/src/ds/DataTable.tsx
+++ b/webapp/app/src/ds/DataTable.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+
+export type DataTableColumn = string | { label: string; width?: string | number; align?: React.CSSProperties["textAlign"]; mono?: boolean };
+export type DataTableCell = React.ReactNode;
+
+export type DataTableProps = {
+  columns?: DataTableColumn[];
+  rows?: DataTableCell[][];
+  dark?: boolean;
+  style?: React.CSSProperties;
+} & Omit<React.TableHTMLAttributes<HTMLTableElement>, "style">;
+
+/**
+ * DataTable — QTableWidget. Column-headed table with alternating row colours.
+ * Two treatments:
+ *   light (default) — measurement panel (alt rows, native header)
+ *   dark            — DAQ data view (#2d2d2d body, #353535 alt, #404040 header)
+ *
+ * `columns` are strings or {label, width, align}. `rows` are arrays of cells;
+ * a cell may be a string/number or a React node (e.g. a channel-coloured value).
+ */
+export function DataTable({
+  columns = [],
+  rows = [],
+  dark = false,
+  style,
+  ...rest
+}: DataTableProps) {
+  const cols = columns.map((c) => (typeof c === "string" ? { label: c } : c));
+  const pal = dark
+    ? {
+        body: "var(--scope-surface)", alt: "var(--scope-row-alt)",
+        header: "var(--scope-header)", grid: "var(--scope-border-3)",
+        text: "#ffffff", headerText: "#ffffff",
+      }
+    : {
+        body: "var(--surface)", alt: "var(--surface-alt)",
+        header: "var(--surface-subtle)", grid: "var(--divider)",
+        text: "var(--text-primary)", headerText: "var(--text-secondary)",
+      };
+
+  return (
+    <table
+      style={{
+        width: "100%",
+        borderCollapse: "collapse",
+        fontFamily: "var(--font-ui)",
+        fontSize: "var(--text-sm)",
+        color: pal.text,
+        background: pal.body,
+        border: `1px solid ${pal.grid}`,
+        ...style,
+      }}
+      {...rest}
+    >
+      <thead>
+        <tr>
+          {cols.map((c, i) => (
+            <th
+              key={i}
+              style={{
+                textAlign: c.align || "left",
+                fontWeight: "var(--weight-bold)",
+                color: pal.headerText,
+                background: pal.header,
+                padding: "7px 10px",
+                borderBottom: `1px solid ${pal.grid}`,
+                width: c.width || "auto",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {c.label}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r, ri) => (
+          <tr key={ri} style={{ background: ri % 2 ? pal.alt : pal.body }}>
+            {r.map((cell, ci) => (
+              <td
+                key={ci}
+                style={{
+                  padding: "6px 10px",
+                  textAlign: cols[ci]?.align || "left",
+                  borderBottom: `1px solid ${pal.grid}`,
+                  fontFamily: cols[ci]?.mono ? "var(--font-mono)" : "inherit",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {cell}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/webapp/app/src/ds/GroupBox.tsx
+++ b/webapp/app/src/ds/GroupBox.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+
+export type GroupBoxProps = {
+  title?: React.ReactNode;
+  titleColor?: string;
+  dark?: boolean;
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+  bodyStyle?: React.CSSProperties;
+} & Omit<React.FieldsetHTMLAttributes<HTMLFieldSetElement>, "style" | "title">;
+
+/**
+ * GroupBox — QGroupBox. A titled, bordered container. The title sits in a
+ * notch on the top border. In the scope UI the title is colour-coded to the
+ * channel it controls (gold / cyan / pink / green), so `titleColor` accepts
+ * any CSS color or a channel token var.
+ *
+ * On the dark scope canvas set `dark` for the panel treatment.
+ */
+export function GroupBox({
+  title,
+  titleColor,
+  dark = false,
+  children,
+  style,
+  bodyStyle,
+  ...rest
+}: GroupBoxProps) {
+  const frame = dark ? "var(--scope-border-2)" : "var(--lc-border)";
+  const bg = dark ? "var(--scope-panel)" : "var(--lc-panel)";
+  const notchBg = dark ? "var(--scope-panel)" : "var(--lc-bg)";
+  const defaultTitle = dark ? "var(--scope-text)" : "var(--lc-text-2)";
+
+  return (
+    <fieldset
+      style={{
+        position: "relative",
+        margin: 0,
+        padding: "14px 12px 12px",
+        border: `1px solid ${frame}`,
+        borderRadius: "var(--lc-radius)",
+        background: bg,
+        boxShadow: dark ? "none" : "var(--lc-elev-1)",
+        minInlineSize: "auto",
+        ...style,
+      }}
+      {...rest}
+    >
+      {title != null && (
+        <legend
+          style={{
+            padding: "0 6px",
+            marginLeft: "4px",
+            fontFamily: "var(--font-ui)",
+            fontSize: "var(--text-sm)",
+            fontWeight: "var(--weight-bold)",
+            color: titleColor || defaultTitle,
+            background: notchBg,
+          }}
+        >
+          {title}
+        </legend>
+      )}
+      <div style={bodyStyle}>{children}</div>
+    </fieldset>
+  );
+}

--- a/webapp/app/src/ds/Reading.tsx
+++ b/webapp/app/src/ds/Reading.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+
+export type ReadingProps = {
+  label?: React.ReactNode;
+  value?: React.ReactNode;
+  unit?: string;
+  mode?: string;
+  modeColor?: string;
+  size?: "sm" | "lg";
+  style?: React.CSSProperties;
+} & Omit<React.HTMLAttributes<HTMLDivElement>, "style">;
+
+/**
+ * Reading — a live instrument readout. Monospace value in scope green
+ * (#00ff00), as used for Measured V / I / W and the big front-panel numbers.
+ * Optional CV/CC-style `mode` badge (green for CV, orange for CC).
+ *
+ *  - size "sm" : inline panel readout (PSU measured values)
+ *  - size "lg" : front-panel hero number (e.g. "30.00 V")
+ */
+export function Reading({
+  label,
+  value,
+  unit = "",
+  mode,
+  modeColor,
+  size = "sm",
+  style,
+  ...rest
+}: ReadingProps) {
+  const big = size === "lg";
+  return (
+    <div
+      style={{
+        display: big ? "flex" : "inline-flex",
+        flexDirection: big ? "column" : "row",
+        alignItems: big ? "flex-start" : "baseline",
+        gap: big ? "2px" : "8px",
+        fontFamily: "var(--font-ui)",
+        ...style,
+      }}
+      {...rest}
+    >
+      {label != null && (
+        <span
+          style={{
+            fontSize: big ? "var(--text-xs)" : "var(--text-sm)",
+            color: "var(--scope-text-muted)",
+            textTransform: big ? "uppercase" : "none",
+            letterSpacing: big ? "var(--tracking-label)" : 0,
+          }}
+        >
+          {label}
+        </span>
+      )}
+      <span
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: big ? "var(--text-2xl)" : "var(--text-base)",
+          fontWeight: "var(--weight-bold)",
+          color: "var(--readout)",
+          lineHeight: 1,
+          letterSpacing: "var(--tracking-mono)",
+        }}
+      >
+        {value}
+        {unit ? <span style={{ fontSize: "0.6em", marginLeft: "4px", opacity: 0.85 }}>{unit}</span> : null}
+      </span>
+      {mode != null && (
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--text-xs)",
+            fontWeight: "var(--weight-bold)",
+            color: modeColor || (mode === "CC" ? "var(--warning)" : "var(--readout)"),
+            border: `1px solid ${modeColor || (mode === "CC" ? "var(--warning)" : "var(--readout)")}`,
+            borderRadius: "var(--radius-sm)",
+            padding: "1px 5px",
+          }}
+        >
+          {mode}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/webapp/app/src/ds/SpinBox.test.tsx
+++ b/webapp/app/src/ds/SpinBox.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SpinBox } from "./SpinBox";
+
+describe("SpinBox", () => {
+  it("puts the accessible name on the editable input, not the wrapper", () => {
+    render(<SpinBox aria-label="V/div C1" value={0.5} onChange={() => {}} />);
+    const field = screen.getByLabelText("V/div C1");
+    expect(field.tagName).toBe("INPUT");
+  });
+
+  it("commits a typed value on blur through the labelled field", async () => {
+    const onChange = vi.fn();
+    render(<SpinBox aria-label="V/div C1" value={0.5} onChange={onChange} />);
+    const field = screen.getByLabelText("V/div C1");
+    await userEvent.clear(field);
+    await userEvent.type(field, "2");
+    await userEvent.tab();
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+});

--- a/webapp/app/src/ds/SpinBox.tsx
+++ b/webapp/app/src/ds/SpinBox.tsx
@@ -12,6 +12,8 @@ export type SpinBoxProps = {
   onChange?: (value: number) => void;
   width?: string | number;
   style?: React.CSSProperties;
+  /** Forwarded to the inner <input>, not the wrapper — see the destructure below. */
+  name?: string;
 } & Omit<React.HTMLAttributes<HTMLDivElement>, "onChange" | "style">;
 
 /**
@@ -31,6 +33,14 @@ export function SpinBox({
   onChange,
   width,
   style,
+  // ARIA/identity props belong on the real editable control, not the layout wrapper.
+  // Spreading them onto the wrapper would leave the <input> with no accessible name,
+  // so getByLabelText / screen readers would land on a non-editable <div>.
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
+  "aria-describedby": ariaDescribedBy,
+  id,
+  name,
   ...rest
 }: SpinBoxProps) {
   const isControlled = value !== undefined;
@@ -100,6 +110,11 @@ export function SpinBox({
     >
       <input
         type="text"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        id={id}
+        name={name}
         disabled={disabled}
         value={editing ? draft : fmt(current)}
         onFocus={() => { setEditing(true); setDraft(String(current)); setFoc(true); }}

--- a/webapp/app/src/ds/SpinBox.tsx
+++ b/webapp/app/src/ds/SpinBox.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+
+export type SpinBoxProps = {
+  value?: number;
+  defaultValue?: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  decimals?: number;
+  suffix?: string;
+  disabled?: boolean;
+  onChange?: (value: number) => void;
+  width?: string | number;
+  style?: React.CSSProperties;
+} & Omit<React.HTMLAttributes<HTMLDivElement>, "onChange" | "style">;
+
+/**
+ * SpinBox — QDoubleSpinBox. Numeric field with a unit suffix and stacked
+ * up/down steppers. Used for V/div, Offset, Trigger Level, Holdoff, Voltage &
+ * Current setpoints. Suffix examples: " V", " A", " s".
+ */
+export function SpinBox({
+  value,
+  defaultValue = 0,
+  min = -Infinity,
+  max = Infinity,
+  step = 0.1,
+  decimals = 3,
+  suffix = "",
+  disabled = false,
+  onChange,
+  width,
+  style,
+  ...rest
+}: SpinBoxProps) {
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = React.useState(defaultValue);
+  const current = isControlled ? (value as number) : internal;
+  const [hover, setHover] = React.useState(false);
+  const [foc, setFoc] = React.useState(false);
+
+  const clamp = (v: number) => Math.min(max, Math.max(min, v));
+  const commit = (v: number) => {
+    const c = clamp(v);
+    if (!isControlled) setInternal(c);
+    onChange && onChange(c);
+  };
+
+  const fmt = (v: number) =>
+    (typeof v === "number" && !Number.isNaN(v) ? v : 0).toFixed(decimals) + suffix;
+
+  const [editing, setEditing] = React.useState(false);
+  const [draft, setDraft] = React.useState("");
+
+  const Stepper = ({ dir }: { dir: 1 | -1 }) => (
+    <button
+      type="button"
+      disabled={disabled}
+      tabIndex={-1}
+      onClick={() => commit(current + dir * step)}
+      style={{
+        flex: 1,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        border: "none",
+        borderLeft: "1px solid var(--lc-border)",
+        borderBottom: dir > 0 ? "1px solid var(--lc-border)" : "none",
+        background: "var(--lc-panel-2)",
+        color: "var(--lc-text-2)",
+        cursor: disabled ? "not-allowed" : "pointer",
+        fontSize: "8px",
+        lineHeight: 1,
+        padding: 0,
+      }}
+    >
+      {dir > 0 ? "▲" : "▼"}
+    </button>
+  );
+
+  return (
+    <div
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        display: "inline-flex",
+        alignItems: "stretch",
+        height: "32px",
+        width: width || "140px",
+        background: "var(--lc-control)",
+        border: `1px solid ${foc ? "var(--lc-accent)" : hover && !disabled ? "var(--lc-border-strong)" : "var(--lc-border-strong)"}`,
+        borderRadius: "var(--lc-radius-sm)",
+        boxShadow: foc ? "0 0 0 3px var(--lc-accent-soft)" : "none",
+        overflow: "hidden",
+        opacity: disabled ? 0.5 : 1,
+        fontFamily: "var(--font-ui)",
+        ...style,
+      }}
+      {...rest}
+    >
+      <input
+        type="text"
+        disabled={disabled}
+        value={editing ? draft : fmt(current)}
+        onFocus={() => { setEditing(true); setDraft(String(current)); setFoc(true); }}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => { setEditing(false); setFoc(false); const n = parseFloat(draft); if (!Number.isNaN(n)) commit(n); }}
+        onKeyDown={(e) => { if (e.key === "Enter") e.currentTarget.blur(); }}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          border: "none",
+          outline: "none",
+          background: "transparent",
+          padding: "0 8px",
+          fontFamily: "var(--font-ui)",
+          fontSize: "var(--text-sm)",
+          color: "var(--lc-text)",
+        }}
+      />
+      <div style={{ display: "flex", flexDirection: "column", width: "18px" }}>
+        <Stepper dir={1} />
+        <Stepper dir={-1} />
+      </div>
+    </div>
+  );
+}

--- a/webapp/app/src/ds/StatusIndicator.tsx
+++ b/webapp/app/src/ds/StatusIndicator.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+
+export type StatusIndicatorState = "connected" | "connecting" | "disconnected" | "error";
+
+export type StatusIndicatorProps = {
+  state?: StatusIndicatorState;
+  label?: React.ReactNode;
+  pulse?: boolean;
+  dark?: boolean;
+  style?: React.CSSProperties;
+} & Omit<React.HTMLAttributes<HTMLSpanElement>, "style">;
+
+/**
+ * StatusIndicator — connection status dot + label, from the toolbar/status bar.
+ * Colours match the README legend:
+ *   connected  🟢 green   connecting 🟡 orange
+ *   disconnected 🔴 red    error      🟠 dark orange
+ *
+ * NOTE: the pulse animation's @keyframes (scpi-pulse) is defined once in
+ * `src/ds/ds.css` (imported from main.tsx), not injected per-instance.
+ */
+const STATES: Record<StatusIndicatorState, { color: string; text: string }> = {
+  connected: { color: "var(--success)", text: "Connected" },
+  connecting: { color: "var(--warning)", text: "Connecting…" },
+  disconnected: { color: "var(--danger)", text: "Disconnected" },
+  error: { color: "var(--ch8)", text: "Error" },
+};
+
+export function StatusIndicator({
+  state = "disconnected",
+  label,
+  pulse,
+  dark = false,
+  style,
+  ...rest
+}: StatusIndicatorProps) {
+  const s = STATES[state] || STATES.disconnected;
+  const doPulse = pulse ?? state === "connecting";
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "7px",
+        fontFamily: "var(--font-ui)",
+        fontSize: "var(--text-sm)",
+        color: dark ? "var(--scope-text-body)" : "var(--text-secondary)",
+        ...style,
+      }}
+      {...rest}
+    >
+      <span
+        style={{
+          width: "9px",
+          height: "9px",
+          borderRadius: "var(--radius-pill)",
+          background: s.color,
+          boxShadow: `0 0 0 3px color-mix(in srgb, ${s.color} 22%, transparent)`,
+          animation: doPulse ? "scpi-pulse 1.1s ease-in-out infinite" : "none",
+          flexShrink: 0,
+        }}
+      />
+      <span>{label ?? s.text}</span>
+    </span>
+  );
+}

--- a/webapp/app/src/ds/Tabs.tsx
+++ b/webapp/app/src/ds/Tabs.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+
+export type TabItem = string | { label: string; value: string };
+
+export type TabsProps = {
+  tabs?: TabItem[];
+  value?: string;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+} & Omit<React.HTMLAttributes<HTMLDivElement>, "onChange" | "style">;
+
+/**
+ * Tabs — QTabWidget tab bar. The control panel's primary navigation
+ * (Channels / Trigger / Timebase / Measurements / …). Light native styling
+ * with an underline on the active tab.
+ */
+export function Tabs({
+  tabs = [],
+  value,
+  defaultValue,
+  onChange,
+  children,
+  style,
+  ...rest
+}: TabsProps) {
+  const norm = tabs.map((t) => (typeof t === "string" ? { label: t, value: t } : t));
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = React.useState(
+    defaultValue ?? (norm[0] && norm[0].value)
+  );
+  const active = isControlled ? value : internal;
+  const [_hover, setHover] = React.useState<string | null>(null);
+
+  const select = (v: string) => {
+    if (!isControlled) setInternal(v);
+    onChange && onChange(v);
+  };
+
+  return (
+    <div style={{ fontFamily: "var(--font-ui)", ...style }} {...rest}>
+      <div
+        role="tablist"
+        style={{
+          display: "inline-flex",
+          gap: "3px",
+          padding: "4px",
+          background: "var(--lc-panel-2)",
+          border: "1px solid var(--lc-border)",
+          borderRadius: "var(--lc-radius)",
+        }}
+      >
+        {norm.map((t) => {
+          const on = t.value === active;
+          return (
+            <button
+              key={t.value}
+              role="tab"
+              aria-selected={on}
+              onClick={() => select(t.value)}
+              onMouseEnter={() => setHover(t.value)}
+              onMouseLeave={() => setHover(null)}
+              style={{
+                border: "none",
+                background: on ? "var(--lc-panel)" : "transparent",
+                color: on ? "var(--lc-text)" : "var(--lc-text-2)",
+                fontSize: "var(--text-sm)",
+                fontWeight: on ? "var(--weight-medium)" : "500",
+                padding: "7px 14px",
+                cursor: "pointer",
+                borderRadius: "var(--lc-radius-sm)",
+                boxShadow: on ? "var(--lc-elev-1)" : "none",
+                whiteSpace: "nowrap",
+                transition: "background 90ms ease, color 90ms ease",
+              }}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+      {children != null && <div style={{ paddingTop: "12px" }}>{children}</div>}
+    </div>
+  );
+}

--- a/webapp/app/src/ds/Terminal.tsx
+++ b/webapp/app/src/ds/Terminal.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+
+export type TerminalLineKind = "command" | "response" | "ok" | "error" | "muted" | "plain";
+export type TerminalLine = { text: string; kind?: TerminalLineKind };
+
+export type TerminalProps = {
+  lines?: TerminalLine[];
+  showInput?: boolean;
+  placeholder?: string;
+  onSend?: (value: string) => void;
+  style?: React.CSSProperties;
+} & Omit<React.HTMLAttributes<HTMLDivElement>, "style">;
+
+/**
+ * Terminal — the SCPI command console (TerminalWidget). Dark #1e1e1e panel,
+ * Courier New, colour-coded lines. Optional input row with the signature
+ * green-bordered field + Send / Clear buttons.
+ *
+ * `lines` is an array of { text, kind } where kind ∈
+ *   command | response | ok | error | muted | plain
+ */
+const LINE_COLORS: Record<TerminalLineKind, string> = {
+  command: "var(--term-command)",
+  response: "var(--term-response)",
+  ok: "var(--term-ok)",
+  error: "var(--term-error)",
+  muted: "var(--term-muted)",
+  plain: "var(--scope-text-body)",
+};
+
+export function Terminal({
+  lines = [],
+  showInput = true,
+  placeholder = "Enter SCPI command here (e.g., *IDN?)",
+  onSend,
+  style,
+  ...rest
+}: TerminalProps) {
+  const [cmd, setCmd] = React.useState("");
+  const [focus, setFocus] = React.useState(false);
+  const send = () => {
+    const v = cmd.trim();
+    if (!v) return;
+    onSend && onSend(v);
+    setCmd("");
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "8px",
+        fontFamily: "var(--font-mono)",
+        ...style,
+      }}
+      {...rest}
+    >
+      <div
+        style={{
+          background: "var(--scope-panel)",
+          color: "var(--scope-text-body)",
+          border: "1px solid var(--scope-border-soft)",
+          borderRadius: "var(--radius-sm)",
+          padding: "10px 12px",
+          fontSize: "var(--text-sm)",
+          lineHeight: 1.55,
+          overflowY: "auto",
+          flex: 1,
+          minHeight: 0,
+        }}
+      >
+        {lines.length === 0 && (
+          <div style={{ color: "var(--term-ok)" }}>=== SCPI Terminal Ready ===</div>
+        )}
+        {lines.map((l, i) => (
+          <div key={i} style={{ color: LINE_COLORS[l.kind ?? "plain"] || LINE_COLORS.plain, whiteSpace: "pre-wrap" }}>
+            {l.text}
+          </div>
+        ))}
+      </div>
+
+      {showInput && (
+        <div style={{ display: "flex", gap: "8px" }}>
+          <input
+            value={cmd}
+            placeholder={placeholder}
+            onChange={(e) => setCmd(e.target.value)}
+            onFocus={() => setFocus(true)}
+            onBlur={() => setFocus(false)}
+            onKeyDown={(e) => { if (e.key === "Enter") send(); }}
+            style={{
+              flex: 1,
+              minWidth: 0,
+              fontFamily: "var(--font-mono)",
+              fontSize: "var(--text-sm)",
+              color: "var(--text-primary)",
+              background: "var(--surface)",
+              padding: "6px 8px",
+              border: `2px solid ${focus ? "var(--success-hover)" : "var(--success)"}`,
+              borderRadius: "var(--radius-sm)",
+              outline: "none",
+            }}
+          />
+          <button
+            type="button"
+            onClick={send}
+            style={{
+              background: "var(--success)", color: "#fff", fontWeight: "var(--weight-bold)",
+              fontFamily: "var(--font-ui)", border: "none", borderRadius: "var(--radius-sm)",
+              padding: "6px 20px", cursor: "pointer",
+            }}
+          >
+            Send
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/app/src/ds/Toolbar.tsx
+++ b/webapp/app/src/ds/Toolbar.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+export type ToolbarProps = {
+  children?: React.ReactNode;
+  right?: React.ReactNode;
+  style?: React.CSSProperties;
+} & Omit<React.HTMLAttributes<HTMLDivElement>, "style">;
+
+/**
+ * Toolbar — the main window's top action bar (below the menu). A light strip
+ * with a bottom border that holds action buttons on the left and, optionally,
+ * status content pushed to the right. Compose Button (variant="ghost" for the
+ * plain text actions) and StatusIndicator inside it.
+ */
+export function Toolbar({ children, right, style, ...rest }: ToolbarProps) {
+  return (
+    <div
+      role="toolbar"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        minHeight: "var(--toolbar-height)",
+        padding: "6px 10px",
+        background: "var(--app-bg)",
+        borderBottom: "1px solid var(--border)",
+        fontFamily: "var(--font-ui)",
+        ...style,
+      }}
+      {...rest}
+    >
+      {children}
+      {right != null && (
+        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: "10px" }}>
+          {right}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Thin vertical rule to group toolbar actions, mirroring the app's separators. */
+export function ToolbarSeparator() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        width: "1px",
+        alignSelf: "stretch",
+        margin: "6px 4px",
+        background: "var(--divider)",
+      }}
+    />
+  );
+}

--- a/webapp/app/src/ds/ds.css
+++ b/webapp/app/src/ds/ds.css
@@ -1,0 +1,4 @@
+@keyframes scpi-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}

--- a/webapp/app/src/features/connect/ConnectDialog.test.tsx
+++ b/webapp/app/src/features/connect/ConnectDialog.test.tsx
@@ -44,4 +44,22 @@ describe("ConnectDialog", () => {
 
     expect(await screen.findByText(/connection refused/i)).toBeInTheDocument();
   });
+
+  it("offers to resume an already-connected session on mount", async () => {
+    const existing = { id: "xyz", label: "bench", mock: false, address: "192.168.1.50", state: "connected", idn: "Siglent,SDS824X HD,1,1", model: "SDS824X HD", dialect: "modern", num_channels: 4 };
+    vi.spyOn(api, "listSessions").mockResolvedValue([existing]);
+    vi.spyOn(api, "discover").mockResolvedValue([]);
+    const onConnected = vi.fn();
+    render(<ConnectDialog onConnected={onConnected} />);
+    await userEvent.click(await screen.findByRole("button", { name: /resume/i }));
+    expect(onConnected).toHaveBeenCalledWith(existing);
+  });
+
+  it("shows no resume section when there are no existing sessions", async () => {
+    vi.spyOn(api, "listSessions").mockResolvedValue([]);
+    render(<ConnectDialog onConnected={vi.fn()} />);
+    // give the mount effect a tick
+    await screen.findByRole("button", { name: /scan network/i });
+    expect(screen.queryByRole("button", { name: /resume/i })).toBeNull();
+  });
 });

--- a/webapp/app/src/features/connect/ConnectDialog.test.tsx
+++ b/webapp/app/src/features/connect/ConnectDialog.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConnectDialog } from "./ConnectDialog";
+import { api } from "../../api/client";
+
+afterEach(() => vi.restoreAllMocks());
+
+const DEVICE = { address: "192.168.1.50", idn: "Siglent Technologies,SDS824X HD,X,1", manufacturer: "Siglent Technologies", model: "SDS824X HD", dialect: "modern", kind: "scope", connected: false };
+const SESSION = { id: "abc", label: "bench", mock: false, address: "192.168.1.50", state: "connected", idn: DEVICE.idn, model: "SDS824X HD", dialect: "modern", num_channels: 4 };
+
+describe("ConnectDialog", () => {
+  it("scans and connects to a discovered instrument", async () => {
+    vi.spyOn(api, "discover").mockResolvedValue([DEVICE]);
+    const createSession = vi.spyOn(api, "createSession").mockResolvedValue(SESSION);
+    const onConnected = vi.fn();
+    render(<ConnectDialog onConnected={onConnected} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /scan network/i }));
+    await screen.findByText("192.168.1.50");
+    await userEvent.click(screen.getByRole("button", { name: /^connect$/i }));
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ address: "192.168.1.50", label: "SDS824X HD" }));
+    await waitFor(() => expect(onConnected).toHaveBeenCalledWith(SESSION));
+  });
+
+  it("connects a mock session without scanning", async () => {
+    const createSession = vi.spyOn(api, "createSession").mockResolvedValue({ ...SESSION, mock: true, address: null });
+    const onConnected = vi.fn();
+    render(<ConnectDialog onConnected={onConnected} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /mock scope/i }));
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ mock: true }));
+    await waitFor(() => expect(onConnected).toHaveBeenCalled());
+  });
+
+  it("shows the server's error detail when connect fails", async () => {
+    const { ApiError } = await import("../../api/client");
+    vi.spyOn(api, "createSession").mockRejectedValue(new ApiError(500, "SiglentConnectionError", "connection refused"));
+    render(<ConnectDialog onConnected={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /mock scope/i }));
+
+    expect(await screen.findByText(/connection refused/i)).toBeInTheDocument();
+  });
+});

--- a/webapp/app/src/features/connect/ConnectDialog.tsx
+++ b/webapp/app/src/features/connect/ConnectDialog.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { ApiError, api } from "../../api/client";
+import type { DiscoveredDevice, SessionInfo } from "../../api/types";
+import { Button } from "../../ds/Button";
+import { GroupBox } from "../../ds/GroupBox";
+
+type Props = { onConnected: (session: SessionInfo) => void };
+
+export function ConnectDialog({ onConnected }: Props) {
+  const [devices, setDevices] = useState<DiscoveredDevice[]>([]);
+  const [scanning, setScanning] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [address, setAddress] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  async function scan() {
+    setScanning(true);
+    setError(null);
+    try {
+      setDevices(await api.discover());
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    } finally {
+      setScanning(false);
+    }
+  }
+
+  async function connect(body: Parameters<typeof api.createSession>[0]) {
+    setBusy(true);
+    setError(null);
+    try {
+      onConnected(await api.createSession(body));
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 620, margin: "48px auto", display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+      <GroupBox title="Find an instrument">
+        <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "center", marginBottom: "var(--space-3)" }}>
+          <Button onClick={scan} disabled={scanning}>
+            {scanning ? "Scanning…" : "Scan network"}
+          </Button>
+          <span style={{ fontSize: "var(--text-xs)", color: "var(--lc-muted)" }}>Scans this machine's subnet on port 5025</span>
+        </div>
+        {devices.length > 0 && (
+          <table style={{ width: "100%", fontSize: "var(--text-sm)", borderCollapse: "collapse" }}>
+            <tbody>
+              {devices.map((device) => (
+                <tr key={device.address} style={{ borderTop: "1px solid var(--lc-border)" }}>
+                  <td style={{ padding: "6px 4px", fontFamily: "var(--font-mono)" }}>{device.address}</td>
+                  <td style={{ padding: "6px 4px" }}>{device.model}</td>
+                  <td style={{ padding: "6px 4px", color: "var(--lc-muted)" }}>{device.dialect}</td>
+                  <td style={{ padding: "6px 4px", textAlign: "right" }}>
+                    {device.connected ? (
+                      <span style={{ color: "var(--lc-muted)" }}>in use</span>
+                    ) : (
+                      <Button size="sm" variant="primary" disabled={busy} onClick={() => connect({ address: device.address, label: device.model })}>
+                        Connect
+                      </Button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </GroupBox>
+
+      <GroupBox title="Connect manually">
+        <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "center" }}>
+          <input
+            aria-label="IP address"
+            value={address}
+            onChange={(event) => setAddress(event.target.value)}
+            placeholder="192.168.1.50"
+            style={{ flex: 1, padding: "6px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--text-sm)", border: "1px solid var(--lc-border-strong)", borderRadius: "var(--lc-radius-sm)", background: "var(--lc-control)", color: "var(--lc-text)" }}
+          />
+          <Button
+            aria-label="Connect manually"
+            variant="primary"
+            disabled={busy || !address.trim()}
+            onClick={() => connect({ address: address.trim(), label: address.trim() })}
+          >
+            Connect
+          </Button>
+        </div>
+      </GroupBox>
+
+      <GroupBox title="No hardware?">
+        <Button disabled={busy} onClick={() => connect({ mock: true })}>
+          Mock scope
+        </Button>
+      </GroupBox>
+
+      {error && (
+        <div role="alert" style={{ padding: "8px 10px", borderRadius: "var(--radius-sm)", background: "color-mix(in srgb, var(--danger) 12%, transparent)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/app/src/features/connect/ConnectDialog.tsx
+++ b/webapp/app/src/features/connect/ConnectDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ApiError, api } from "../../api/client";
 import type { DiscoveredDevice, SessionInfo } from "../../api/types";
 import { Button } from "../../ds/Button";
@@ -12,6 +12,14 @@ export function ConnectDialog({ onConnected }: Props) {
   const [busy, setBusy] = useState(false);
   const [address, setAddress] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [existingSessions, setExistingSessions] = useState<SessionInfo[]>([]);
+
+  useEffect(() => {
+    api
+      .listSessions()
+      .then(setExistingSessions)
+      .catch(() => setExistingSessions([]));
+  }, []);
 
   async function scan() {
     setScanning(true);
@@ -39,6 +47,27 @@ export function ConnectDialog({ onConnected }: Props) {
 
   return (
     <div style={{ maxWidth: 620, margin: "48px auto", display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+      {existingSessions.length > 0 && (
+        <GroupBox title="Resume a session">
+          <table style={{ width: "100%", fontSize: "var(--text-sm)", borderCollapse: "collapse" }}>
+            <tbody>
+              {existingSessions.map((s) => (
+                <tr key={s.id} style={{ borderTop: "1px solid var(--lc-border)" }}>
+                  <td style={{ padding: "6px 4px" }}>{s.label}</td>
+                  <td style={{ padding: "6px 4px" }}>{s.model}</td>
+                  <td style={{ padding: "6px 4px", fontFamily: "var(--font-mono)", color: "var(--lc-muted)" }}>{s.address ?? "mock"}</td>
+                  <td style={{ padding: "6px 4px", textAlign: "right" }}>
+                    <Button size="sm" variant="primary" onClick={() => onConnected(s)}>
+                      Resume
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </GroupBox>
+      )}
+
       <GroupBox title="Find an instrument">
         <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "center", marginBottom: "var(--space-3)" }}>
           <Button onClick={scan} disabled={scanning}>

--- a/webapp/app/src/features/controls/ChannelsPanel.test.tsx
+++ b/webapp/app/src/features/controls/ChannelsPanel.test.tsx
@@ -40,6 +40,16 @@ describe("ChannelsPanel", () => {
     expect(useSession.getState().scope?.channels["2"].enabled).toBe(false);
   });
 
+  it("editing V/div by its accessible name PATCHes the channel", async () => {
+    const patchChannel = vi.spyOn(api, "patchChannel").mockResolvedValue(STATE);
+    render(<ChannelsPanel />);
+    const field = screen.getByLabelText("V/div C1");
+    await userEvent.clear(field);
+    await userEvent.type(field, "2");
+    await userEvent.tab();
+    await waitFor(() => expect(patchChannel).toHaveBeenCalledWith("abc", 1, { voltage_scale: 2 }));
+  });
+
   it("changing coupling PATCHes the new value", async () => {
     const patchChannel = vi.spyOn(api, "patchChannel").mockResolvedValue(STATE);
     render(<ChannelsPanel />);

--- a/webapp/app/src/features/controls/ChannelsPanel.test.tsx
+++ b/webapp/app/src/features/controls/ChannelsPanel.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChannelsPanel } from "./ChannelsPanel";
+import { api } from "../../api/client";
+import { useSession } from "../../store/session";
+
+const STATE = {
+  run_state: "STOP",
+  timebase: 0.001,
+  channels: {
+    "1": { enabled: true, voltage_scale: 0.5, voltage_offset: 0, coupling: "DC", probe_ratio: 10 },
+    "2": { enabled: false, voltage_scale: 1, voltage_offset: 0, coupling: "AC", probe_ratio: 1 },
+  },
+  trigger: { mode: "AUTO", source: "C1", level: 0.5, slope: "POS", coupling: "DC" },
+};
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "SDS1104X-E", dialect: "legacy", num_channels: 2 });
+  useSession.getState().applyState(STATE);
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("ChannelsPanel", () => {
+  it("renders one group per channel with its settings", () => {
+    render(<ChannelsPanel />);
+    expect(screen.getByText("C1")).toBeInTheDocument();
+    expect(screen.getByText("C2")).toBeInTheDocument();
+  });
+
+  it("toggling enable PATCHes the channel and does not mutate the store directly", async () => {
+    const patchChannel = vi.spyOn(api, "patchChannel").mockResolvedValue(STATE);
+    render(<ChannelsPanel />);
+
+    await userEvent.click(screen.getByLabelText("Enable C2"));
+
+    await waitFor(() => expect(patchChannel).toHaveBeenCalledWith("abc", 2, { enabled: true }));
+    // store still shows the server's last snapshot — the WS broadcast is the only writer
+    expect(useSession.getState().scope?.channels["2"].enabled).toBe(false);
+  });
+
+  it("changing coupling PATCHes the new value", async () => {
+    const patchChannel = vi.spyOn(api, "patchChannel").mockResolvedValue(STATE);
+    render(<ChannelsPanel />);
+
+    await userEvent.selectOptions(screen.getByLabelText("Coupling C1"), "AC");
+
+    await waitFor(() => expect(patchChannel).toHaveBeenCalledWith("abc", 1, { coupling: "AC" }));
+  });
+});

--- a/webapp/app/src/features/controls/ChannelsPanel.tsx
+++ b/webapp/app/src/features/controls/ChannelsPanel.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { ApiError, api } from "../../api/client";
+import type { ChannelPatch, ChannelState } from "../../api/types";
+import { Checkbox } from "../../ds/Checkbox";
+import { ComboBox } from "../../ds/ComboBox";
+import { GroupBox } from "../../ds/GroupBox";
+import { SpinBox } from "../../ds/SpinBox";
+import { useSession } from "../../store/session";
+
+// Stable reference: zustand v5 hands the selector straight to useSyncExternalStore
+// with no memoization, so a fresh `{}` per snapshot would loop forever while scope is null.
+const NO_CHANNELS: Record<string, ChannelState> = {};
+
+const COUPLINGS = ["DC", "AC", "GND"];
+const PROBE_RATIOS = ["1", "10", "100"];
+
+export function ChannelsPanel() {
+  const session = useSession((s) => s.session);
+  const channels = useSession((s) => s.scope?.channels ?? NO_CHANNELS);
+  const [error, setError] = useState<string | null>(null);
+
+  async function send(channel: number, patch: ChannelPatch) {
+    if (!session) return;
+    setError(null);
+    try {
+      await api.patchChannel(session.id, channel, patch);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  const numbers = Object.keys(channels)
+    .map((key) => Number(key))
+    .sort((a, b) => a - b);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+      {numbers.map((n) => {
+        const channel = channels[String(n)];
+        return (
+          <GroupBox key={n} title={`C${n}`} titleColor={`var(--ch${n})`}>
+            <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+              <Checkbox
+                aria-label={`Enable C${n}`}
+                checked={channel.enabled}
+                onChange={(next) => send(n, { enabled: next })}
+              />
+              <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+                V/div
+                <SpinBox
+                  aria-label={`V/div C${n}`}
+                  value={channel.voltage_scale}
+                  step={0.1}
+                  decimals={3}
+                  suffix=" V"
+                  onChange={(value) => send(n, { voltage_scale: value })}
+                />
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+                Offset
+                <SpinBox
+                  aria-label={`Offset C${n}`}
+                  value={channel.voltage_offset}
+                  step={0.1}
+                  decimals={3}
+                  suffix=" V"
+                  onChange={(value) => send(n, { voltage_offset: value })}
+                />
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+                Coupling
+                <ComboBox
+                  aria-label={`Coupling C${n}`}
+                  options={COUPLINGS}
+                  value={channel.coupling}
+                  onChange={(value) => send(n, { coupling: value })}
+                />
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+                Probe
+                <ComboBox
+                  aria-label={`Probe C${n}`}
+                  options={channel.probe_ratio == null ? ["", ...PROBE_RATIOS] : PROBE_RATIOS}
+                  value={channel.probe_ratio == null ? "" : String(channel.probe_ratio)}
+                  onChange={(value) => send(n, { probe_ratio: Number(value) })}
+                />
+              </div>
+            </div>
+          </GroupBox>
+        );
+      })}
+      {error && (
+        <div role="alert" style={{ padding: "8px 10px", borderRadius: "var(--radius-sm)", background: "color-mix(in srgb, var(--danger) 12%, transparent)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/app/src/features/controls/ScopeToolbar.test.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.test.tsx
@@ -39,4 +39,13 @@ describe("ScopeToolbar", () => {
     await userEvent.click(screen.getByRole("button", { name: "Run" }));
     expect(await screen.findByRole("alert")).toHaveTextContent("session abc is error");
   });
+
+  it("returns to disconnected even if the session is already gone (DELETE 404)", async () => {
+    const { ApiError } = await import("../../api/client");
+    vi.spyOn(api, "deleteSession").mockRejectedValue(new ApiError(404, "HTTPException", "unknown session abc"));
+    render(<ScopeToolbar />);
+    await userEvent.click(screen.getByRole("button", { name: /disconnect/i }));
+    await waitFor(() => expect(useSession.getState().session).toBeNull());
+    expect(useSession.getState().status).toBe("disconnected");
+  });
 });

--- a/webapp/app/src/features/controls/ScopeToolbar.test.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ScopeToolbar } from "./ScopeToolbar";
+import { api } from "../../api/client";
+import { useSession } from "../../store/session";
+
+const STATE = { run_state: "STOP", timebase: 0.001, channels: { "1": { enabled: true, voltage_scale: 0.5, voltage_offset: 0, coupling: "DC", probe_ratio: 10 } }, trigger: { mode: "AUTO", source: "C1", level: 0, slope: "POS", coupling: "DC" } };
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4 });
+  useSession.getState().applyState(STATE);
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("ScopeToolbar", () => {
+  it.each([
+    ["Run", "run"],
+    ["Stop", "stop"],
+    ["Single", "single"],
+    ["Auto", "auto"],
+  ])("%s posts the %s op", async (label, op) => {
+    const runOp = vi.spyOn(api, "runOp").mockResolvedValue(STATE);
+    render(<ScopeToolbar />);
+    await userEvent.click(screen.getByRole("button", { name: label }));
+    await waitFor(() => expect(runOp).toHaveBeenCalledWith("abc", op));
+  });
+
+  it("shows the run state from the store", () => {
+    render(<ScopeToolbar />);
+    expect(screen.getByText("STOP")).toBeInTheDocument();
+  });
+
+  it("surfaces an ApiError detail", async () => {
+    const { ApiError } = await import("../../api/client");
+    vi.spyOn(api, "runOp").mockRejectedValue(new ApiError(409, "SessionError", "session abc is error"));
+    render(<ScopeToolbar />);
+    await userEvent.click(screen.getByRole("button", { name: "Run" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("session abc is error");
+  });
+});

--- a/webapp/app/src/features/controls/ScopeToolbar.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.tsx
@@ -4,6 +4,7 @@ import type { RunOp } from "../../api/types";
 import { Button } from "../../ds/Button";
 import { Toolbar, ToolbarSeparator } from "../../ds/Toolbar";
 import { useSession } from "../../store/session";
+import { ExportButton } from "../export/ExportButton";
 
 export function ScopeToolbar() {
   const session = useSession((s) => s.session);
@@ -33,7 +34,14 @@ export function ScopeToolbar() {
 
   return (
     <div style={{ display: "flex", flexDirection: "column" }}>
-      <Toolbar right={<Button variant="danger" onClick={disconnect}>Disconnect</Button>}>
+      <Toolbar
+        right={
+          <>
+            <ExportButton />
+            <Button variant="danger" onClick={disconnect}>Disconnect</Button>
+          </>
+        }
+      >
         <Button variant="ghost" onClick={() => op("run")}>Run</Button>
         <Button variant="ghost" onClick={() => op("stop")}>Stop</Button>
         <Button variant="ghost" onClick={() => op("single")}>Single</Button>

--- a/webapp/app/src/features/controls/ScopeToolbar.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.tsx
@@ -26,9 +26,10 @@ export function ScopeToolbar() {
     setError(null);
     try {
       await api.deleteSession(session.id);
+    } catch {
+      // already gone server-side (404) or unreachable — we're disconnecting locally regardless
+    } finally {
       useSession.getState().clearSession();
-    } catch (err) {
-      setError(err instanceof ApiError ? err.detail : String(err));
     }
   }
 

--- a/webapp/app/src/features/controls/ScopeToolbar.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { ApiError, api } from "../../api/client";
+import type { RunOp } from "../../api/types";
+import { Button } from "../../ds/Button";
+import { Toolbar, ToolbarSeparator } from "../../ds/Toolbar";
+import { useSession } from "../../store/session";
+
+export function ScopeToolbar() {
+  const session = useSession((s) => s.session);
+  const runState = useSession((s) => s.scope?.run_state);
+  const [error, setError] = useState<string | null>(null);
+
+  async function op(next: RunOp) {
+    if (!session) return;
+    setError(null);
+    try {
+      await api.runOp(session.id, next);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  async function disconnect() {
+    if (!session) return;
+    setError(null);
+    try {
+      await api.deleteSession(session.id);
+      useSession.getState().clearSession();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      <Toolbar right={<Button variant="danger" onClick={disconnect}>Disconnect</Button>}>
+        <Button variant="ghost" onClick={() => op("run")}>Run</Button>
+        <Button variant="ghost" onClick={() => op("stop")}>Stop</Button>
+        <Button variant="ghost" onClick={() => op("single")}>Single</Button>
+        <Button variant="ghost" onClick={() => op("auto")}>Auto</Button>
+        <ToolbarSeparator />
+        <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-sm)", color: "var(--lc-text-2)" }}>{runState}</span>
+      </Toolbar>
+      {error && (
+        <div role="alert" style={{ padding: "8px 10px", borderRadius: "var(--radius-sm)", background: "color-mix(in srgb, var(--danger) 12%, transparent)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/app/src/features/controls/TriggerPanel.test.tsx
+++ b/webapp/app/src/features/controls/TriggerPanel.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TriggerPanel } from "./TriggerPanel";
+import { api } from "../../api/client";
+import { useSession } from "../../store/session";
+
+const NULL_TRIGGER_STATE = {
+  run_state: "STOP",
+  timebase: 0.001,
+  channels: {
+    "1": { enabled: true, voltage_scale: 0.5, voltage_offset: 0, coupling: "DC", probe_ratio: null },
+  },
+  trigger: { mode: "AUTO", source: null, level: null, slope: null, coupling: null },
+};
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4 });
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("TriggerPanel null-tolerance", () => {
+  it("renders without crashing when trigger fields are null", () => {
+    useSession.getState().applyState(NULL_TRIGGER_STATE);
+    expect(() => render(<TriggerPanel />)).not.toThrow();
+    expect(screen.getByLabelText("Trigger level")).toBeInTheDocument();
+  });
+
+  it("renders without crashing before any scope state has arrived", () => {
+    // scope is still null here — this is the state right after setSession(), before the
+    // first WS `state` broadcast lands.
+    expect(() => render(<TriggerPanel />)).not.toThrow();
+    expect(screen.getByLabelText("Timebase")).toBeInTheDocument();
+  });
+
+  it("still allows setting a value on a null trigger source", async () => {
+    useSession.getState().applyState(NULL_TRIGGER_STATE);
+    const patchTrigger = vi.spyOn(api, "patchTrigger").mockResolvedValue(NULL_TRIGGER_STATE);
+    render(<TriggerPanel />);
+
+    await userEvent.selectOptions(screen.getByLabelText("Trigger source"), "C2");
+
+    await waitFor(() => expect(patchTrigger).toHaveBeenCalledWith("abc", { source: "C2" }));
+  });
+});

--- a/webapp/app/src/features/controls/TriggerPanel.tsx
+++ b/webapp/app/src/features/controls/TriggerPanel.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import { ApiError, api } from "../../api/client";
+import type { TriggerPatch } from "../../api/types";
+import { ComboBox } from "../../ds/ComboBox";
+import { GroupBox } from "../../ds/GroupBox";
+import { SpinBox } from "../../ds/SpinBox";
+import { useSession } from "../../store/session";
+
+const MODES = ["AUTO", "NORM", "SINGLE", "STOP"];
+const SLOPES = ["POS", "NEG"];
+
+function withNull(options: string[], value: string | null) {
+  return value == null ? ["", ...options] : options;
+}
+
+export function TriggerPanel() {
+  const session = useSession((s) => s.session);
+  const trigger = useSession((s) => s.scope?.trigger);
+  const timebase = useSession((s) => s.scope?.timebase);
+  const numChannels = session?.num_channels ?? 0;
+  const [error, setError] = useState<string | null>(null);
+
+  async function send(patch: TriggerPatch) {
+    if (!session) return;
+    setError(null);
+    try {
+      await api.patchTrigger(session.id, patch);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  async function sendTimebase(seconds: number) {
+    if (!session) return;
+    setError(null);
+    try {
+      await api.patchTimebase(session.id, seconds);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  const sources = [...Array.from({ length: numChannels }, (_, i) => `C${i + 1}`), "EX", "LINE"];
+
+  return (
+    <GroupBox title="Trigger">
+      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+          Mode
+          <ComboBox
+            aria-label="Trigger mode"
+            options={MODES}
+            value={trigger?.mode ?? ""}
+            onChange={(value) => send({ mode: value })}
+          />
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+          Source
+          <ComboBox
+            aria-label="Trigger source"
+            options={withNull(sources, trigger?.source ?? null)}
+            value={trigger?.source ?? ""}
+            onChange={(value) => send({ source: value })}
+          />
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+          Slope
+          <ComboBox
+            aria-label="Trigger slope"
+            options={withNull(SLOPES, trigger?.slope ?? null)}
+            value={trigger?.slope ?? ""}
+            onChange={(value) => send({ slope: value })}
+          />
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+          Level
+          <SpinBox
+            aria-label="Trigger level"
+            value={trigger?.level ?? 0}
+            suffix=" V"
+            onChange={(value) => send({ level: value })}
+          />
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+          Timebase
+          <SpinBox
+            aria-label="Timebase"
+            value={timebase ?? 0}
+            decimals={6}
+            suffix=" s/div"
+            onChange={(value) => sendTimebase(value)}
+          />
+        </div>
+      </div>
+      {error && (
+        <div role="alert" style={{ padding: "8px 10px", borderRadius: "var(--radius-sm)", background: "color-mix(in srgb, var(--danger) 12%, transparent)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </div>
+      )}
+    </GroupBox>
+  );
+}

--- a/webapp/app/src/features/export/ExportButton.test.tsx
+++ b/webapp/app/src/features/export/ExportButton.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ExportButton } from "./ExportButton";
+import { useSession } from "../../store/session";
+
+const BASE = { run_state: "STOP", timebase: 0.001, trigger: { mode: "AUTO", source: "C1", level: 0, slope: "POS", coupling: "DC" } };
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4 });
+});
+
+describe("ExportButton", () => {
+  it("links to the capture URL for enabled channels only", () => {
+    useSession.getState().applyState({
+      ...BASE,
+      channels: {
+        "1": { enabled: true, voltage_scale: 1, voltage_offset: 0, coupling: "DC", probe_ratio: 1 },
+        "2": { enabled: false, voltage_scale: 1, voltage_offset: 0, coupling: "DC", probe_ratio: 1 },
+        "3": { enabled: true, voltage_scale: 1, voltage_offset: 0, coupling: "DC", probe_ratio: 1 },
+      },
+    });
+    render(<ExportButton />);
+    const link = screen.getByRole("link", { name: /export csv/i });
+    expect(link).toHaveAttribute("href", "/api/sessions/abc/scope/capture.csv?channels=1,3");
+    expect(link).toHaveAttribute("download");
+  });
+
+  it("is disabled when no channel is enabled", () => {
+    useSession.getState().applyState({ ...BASE, channels: { "1": { enabled: false, voltage_scale: 1, voltage_offset: 0, coupling: "DC", probe_ratio: 1 } } });
+    render(<ExportButton />);
+    expect(screen.getByText(/export csv/i).closest("a")).toBeNull();
+  });
+});

--- a/webapp/app/src/features/export/ExportButton.tsx
+++ b/webapp/app/src/features/export/ExportButton.tsx
@@ -1,0 +1,27 @@
+import { api } from "../../api/client";
+import type { ChannelState } from "../../api/types";
+import { useSession } from "../../store/session";
+
+// Stable reference: zustand v5 hands the selector straight to useSyncExternalStore
+// with no memoization, so a fresh `{}` per snapshot would loop forever while scope is null.
+const NO_CHANNELS: Record<string, ChannelState> = {};
+
+export function ExportButton() {
+  const session = useSession((s) => s.session);
+  const channels = useSession((s) => s.scope?.channels ?? NO_CHANNELS);
+  const enabled = Object.entries(channels)
+    .filter(([, channel]) => channel.enabled)
+    .map(([key]) => Number(key))
+    .sort((a, b) => a - b);
+
+  const style = { fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "6px 12px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", textDecoration: "none" } as const;
+
+  if (!session || enabled.length === 0) {
+    return <span style={{ ...style, color: "var(--lc-muted)", opacity: 0.6 }}>Export CSV</span>;
+  }
+  return (
+    <a href={api.captureUrl(session.id, enabled)} download style={style}>
+      Export CSV
+    </a>
+  );
+}

--- a/webapp/app/src/features/measure/MeasurePanel.test.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.test.tsx
@@ -77,4 +77,69 @@ describe("MeasurePanel", () => {
       ]),
     );
   });
+
+  // The backend only broadcasts measurements when its list is NON-empty
+  // (sessions.py: `if self.measurements and self._poll_count % N == 0`), so after deselecting
+  // everything the store keeps the last streamed values forever. Falling back to the store
+  // would re-check the box and resurrect the measurement on the next PUT.
+  it("deselecting the last measurement stays deselected (server never broadcasts an empty list)", async () => {
+    const setMeasurements = vi
+      .spyOn(api, "setMeasurements")
+      .mockResolvedValueOnce({ measurements: [{ channel: 1, mtype: "PKPK" }] })
+      .mockResolvedValueOnce({ measurements: [] });
+    render(<MeasurePanel />);
+
+    await userEvent.click(screen.getByLabelText("PKPK C1"));
+    await waitFor(() => expect(setMeasurements).toHaveBeenCalledWith("abc", [{ channel: 1, mtype: "PKPK" }]));
+
+    // the stream delivers a value for the active measurement
+    act(() => useSession.getState().applyMeasurements([{ channel: 1, mtype: "PKPK", value: 2.5 }]));
+
+    // now uncheck it — this must PUT [] and STAY unchecked
+    await userEvent.click(screen.getByLabelText("PKPK C1"));
+    await waitFor(() => expect(setMeasurements).toHaveBeenLastCalledWith("abc", []));
+
+    // and a subsequent selection must NOT resurrect PKPK
+    setMeasurements.mockResolvedValueOnce({ measurements: [{ channel: 1, mtype: "FREQ" }] });
+    await userEvent.click(screen.getByLabelText("FREQ C1"));
+    await waitFor(() => expect(setMeasurements).toHaveBeenLastCalledWith("abc", [{ channel: 1, mtype: "FREQ" }]));
+  });
+
+  // Racing toggles: a slow PUT must not settle the selection after a newer toggle is in flight.
+  // Deterministic — the first response is resolved by hand, no timers.
+  it("a stale PUT response does not clobber a newer in-flight toggle", async () => {
+    type Ack = { measurements: { channel: number; mtype: string }[] };
+    let resolveFirst!: (value: Ack) => void;
+    const first = new Promise<Ack>((resolve) => { resolveFirst = resolve; });
+    const second = new Promise<Ack>(() => {}); // still in flight for the whole test
+
+    const setMeasurements = vi
+      .spyOn(api, "setMeasurements")
+      .mockReturnValueOnce(first)
+      .mockReturnValueOnce(second)
+      .mockResolvedValue({ measurements: [] });
+    render(<MeasurePanel />);
+
+    await userEvent.click(screen.getByLabelText("PKPK C1")); // PUT #1 — slow
+    await userEvent.click(screen.getByLabelText("FREQ C1")); // PUT #2 — supersedes it
+    await waitFor(() =>
+      expect(setMeasurements).toHaveBeenLastCalledWith("abc", [
+        { channel: 1, mtype: "PKPK" },
+        { channel: 1, mtype: "FREQ" },
+      ]),
+    );
+
+    // PUT #1 lands late, echoing only PKPK. It is stale and must be ignored — if it settles the
+    // selection, both boxes flap to unchecked and the next click drops PKPK *and* FREQ.
+    await act(async () => { resolveFirst({ measurements: [{ channel: 1, mtype: "PKPK" }] }); });
+
+    await userEvent.click(screen.getByLabelText("MEAN C1"));
+    await waitFor(() =>
+      expect(setMeasurements).toHaveBeenLastCalledWith("abc", [
+        { channel: 1, mtype: "PKPK" },
+        { channel: 1, mtype: "FREQ" },
+        { channel: 1, mtype: "MEAN" },
+      ]),
+    );
+  });
 });

--- a/webapp/app/src/features/measure/MeasurePanel.test.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MeasurePanel } from "./MeasurePanel";
@@ -33,5 +33,48 @@ describe("MeasurePanel", () => {
 
     expect(screen.getByText("2.500")).toBeInTheDocument();
     expect(screen.getByText("--")).toBeInTheDocument();
+  });
+
+  it("keeps the server's selection after a remount instead of re-seeding stale local state", async () => {
+    const setMeasurements = vi.spyOn(api, "setMeasurements").mockResolvedValue({ measurements: [] });
+    // server truth: PKPK C1 is already active and streaming
+    useSession.getState().applyMeasurements([{ channel: 1, mtype: "PKPK", value: 2.5 }]);
+
+    const view = render(<MeasurePanel />);
+    expect(screen.getByLabelText("PKPK C1")).toBeInTheDocument();
+
+    // simulate a rail-tab switch away and back
+    view.unmount();
+    render(<MeasurePanel />);
+
+    // now toggle a DIFFERENT measurement — the PUT must preserve the server's existing PKPK C1
+    await userEvent.click(screen.getByLabelText("FREQ C1"));
+
+    await waitFor(() =>
+      expect(setMeasurements).toHaveBeenCalledWith("abc", [
+        { channel: 1, mtype: "PKPK" },
+        { channel: 1, mtype: "FREQ" },
+      ]),
+    );
+  });
+
+  // The remount test above only exercises the seed path (the store is already correct at mount).
+  // The selection must track the store on EVERY render: a measurement that arrives on the stream
+  // while the panel stays mounted must survive the next toggle's full-replacement PUT.
+  it("computes the PUT from the server's latest list, not a local mirror captured at mount", async () => {
+    const setMeasurements = vi.spyOn(api, "setMeasurements").mockResolvedValue({ measurements: [] });
+    render(<MeasurePanel />); // store starts with no measurements
+
+    // server truth arrives on the stream after mount (restored session / another client / late broadcast)
+    act(() => useSession.getState().applyMeasurements([{ channel: 1, mtype: "PKPK", value: 2.5 }]));
+
+    await userEvent.click(screen.getByLabelText("FREQ C1"));
+
+    await waitFor(() =>
+      expect(setMeasurements).toHaveBeenCalledWith("abc", [
+        { channel: 1, mtype: "PKPK" },
+        { channel: 1, mtype: "FREQ" },
+      ]),
+    );
   });
 });

--- a/webapp/app/src/features/measure/MeasurePanel.test.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MeasurePanel } from "./MeasurePanel";
+import { api } from "../../api/client";
+import { useSession } from "../../store/session";
+
+const STATE = { run_state: "STOP", timebase: 0.001, channels: { "1": { enabled: true, voltage_scale: 0.5, voltage_offset: 0, coupling: "DC", probe_ratio: 10 } }, trigger: { mode: "AUTO", source: "C1", level: 0, slope: "POS", coupling: "DC" } };
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4 });
+  useSession.getState().applyState(STATE);
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("MeasurePanel", () => {
+  it("PUTs the selected measurement list", async () => {
+    const setMeasurements = vi.spyOn(api, "setMeasurements").mockResolvedValue({ measurements: [{ channel: 1, mtype: "PKPK" }] });
+    render(<MeasurePanel />);
+
+    await userEvent.click(screen.getByLabelText("PKPK C1"));
+
+    await waitFor(() => expect(setMeasurements).toHaveBeenCalledWith("abc", [{ channel: 1, mtype: "PKPK" }]));
+  });
+
+  it("renders streamed values and shows -- for nulls", () => {
+    useSession.getState().applyMeasurements([
+      { channel: 1, mtype: "PKPK", value: 2.5 },
+      { channel: 1, mtype: "FREQ", value: null },
+    ]);
+    render(<MeasurePanel />);
+
+    expect(screen.getByText("2.500")).toBeInTheDocument();
+    expect(screen.getByText("--")).toBeInTheDocument();
+  });
+});

--- a/webapp/app/src/features/measure/MeasurePanel.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { ApiError, api } from "../../api/client";
+import type { ChannelState } from "../../api/types";
+import { Checkbox } from "../../ds/Checkbox";
+import { DataTable } from "../../ds/DataTable";
+import { GroupBox } from "../../ds/GroupBox";
+import { useSession } from "../../store/session";
+
+// Stable reference: zustand v5 hands the selector straight to useSyncExternalStore
+// with no memoization, so a fresh `{}` per snapshot would loop forever while scope is null.
+const NO_CHANNELS: Record<string, ChannelState> = {};
+
+const TYPES = ["PKPK", "AMPL", "MEAN", "RMS", "FREQ", "PER", "MAX", "MIN"];
+
+type Selection = { channel: number; mtype: string };
+
+export function MeasurePanel() {
+  const session = useSession((s) => s.session);
+  const channels = useSession((s) => s.scope?.channels ?? NO_CHANNELS);
+  // s.measurements is already a stable array reference in the store — select it
+  // directly (no `?? []` fallback, which would fabricate a new array every render).
+  const measurements = useSession((s) => s.measurements);
+  const [error, setError] = useState<string | null>(null);
+  // Local selection state seeds from whatever the server already reports as active
+  // (e.g. after a reload) so the checkboxes aren't out of sync with the value table.
+  const [selected, setSelected] = useState<Selection[]>(() =>
+    measurements.map((m) => ({ channel: m.channel, mtype: m.mtype }))
+  );
+
+  const channelNumbers = Object.keys(channels)
+    .map(Number)
+    .filter((n) => channels[String(n)]?.enabled)
+    .sort((a, b) => a - b);
+
+  async function toggle(channel: number, mtype: string, checked: boolean) {
+    const next = checked
+      ? [...selected, { channel, mtype }]
+      : selected.filter((item) => !(item.channel === channel && item.mtype === mtype));
+    setSelected(next);
+    if (!session) return;
+    setError(null);
+    try {
+      await api.setMeasurements(session.id, next);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  const rows = measurements.map((m) => [
+    `C${m.channel}`,
+    m.mtype,
+    m.value === null ? "--" : m.value.toFixed(3),
+  ]);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+      <GroupBox title="Measurements">
+        {channelNumbers.length === 0 && (
+          <div style={{ color: "var(--lc-muted)", fontSize: "var(--text-sm)" }}>No channels enabled.</div>
+        )}
+        <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+          {channelNumbers.map((n) => (
+            <div key={n}>
+              <div style={{ fontWeight: "var(--weight-bold)", color: `var(--ch${n})`, marginBottom: "4px" }}>{`C${n}`}</div>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "6px 14px" }}>
+                {TYPES.map((mtype) => (
+                  <Checkbox
+                    key={mtype}
+                    aria-label={`${mtype} C${n}`}
+                    label={mtype}
+                    checked={selected.some((s) => s.channel === n && s.mtype === mtype)}
+                    onChange={(next) => toggle(n, mtype, next)}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </GroupBox>
+
+      {selected.length === 0 && (
+        <div style={{ color: "var(--lc-muted)", fontSize: "var(--text-sm)" }}>
+          Select a measurement above to see live values.
+        </div>
+      )}
+
+      {session?.dialect === "modern" && (
+        <div style={{ color: "var(--lc-muted)", fontSize: "var(--text-sm)" }}>
+          Measurements are unavailable on modern-dialect scopes.
+        </div>
+      )}
+
+      <DataTable
+        columns={["Ch", "Measurement", { label: "Value", align: "right", mono: true }]}
+        rows={rows}
+      />
+
+      {error && (
+        <div role="alert" style={{ padding: "8px 10px", borderRadius: "var(--radius-sm)", background: "color-mix(in srgb, var(--danger) 12%, transparent)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/app/src/features/measure/MeasurePanel.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { ApiError, api } from "../../api/client";
 import type { ChannelState } from "../../api/types";
 import { Checkbox } from "../../ds/Checkbox";
@@ -21,15 +21,21 @@ export function MeasurePanel() {
   // directly (no `?? []` fallback, which would fabricate a new array every render).
   const measurements = useSession((s) => s.measurements);
   const [error, setError] = useState<string | null>(null);
-  // No local mirror of the selection: the server is the source of truth. A local copy seeded
-  // once at mount goes stale (the stream lags the PUT by up to a broadcast interval, and a rail
-  // tab switch unmounts us), and since PUT /measurements is a FULL REPLACEMENT the next toggle
-  // computed from a stale list would silently drop a measurement the server still has active.
-  // `pending` is only an optimistic overlay for the in-flight toggle, so the checkbox responds
-  // instantly; it clears when the PUT resolves and the streamed truth takes over again.
+  // No local mirror of the selection — the server owns it. But the stream alone cannot carry it:
+  // the backend only broadcasts measurements while its list is NON-empty
+  // (sessions.py: `if self.measurements and self._poll_count % N == 0`), so once you deselect the
+  // last one the store keeps the final streamed values forever. Falling back to the store there
+  // would re-check the box and resurrect the measurement on the next full-replacement PUT.
+  //
+  // The PUT response IS server truth (scope.py echoes the stored list), so we settle to it.
+  // Precedence: in-flight optimistic > last acknowledged > streamed values.
   const [pending, setPending] = useState<Selection[] | null>(null);
+  const [acked, setAcked] = useState<Selection[] | null>(null);
+  // Monotonic request id: a slow PUT must never settle the selection after a newer toggle
+  // superseded it, or both boxes flap to unchecked and the next click drops them server-side.
+  const requestId = useRef(0);
 
-  const selected: Selection[] = pending ?? measurements.map((m) => ({ channel: m.channel, mtype: m.mtype }));
+  const selected: Selection[] = pending ?? acked ?? measurements.map((m) => ({ channel: m.channel, mtype: m.mtype }));
   const isChecked = (channel: number, mtype: string) =>
     selected.some((s) => s.channel === channel && s.mtype === mtype);
 
@@ -43,22 +49,29 @@ export function MeasurePanel() {
     const next = isChecked(channel, mtype)
       ? selected.filter((s) => !(s.channel === channel && s.mtype === mtype))
       : [...selected, { channel, mtype }];
+    const id = ++requestId.current;
     setPending(next);
     setError(null);
     try {
-      await api.setMeasurements(session.id, next);
+      const result = await api.setMeasurements(session.id, next);
+      if (id === requestId.current) {
+        setAcked(result.measurements); // durable across the empty-list broadcast gap
+        setPending(null);
+      }
+      // else: stale response, a newer toggle is in flight — it will settle the selection
     } catch (err) {
-      setError(err instanceof ApiError ? err.detail : String(err));
-    } finally {
-      setPending(null); // fall back to the server's truth
+      if (id === requestId.current) {
+        setError(err instanceof ApiError ? err.detail : String(err));
+        setPending(null); // failed: fall back to the last known truth
+      }
     }
   }
 
-  const rows = measurements.map((m) => [
-    `C${m.channel}`,
-    m.mtype,
-    m.value === null ? "--" : m.value.toFixed(3),
-  ]);
+  // Only render values for measurements that are actually selected — a deselected one lingers in
+  // the store (no empty-list broadcast) and would otherwise keep showing a stale row.
+  const rows = measurements
+    .filter((m) => isChecked(m.channel, m.mtype))
+    .map((m) => [`C${m.channel}`, m.mtype, m.value === null ? "--" : m.value.toFixed(3)]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>

--- a/webapp/app/src/features/measure/MeasurePanel.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.tsx
@@ -21,28 +21,36 @@ export function MeasurePanel() {
   // directly (no `?? []` fallback, which would fabricate a new array every render).
   const measurements = useSession((s) => s.measurements);
   const [error, setError] = useState<string | null>(null);
-  // Local selection state seeds from whatever the server already reports as active
-  // (e.g. after a reload) so the checkboxes aren't out of sync with the value table.
-  const [selected, setSelected] = useState<Selection[]>(() =>
-    measurements.map((m) => ({ channel: m.channel, mtype: m.mtype }))
-  );
+  // No local mirror of the selection: the server is the source of truth. A local copy seeded
+  // once at mount goes stale (the stream lags the PUT by up to a broadcast interval, and a rail
+  // tab switch unmounts us), and since PUT /measurements is a FULL REPLACEMENT the next toggle
+  // computed from a stale list would silently drop a measurement the server still has active.
+  // `pending` is only an optimistic overlay for the in-flight toggle, so the checkbox responds
+  // instantly; it clears when the PUT resolves and the streamed truth takes over again.
+  const [pending, setPending] = useState<Selection[] | null>(null);
+
+  const selected: Selection[] = pending ?? measurements.map((m) => ({ channel: m.channel, mtype: m.mtype }));
+  const isChecked = (channel: number, mtype: string) =>
+    selected.some((s) => s.channel === channel && s.mtype === mtype);
 
   const channelNumbers = Object.keys(channels)
     .map(Number)
     .filter((n) => channels[String(n)]?.enabled)
     .sort((a, b) => a - b);
 
-  async function toggle(channel: number, mtype: string, checked: boolean) {
-    const next = checked
-      ? [...selected, { channel, mtype }]
-      : selected.filter((item) => !(item.channel === channel && item.mtype === mtype));
-    setSelected(next);
+  async function toggle(channel: number, mtype: string) {
     if (!session) return;
+    const next = isChecked(channel, mtype)
+      ? selected.filter((s) => !(s.channel === channel && s.mtype === mtype))
+      : [...selected, { channel, mtype }];
+    setPending(next);
     setError(null);
     try {
       await api.setMeasurements(session.id, next);
     } catch (err) {
       setError(err instanceof ApiError ? err.detail : String(err));
+    } finally {
+      setPending(null); // fall back to the server's truth
     }
   }
 
@@ -68,8 +76,8 @@ export function MeasurePanel() {
                     key={mtype}
                     aria-label={`${mtype} C${n}`}
                     label={mtype}
-                    checked={selected.some((s) => s.channel === n && s.mtype === mtype)}
-                    onChange={(next) => toggle(n, mtype, next)}
+                    checked={isChecked(n, mtype)}
+                    onChange={() => toggle(n, mtype)}
                   />
                 ))}
               </div>

--- a/webapp/app/src/features/readout/ReadoutStrip.test.tsx
+++ b/webapp/app/src/features/readout/ReadoutStrip.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ReadoutStrip } from "./ReadoutStrip";
+import { useSession } from "../../store/session";
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4 });
+  useSession.getState().applyState({
+    run_state: "TRIGD",
+    timebase: 0.001,
+    channels: { "1": { enabled: true, voltage_scale: 0.5, voltage_offset: 0, coupling: "DC", probe_ratio: 10 }, "2": { enabled: false, voltage_scale: 1, voltage_offset: 0, coupling: "AC", probe_ratio: 1 } },
+    trigger: { mode: "AUTO", source: "C1", level: 0, slope: "POS", coupling: "DC" },
+  });
+});
+
+describe("ReadoutStrip", () => {
+  it("shows a card for each enabled channel with its Vpp when measured", () => {
+    useSession.getState().applyMeasurements([{ channel: 1, mtype: "PKPK", value: 2.5 }]);
+    render(<ReadoutStrip />);
+    expect(screen.getByText("C1")).toBeInTheDocument();
+    expect(screen.queryByText("C2")).toBeNull();
+    expect(screen.getByText(/2\.500/)).toBeInTheDocument();
+  });
+
+  it("shows placeholder dashes when no measurement has arrived", () => {
+    render(<ReadoutStrip />);
+    expect(screen.getByText("--.--")).toBeInTheDocument();
+  });
+});

--- a/webapp/app/src/features/readout/ReadoutStrip.tsx
+++ b/webapp/app/src/features/readout/ReadoutStrip.tsx
@@ -1,0 +1,76 @@
+import type { ChannelState, MeasurementValue } from "../../api/types";
+import { Reading } from "../../ds/Reading";
+import { useSession } from "../../store/session";
+
+// Stable reference: zustand v5 hands the selector straight to useSyncExternalStore
+// with no memoization, so a fresh `{}` per snapshot would loop forever while scope is null.
+const NO_CHANNELS: Record<string, ChannelState> = {};
+
+function formatValue(measurement: MeasurementValue | undefined): string {
+  if (measurement === undefined || measurement.value === null || measurement.value === undefined) {
+    return "--.--";
+  }
+  return measurement.value.toFixed(3);
+}
+
+export function ReadoutStrip() {
+  const channels = useSession((s) => s.scope?.channels ?? NO_CHANNELS);
+  // s.measurements is already a stable array reference in the store — select it
+  // directly (no `?? []` fallback, which would fabricate a new array every render).
+  const measurements = useSession((s) => s.measurements);
+
+  const numbers = Object.keys(channels)
+    .map((key) => Number(key))
+    .filter((n) => channels[String(n)]?.enabled)
+    .sort((a, b) => a - b);
+
+  if (numbers.length === 0) return null;
+
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)" }}>
+      {numbers.map((n) => {
+        const channel = channels[String(n)];
+        const pkpk = measurements.find((m) => m.channel === n && m.mtype === "PKPK");
+        const freq = measurements.find((m) => m.channel === n && m.mtype === "FREQ");
+        return (
+          <div
+            key={n}
+            style={{
+              position: "relative",
+              display: "flex",
+              paddingLeft: "13px",
+              paddingTop: "6px",
+              paddingBottom: "6px",
+              paddingRight: "14px",
+              background: "var(--lc-panel)",
+              border: "1px solid var(--lc-border)",
+              borderRadius: "var(--lc-radius-sm)",
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                position: "absolute",
+                left: 0,
+                top: 0,
+                bottom: 0,
+                width: "5px",
+                background: `var(--ch${n})`,
+                borderTopLeftRadius: "var(--lc-radius-sm)",
+                borderBottomLeftRadius: "var(--lc-radius-sm)",
+              }}
+            />
+            <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+              <span style={{ fontWeight: "var(--weight-bold)", color: `var(--ch${n})` }}>{`C${n}`}</span>
+              <span style={{ fontSize: "var(--text-sm)", color: "var(--lc-muted)" }}>
+                {`${channel.coupling} · ${channel.voltage_scale} V/div`}
+              </span>
+              <Reading value={formatValue(pkpk)} unit="V" size="lg" />
+              {freq && <Reading label="FREQ" value={formatValue(freq)} unit="Hz" size="sm" />}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/webapp/app/src/features/terminal/TerminalPanel.test.tsx
+++ b/webapp/app/src/features/terminal/TerminalPanel.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalPanel } from "./TerminalPanel";
+import { api } from "../../api/client";
+import { useSession } from "../../store/session";
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4 });
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("TerminalPanel", () => {
+  it("sends a command and shows the response", async () => {
+    vi.spyOn(api, "command").mockResolvedValue({ command: "*IDN?", response: "Siglent,SDS1104X-E,1,1" });
+    render(<TerminalPanel />);
+
+    await userEvent.type(screen.getByPlaceholderText(/scpi command/i), "*IDN?");
+    await userEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    expect(await screen.findByText(/Siglent,SDS1104X-E/)).toBeInTheDocument();
+    expect(screen.getByText(/\*IDN\?/)).toBeInTheDocument();
+  });
+
+  it("renders a timeout error as an error line", async () => {
+    const { ApiError } = await import("../../api/client");
+    vi.spyOn(api, "command").mockRejectedValue(new ApiError(504, "SiglentTimeoutError", "no response for query: BOGUS?"));
+    render(<TerminalPanel />);
+
+    await userEvent.type(screen.getByPlaceholderText(/scpi command/i), "BOGUS?");
+    await userEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    expect(await screen.findByText(/no response for query/i)).toBeInTheDocument();
+  });
+});

--- a/webapp/app/src/features/terminal/TerminalPanel.tsx
+++ b/webapp/app/src/features/terminal/TerminalPanel.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { ApiError, api } from "../../api/client";
+import { Terminal, type TerminalLine } from "../../ds/Terminal";
+import { useSession } from "../../store/session";
+
+export function TerminalPanel() {
+  const session = useSession((s) => s.session);
+  const [lines, setLines] = useState<TerminalLine[]>([]);
+
+  async function onSend(command: string) {
+    setLines((prev) => [...prev, { text: "> " + command, kind: "command" }]);
+    if (!session) return;
+    try {
+      const result = await api.command(session.id, command);
+      setLines((prev) => [
+        ...prev,
+        { text: result.response ?? "(no response)", kind: result.response ? "response" : "muted" },
+      ]);
+    } catch (err) {
+      const detail = err instanceof ApiError ? err.detail : String(err);
+      setLines((prev) => [...prev, { text: detail, kind: "error" }]);
+    }
+  }
+
+  return (
+    <Terminal
+      lines={lines}
+      onSend={onSend}
+      placeholder="Enter SCPI command here (e.g., *IDN?)"
+      style={{ height: "100%" }}
+    />
+  );
+}

--- a/webapp/app/src/features/waveform/WaveformCanvas.test.tsx
+++ b/webapp/app/src/features/waveform/WaveformCanvas.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import { StrictMode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { WaveformCanvas } from "./WaveformCanvas";
+import { useSession } from "../../store/session";
+
+beforeEach(() => useSession.getState().clearSession());
+
+describe("WaveformCanvas", () => {
+  it("renders with a null scope without an infinite render loop", () => {
+    expect(() => render(<WaveformCanvas />)).not.toThrow();
+  });
+
+  it("renders under StrictMode double-mount without throwing", () => {
+    expect(() =>
+      render(
+        <StrictMode>
+          <WaveformCanvas />
+        </StrictMode>,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/webapp/app/src/features/waveform/WaveformCanvas.tsx
+++ b/webapp/app/src/features/waveform/WaveformCanvas.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef } from "react";
+import { getFrame, subscribeFrames } from "./frames";
+import { useSession } from "../../store/session";
+
+const TRACE = ["#FFDC32", "#40E0D0", "#FF69B4", "#32FF64"];
+const DIVS_X = 14;
+const DIVS_Y = 10;
+const PAD = 8;
+
+export function WaveformCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const channels = useSession((s) => s.scope?.channels ?? {});
+  const enabled = Object.entries(channels)
+    .filter(([, channel]) => channel.enabled)
+    .map(([key]) => Number(key));
+  const enabledKey = enabled.join(",");
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap) return;
+
+    let raf = 0;
+    let dirty = true;
+    const unsubscribe = subscribeFrames(() => {
+      dirty = true;
+    });
+
+    const draw = () => {
+      raf = requestAnimationFrame(draw);
+      if (!dirty) return;
+      dirty = false;
+
+      const dpr = window.devicePixelRatio || 1;
+      const w = wrap.clientWidth;
+      const h = wrap.clientHeight;
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      canvas.style.width = `${w}px`;
+      canvas.style.height = `${h}px`;
+
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.fillStyle = "#0d1117";
+      ctx.fillRect(0, 0, w, h);
+
+      const gw = w - PAD * 2;
+      const gh = h - PAD * 2;
+
+      ctx.save();
+      ctx.setLineDash([1, 3]);
+      ctx.strokeStyle = "#30363d";
+      ctx.lineWidth = 1;
+      for (let i = 1; i < DIVS_X; i += 1) {
+        const x = PAD + (gw * i) / DIVS_X;
+        ctx.beginPath();
+        ctx.moveTo(x, PAD);
+        ctx.lineTo(x, PAD + gh);
+        ctx.stroke();
+      }
+      for (let i = 1; i < DIVS_Y; i += 1) {
+        const y = PAD + (gh * i) / DIVS_Y;
+        ctx.beginPath();
+        ctx.moveTo(PAD, y);
+        ctx.lineTo(PAD + gw, y);
+        ctx.stroke();
+      }
+      ctx.restore();
+
+      ctx.strokeStyle = "#3d444d";
+      ctx.beginPath();
+      ctx.moveTo(PAD + gw / 2, PAD);
+      ctx.lineTo(PAD + gw / 2, PAD + gh);
+      ctx.moveTo(PAD, PAD + gh / 2);
+      ctx.lineTo(PAD + gw, PAD + gh / 2);
+      ctx.stroke();
+
+      let drew = false;
+      enabled.forEach((channel) => {
+        const frame = getFrame(channel);
+        if (!frame || frame.points.length === 0) return;
+        const scale = channels[String(channel)]?.voltage_scale ?? 1;
+        const fullScale = scale * DIVS_Y; // volts across the full canvas height
+        ctx.strokeStyle = TRACE[(channel - 1) % TRACE.length];
+        ctx.lineWidth = 2;
+        ctx.lineJoin = "round";
+        ctx.beginPath();
+        frame.points.forEach((volts, index) => {
+          const x = PAD + (gw * index) / Math.max(1, frame.points.length - 1);
+          const y = PAD + gh / 2 - (volts / fullScale) * gh;
+          if (index === 0) ctx.moveTo(x, y);
+          else ctx.lineTo(x, y);
+        });
+        ctx.stroke();
+        drew = true;
+      });
+
+      if (!drew) {
+        ctx.fillStyle = "#8b949e";
+        ctx.font = "13px var(--font-ui), sans-serif";
+        ctx.textAlign = "center";
+        ctx.fillText("No data — enable a channel and press Run", w / 2, h / 2);
+      }
+    };
+
+    raf = requestAnimationFrame(draw);
+    return () => {
+      cancelAnimationFrame(raf);
+      unsubscribe();
+    };
+  }, [enabledKey, channels]);
+
+  return (
+    <div ref={wrapRef} style={{ position: "relative", flex: 1, minHeight: 320, background: "#0d1117", border: "1px solid var(--scope-border-2)", borderRadius: "var(--lc-radius)" }}>
+      <canvas ref={canvasRef} />
+    </div>
+  );
+}

--- a/webapp/app/src/features/waveform/WaveformCanvas.tsx
+++ b/webapp/app/src/features/waveform/WaveformCanvas.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { getFrame, subscribeFrames } from "./frames";
+import type { ChannelState } from "../../api/types";
 import { useSession } from "../../store/session";
 
 const TRACE = ["#FFDC32", "#40E0D0", "#FF69B4", "#32FF64"];
@@ -7,10 +8,14 @@ const DIVS_X = 14;
 const DIVS_Y = 10;
 const PAD = 8;
 
+// Stable reference: zustand v5 hands the selector straight to useSyncExternalStore
+// with no memoization, so a fresh `{}` per snapshot would loop forever while scope is null.
+const NO_CHANNELS: Record<string, ChannelState> = {};
+
 export function WaveformCanvas() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
-  const channels = useSession((s) => s.scope?.channels ?? {});
+  const channels = useSession((s) => s.scope?.channels ?? NO_CHANNELS);
   const enabled = Object.entries(channels)
     .filter(([, channel]) => channel.enabled)
     .map(([key]) => Number(key));
@@ -78,6 +83,10 @@ export function WaveformCanvas() {
       ctx.stroke();
 
       let drew = false;
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(PAD, PAD, gw, gh);
+      ctx.clip(); // keep out-of-range traces inside the graticule
       enabled.forEach((channel) => {
         const frame = getFrame(channel);
         if (!frame || frame.points.length === 0) return;
@@ -96,10 +105,11 @@ export function WaveformCanvas() {
         ctx.stroke();
         drew = true;
       });
+      ctx.restore();
 
       if (!drew) {
         ctx.fillStyle = "#8b949e";
-        ctx.font = "13px var(--font-ui), sans-serif";
+        ctx.font = "13px 'Segoe UI', sans-serif";
         ctx.textAlign = "center";
         ctx.fillText("No data — enable a channel and press Run", w / 2, h / 2);
       }

--- a/webapp/app/src/features/waveform/frames.test.ts
+++ b/webapp/app/src/features/waveform/frames.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearFrames, getFrame, setFrame, subscribeFrames } from "./frames";
+
+beforeEach(() => clearFrames());
+
+describe("frame buffer", () => {
+  it("stores and returns the latest frame per channel", () => {
+    setFrame(1, { t0: 0, dt: 1e-6, points: [0, 1] });
+    setFrame(1, { t0: 0, dt: 1e-6, points: [2, 3] });
+    setFrame(2, { t0: 0, dt: 1e-6, points: [4] });
+    expect(getFrame(1)?.points).toEqual([2, 3]);
+    expect(getFrame(2)?.points).toEqual([4]);
+  });
+
+  it("notifies subscribers on each frame and stops after unsubscribe", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeFrames(listener);
+    setFrame(1, { t0: 0, dt: 1, points: [1] });
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    setFrame(1, { t0: 0, dt: 1, points: [2] });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearFrames empties the buffer", () => {
+    setFrame(1, { t0: 0, dt: 1, points: [1] });
+    clearFrames();
+    expect(getFrame(1)).toBeUndefined();
+  });
+});

--- a/webapp/app/src/features/waveform/frames.ts
+++ b/webapp/app/src/features/waveform/frames.ts
@@ -1,0 +1,22 @@
+export type Frame = { t0: number; dt: number; points: number[] };
+
+const frames = new Map<number, Frame>();
+const listeners = new Set<() => void>();
+
+export function setFrame(channel: number, frame: Frame): void {
+  frames.set(channel, frame);
+  listeners.forEach((listener) => listener());
+}
+
+export function getFrame(channel: number): Frame | undefined {
+  return frames.get(channel);
+}
+
+export function clearFrames(): void {
+  frames.clear();
+}
+
+export function subscribeFrames(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/webapp/app/src/main.tsx
+++ b/webapp/app/src/main.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "@design/styles.css";
+import "./ds/ds.css";
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/webapp/app/src/store/session.test.ts
+++ b/webapp/app/src/store/session.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSession } from "./session";
+import type { ScopeState, SessionInfo } from "../api/types";
+
+const SESSION: SessionInfo = { id: "abc", label: "bench", mock: false, address: "192.168.1.50", state: "connected", idn: "Siglent,SDS824X HD,1,1", model: "SDS824X HD", dialect: "modern", num_channels: 4 };
+
+const STATE: ScopeState = {
+  run_state: "STOP",
+  timebase: 0.001,
+  channels: { "1": { enabled: true, voltage_scale: 0.5, voltage_offset: 0, coupling: "DC", probe_ratio: 10 } },
+  trigger: { mode: "AUTO", source: "C1", level: 0.5, slope: "POS", coupling: "DC" },
+};
+
+beforeEach(() => useSession.getState().clearSession());
+
+describe("session store", () => {
+  it("starts empty and disconnected", () => {
+    const s = useSession.getState();
+    expect(s.session).toBeNull();
+    expect(s.scope).toBeNull();
+    expect(s.status).toBe("disconnected");
+  });
+
+  it("applyState replaces the scope snapshot", () => {
+    useSession.getState().setSession(SESSION);
+    useSession.getState().applyState(STATE);
+    expect(useSession.getState().scope?.timebase).toBe(0.001);
+    expect(useSession.getState().scope?.channels["1"].enabled).toBe(true);
+    useSession.getState().applyState({ ...STATE, timebase: 0.002 });
+    expect(useSession.getState().scope?.timebase).toBe(0.002);
+  });
+
+  it("tolerates null trigger fields (legacy/modern degrade)", () => {
+    useSession.getState().applyState({ ...STATE, trigger: { mode: "AUTO", source: null, level: null, slope: null, coupling: null } });
+    expect(useSession.getState().scope?.trigger.level).toBeNull();
+  });
+
+  it("clearSession resets everything", () => {
+    useSession.getState().setSession(SESSION);
+    useSession.getState().applyState(STATE);
+    useSession.getState().applyMeasurements([{ channel: 1, mtype: "PKPK", value: 2 }]);
+    useSession.getState().clearSession();
+    const s = useSession.getState();
+    expect(s.session).toBeNull();
+    expect(s.scope).toBeNull();
+    expect(s.measurements).toEqual([]);
+    expect(s.status).toBe("disconnected");
+  });
+
+  it("applyMeasurements stores nulls as-is", () => {
+    useSession.getState().applyMeasurements([{ channel: 1, mtype: "FREQ", value: null }]);
+    expect(useSession.getState().measurements[0].value).toBeNull();
+  });
+});

--- a/webapp/app/src/store/session.ts
+++ b/webapp/app/src/store/session.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import type { MeasurementValue, ScopeState, SessionInfo } from "../api/types";
+
+export type ConnStatus = "disconnected" | "connecting" | "connected" | "error";
+
+type SessionStore = {
+  session: SessionInfo | null;
+  scope: ScopeState | null;
+  status: ConnStatus;
+  error: string | null;
+  measurements: MeasurementValue[];
+  setSession: (session: SessionInfo) => void;
+  clearSession: () => void;
+  applyState: (state: ScopeState) => void;
+  applyMeasurements: (values: MeasurementValue[]) => void;
+  setStatus: (status: ConnStatus) => void;
+  setError: (error: string | null) => void;
+};
+
+export const useSession = create<SessionStore>((set) => ({
+  session: null,
+  scope: null,
+  status: "disconnected",
+  error: null,
+  measurements: [],
+  setSession: (session) => set({ session, status: "connected", error: null }),
+  clearSession: () => set({ session: null, scope: null, status: "disconnected", error: null, measurements: [] }),
+  applyState: (scope) => set({ scope }),
+  applyMeasurements: (measurements) => set({ measurements }),
+  setStatus: (status) => set({ status }),
+  setError: (error) => set({ error, status: error ? "error" : "connected" }),
+}));

--- a/webapp/app/src/stream/useStream.test.ts
+++ b/webapp/app/src/stream/useStream.test.ts
@@ -18,14 +18,21 @@ class FakeWebSocket {
   }
 
   send() {}
-  close() {
+  close(code = 1000) {
     this.closed = true;
+    queueMicrotask(() => this.onclose?.({ code } as CloseEvent));
   }
 
   emit(message: unknown) {
     this.onmessage?.({ data: JSON.stringify(message) });
   }
+
+  emitClose(code: number) {
+    queueMicrotask(() => this.onclose?.({ code } as CloseEvent));
+  }
 }
+
+const SESSION = { id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4 };
 
 beforeEach(() => {
   vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
@@ -82,5 +89,44 @@ describe("useStream", () => {
     FakeWebSocket.last = null;
     renderHook(() => useStream(null));
     expect(FakeWebSocket.last).toBeNull();
+  });
+
+  it("treats a 4410 close from the live socket as a clean session end", async () => {
+    useSession.getState().setSession(SESSION);
+    renderHook(() => useStream("abc"));
+
+    FakeWebSocket.last!.emitClose(4410);
+    await waitFor(() => expect(useSession.getState().session).toBeNull());
+    expect(useSession.getState().status).toBe("disconnected");
+  });
+
+  it("surfaces an unexpected close from the live socket as an error", async () => {
+    useSession.getState().setSession(SESSION);
+    renderHook(() => useStream("abc"));
+
+    FakeWebSocket.last!.emitClose(1006);
+    await waitFor(() => expect(useSession.getState().status).toBe("error"));
+    expect(useSession.getState().error).toBe("stream disconnected");
+  });
+
+  it("ignores a late close from an already torn-down socket", async () => {
+    const first = renderHook(() => useStream("abc"));
+    const staleSocket = FakeWebSocket.last!;
+    first.unmount();
+
+    // A second, live stream takes over (StrictMode remount / session-id change).
+    renderHook(() => useStream("abc"));
+    const liveSocket = FakeWebSocket.last!;
+    expect(liveSocket).not.toBe(staleSocket);
+    useSession.getState().setSession(SESSION);
+
+    // The dead socket's close events land late — they must not touch the store.
+    staleSocket.emitClose(1006);
+    staleSocket.emitClose(4410);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(useSession.getState().session).toEqual(SESSION);
+    expect(useSession.getState().status).toBe("connected");
+    expect(useSession.getState().error).toBeNull();
   });
 });

--- a/webapp/app/src/stream/useStream.test.ts
+++ b/webapp/app/src/stream/useStream.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useStream } from "./useStream";
+import { useSession } from "../store/session";
+import { getFrame, clearFrames } from "../features/waveform/frames";
+
+class FakeWebSocket {
+  static last: FakeWebSocket | null = null;
+  url: string;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.last = this;
+  }
+
+  send() {}
+  close() {
+    this.closed = true;
+  }
+
+  emit(message: unknown) {
+    this.onmessage?.({ data: JSON.stringify(message) });
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+  useSession.getState().clearSession();
+  clearFrames();
+});
+
+const STATE = { run_state: "STOP", timebase: 0.001, channels: { "1": { enabled: true, voltage_scale: 0.5, voltage_offset: 0, coupling: "DC", probe_ratio: 10 } }, trigger: { mode: "AUTO", source: "C1", level: 0, slope: "POS", coupling: "DC" } };
+
+describe("useStream", () => {
+  it("opens a socket for the session and applies state messages to the store", async () => {
+    renderHook(() => useStream("abc"));
+    expect(FakeWebSocket.last?.url).toContain("/api/sessions/abc/stream");
+
+    FakeWebSocket.last!.emit({ type: "state", state: STATE });
+    await waitFor(() => expect(useSession.getState().scope?.timebase).toBe(0.001));
+  });
+
+  it("routes waveform frames to the frame buffer, not the store", async () => {
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({ type: "waveform", channel: 1, t0: 0, dt: 1e-6, points: [0, 0.5, 1] });
+
+    await waitFor(() => expect(getFrame(1)?.points).toEqual([0, 0.5, 1]));
+    expect(useSession.getState().scope).toBeNull();
+  });
+
+  it("applies measurement messages", async () => {
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({ type: "measurements", values: [{ channel: 1, mtype: "PKPK", value: 2 }] });
+    await waitFor(() => expect(useSession.getState().measurements[0].value).toBe(2));
+  });
+
+  it("treats a closed message as a clean session end", async () => {
+    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4 });
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({ type: "closed" });
+    await waitFor(() => expect(useSession.getState().session).toBeNull());
+    expect(useSession.getState().status).toBe("disconnected");
+  });
+
+  it("surfaces an error message as an error status", async () => {
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({ type: "error", detail: "connection lost" });
+    await waitFor(() => expect(useSession.getState().status).toBe("error"));
+    expect(useSession.getState().error).toBe("connection lost");
+  });
+
+  it("closes the socket on unmount and opens none without a session", () => {
+    const { unmount } = renderHook(() => useStream("abc"));
+    const socket = FakeWebSocket.last!;
+    unmount();
+    expect(socket.closed).toBe(true);
+
+    FakeWebSocket.last = null;
+    renderHook(() => useStream(null));
+    expect(FakeWebSocket.last).toBeNull();
+  });
+});

--- a/webapp/app/src/stream/useStream.ts
+++ b/webapp/app/src/stream/useStream.ts
@@ -37,7 +37,11 @@ export function useStream(sessionId: string | null): void {
     };
 
     return () => {
-      ended = true; // suppress the error path on our own teardown
+      // close() is async in browsers: detach the handlers so this socket's late
+      // close event can never clear/error a session a newer socket already owns.
+      socket.onmessage = null;
+      socket.onclose = null;
+      socket.onerror = null;
       socket.close();
       clearFrames();
     };

--- a/webapp/app/src/stream/useStream.ts
+++ b/webapp/app/src/stream/useStream.ts
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import type { StreamMessage } from "../api/types";
+import { clearFrames, setFrame } from "../features/waveform/frames";
+import { useSession } from "../store/session";
+
+const CLOSE_SESSION_ENDED = 4410;
+
+export function useStream(sessionId: string | null): void {
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const socket = new WebSocket(`${protocol}//${window.location.host}/api/sessions/${sessionId}/stream`);
+    let ended = false;
+
+    socket.onmessage = (event: MessageEvent) => {
+      const message = JSON.parse(event.data as string) as StreamMessage;
+      const store = useSession.getState();
+      if (message.type === "state") store.applyState(message.state);
+      else if (message.type === "waveform") setFrame(message.channel, { t0: message.t0, dt: message.dt, points: message.points });
+      else if (message.type === "measurements") store.applyMeasurements(message.values);
+      else if (message.type === "error") store.setError(message.detail);
+      else if (message.type === "closed") {
+        ended = true;
+        clearFrames();
+        store.clearSession();
+      }
+    };
+
+    socket.onclose = (event: CloseEvent) => {
+      if (ended || event.code === CLOSE_SESSION_ENDED) {
+        clearFrames();
+        useSession.getState().clearSession();
+        return;
+      }
+      useSession.getState().setError("stream disconnected");
+    };
+
+    return () => {
+      ended = true; // suppress the error path on our own teardown
+      socket.close();
+      clearFrames();
+    };
+  }, [sessionId]);
+}

--- a/webapp/app/src/test/setup.ts
+++ b/webapp/app/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/webapp/app/tsconfig.json
+++ b/webapp/app/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "types": ["vite/client", "node"],
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "vite.config.ts", "vitest.config.ts"]
+}

--- a/webapp/app/tsconfig.json
+++ b/webapp/app/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "types": ["vite/client", "node"],
+    "types": ["vite/client"],
 
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
@@ -20,5 +20,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src", "vite.config.ts", "vitest.config.ts"]
+  "include": ["src"]
 }

--- a/webapp/app/tsconfig.node.json
+++ b/webapp/app/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}

--- a/webapp/app/vite.config.ts
+++ b/webapp/app/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: { alias: { "@design": resolve(__dirname, "../design") } },
+  server: {
+    proxy: {
+      "/api": { target: "http://127.0.0.1:8765", ws: true, changeOrigin: true },
+    },
+  },
+  build: { outDir: "dist", emptyOutDir: true },
+});

--- a/webapp/app/vitest.config.ts
+++ b/webapp/app/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: { alias: { "@design": resolve(__dirname, "../design") } },
+  test: { environment: "jsdom", globals: true, setupFiles: ["./src/test/setup.ts"] },
+});

--- a/webapp/design/components/controls/Button.jsx
+++ b/webapp/design/components/controls/Button.jsx
@@ -1,0 +1,119 @@
+import React from "react";
+
+/**
+ * Button — the app's push button (QPushButton).
+ *
+ * Variants map to the real setStyleSheet blocks in the PyQt6 source:
+ *  - default  : native light Qt button (Auto Scale, Add, Update Now…)
+ *  - primary  : Connect / Send — success green (#4CAF50)
+ *  - danger   : Disconnect / Clear — red (#f44336)
+ *  - critical : "All Outputs OFF (Safety)" — crimson, larger radius/padding
+ *  - ghost    : flat toolbar text actions (Run, Stop, Single, Capture…)
+ */
+export function Button({
+  children,
+  variant = "default",
+  size = "md",
+  icon = null,
+  disabled = false,
+  fullWidth = false,
+  onClick,
+  type = "button",
+  style,
+  ...rest
+}) {
+  const sizes = {
+    sm: { fontSize: "var(--text-xs)", padding: "4px 12px", height: "var(--control-height-sm)" },
+    md: { fontSize: "var(--text-sm)", padding: "7px 20px", height: "32px" },
+  };
+
+  const base = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "6px",
+    fontFamily: "var(--font-ui)",
+    fontWeight: "var(--weight-medium)",
+    lineHeight: 1,
+    border: "1px solid transparent",
+    borderRadius: "var(--lc-radius-sm)",
+    cursor: disabled ? "not-allowed" : "pointer",
+    userSelect: "none",
+    whiteSpace: "nowrap",
+    transition: "background-color 90ms ease, border-color 90ms ease, filter 90ms ease",
+    width: fullWidth ? "100%" : "auto",
+    opacity: disabled ? 0.5 : 1,
+    ...sizes[size],
+  };
+
+  const variants = {
+    default: {
+      background: "var(--lc-panel)",
+      borderColor: "var(--lc-border-strong)",
+      color: "var(--lc-text)",
+    },
+    primary: {
+      background: "var(--success)",
+      color: "#ffffff",
+      fontWeight: "var(--weight-bold)",
+      borderColor: "transparent",
+    },
+    danger: {
+      background: "var(--danger)",
+      color: "#ffffff",
+      fontWeight: "var(--weight-bold)",
+      borderColor: "transparent",
+    },
+    critical: {
+      background: "var(--critical)",
+      color: "#ffffff",
+      fontWeight: "var(--weight-bold)",
+      borderRadius: "var(--radius-md)",
+      padding: "10px 20px",
+      borderColor: "transparent",
+    },
+    ghost: {
+      background: "transparent",
+      color: "var(--text-primary)",
+      borderColor: "transparent",
+      padding: size === "sm" ? "4px 10px" : "6px 14px",
+    },
+  };
+
+  const hoverBg = {
+    default: "var(--lc-control-hover)",
+    primary: "var(--success-hover)",
+    danger: "var(--danger-hover)",
+    critical: "var(--critical-hover)",
+    ghost: "rgba(0,0,0,0.06)",
+  };
+  const pressBg = {
+    default: "var(--lc-panel-2)",
+    primary: "var(--success-pressed)",
+    danger: "var(--danger-pressed)",
+    critical: "var(--critical-hover)",
+    ghost: "rgba(0,0,0,0.11)",
+  };
+
+  const [state, setState] = React.useState("rest");
+  const dyn =
+    !disabled && state === "hover" ? { background: hoverBg[variant] } :
+    !disabled && state === "active" ? { background: pressBg[variant] } : {};
+
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      onClick={onClick}
+      onMouseEnter={() => setState("hover")}
+      onMouseLeave={() => setState("rest")}
+      onMouseDown={() => setState("active")}
+      onMouseUp={() => setState("hover")}
+      style={{ ...base, ...variants[variant], ...dyn, ...style }}
+      {...rest}
+    >
+      {icon && <span style={{ display: "inline-flex", fontSize: "1.05em" }}>{icon}</span>}
+      {children}
+    </button>
+  );
+}

--- a/webapp/design/components/controls/Checkbox.jsx
+++ b/webapp/design/components/controls/Checkbox.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+/**
+ * Checkbox — QCheckBox. Square box with a check, label to the right.
+ * Used for Enable channel, Bandwidth Limit, Grid, Timestamp, Statistics…
+ */
+export function Checkbox({
+  label,
+  checked,
+  defaultChecked = false,
+  disabled = false,
+  bold = false,
+  onChange,
+  style,
+  ...rest
+}) {
+  const isControlled = checked !== undefined;
+  const [internal, setInternal] = React.useState(defaultChecked);
+  const value = isControlled ? checked : internal;
+
+  const toggle = () => {
+    if (disabled) return;
+    if (!isControlled) setInternal(!value);
+    onChange && onChange(!value);
+  };
+
+  return (
+    <label
+      onClick={toggle}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "8px",
+        fontFamily: "var(--font-ui)",
+        fontSize: "var(--text-sm)",
+        fontWeight: bold ? "var(--weight-bold)" : "var(--weight-normal)",
+        color: "var(--text-primary)",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+        userSelect: "none",
+        ...style,
+      }}
+      {...rest}
+    >
+      <span
+        style={{
+          width: "17px",
+          height: "17px",
+          flexShrink: 0,
+          borderRadius: "5px",
+          border: `1px solid ${value ? "var(--success)" : "var(--lc-border-strong)"}`,
+          background: value ? "var(--success)" : "var(--lc-control)",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          transition: "background-color 90ms ease, border-color 90ms ease",
+        }}
+      >
+        {value && (
+          <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+            <path d="M2.5 6.2L4.8 8.5L9.5 3.5" stroke="#fff" strokeWidth="1.8"
+              strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+      </span>
+      {label}
+    </label>
+  );
+}

--- a/webapp/design/components/controls/ComboBox.jsx
+++ b/webapp/design/components/controls/ComboBox.jsx
@@ -1,0 +1,89 @@
+import React from "react";
+
+/**
+ * ComboBox — QComboBox dropdown. Native light Qt select with a chevron.
+ * Used for Coupling (DC/AC/GND), Probe ratio, Trigger Mode/Source/Slope,
+ * Channel pickers, Math operation, Window function…
+ */
+export function ComboBox({
+  options = [],
+  value,
+  defaultValue,
+  disabled = false,
+  onChange,
+  width,
+  style,
+  ...rest
+}) {
+  const norm = options.map((o) =>
+    typeof o === "string" ? { label: o, value: o } : o
+  );
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = React.useState(
+    defaultValue ?? (norm[0] && norm[0].value)
+  );
+  const current = isControlled ? value : internal;
+
+  const [hover, setHover] = React.useState(false);
+  const [foc, setFoc] = React.useState(false);
+
+  const handle = (e) => {
+    const v = e.target.value;
+    if (!isControlled) setInternal(v);
+    onChange && onChange(v);
+  };
+
+  return (
+    <div
+      style={{ position: "relative", display: "inline-block", width: width || "auto", ...style }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <select
+        value={current}
+        disabled={disabled}
+        onChange={handle}
+        style={{
+          appearance: "none",
+          WebkitAppearance: "none",
+          MozAppearance: "none",
+          width: "100%",
+          height: "32px",
+          padding: "0 28px 0 10px",
+          fontFamily: "var(--font-ui)",
+          fontSize: "var(--text-sm)",
+          color: "var(--lc-text)",
+          background: "var(--lc-control)",
+          border: `1px solid ${foc ? "var(--lc-accent)" : hover && !disabled ? "var(--lc-border-strong)" : "var(--lc-border-strong)"}`,
+          borderRadius: "var(--lc-radius-sm)",
+          boxShadow: foc ? "0 0 0 3px var(--lc-accent-soft)" : "none",
+          cursor: disabled ? "not-allowed" : "pointer",
+          opacity: disabled ? 0.5 : 1,
+          outline: "none",
+        }}
+        onFocus={() => setFoc(true)}
+        onBlur={() => setFoc(false)}
+        {...rest}
+      >
+        {norm.map((o) => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+      <span
+        aria-hidden
+        style={{
+          position: "absolute",
+          right: "9px",
+          top: "50%",
+          transform: "translateY(-50%)",
+          pointerEvents: "none",
+          color: "var(--lc-text-2)",
+          fontSize: "10px",
+          lineHeight: 1,
+        }}
+      >
+        ▾
+      </span>
+    </div>
+  );
+}

--- a/webapp/design/components/controls/SpinBox.jsx
+++ b/webapp/design/components/controls/SpinBox.jsx
@@ -1,0 +1,113 @@
+import React from "react";
+
+/**
+ * SpinBox — QDoubleSpinBox. Numeric field with a unit suffix and stacked
+ * up/down steppers. Used for V/div, Offset, Trigger Level, Holdoff, Voltage &
+ * Current setpoints. Suffix examples: " V", " A", " s".
+ */
+export function SpinBox({
+  value,
+  defaultValue = 0,
+  min = -Infinity,
+  max = Infinity,
+  step = 0.1,
+  decimals = 3,
+  suffix = "",
+  disabled = false,
+  onChange,
+  width,
+  style,
+  ...rest
+}) {
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = React.useState(defaultValue);
+  const current = isControlled ? value : internal;
+  const [hover, setHover] = React.useState(false);
+  const [foc, setFoc] = React.useState(false);
+
+  const clamp = (v) => Math.min(max, Math.max(min, v));
+  const commit = (v) => {
+    const c = clamp(v);
+    if (!isControlled) setInternal(c);
+    onChange && onChange(c);
+  };
+
+  const fmt = (v) =>
+    (typeof v === "number" && !Number.isNaN(v) ? v : 0).toFixed(decimals) + suffix;
+
+  const [editing, setEditing] = React.useState(false);
+  const [draft, setDraft] = React.useState("");
+
+  const Stepper = ({ dir }) => (
+    <button
+      type="button"
+      disabled={disabled}
+      tabIndex={-1}
+      onClick={() => commit(current + dir * step)}
+      style={{
+        flex: 1,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        border: "none",
+        borderLeft: "1px solid var(--lc-border)",
+        borderBottom: dir > 0 ? "1px solid var(--lc-border)" : "none",
+        background: "var(--lc-panel-2)",
+        color: "var(--lc-text-2)",
+        cursor: disabled ? "not-allowed" : "pointer",
+        fontSize: "8px",
+        lineHeight: 1,
+        padding: 0,
+      }}
+    >
+      {dir > 0 ? "▲" : "▼"}
+    </button>
+  );
+
+  return (
+    <div
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        display: "inline-flex",
+        alignItems: "stretch",
+        height: "32px",
+        width: width || "140px",
+        background: "var(--lc-control)",
+        border: `1px solid ${foc ? "var(--lc-accent)" : hover && !disabled ? "var(--lc-border-strong)" : "var(--lc-border-strong)"}`,
+        borderRadius: "var(--lc-radius-sm)",
+        boxShadow: foc ? "0 0 0 3px var(--lc-accent-soft)" : "none",
+        overflow: "hidden",
+        opacity: disabled ? 0.5 : 1,
+        fontFamily: "var(--font-ui)",
+        ...style,
+      }}
+      {...rest}
+    >
+      <input
+        type="text"
+        disabled={disabled}
+        value={editing ? draft : fmt(current)}
+        onFocus={() => { setEditing(true); setDraft(String(current)); setFoc(true); }}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => { setEditing(false); setFoc(false); const n = parseFloat(draft); if (!Number.isNaN(n)) commit(n); }}
+        onKeyDown={(e) => { if (e.key === "Enter") e.currentTarget.blur(); }}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          border: "none",
+          outline: "none",
+          background: "transparent",
+          padding: "0 8px",
+          fontFamily: "var(--font-ui)",
+          fontSize: "var(--text-sm)",
+          color: "var(--lc-text)",
+        }}
+      />
+      <div style={{ display: "flex", flexDirection: "column", width: "18px" }}>
+        <Stepper dir={1} />
+        <Stepper dir={-1} />
+      </div>
+    </div>
+  );
+}

--- a/webapp/design/components/data/DataTable.jsx
+++ b/webapp/design/components/data/DataTable.jsx
@@ -1,0 +1,89 @@
+import React from "react";
+
+/**
+ * DataTable — QTableWidget. Column-headed table with alternating row colours.
+ * Two treatments:
+ *   light (default) — measurement panel (alt rows, native header)
+ *   dark            — DAQ data view (#2d2d2d body, #353535 alt, #404040 header)
+ *
+ * `columns` are strings or {label, width, align}. `rows` are arrays of cells;
+ * a cell may be a string/number or a React node (e.g. a channel-coloured value).
+ */
+export function DataTable({
+  columns = [],
+  rows = [],
+  dark = false,
+  style,
+  ...rest
+}) {
+  const cols = columns.map((c) => (typeof c === "string" ? { label: c } : c));
+  const pal = dark
+    ? {
+        body: "var(--scope-surface)", alt: "var(--scope-row-alt)",
+        header: "var(--scope-header)", grid: "var(--scope-border-3)",
+        text: "#ffffff", headerText: "#ffffff",
+      }
+    : {
+        body: "var(--surface)", alt: "var(--surface-alt)",
+        header: "var(--surface-subtle)", grid: "var(--divider)",
+        text: "var(--text-primary)", headerText: "var(--text-secondary)",
+      };
+
+  return (
+    <table
+      style={{
+        width: "100%",
+        borderCollapse: "collapse",
+        fontFamily: "var(--font-ui)",
+        fontSize: "var(--text-sm)",
+        color: pal.text,
+        background: pal.body,
+        border: `1px solid ${pal.grid}`,
+        ...style,
+      }}
+      {...rest}
+    >
+      <thead>
+        <tr>
+          {cols.map((c, i) => (
+            <th
+              key={i}
+              style={{
+                textAlign: c.align || "left",
+                fontWeight: "var(--weight-bold)",
+                color: pal.headerText,
+                background: pal.header,
+                padding: "7px 10px",
+                borderBottom: `1px solid ${pal.grid}`,
+                width: c.width || "auto",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {c.label}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r, ri) => (
+          <tr key={ri} style={{ background: ri % 2 ? pal.alt : pal.body }}>
+            {r.map((cell, ci) => (
+              <td
+                key={ci}
+                style={{
+                  padding: "6px 10px",
+                  textAlign: cols[ci]?.align || "left",
+                  borderBottom: `1px solid ${pal.grid}`,
+                  fontFamily: cols[ci]?.mono ? "var(--font-mono)" : "inherit",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {cell}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/webapp/design/components/data/Reading.jsx
+++ b/webapp/design/components/data/Reading.jsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+/**
+ * Reading — a live instrument readout. Monospace value in scope green
+ * (#00ff00), as used for Measured V / I / W and the big front-panel numbers.
+ * Optional CV/CC-style `mode` badge (green for CV, orange for CC).
+ *
+ *  - size "sm" : inline panel readout (PSU measured values)
+ *  - size "lg" : front-panel hero number (e.g. "30.00 V")
+ */
+export function Reading({
+  label,
+  value,
+  unit = "",
+  mode,
+  modeColor,
+  size = "sm",
+  style,
+  ...rest
+}) {
+  const big = size === "lg";
+  return (
+    <div
+      style={{
+        display: big ? "flex" : "inline-flex",
+        flexDirection: big ? "column" : "row",
+        alignItems: big ? "flex-start" : "baseline",
+        gap: big ? "2px" : "8px",
+        fontFamily: "var(--font-ui)",
+        ...style,
+      }}
+      {...rest}
+    >
+      {label != null && (
+        <span
+          style={{
+            fontSize: big ? "var(--text-xs)" : "var(--text-sm)",
+            color: "var(--scope-text-muted)",
+            textTransform: big ? "uppercase" : "none",
+            letterSpacing: big ? "var(--tracking-label)" : 0,
+          }}
+        >
+          {label}
+        </span>
+      )}
+      <span
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: big ? "var(--text-2xl)" : "var(--text-base)",
+          fontWeight: "var(--weight-bold)",
+          color: "var(--readout)",
+          lineHeight: 1,
+          letterSpacing: "var(--tracking-mono)",
+        }}
+      >
+        {value}
+        {unit ? <span style={{ fontSize: "0.6em", marginLeft: "4px", opacity: 0.85 }}>{unit}</span> : null}
+      </span>
+      {mode != null && (
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--text-xs)",
+            fontWeight: "var(--weight-bold)",
+            color: modeColor || (mode === "CC" ? "var(--warning)" : "var(--readout)"),
+            border: `1px solid ${modeColor || (mode === "CC" ? "var(--warning)" : "var(--readout)")}`,
+            borderRadius: "var(--radius-sm)",
+            padding: "1px 5px",
+          }}
+        >
+          {mode}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/webapp/design/components/data/StatusIndicator.jsx
+++ b/webapp/design/components/data/StatusIndicator.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+
+/**
+ * StatusIndicator — connection status dot + label, from the toolbar/status bar.
+ * Colours match the README legend:
+ *   connected  🟢 green   connecting 🟡 orange
+ *   disconnected 🔴 red    error      🟠 dark orange
+ */
+const STATES = {
+  connected: { color: "var(--success)", text: "Connected" },
+  connecting: { color: "var(--warning)", text: "Connecting…" },
+  disconnected: { color: "var(--danger)", text: "Disconnected" },
+  error: { color: "var(--ch8)", text: "Error" },
+};
+
+export function StatusIndicator({
+  state = "disconnected",
+  label,
+  pulse,
+  dark = false,
+  style,
+  ...rest
+}) {
+  const s = STATES[state] || STATES.disconnected;
+  const doPulse = pulse ?? state === "connecting";
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "7px",
+        fontFamily: "var(--font-ui)",
+        fontSize: "var(--text-sm)",
+        color: dark ? "var(--scope-text-body)" : "var(--text-secondary)",
+        ...style,
+      }}
+      {...rest}
+    >
+      <span
+        style={{
+          width: "9px",
+          height: "9px",
+          borderRadius: "var(--radius-pill)",
+          background: s.color,
+          boxShadow: `0 0 0 3px color-mix(in srgb, ${s.color} 22%, transparent)`,
+          animation: doPulse ? "scpi-pulse 1.1s ease-in-out infinite" : "none",
+          flexShrink: 0,
+        }}
+      />
+      <span>{label ?? s.text}</span>
+      <style>{`@keyframes scpi-pulse{0%,100%{opacity:1}50%{opacity:.35}}`}</style>
+    </span>
+  );
+}

--- a/webapp/design/components/data/Terminal.jsx
+++ b/webapp/design/components/data/Terminal.jsx
@@ -1,0 +1,109 @@
+import React from "react";
+
+/**
+ * Terminal — the SCPI command console (TerminalWidget). Dark #1e1e1e panel,
+ * Courier New, colour-coded lines. Optional input row with the signature
+ * green-bordered field + Send / Clear buttons.
+ *
+ * `lines` is an array of { text, kind } where kind ∈
+ *   command | response | ok | error | muted | plain
+ */
+const LINE_COLORS = {
+  command: "var(--term-command)",
+  response: "var(--term-response)",
+  ok: "var(--term-ok)",
+  error: "var(--term-error)",
+  muted: "var(--term-muted)",
+  plain: "var(--scope-text-body)",
+};
+
+export function Terminal({
+  lines = [],
+  showInput = true,
+  placeholder = "Enter SCPI command here (e.g., *IDN?)",
+  onSend,
+  style,
+  ...rest
+}) {
+  const [cmd, setCmd] = React.useState("");
+  const [focus, setFocus] = React.useState(false);
+  const send = () => {
+    const v = cmd.trim();
+    if (!v) return;
+    onSend && onSend(v);
+    setCmd("");
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "8px",
+        fontFamily: "var(--font-mono)",
+        ...style,
+      }}
+      {...rest}
+    >
+      <div
+        style={{
+          background: "var(--scope-panel)",
+          color: "var(--scope-text-body)",
+          border: "1px solid var(--scope-border-soft)",
+          borderRadius: "var(--radius-sm)",
+          padding: "10px 12px",
+          fontSize: "var(--text-sm)",
+          lineHeight: 1.55,
+          overflowY: "auto",
+          flex: 1,
+          minHeight: 0,
+        }}
+      >
+        {lines.length === 0 && (
+          <div style={{ color: "var(--term-ok)" }}>=== SCPI Terminal Ready ===</div>
+        )}
+        {lines.map((l, i) => (
+          <div key={i} style={{ color: LINE_COLORS[l.kind] || LINE_COLORS.plain, whiteSpace: "pre-wrap" }}>
+            {l.text}
+          </div>
+        ))}
+      </div>
+
+      {showInput && (
+        <div style={{ display: "flex", gap: "8px" }}>
+          <input
+            value={cmd}
+            placeholder={placeholder}
+            onChange={(e) => setCmd(e.target.value)}
+            onFocus={() => setFocus(true)}
+            onBlur={() => setFocus(false)}
+            onKeyDown={(e) => { if (e.key === "Enter") send(); }}
+            style={{
+              flex: 1,
+              minWidth: 0,
+              fontFamily: "var(--font-mono)",
+              fontSize: "var(--text-sm)",
+              color: "var(--text-primary)",
+              background: "var(--surface)",
+              padding: "6px 8px",
+              border: `2px solid ${focus ? "var(--success-hover)" : "var(--success)"}`,
+              borderRadius: "var(--radius-sm)",
+              outline: "none",
+            }}
+          />
+          <button
+            type="button"
+            onClick={send}
+            style={{
+              background: "var(--success)", color: "#fff", fontWeight: "var(--weight-bold)",
+              fontFamily: "var(--font-ui)", border: "none", borderRadius: "var(--radius-sm)",
+              padding: "6px 20px", cursor: "pointer",
+            }}
+          >
+            Send
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/design/components/layout/GroupBox.jsx
+++ b/webapp/design/components/layout/GroupBox.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+/**
+ * GroupBox — QGroupBox. A titled, bordered container. The title sits in a
+ * notch on the top border. In the scope UI the title is colour-coded to the
+ * channel it controls (gold / cyan / pink / green), so `titleColor` accepts
+ * any CSS color or a channel token var.
+ *
+ * On the dark scope canvas set `dark` for the panel treatment.
+ */
+export function GroupBox({
+  title,
+  titleColor,
+  dark = false,
+  children,
+  style,
+  bodyStyle,
+  ...rest
+}) {
+  const frame = dark ? "var(--scope-border-2)" : "var(--lc-border)";
+  const bg = dark ? "var(--scope-panel)" : "var(--lc-panel)";
+  const notchBg = dark ? "var(--scope-panel)" : "var(--lc-bg)";
+  const defaultTitle = dark ? "var(--scope-text)" : "var(--lc-text-2)";
+
+  return (
+    <fieldset
+      style={{
+        position: "relative",
+        margin: 0,
+        padding: "14px 12px 12px",
+        border: `1px solid ${frame}`,
+        borderRadius: "var(--lc-radius)",
+        background: bg,
+        boxShadow: dark ? "none" : "var(--lc-elev-1)",
+        minInlineSize: "auto",
+        ...style,
+      }}
+      {...rest}
+    >
+      {title != null && (
+        <legend
+          style={{
+            padding: "0 6px",
+            marginLeft: "4px",
+            fontFamily: "var(--font-ui)",
+            fontSize: "var(--text-sm)",
+            fontWeight: "var(--weight-bold)",
+            color: titleColor || defaultTitle,
+            background: notchBg,
+          }}
+        >
+          {title}
+        </legend>
+      )}
+      <div style={bodyStyle}>{children}</div>
+    </fieldset>
+  );
+}

--- a/webapp/design/components/layout/Tabs.jsx
+++ b/webapp/design/components/layout/Tabs.jsx
@@ -1,0 +1,75 @@
+import React from "react";
+
+/**
+ * Tabs — QTabWidget tab bar. The control panel's primary navigation
+ * (Channels / Trigger / Timebase / Measurements / …). Light native styling
+ * with an underline on the active tab.
+ */
+export function Tabs({
+  tabs = [],
+  value,
+  defaultValue,
+  onChange,
+  children,
+  style,
+  ...rest
+}) {
+  const norm = tabs.map((t) => (typeof t === "string" ? { label: t, value: t } : t));
+  const isControlled = value !== undefined;
+  const [internal, setInternal] = React.useState(
+    defaultValue ?? (norm[0] && norm[0].value)
+  );
+  const active = isControlled ? value : internal;
+  const [hover, setHover] = React.useState(null);
+
+  const select = (v) => {
+    if (!isControlled) setInternal(v);
+    onChange && onChange(v);
+  };
+
+  return (
+    <div style={{ fontFamily: "var(--font-ui)", ...style }} {...rest}>
+      <div
+        role="tablist"
+        style={{
+          display: "inline-flex",
+          gap: "3px",
+          padding: "4px",
+          background: "var(--lc-panel-2)",
+          border: "1px solid var(--lc-border)",
+          borderRadius: "var(--lc-radius)",
+        }}
+      >
+        {norm.map((t) => {
+          const on = t.value === active;
+          return (
+            <button
+              key={t.value}
+              role="tab"
+              aria-selected={on}
+              onClick={() => select(t.value)}
+              onMouseEnter={() => setHover(t.value)}
+              onMouseLeave={() => setHover(null)}
+              style={{
+                border: "none",
+                background: on ? "var(--lc-panel)" : "transparent",
+                color: on ? "var(--lc-text)" : "var(--lc-text-2)",
+                fontSize: "var(--text-sm)",
+                fontWeight: on ? "var(--weight-medium)" : "500",
+                padding: "7px 14px",
+                cursor: "pointer",
+                borderRadius: "var(--lc-radius-sm)",
+                boxShadow: on ? "var(--lc-elev-1)" : "none",
+                whiteSpace: "nowrap",
+                transition: "background 90ms ease, color 90ms ease",
+              }}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+      {children != null && <div style={{ paddingTop: "12px" }}>{children}</div>}
+    </div>
+  );
+}

--- a/webapp/design/components/layout/Toolbar.jsx
+++ b/webapp/design/components/layout/Toolbar.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+/**
+ * Toolbar — the main window's top action bar (below the menu). A light strip
+ * with a bottom border that holds action buttons on the left and, optionally,
+ * status content pushed to the right. Compose Button (variant="ghost" for the
+ * plain text actions) and StatusIndicator inside it.
+ */
+export function Toolbar({ children, right, style, ...rest }) {
+  return (
+    <div
+      role="toolbar"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        minHeight: "var(--toolbar-height)",
+        padding: "6px 10px",
+        background: "var(--app-bg)",
+        borderBottom: "1px solid var(--border)",
+        fontFamily: "var(--font-ui)",
+        ...style,
+      }}
+      {...rest}
+    >
+      {children}
+      {right != null && (
+        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: "10px" }}>
+          {right}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Thin vertical rule to group toolbar actions, mirroring the app's separators. */
+export function ToolbarSeparator() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        width: "1px",
+        alignSelf: "stretch",
+        margin: "6px 4px",
+        background: "var(--divider)",
+      }}
+    />
+  );
+}

--- a/webapp/design/readme.md
+++ b/webapp/design/readme.md
@@ -1,0 +1,241 @@
+# SCPI Instrument Control — Design System
+
+A design system reconstructed from the **SCPI Instrument Control** project: a
+universal Python library **and PyQt6 desktop application** for controlling
+SCPI-compatible bench test equipment — oscilloscopes, power supplies (PSU),
+arbitrary waveform generators (AWG) and data-acquisition (DAQ) units — over
+Ethernet/LAN.
+
+This system captures the visual language of that desktop app so you can design
+new screens, dialogs, slides and marketing that look like they belong to the
+product.
+
+## Sources
+
+Everything here was reconstructed from real source, not memory:
+
+- **GitHub — primary source:** https://github.com/little-did-I-know/SCPI-Instrument-Control
+  (branch `main`). The visual language was lifted from the PyQt6 GUI code under
+  `scpi_control/gui/` — `main_window.py`, `widgets/*.py` (channel_control,
+  trigger_control, measurement_panel, psu_control, terminal_widget,
+  waveform_display_pg, daq_data_view, …) — where every colour, font, padding and
+  radius is set via `setStyleSheet` / `pg.mkPen` / `QColor`. Values here are
+  lifted verbatim.
+- **Brand assets:** `resources/Test Equipment.png` / `.ico` and the wide variant
+  (copied into `resources/`), plus `docs/images/*.png` reference screenshots.
+- **Docs:** `docs/gui/interface.md` and `docs/gui/overview.md` for the window
+  anatomy, tab inventory and interaction model.
+
+Explore the repository above to build higher-fidelity designs — the widget
+source is the ground truth for any control this system doesn't yet cover.
+
+---
+
+## The two surfaces
+
+The product lives on **two coexisting surfaces**, and every design decision
+follows from which one you are on:
+
+1. **Desktop chrome (light).** The window, menus, toolbar, control-panel tabs
+   and form controls are **native, light-themed Qt widgets** — white/`#f3f3f3`
+   surfaces, thin grey borders, black text. The app does *not* apply a global
+   dark theme.
+2. **The scope canvas (dark).** The waveform display, live-data plots, SCPI
+   terminal and measured-value readouts are **dark** (`#0d1117` / `#1e1e1e`),
+   with a dotted division grid and bright, saturated content. This is the
+   brand's signature — a piece of instrument on a desktop.
+
+---
+
+## CONTENT FUNDAMENTALS
+
+How the product writes copy:
+
+- **Voice: terse, technical, imperative.** UI actions are bare verbs — “Connect”,
+  “Disconnect”, “Run”, “Stop”, “Single”, “Force Trigger”, “Auto Scale”,
+  “Clear All”. No marketing fluff in the app.
+- **Domain vocabulary is exact and unexpanded.** Uses instrument terminology
+  and abbreviations as-is: `V/div`, `Vpp`, `Vrms`, `SNR`, `THD`, `C1`–`C4`,
+  `TDIV`, `DC/AC/GND`, `POS/NEG`, `AUTO/NORMAL/SINGLE/STOP`, `20MHz`, `µs`, `kHz`.
+  Never soften these into plain English.
+- **Person:** instructional docs address the reader as **you** (“Enter your
+  oscilloscope's IP address”, “Press Utility on the oscilloscope”). Log/status
+  lines are impersonal and system-voiced (“=== Oscilloscope Connected ===”,
+  “ERROR: Not connected to oscilloscope”).
+- **Casing:** Title Case for buttons, tabs and menus (“Capture Waveform”,
+  “Visual Measure”). SCPI commands are UPPERCASE (`*IDN?`, `C1:VDIV 1V`).
+  Units keep canonical casing (`kHz`, `mV`, `ms`, `Ω`).
+- **Numbers are formatted with fixed precision + unit.** Readouts read
+  `0.000 V`, `2.000 A`, `1.000 kHz`, `35.0 ns` — 3 decimals for volts/amps,
+  auto-ranged SI units for time/frequency.
+- **Emoji:** used **sparingly and only as functional status/section markers** in
+  docs and a few labels — 🟢🟡🔴🟠 for connection state, ⚠ on the safety
+  “All Outputs OFF” button, and occasional 🎨/📊 section flags in docs. Not
+  decorative; do not sprinkle emoji into the UI.
+- **Tone:** confident, helpful, lab-grade. Docs include “Quick Tip” / “!!! tip”
+  callouts. The vibe is *engineer's instrument*, not consumer gadget.
+
+---
+
+## VISUAL FOUNDATIONS
+
+**Colour.**
+- *Light chrome:* `--app-bg #f3f3f3`, `--surface #ffffff`, borders `#cfcfcf` /
+  `#a0a0a0`, text `#1a1a1a` with `#888` hints.
+- *Dark scope canvas:* `--scope-canvas #0d1117` (GitHub-dark, chosen in
+  `waveform_display_pg.py`), panels `#1e1e1e`/`#2d2d2d`, borders/grid `#30363d`,
+  text `#e6edf3` with `#8b949e` muted ticks.
+- *Channel identity* is the strongest colour signal: **CH1 gold `#FFD700`,
+  CH2 cyan `#00CED1`, CH3 magenta `#FF1493`, CH4 green `#00FF00`** (with vibrant
+  trace variants `#FFDC32 / #40E0D0 / #FF69B4 / #32FF64` on the canvas), plus
+  DAQ extras (tomato, purple, sea-green, orange). Channel colour appears on the
+  group-box title, cursor labels and the trace.
+- *Semantic actions:* success/Connect green `#4CAF50`, danger/Disconnect red
+  `#f44336`, safety-critical crimson `#DC143C`, warning/CC-mode orange `#FFA500`,
+  info blue `#2196F3`. Live readouts are pure green `#00ff00`.
+- No brand gradients. No purple/blue hero gradients. Colour is functional
+  (identity + status), never decorative.
+
+**Type.** Two families. `--font-ui` = Segoe UI (the native Windows Qt font);
+`--font-mono` = Courier New — used for **every** numeric readout, the SCPI
+terminal, FFT peak tables and command examples. Sizes track Qt point sizes
+(8/9/10/11/12pt → 11–16px) with larger 20/28px front-panel readouts. Weights
+400/600/700.
+
+**Spacing & density.** Dense and utilitarian: 5px layout margins, 6px control
+padding, 6×20px buttons, 10px on the safety button. Do not inflate to an 8px
+web grid — the app is tight on purpose.
+
+**Radius, borders, elevation.** Small radii: 3px on controls/inputs/buttons,
+5px on emphasis/safety buttons. Focused inputs get a **2px solid green**
+(`#4CAF50`) border — a signature detail from the terminal input. Borders are
+1px hairlines. The UI is **flat**: shadows are reserved for floating dialogs and
+dropdown popups only — no card drop-shadows in the panels.
+
+**Backgrounds & texture.** Flat fills only. The scope canvas carries a **dotted
+14×10 division grid** (`#30363d`, ~0.2 alpha) with a slightly brighter centre
+crosshair — that grid *is* the texture. No photographic backgrounds, no
+patterns, no blur/glass. The one photographic asset is the project hero image
+(bench instruments on black), used for PyPI/GitHub/docs — not inside the app.
+
+**Cards / containers.** The container primitive is the **GroupBox** — a 1px
+bordered rectangle with a title sitting in a notch on the top border, the title
+colour-coded to its channel. No rounded cards, no left-border-accent cards.
+
+**Motion.** Minimal and functional. Real-time plotting is the only continuous
+motion (the trace scrolls while running). Buttons transition background colour
+on hover/press over ~90ms; the connecting-status dot pulses. No easing-heavy
+entrances, no bounce, no decorative loops.
+
+**Hover / press states.** Buttons darken on press (Connect `#4CAF50` → hover
+`#45a049` → pressed `#3d8b40`; Disconnect `#f44336` → `#da190b` → `#c1170a`);
+default light buttons go `#f0f0f0` → `#e8e8e8` → `#dcdcdc`; ghost/toolbar
+actions get a faint grey wash. Inputs/selects darken their border on hover and
+turn the border green on focus.
+
+---
+
+## ICONOGRAPHY
+
+- **The app is almost icon-free.** The reference main window uses **text labels,
+  not icons**, for toolbar actions (“Run”, “Stop”, “Single”, “Capture
+  Waveform”). There is **no bundled icon font and no SVG icon set** in the
+  source — do not invent one.
+- **Status is communicated with coloured dots**, described in docs as the
+  emoji 🟢 (connected) / 🟡 (connecting) / 🔴 (disconnected) / 🟠 (error). The
+  `StatusIndicator` component reproduces these as coloured dots, which is the
+  correct, on-brand treatment.
+- **Emoji as functional glyphs** appear in a few places: ⚠ on the safety
+  “All Outputs OFF” button, and 🎨/📊 as doc section markers. Use emoji only in
+  these functional roles.
+- **Steppers/chevrons** are the only ui glyphs (spin-box ▲▼, combo-box ▾),
+  rendered as unicode, matching native Qt.
+- **If you need an icon set** for a new surface, add a CDN line icon set
+  (e.g. Lucide) at a 1.5–2px stroke to sit with the hairline borders, and note
+  the addition — but prefer text labels, as the product does. *(No icon set is
+  wired in by default.)*
+- **Brand image:** `resources/Test Equipment.png` (the hero render of an
+  oscilloscope, PSU and AWG on black) is the closest thing to a logo. There is
+  **no vector logo or wordmark** in the source; render the product name in type
+  (see the Brand → Wordmark card) wherever a mark is needed.
+
+---
+
+## Components
+
+Reusable React primitives, reconstructed from the PyQt6 widget vocabulary the
+source defines. Import from `window.SCPIInstrumentControlDesignSystem_b228f5`.
+
+**Controls** (`components/controls/`)
+- **Button** — push button (QPushButton) with `default` / `primary` (Connect) /
+  `danger` (Disconnect) / `critical` (safety) / `ghost` (toolbar) variants.
+- **Checkbox** — QCheckBox toggle with label (Enable, Bandwidth Limit, Grid…).
+- **ComboBox** — QComboBox dropdown (Coupling, Probe, Trigger source…).
+- **SpinBox** — QDoubleSpinBox numeric field with unit suffix + steppers.
+
+**Layout** (`components/layout/`)
+- **GroupBox** — titled bordered panel with a colour-coded title; the control
+  cluster container.
+- **Tabs** — QTabWidget control-panel tab bar.
+- **Toolbar** (+ **ToolbarSeparator**) — the main-window action strip.
+
+**Data & readouts** (`components/data/`)
+- **Reading** — monospace live readout in scope green, with CV/CC mode badge.
+- **StatusIndicator** — coloured connection-status dot + label.
+- **DataTable** — QTableWidget with alternating rows (light + dark variants).
+- **Terminal** — the SCPI command console (colour-coded output + input row).
+
+Each component directory carries `<Name>.jsx`, `<Name>.d.ts`, `<Name>.prompt.md`
+and a `*.card.html` showcase.
+
+## UI Kits
+
+- **`ui_kits/instrument-gui-modern/`** — an **interactive recreation of the
+  oscilloscope main window** in the modern **light-console** style: header with
+  wordmark + status pill, a standout live-readout strip (per-channel Vpp/freq
+  cards with channel-colour accents), left control rail (Channels / Trigger /
+  Measure / Terminal), and the dark waveform canvas framed as the instrument
+  window. Click **Connect** to bring it online, enable channels to draw traces,
+  and Run/Stop the live view. Built by composing the components above. Backed by
+  the `--lc-*` (light) and `--console-*` (dark alternate) theme tokens.
+
+## Foundations (Design System tab)
+
+Specimen cards live in `guidelines/` and populate the Design System tab, grouped
+**Colors** (channels, traces, semantic, light chrome, scope dark, readout/
+terminal), **Type** (UI face, mono/readout face, scale), **Spacing** (scale,
+radius/borders, density-in-use) and **Brand** (wordmark, hero image).
+
+---
+
+## Repo index (manifest)
+
+- `styles.css` — root entry; `@import`s all tokens. Consumers link this only.
+- `tokens/` — `colors.css`, `scope.css`, `typography.css`, `spacing.css`,
+  `fonts.css`, `theme-console.css` (modern light `--lc-*` + dark `--console-*`).
+- `components/` — `controls/`, `layout/`, `data/`.
+- `ui_kits/instrument-gui-modern/` — main-window recreation, modern light
+  console (`index.html`, `app.jsx`, `WaveformCanvas.jsx`).
+- `guidelines/` — foundation specimen cards.
+- `resources/` — brand hero image + icon, reference screenshots.
+- `SKILL.md` — Agent-Skill wrapper.
+- Generated (do not edit): `_ds_bundle.js`, `_ds_manifest.json`,
+  `_adherence.oxlintrc.json`.
+
+---
+
+## ⚠ Font substitution — needs your input
+
+The desktop app uses **Segoe UI** (Windows system font) for UI and **Courier
+New** for readouts/terminal. Neither ships a font file:
+
+- **Segoe UI** → the specimen cards load **Source Sans 3** (Google Fonts) as a
+  cross-platform stand-in; `--font-ui` still lists `"Segoe UI"` first so it
+  renders natively on Windows. On Windows this is exact; elsewhere it's an
+  approximation.
+- **Courier New** is near-universal and kept as-is (`"Cascadia Code"` is listed
+  first as an optional upgrade if you upload it).
+
+**If you have the licensed Segoe UI (or want a different UI face), please share
+the font files and I'll wire them in via `@font-face` for pixel-exact
+specimens.**

--- a/webapp/design/styles.css
+++ b/webapp/design/styles.css
@@ -1,0 +1,10 @@
+/* SCPI Instrument Control — Design System
+ * Root stylesheet. Consumers link ONLY this file.
+ * This file is a manifest of @imports; add no rules here directly. */
+
+@import "tokens/fonts.css";
+@import "tokens/colors.css";
+@import "tokens/scope.css";
+@import "tokens/typography.css";
+@import "tokens/spacing.css";
+@import "tokens/theme-console.css";

--- a/webapp/design/tokens/colors.css
+++ b/webapp/design/tokens/colors.css
@@ -1,0 +1,67 @@
+/* SCPI Instrument Control — Color System
+ *
+ * Two coexisting surfaces:
+ *   1. Native desktop chrome  — light Qt widgets (window, panels, forms).
+ *   2. The scope canvas       — dark instrument display (waveforms, terminal,
+ *                               live readouts). This is the brand's signature.
+ *
+ * All hex values are lifted verbatim from the PyQt6 source (setStyleSheet /
+ * pg.mkPen / QColor calls). Do not round them.
+ */
+:root {
+  /* ---- Light desktop chrome (native Qt) ---- */
+  --app-bg: #f3f3f3;          /* main window background */
+  --surface: #ffffff;          /* input fields, cards, table body */
+  --surface-subtle: #f0f0f0;   /* info banners, inactive tabs */
+  --surface-alt: #fafafa;      /* alternating light rows */
+  --border: #cfcfcf;           /* default control border */
+  --border-strong: #a0a0a0;    /* group frames, hover borders */
+  --divider: #e2e2e2;
+
+  --text-primary: #1a1a1a;
+  --text-secondary: #555555;
+  --text-muted: #888888;       /* hints, instruction labels (#888) */
+  --text-faint: #666666;
+
+  /* ---- Oscilloscope channel colors (control-label / classic scope) ---- */
+  --ch1: #FFD700;              /* Yellow / Gold */
+  --ch2: #00CED1;              /* Cyan */
+  --ch3: #FF1493;              /* Deep Pink / Magenta */
+  --ch4: #00FF00;              /* Green */
+  --ch5: #FF6347;              /* Tomato (DAQ) */
+  --ch6: #9370DB;              /* Medium Purple (DAQ) */
+  --ch7: #20B2AA;              /* Light Sea Green (DAQ) */
+  --ch8: #FF8C00;              /* Dark Orange (DAQ) */
+
+  /* ---- Waveform trace colors (vibrant, rendered on scope canvas) ---- */
+  --trace1: #FFDC32;           /* rgb(255,220,50)  bright yellow */
+  --trace2: #40E0D0;           /* rgb(64,224,208)  turquoise */
+  --trace3: #FF69B4;           /* rgb(255,105,180) hot pink */
+  --trace4: #32FF64;           /* rgb(50,255,100)  bright green */
+  --trace-reference: #FFA500;  /* rgb(255,165,0)   orange dashed overlay */
+  --trace-difference: #FF1493; /* rgb(255,20,147)  difference trace */
+
+  /* ---- Semantic action colors ---- */
+  --success: #4CAF50;          /* Connect / OK */
+  --success-hover: #45a049;
+  --success-pressed: #3d8b40;
+  --danger: #f44336;           /* Disconnect / Clear / errors */
+  --danger-hover: #da190b;
+  --danger-pressed: #c1170a;
+  --critical: #DC143C;         /* All-Outputs-OFF safety */
+  --critical-hover: #B22222;
+  --warning: #FFA500;          /* Constant-Current (CC) mode */
+  --info: #2196F3;             /* metrics / CPU label */
+
+  /* ---- Live readout ---- */
+  --readout: #00ff00;          /* measured V / I / W value text */
+  --readout-mode: #FFD700;     /* CV/CC mode label (idle gold) */
+
+  /* ---- Semantic aliases (prefer these in app code) ---- */
+  --text-body: var(--text-primary);
+  --text-label: var(--text-secondary);
+  --surface-card: var(--surface);
+  --border-control: var(--border);
+  --btn-primary-bg: var(--success);
+  --btn-danger-bg: var(--danger);
+}

--- a/webapp/design/tokens/fonts.css
+++ b/webapp/design/tokens/fonts.css
@@ -1,0 +1,9 @@
+/* SCPI Instrument Control — Webfonts
+ *
+ * The application is a native PyQt6 desktop app. Its UI font is the OS default
+ * "Segoe UI" (Windows), and its console/readout font is "Courier New".
+ * Neither ships a font file. For cross-platform specimen fidelity we load
+ * Source Sans 3 as a close stand-in for Segoe UI (SUBSTITUTION — flagged in
+ * readme.md). Courier New is near-universal and kept as-is.
+ */
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,400;0,600;0,700;1,400&display=swap');

--- a/webapp/design/tokens/scope.css
+++ b/webapp/design/tokens/scope.css
@@ -1,0 +1,39 @@
+/* SCPI Instrument Control — Scope Canvas Tokens
+ *
+ * The dark instrument surface used for the waveform display, terminal output,
+ * live-data plots and readout panels. Background is GitHub-dark (#0d1117), the
+ * value chosen in waveform_display_pg.py. Grid/axis colors are the muted GitHub
+ * palette; readout text is bright to read at a glance across a lab bench.
+ */
+:root {
+  /* Backgrounds (darkest → lightest) */
+  --scope-canvas: #0d1117;     /* plot / waveform background */
+  --scope-panel: #1e1e1e;      /* terminal & data-plot background */
+  --scope-surface: #2d2d2d;    /* dark table body / raised panel */
+  --scope-row-alt: #353535;    /* alternating dark rows */
+  --scope-header: #404040;     /* dark table header */
+
+  /* Borders */
+  --scope-border: #30363d;     /* grid lines, axis lines */
+  --scope-border-2: #404040;   /* panel border */
+  --scope-border-3: #505050;   /* table gridline / header edge */
+  --scope-border-soft: #444444;/* separators inside panels */
+
+  /* Text on dark */
+  --scope-text: #e6edf3;       /* primary axis title / labels */
+  --scope-text-body: #d4d4d4;  /* terminal body text */
+  --scope-text-muted: #8b949e; /* muted axis ticks / secondary */
+  --scope-text-faint: #888888;
+
+  /* Terminal syntax palette (VS Code dark derived) */
+  --term-command: #569cd6;     /* echoed command ("> *IDN?") */
+  --term-response: #4ec9b0;    /* query response / cmd keyword */
+  --term-ok: #4CAF50;          /* OK / connected banner */
+  --term-error: #f44336;       /* error lines */
+  --term-muted: #888888;       /* system notices */
+
+  /* Grid geometry (matches scope face: 14 x 10 divisions) */
+  --grid-divs-x: 14;   /* @kind other */
+  --grid-divs-y: 10;   /* @kind other */
+  --grid-alpha: 0.2;   /* @kind other */
+}

--- a/webapp/design/tokens/spacing.css
+++ b/webapp/design/tokens/spacing.css
@@ -1,0 +1,47 @@
+/* SCPI Instrument Control — Spacing, Radius, Borders, Shadow
+ *
+ * The desktop app is dense and utilitarian. Layout margins are 5px
+ * (QVBoxLayout.setContentsMargins(5,5,5,5)); control padding 6px; buttons
+ * 6px 20px; safety button 10px. Radii are small (3px controls, 5px emphasis
+ * buttons). These tokens encode that measured density — do not inflate them.
+ */
+:root {
+  /* Spacing scale */
+  --space-0: 0;
+  --space-1: 2px;
+  --space-2: 4px;
+  --space-3: 5px;    /* Qt layout content margin */
+  --space-4: 6px;    /* control inner padding */
+  --space-5: 8px;
+  --space-6: 10px;   /* safety button / info banner padding */
+  --space-7: 12px;
+  --space-8: 16px;
+  --space-9: 20px;   /* button horizontal padding */
+  --space-10: 24px;
+  --space-12: 32px;
+
+  /* Radius */
+  --radius-none: 0;
+  --radius-sm: 3px;   /* default controls, inputs, buttons */
+  --radius-md: 5px;   /* emphasis / safety buttons */
+  --radius-lg: 8px;
+  --radius-pill: 999px;
+
+  /* Border widths */
+  --border-thin: 1px;
+  --border-thick: 2px;  /* focused input (2px solid) */
+
+  /* Elevation — the app is largely flat; shadows are reserved for
+     floating dialogs and dropdown popups only. */
+  --shadow-none: none;
+  --shadow-popup: 0 2px 8px rgba(0, 0, 0, 0.18);
+  --shadow-dialog: 0 8px 28px rgba(0, 0, 0, 0.28);
+
+  /* Control sizing */
+  --control-height: 28px;
+  --control-height-sm: 24px;
+  --toolbar-height: 44px;
+
+  /* Focus ring — uses the Connect green, as in the terminal input */
+  --focus-ring: var(--success);
+}

--- a/webapp/design/tokens/theme-console.css
+++ b/webapp/design/tokens/theme-console.css
@@ -1,0 +1,72 @@
+/* SCPI Instrument Control — Console Theme (modern dark shell)
+ *
+ * An additive, opt-in theme that extends the brand's dark scope canvas to the
+ * whole application chrome — a cohesive "instrument console" look. Values stay
+ * within the existing scope palette (GitHub-dark family) so nothing goes
+ * off-brand; they just raise contrast and elevation for a modern feel.
+ *
+ * Use by setting data-theme="console" on a shell root (or read the vars
+ * directly). Pairs with the channel-colour language and mono readouts.
+ */
+:root {
+  /* Console surfaces (darkest shell → raised panel → control) */
+  --console-bg: #0b0e14;          /* app shell background */
+  --console-panel: #12161f;       /* rails, cards, header/footer */
+  --console-panel-2: #171c27;     /* nested / raised surface */
+  --console-control: #1b212e;     /* inputs, secondary buttons */
+  --console-control-hover: #232a3a;
+
+  /* Console borders + hairlines */
+  --console-border: #232a36;      /* default hairline */
+  --console-border-strong: #313a4a;
+  --console-divider: #1a202b;
+
+  /* Console text */
+  --console-text: #e8edf5;        /* primary */
+  --console-text-2: #aab4c4;      /* secondary */
+  --console-muted: #6b7688;       /* tertiary / captions */
+
+  /* Emphasis — a single cool accent for focus/active, distinct from the
+     semantic action greens/reds so hierarchy stays legible. */
+  --console-accent: #38bdf8;      /* active tab / focus ring / selection */
+  --console-accent-soft: rgba(56, 189, 248, 0.14);
+
+  /* Elevation for the modern look — soft, dark, never heavy. */
+  --console-elev-1: 0 1px 0 rgba(255,255,255,0.03), 0 1px 3px rgba(0,0,0,0.45);
+  --console-elev-2: 0 2px 6px rgba(0,0,0,0.5), 0 8px 24px rgba(0,0,0,0.35);
+
+  /* Radius bumped one notch vs. native Qt for a softer, current feel
+     (still restrained — not web-slop). */
+  --console-radius: 8px;
+  --console-radius-sm: 6px;
+}
+
+/* ---- Light console (DEFAULT modern shell) ----
+ * A bright, elevated lab interface: soft off-white shell, white raised panels,
+ * cool hairline borders, gentle shadows and channel-colour accents doing the
+ * emphasis. This is the default modern treatment; the dark --console-* set
+ * above is the opt-in alternate. */
+:root {
+  --lc-bg: #eef2f7;              /* app shell (soft cool off-white) */
+  --lc-panel: #ffffff;          /* raised cards / rails / header */
+  --lc-panel-2: #f4f7fb;        /* nested / inset surface */
+  --lc-control: #ffffff;        /* inputs */
+  --lc-control-hover: #f4f7fb;
+
+  --lc-border: #dde4ee;         /* default hairline */
+  --lc-border-strong: #c3cddc;  /* control / hover border */
+  --lc-divider: #eaeff5;
+
+  --lc-text: #10161f;           /* primary ink */
+  --lc-text-2: #56606f;         /* secondary */
+  --lc-muted: #8a94a3;          /* captions / tertiary */
+
+  --lc-accent: #1f7ae0;         /* active tab / focus ring */
+  --lc-accent-soft: rgba(31, 122, 224, 0.12);
+
+  --lc-elev-1: 0 1px 2px rgba(16, 22, 31, 0.06), 0 1px 3px rgba(16, 22, 31, 0.08);
+  --lc-elev-2: 0 4px 12px rgba(16, 22, 31, 0.08), 0 12px 28px rgba(16, 22, 31, 0.10);
+
+  --lc-radius: 10px;
+  --lc-radius-sm: 7px;
+}

--- a/webapp/design/tokens/typography.css
+++ b/webapp/design/tokens/typography.css
@@ -1,0 +1,44 @@
+/* SCPI Instrument Control — Typography
+ *
+ * Two families, both mirroring the desktop app:
+ *   --font-ui   : the native Segoe UI (system-first, Source Sans 3 webfont
+ *                 stand-in for cross-platform specimens — flagged in readme).
+ *   --font-mono : Courier New — used for every numeric readout, SCPI terminal,
+ *                 FFT peak table and measured-value label in the source.
+ *
+ * Sizes track Qt point sizes used in the code (8pt / 9pt / 10pt / 11pt / 12pt),
+ * converted to px at the Qt default 96dpi (1pt ≈ 1.333px).
+ */
+:root {
+  --font-ui: "Segoe UI", "Source Sans 3", system-ui, -apple-system,
+             BlinkMacSystemFont, Roboto, sans-serif;
+  --font-mono: "Courier New", ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* Font sizes (Qt pt → px) */
+  --text-2xs: 11px;   /*  8pt — example command lists */
+  --text-xs: 12px;    /*  9pt — hints, instruction labels, small tables */
+  --text-sm: 13px;    /* 10pt — control input text, terminal input */
+  --text-base: 14px;  /* default body */
+  --text-md: 15px;    /* 11pt — plot axis labels */
+  --text-lg: 16px;    /* 12pt — plot title, section headers */
+  --text-xl: 20px;    /* readout values */
+  --text-2xl: 28px;   /* hero instrument readout (e.g. "30.00 V") */
+
+  /* Weights */
+  --weight-normal: 400;
+  --weight-medium: 600;
+  --weight-bold: 700;
+
+  /* Line heights */
+  --leading-tight: 1.2;
+  --leading-normal: 1.45;
+  --leading-relaxed: 1.6;
+
+  /* Letter spacing */
+  --tracking-mono: 0.01em;
+  --tracking-label: 0.02em;
+
+  /* Semantic aliases */
+  --font-readout: var(--font-mono);
+  --font-terminal: var(--font-mono);
+}

--- a/webapp/design/ui_kits/instrument-gui-modern/WaveformCanvas.jsx
+++ b/webapp/design/ui_kits/instrument-gui-modern/WaveformCanvas.jsx
@@ -1,0 +1,121 @@
+// WaveformCanvas — the dark scope display: 14×10 division grid + animated
+// channel traces. Data-visualization canvas (not iconography). Colours come
+// from the design-system trace tokens.
+function WaveformCanvas({ channels, running, showGrid }) {
+  const canvasRef = React.useRef(null);
+  const wrapRef = React.useRef(null);
+  const phaseRef = React.useRef(0);
+  const rafRef = React.useRef(null);
+
+  const TRACE = {
+    1: "#FFDC32", 2: "#40E0D0", 3: "#FF69B4", 4: "#32FF64",
+  };
+
+  React.useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap) return;
+    const ctx = canvas.getContext("2d");
+
+    const draw = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const w = wrap.clientWidth, h = wrap.clientHeight;
+      if (canvas.width !== w * dpr || canvas.height !== h * dpr) {
+        canvas.width = w * dpr; canvas.height = h * dpr;
+        canvas.style.width = w + "px"; canvas.style.height = h + "px";
+      }
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, w, h);
+
+      // background
+      ctx.fillStyle = "#0d1117";
+      ctx.fillRect(0, 0, w, h);
+
+      const padL = 8, padR = 8, padT = 8, padB = 8;
+      const gx = padL, gy = padT, gw = w - padL - padR, gh = h - padT - padB;
+
+      // grid — 14 x 10 divisions, dotted
+      if (showGrid) {
+        ctx.strokeStyle = "#30363d";
+        ctx.lineWidth = 1;
+        ctx.setLineDash([1, 3]);
+        for (let i = 0; i <= 14; i++) {
+          const x = gx + (gw * i) / 14;
+          ctx.beginPath(); ctx.moveTo(x, gy); ctx.lineTo(x, gy + gh); ctx.stroke();
+        }
+        for (let j = 0; j <= 10; j++) {
+          const y = gy + (gh * j) / 10;
+          ctx.beginPath(); ctx.moveTo(gx, y); ctx.lineTo(gx + gw, y); ctx.stroke();
+        }
+        ctx.setLineDash([]);
+        // center crosshair, slightly brighter
+        ctx.strokeStyle = "#3d444d";
+        ctx.beginPath(); ctx.moveTo(gx + gw / 2, gy); ctx.lineTo(gx + gw / 2, gy + gh); ctx.stroke();
+        ctx.beginPath(); ctx.moveTo(gx, gy + gh / 2); ctx.lineTo(gx + gw, gy + gh / 2); ctx.stroke();
+      }
+
+      // traces
+      const active = channels.filter((c) => c.enabled);
+      if (active.length === 0) {
+        ctx.fillStyle = "#8b949e";
+        ctx.font = "13px 'Segoe UI', system-ui, sans-serif";
+        ctx.textAlign = "center";
+        ctx.fillText("No data — enable a channel", w / 2, h / 2);
+      } else {
+        active.forEach((c) => {
+          ctx.strokeStyle = TRACE[c.num] || "#ffffff";
+          ctx.lineWidth = 2;
+          ctx.lineJoin = "round";
+          ctx.beginPath();
+          const cyc = c.freq;      // cycles across the screen
+          const amp = (gh / 2) * c.amp;
+          const yMid = gy + gh / 2 - c.offset * (gh / 10);
+          for (let px = 0; px <= gw; px++) {
+            const t = px / gw;
+            let v;
+            if (c.shape === "square") {
+              v = Math.sign(Math.sin(2 * Math.PI * cyc * t + phaseRef.current + c.phase)) || 1;
+            } else if (c.shape === "triangle") {
+              v = (2 / Math.PI) * Math.asin(Math.sin(2 * Math.PI * cyc * t + phaseRef.current + c.phase));
+            } else {
+              v = Math.sin(2 * Math.PI * cyc * t + phaseRef.current + c.phase);
+            }
+            const x = gx + px;
+            const y = yMid - v * amp;
+            px === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+          }
+          ctx.stroke();
+        });
+      }
+    };
+
+    let last = performance.now();
+    const loop = (now) => {
+      if (running) { phaseRef.current += (now - last) / 1000 * 3; }
+      last = now;
+      draw();
+      rafRef.current = requestAnimationFrame(loop);
+    };
+    rafRef.current = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [channels, running, showGrid]);
+
+  return (
+    <div ref={wrapRef} style={{ position: "relative", width: "100%", height: "100%" }}>
+      <canvas ref={canvasRef} style={{ display: "block" }} />
+      <div style={{
+        position: "absolute", top: 8, left: 0, right: 0, textAlign: "center",
+        color: "#e6edf3", fontFamily: "var(--font-ui)", fontSize: "15px", pointerEvents: "none",
+      }}>Waveform Display</div>
+      <div style={{
+        position: "absolute", left: 10, top: "50%", transform: "rotate(-90deg) translateX(50%)",
+        transformOrigin: "left center", color: "#8b949e", fontSize: "11px", fontFamily: "var(--font-ui)", pointerEvents: "none",
+      }}>Voltage (V)</div>
+      <div style={{
+        position: "absolute", bottom: 8, left: 0, right: 0, textAlign: "center",
+        color: "#8b949e", fontSize: "11px", fontFamily: "var(--font-ui)", pointerEvents: "none",
+      }}>Time (s)</div>
+    </div>
+  );
+}
+window.WaveformCanvas = WaveformCanvas;

--- a/webapp/design/ui_kits/instrument-gui-modern/app.jsx
+++ b/webapp/design/ui_kits/instrument-gui-modern/app.jsx
@@ -1,0 +1,278 @@
+// Instrument Control GUI — CONSOLE (light, default modern shell).
+// A bright, elevated lab interface. The dark scope canvas stays as the
+// "instrument window"; the chrome is light, modern, with channel-colour
+// accents and a standout live-readout strip.
+// Reuses design-system Button / StatusIndicator / DataTable / Terminal.
+const NS = window.SCPIInstrumentControlDesignSystem_b228f5;
+const { Button, StatusIndicator, DataTable, Terminal } = NS;
+
+const TRACE = { 1: "#E0A800", 2: "#0F9FB0", 3: "#E01A7F", 4: "#1FA83B" }; // ink-legible channel accents on light
+const DOT = { 1: "#FFDC32", 2: "#40E0D0", 3: "#FF69B4", 4: "#32FF64" };   // vibrant swatch (matches trace on canvas)
+const COUPLING = ["DC", "AC", "GND"];
+const PROBES = ["0.1X", "1X", "10X", "100X", "1000X"];
+
+const DEFAULTS = [
+  { num: 1, enabled: true,  vdiv: 1.0, coupling: "DC", offset: 0,  freq: 3, amp: 0.70, phase: 0.0, shape: "sine" },
+  { num: 2, enabled: true,  vdiv: 0.5, coupling: "AC", offset: -2, freq: 5, amp: 0.50, phase: 1.0, shape: "sine" },
+  { num: 3, enabled: false, vdiv: 2.0, coupling: "DC", offset: 2,  freq: 2, amp: 0.60, phase: 0.5, shape: "square" },
+  { num: 4, enabled: false, vdiv: 1.0, coupling: "DC", offset: -3, freq: 4, amp: 0.40, phase: 2.0, shape: "triangle" },
+];
+
+const S = {
+  shell: { display: "flex", flexDirection: "column", height: "100vh", background: "var(--lc-bg)",
+           color: "var(--lc-text)", fontFamily: "var(--font-ui)" },
+  panel: { background: "var(--lc-panel)", border: "1px solid var(--lc-border)",
+           borderRadius: "var(--lc-radius)", boxShadow: "var(--lc-elev-1)" },
+  cap: { fontSize: 11, letterSpacing: ".06em", textTransform: "uppercase", color: "var(--lc-muted)",
+         display: "block", marginBottom: 4 },
+};
+
+// ---- Light form controls (console-styled) ----
+function LSelect({ options, value, onChange, width }) {
+  const norm = options.map((o) => (typeof o === "string" ? { label: o, value: o } : o));
+  return (
+    <div style={{ position: "relative", width: width || "100%" }}>
+      <select value={value} onChange={(e) => onChange && onChange(e.target.value)}
+        style={{ appearance: "none", WebkitAppearance: "none", width: "100%", height: 32,
+          padding: "0 26px 0 10px", fontFamily: "var(--font-ui)", fontSize: 13, color: "var(--lc-text)",
+          background: "var(--lc-control)", border: "1px solid var(--lc-border-strong)",
+          borderRadius: "var(--lc-radius-sm)", cursor: "pointer", outline: "none" }}>
+        {norm.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+      </select>
+      <span style={{ position: "absolute", right: 10, top: "50%", transform: "translateY(-50%)",
+        pointerEvents: "none", color: "var(--lc-muted)", fontSize: 10 }}>▾</span>
+    </div>
+  );
+}
+function LSpin({ value, min, max, step = 0.1, decimals = 3, suffix = "", onChange, width }) {
+  const clamp = (v) => Math.min(max ?? Infinity, Math.max(min ?? -Infinity, v));
+  const [foc, setFoc] = React.useState(false);
+  const nudge = (d) => onChange && onChange(clamp(value + d * step));
+  return (
+    <div style={{ display: "flex", height: 32, width: width || "100%", background: "var(--lc-control)",
+      border: `1px solid ${foc ? "var(--lc-accent)" : "var(--lc-border-strong)"}`,
+      borderRadius: "var(--lc-radius-sm)", overflow: "hidden",
+      boxShadow: foc ? "0 0 0 3px var(--lc-accent-soft)" : "none" }}>
+      <input value={value.toFixed(decimals) + suffix} onFocus={() => setFoc(true)}
+        onBlur={(e) => { setFoc(false); const n = parseFloat(e.target.value); if (!isNaN(n)) onChange && onChange(clamp(n)); }}
+        onChange={() => {}} readOnly
+        style={{ flex: 1, minWidth: 0, border: "none", outline: "none", background: "transparent",
+          padding: "0 10px", fontFamily: "var(--font-mono)", fontSize: 13, color: "var(--lc-text)" }} />
+      <div style={{ display: "flex", flexDirection: "column", width: 20, borderLeft: "1px solid var(--lc-border)" }}>
+        <button onClick={() => nudge(1)} style={spinBtn}>▲</button>
+        <button onClick={() => nudge(-1)} style={{ ...spinBtn, borderTop: "1px solid var(--lc-border)" }}>▼</button>
+      </div>
+    </div>
+  );
+}
+const spinBtn = { flex: 1, border: "none", background: "var(--lc-panel-2)", color: "var(--lc-text-2)",
+  cursor: "pointer", fontSize: 7, lineHeight: 1, padding: 0 };
+function LCheck({ label, checked, onChange, accent }) {
+  return (
+    <label onClick={() => onChange && onChange(!checked)}
+      style={{ display: "inline-flex", alignItems: "center", gap: 8, cursor: "pointer", fontSize: 13, userSelect: "none" }}>
+      <span style={{ width: 17, height: 17, borderRadius: 5, flexShrink: 0, display: "inline-flex",
+        alignItems: "center", justifyContent: "center",
+        background: checked ? (accent || "var(--lc-accent)") : "var(--lc-control)",
+        border: `1px solid ${checked ? (accent || "var(--lc-accent)") : "var(--lc-border-strong)"}` }}>
+        {checked && <svg width="11" height="11" viewBox="0 0 12 12"><path d="M2.5 6.2L4.8 8.5L9.5 3.5"
+          stroke="#fff" strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round" /></svg>}
+      </span>
+      {label}
+    </label>
+  );
+}
+
+// ---- Standout live-readout strip ----
+function ReadoutStrip({ channels, running, sampleRate }) {
+  const active = channels.filter((c) => c.enabled);
+  return (
+    <div style={{ display: "flex", gap: 12, padding: "14px 16px 4px", alignItems: "stretch", flexWrap: "wrap" }}>
+      {active.length === 0 && (
+        <div style={{ ...S.panel, flex: 1, padding: "16px 18px", color: "var(--lc-muted)", fontSize: 13 }}>
+          No active channels — enable a channel to see live measurements.
+        </div>
+      )}
+      {active.map((c) => {
+        const vpp = (c.amp * c.vdiv * 4).toFixed(2);
+        const freq = (c.freq * 100).toFixed(1);
+        return (
+          <div key={c.num} style={{ ...S.panel, minWidth: 200, flex: "1 1 200px", padding: "14px 16px 14px 18px",
+            position: "relative", overflow: "hidden", boxShadow: "var(--lc-elev-1)" }}>
+            <span style={{ position: "absolute", left: 0, top: 0, bottom: 0, width: 5, background: DOT[c.num] }} />
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: "var(--font-mono)",
+                fontWeight: 700, fontSize: 12, color: TRACE[c.num] }}>
+                <span style={{ width: 9, height: 9, borderRadius: 999, background: DOT[c.num] }} />C{c.num}
+              </span>
+              <span style={{ fontSize: 11, color: "var(--lc-muted)", fontFamily: "var(--font-mono)" }}>{c.coupling} · {c.vdiv} V/div</span>
+            </div>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 7 }}>
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: 32, fontWeight: 700, lineHeight: 1,
+                color: "var(--lc-text)", letterSpacing: "-0.01em" }}>{running ? vpp : "--.--"}</span>
+              <span style={{ fontSize: 13, color: "var(--lc-text-2)", fontWeight: 600 }}>Vpp</span>
+            </div>
+            <div style={{ fontFamily: "var(--font-mono)", fontSize: 12, color: "var(--lc-text-2)", marginTop: 5 }}>
+              {running ? `${freq} kHz` : "—"}
+            </div>
+          </div>
+        );
+      })}
+      <div style={{ ...S.panel, minWidth: 168, padding: "14px 16px", display: "flex", flexDirection: "column", justifyContent: "center", gap: 8 }}>
+        <div><span style={S.cap}>Sample rate</span><span style={{ fontFamily: "var(--font-mono)", fontSize: 17, fontWeight: 600 }}>{sampleRate}</span></div>
+        <div style={{ display: "flex", gap: 18 }}>
+          <div><span style={S.cap}>FPS</span><span style={{ fontFamily: "var(--font-mono)", fontSize: 17, fontWeight: 600, color: running ? "#1FA83B" : "var(--lc-muted)" }}>{running ? 45 : 0}</span></div>
+          <div><span style={S.cap}>Mem</span><span style={{ fontFamily: "var(--font-mono)", fontSize: 17, fontWeight: 600 }}>14 Mpts</span></div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TabStrip({ tabs, value, onChange }) {
+  return (
+    <div style={{ display: "flex", gap: 3, padding: 4, background: "var(--lc-panel-2)",
+      borderRadius: "var(--lc-radius)", border: "1px solid var(--lc-border)" }}>
+      {tabs.map((t) => {
+        const on = t === value;
+        return (
+          <button key={t} onClick={() => onChange(t)}
+            style={{ flex: 1, border: "none", cursor: "pointer", fontFamily: "var(--font-ui)", fontSize: 13,
+              fontWeight: on ? 600 : 500, padding: "8px 6px", borderRadius: "var(--lc-radius-sm)",
+              color: on ? "var(--lc-text)" : "var(--lc-text-2)",
+              background: on ? "var(--lc-panel)" : "transparent",
+              boxShadow: on ? "var(--lc-elev-1)" : "none" }}>{t}</button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ChannelCard({ c, update }) {
+  return (
+    <div style={{ ...S.panel, background: "var(--lc-panel)", padding: 0, overflow: "hidden" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between",
+        padding: "11px 13px", borderBottom: "1px solid var(--lc-divider)",
+        borderLeft: `4px solid ${DOT[c.num]}` }}>
+        <LCheck label={<b style={{ color: TRACE[c.num] }}>Channel {c.num}</b>} checked={c.enabled}
+          accent={DOT[c.num]} onChange={(v) => update(c.num, { enabled: v })} />
+        <Button size="sm">Auto Scale</Button>
+      </div>
+      <div style={{ padding: 13, display: "grid", gridTemplateColumns: "1fr 1fr", gap: 11,
+        opacity: c.enabled ? 1 : 0.5 }}>
+        <label style={S.cap}>V/div<LSpin value={c.vdiv} min={0.001} max={10} suffix=" V" onChange={(v) => update(c.num, { vdiv: v })} /></label>
+        <label style={S.cap}>Offset<LSpin value={c.offset} min={-10} max={10} suffix=" V" onChange={(v) => update(c.num, { offset: v })} /></label>
+        <label style={S.cap}>Coupling<LSelect options={COUPLING} value={c.coupling} onChange={(v) => update(c.num, { coupling: v })} /></label>
+        <label style={S.cap}>Probe<LSelect options={PROBES} value="10X" onChange={() => {}} /></label>
+      </div>
+    </div>
+  );
+}
+
+function AppConsole() {
+  const [conn, setConn] = React.useState("disconnected");
+  const [running, setRunning] = React.useState(false);
+  const [showGrid, setShowGrid] = React.useState(true);
+  const [tab, setTab] = React.useState("Channels");
+  const [channels, setChannels] = React.useState(DEFAULTS);
+  const [term, setTerm] = React.useState([]);
+  const connected = conn === "connected";
+  const update = (num, patch) => setChannels((cs) => cs.map((c) => (c.num === num ? { ...c, ...patch } : c)));
+
+  const connect = () => {
+    if (conn !== "disconnected") return;
+    setConn("connecting");
+    setTimeout(() => { setConn("connected"); setRunning(true);
+      setTerm((t) => [...t, { text: "=== Oscilloscope Connected ===", kind: "ok" },
+        { text: "> *IDN?", kind: "command" }, { text: "  Siglent,SDS824X HD,SN12345,1.2.3.4", kind: "response" }]);
+    }, 900);
+  };
+  const disconnect = () => { setConn("disconnected"); setRunning(false); };
+  const sendCmd = (cmd) => setTerm((t) => [...t, { text: `> ${cmd}`, kind: "command" },
+    cmd.includes("?") ? { text: "  1.000E+00", kind: "response" } : { text: "  OK", kind: "ok" }]);
+
+  const measRows = channels.filter((c) => c.enabled).flatMap((c) => [
+    [<span style={{ color: TRACE[c.num], fontWeight: 700 }}>C{c.num}</span>, "Frequency", `${(c.freq * 100).toFixed(1)} kHz`],
+    [<span style={{ color: TRACE[c.num], fontWeight: 700 }}>C{c.num}</span>, "Peak-to-Peak", `${(c.amp * c.vdiv * 4).toFixed(3)} V`],
+    [<span style={{ color: TRACE[c.num], fontWeight: 700 }}>C{c.num}</span>, "RMS", `${(c.amp * c.vdiv * 1.41).toFixed(3)} V`],
+  ]);
+
+  return (
+    <div style={S.shell}>
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "center", gap: 14, padding: "12px 18px",
+        background: "var(--lc-panel)", borderBottom: "1px solid var(--lc-border)", boxShadow: "var(--lc-elev-1)", zIndex: 2 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 11 }}>
+          <div style={{ width: 32, height: 32, borderRadius: 9, border: "1.5px solid var(--lc-text)",
+            display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "var(--font-mono)", fontSize: 17 }}>〜</div>
+          <div>
+            <div style={{ fontSize: 14, fontWeight: 700, lineHeight: 1.1 }}>SCPI Instrument Control</div>
+            <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--lc-muted)" }}>SDS824X HD · 192.168.1.100:5024</div>
+          </div>
+        </div>
+        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 12 }}>
+          <div style={{ padding: "6px 13px", borderRadius: 999, background: "var(--lc-panel-2)",
+            border: "1px solid var(--lc-border)" }}>
+            <StatusIndicator state={conn} label={connected ? "Connected" : conn === "connecting" ? "Connecting…" : "Offline"} />
+          </div>
+          <Button variant="primary" onClick={connect} disabled={conn !== "disconnected"}>Connect</Button>
+          <Button variant="danger" onClick={disconnect} disabled={!connected}>Disconnect</Button>
+        </div>
+      </div>
+
+      {/* Standout readout strip */}
+      <ReadoutStrip channels={connected ? channels : []} running={running && connected} sampleRate={connected ? "2 GSa/s" : "—"} />
+
+      {/* Body */}
+      <div style={{ display: "flex", flex: 1, minHeight: 0, gap: 14, padding: "10px 16px 16px" }}>
+        {/* Left rail */}
+        <div style={{ width: 380, flexShrink: 0, display: "flex", flexDirection: "column", gap: 12, minHeight: 0 }}>
+          <TabStrip tabs={["Channels", "Trigger", "Measure", "Terminal"]} value={tab} onChange={setTab} />
+          <div style={{ ...S.panel, flex: 1, padding: 13, overflowY: "auto", opacity: connected ? 1 : 0.55,
+            pointerEvents: connected ? "auto" : "none" }}>
+            {tab === "Channels" && <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>{channels.map((c) => <ChannelCard key={c.num} c={c} update={update} />)}</div>}
+            {tab === "Trigger" && (
+              <div style={{ display: "grid", gap: 12 }}>
+                <label style={S.cap}>Mode<LSelect options={["AUTO", "NORMAL", "SINGLE", "STOP"]} value="AUTO" onChange={() => {}} /></label>
+                <label style={S.cap}>Source<LSelect options={["C1", "C2", "C3", "C4", "EX", "LINE"]} value="C1" onChange={() => {}} /></label>
+                <label style={S.cap}>Slope<LSelect options={["POS", "NEG"]} value="POS" onChange={() => {}} /></label>
+                <label style={S.cap}>Level<LSpin value={0} min={-10} max={10} suffix=" V" onChange={() => {}} /></label>
+                <div style={{ display: "flex", gap: 8, marginTop: 2 }}><Button fullWidth>Force Trigger</Button><Button fullWidth>Set 50%</Button></div>
+              </div>
+            )}
+            {tab === "Measure" && (measRows.length
+              ? <DataTable columns={["Ch", "Measurement", { label: "Value", align: "right", mono: true }]} rows={measRows} />
+              : <div style={{ fontSize: 13, color: "var(--lc-muted)" }}>Enable a channel to see measurements.</div>)}
+            {tab === "Terminal" && <div style={{ height: 440 }}><Terminal lines={term} onSend={sendCmd} style={{ height: "100%" }} /></div>}
+          </div>
+        </div>
+
+        {/* Display — dark scope canvas framed as the instrument window */}
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 12, minWidth: 0 }}>
+          <div style={{ ...S.panel, flex: 1, overflow: "hidden", minHeight: 0, padding: 6, boxShadow: "var(--lc-elev-2)" }}>
+            <div style={{ height: "100%", borderRadius: "calc(var(--lc-radius) - 4px)", overflow: "hidden" }}>
+              <window.WaveformCanvas channels={connected ? channels : []} running={running && connected} showGrid={showGrid} />
+            </div>
+          </div>
+          <div style={{ ...S.panel, display: "flex", alignItems: "center", gap: 14, padding: "9px 13px" }}>
+            <div style={{ display: "flex", gap: 8 }}>
+              {channels.filter((c) => c.enabled).map((c) => (
+                <span key={c.num} style={{ display: "inline-flex", alignItems: "center", gap: 6, fontFamily: "var(--font-mono)",
+                  fontSize: 12, padding: "4px 9px", borderRadius: 999, background: "var(--lc-panel-2)", border: "1px solid var(--lc-border)" }}>
+                  <span style={{ width: 8, height: 8, borderRadius: 999, background: DOT[c.num] }} />C{c.num}
+                </span>
+              ))}
+            </div>
+            <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 12 }}>
+              <LCheck label="Grid" checked={showGrid} onChange={setShowGrid} />
+              <Button variant="ghost" size="sm" onClick={() => connected && setRunning(true)}>Run</Button>
+              <Button variant="ghost" size="sm" onClick={() => setRunning(false)}>Stop</Button>
+              <Button variant="ghost" size="sm">Export</Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+window.AppConsole = AppConsole;

--- a/webapp/design/ui_kits/instrument-gui-modern/index.html
+++ b/webapp/design/ui_kits/instrument-gui-modern/index.html
@@ -1,0 +1,28 @@
+<!-- @dsCard group="Instrument GUI" viewport="1280x800" name="Instrument Control GUI — Console" subtitle="Modern light console: elevated panels, channel accents, standout readouts" -->
+<!-- @startingPoint section="Screens" subtitle="Modern light instrument console — connect, enable channels, run live" viewport="1280x800" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Instrument Control GUI — Modern</title>
+<link rel="stylesheet" href="../../styles.css" />
+<style>
+  html, body, #root { margin: 0; height: 100%; }
+  body { background: var(--lc-bg); }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="../../_ds_bundle.js"></script>
+<script type="text/babel" src="WaveformCanvas.jsx"></script>
+<script type="text/babel" src="app.jsx"></script>
+<script type="text/babel">
+  const App = window.AppConsole;
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Description

The V1 browser UI for the lab gateway (Plan B, following the merged backend in #50). A React 19 / Vite / TypeScript app in `webapp/app/` drives the gateway API end to end: discover/connect instruments (or resume an existing session, or a hardware-free mock), a live waveform canvas, channel/timebase/trigger controls, a SCPI terminal, a measurement panel, CSV export, and a per-channel readout strip. FastAPI serves the built UI in production with a path-traversal-hardened SPA fallback.

The design principle throughout is that the server is the single source of truth: UI actions send REST mutations, and the Zustand store only advances from WebSocket `state`/`measurements` broadcasts. Waveform frames bypass React state entirely (module-level ring buffer → canvas rAF) so 4 Hz streaming never re-renders the tree. The 11 components in `webapp/design/` are ported to typed TSX in `src/ds/`; the originals are left untouched as reference.

## Related Issues

None

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test coverage improvement
- [x] CI/CD improvement

## Changes Made

- New Vite/React/TS app in `webapp/app/`: typed API client, Zustand store, WebSocket stream hook, and feature slices for connect/discover, waveform, controls, terminal, measurements, export, and the readout strip
- Ported the 11 `webapp/design` components to typed TSX in `src/ds/` (originals untouched); fixed `SpinBox` to forward its accessible name to the editable input
- FastAPI serves the built UI: SPA catch-all route with `resolve()` + `is_relative_to()` containment (unmatched `/api/*` keeps the JSON `{error, detail}` 404 shape); `make webapp-install` / `webapp-build` targets; the release workflow now builds the frontend into the package
- CI gains a `frontend` job (Node 24, `npm ci`, Vitest, typecheck + build); README documents the dev proxy and build flow

## Testing

- [x] Tests pass locally (`make test` / `pytest tests/`; `npm test` in `webapp/app/`)
- [x] Added tests for new functionality
- [x] Tested with real hardware (backend #50 validated against a real scope; frontend smoke-tested against a mock session)
- [ ] All CI checks pass

### Test Details

**Test environment:**

- OS: Windows 11 Pro
- Python version: 3.12.7 / Node 24
- Oscilloscope model (if applicable): mock session in CI; real-scope validation done on the merged backend

**Test results:**

```
Frontend (webapp/app): 56 passed
Python: 558 passed, 19 skipped
```

Frontend tests are Vitest + React Testing Library (jsdom), covering the API client, store, stream lifecycle (including the WebSocket teardown race and the 4410 clean-close), each feature slice's real user path, and the SPA path-traversal containment (Python side).

## Code Quality

- [x] Code follows the project style guidelines
- [x] Code is formatted (Black 26.5.1 on Python; Prettier defaults + `tsc --noEmit` on the frontend)
- [x] Self-reviewed the code
- [x] Commented complex code sections
- [x] Updated docstrings for modified functions/classes
- [x] No new linting warnings introduced

## Documentation

- [x] Updated README.md (if needed)
- [ ] Updated CHANGELOG.md with changes
- [x] Added/updated docstrings
- [ ] Added/updated examples (if applicable)
- [x] Updated type hints

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation

## Additional Notes

No authentication in V1 by design (the gateway binds `127.0.0.1` unless started with `--host 0.0.0.0`). A short post-merge backlog of non-blocking follow-ups exists — most notably a real `<input>` inside the design-system `Checkbox` (it's currently keyboard-inoperable) and a backend `GET /api/sessions/{id}/scope/measurements` endpoint so the measurement selection can fully sync (today the stream carries measurement values but not the selection). Neither affects the primary connect → view → control → capture flow.