### PR TITLE
fix: wrap the control-panel tab strip so it never overflows the rail

### DIFF
--- a/webapp/app/src/ds/Tabs.test.tsx
+++ b/webapp/app/src/ds/Tabs.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Tabs } from "./Tabs";
+
+const RAIL_TABS = ["Channels", "Trigger", "Measure", "Terminal"];
+
+describe("Tabs", () => {
+  it("renders every tab, including the last, as a real tab element", () => {
+    render(<Tabs tabs={RAIL_TABS} value="Channels" onChange={() => {}} />);
+    const tablist = screen.getByRole("tablist");
+    const tabs = within(tablist).getAllByRole("tab");
+    expect(tabs.map((t) => t.textContent)).toEqual(RAIL_TABS);
+  });
+
+  it("wraps the tab strip so it cannot overflow a narrow rail", () => {
+    // The rail is a fixed-width column; the strip must wrap to fit, never clip.
+    render(<Tabs tabs={RAIL_TABS} value="Channels" onChange={() => {}} />);
+    const tablist = screen.getByRole("tablist");
+    expect(tablist.style.flexWrap).toBe("wrap");
+    expect(tablist.style.maxWidth).toBe("100%");
+  });
+
+  it("selects a tab on click", async () => {
+    const onChange = vi.fn();
+    render(<Tabs tabs={RAIL_TABS} value="Channels" onChange={onChange} />);
+    await userEvent.click(screen.getByRole("tab", { name: "Terminal" }));
+    expect(onChange).toHaveBeenCalledWith("Terminal");
+  });
+});

--- a/webapp/app/src/ds/Tabs.tsx
+++ b/webapp/app/src/ds/Tabs.tsx
@@ -44,6 +44,8 @@ export function Tabs({
         role="tablist"
         style={{
           display: "inline-flex",
+          flexWrap: "wrap",
+          maxWidth: "100%",
           gap: "3px",
           padding: "4px",
           background: "var(--lc-panel-2)",


### PR DESCRIPTION
## Description

The instrument view's left-rail tabs (Channels / Trigger / Measure / Terminal) overflowed the rail: "Terminal" clipped to "Ter" and a horizontal scrollbar appeared, confirmed against a real SDS824X HD.

**Root cause:** `ds/Tabs.tsx` rendered the tab strip as a single `inline-flex` row of `white-space: nowrap` buttons, giving it a ~355px intrinsic width that could not shrink or wrap. The rail is a fixed 280px column (`App.tsx`), so the strip overflowed. This would break for any rail narrower than the strip's content, and worsens as more tabs are added.

**Fix:** let the tab strip wrap — `flex-wrap: wrap` + `max-width: 100%` on the tablist. The tabs now flow onto additional rows to fit any rail width and any tab count, with no clipping and no horizontal scroll.

## Related Issues

None

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test coverage improvement
- [ ] CI/CD improvement

## Changes Made

- `ds/Tabs.tsx`: tablist gains `flexWrap: "wrap"` + `maxWidth: "100%"` so the strip wraps within its container instead of overflowing
- Added `ds/Tabs.test.tsx`: all tabs render (including the last), the wrap contract holds (regression guard), and click selects a tab

## Testing

- [x] Tests pass locally (`npm test` in `webapp/app/`)
- [x] Added tests for the fix
- [x] Tested with real hardware (verified against a live SDS824X HD; tabs now wrap and Terminal is fully visible)
- [ ] All CI checks pass

### Test Details

**Test environment:**

- OS: Windows 11 Pro
- Node version: 24
- Oscilloscope model: SDS824X HD (192.168.1.207)

**Test results:**

```
Frontend: 59 passed (56 baseline + 3 new Tabs tests)
Build: clean
```

Visual confirmation on hardware: the four tabs wrap to a second row, "Terminal" is fully readable, and the horizontal scrollbar is gone.

## Code Quality

- [x] Code follows the project style guidelines
- [x] Code is formatted (Prettier + `tsc --noEmit`)
- [x] Self-reviewed the code
- [x] No new linting warnings introduced

## Additional Notes

`ds/Tabs` is consumed only by the instrument view's rail, so the wrap change is contained. A pre-existing dead `_hover` state remains in the component; left untouched to keep this fix minimal.