### PR TITLE
fix: stable device keys and search no-match feedback on the home screen

### DIFF
--- a/webapp/app/src/features/home/HomeScreen.tsx
+++ b/webapp/app/src/features/home/HomeScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiError, api } from "../../api/client";
 import type { DiscoveredDevice, SessionInfo } from "../../api/types";
 import { GroupBox } from "../../ds/GroupBox";
+import { deviceKey } from "./deviceKey";
 import { GettingStarted } from "./GettingStarted";
 import { Hero } from "./Hero";
 import { InstrumentDashboard } from "./InstrumentDashboard";
@@ -22,7 +23,7 @@ export function HomeScreen({ onConnected }: Props) {
   const [scanning, setScanning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
-  const [busyAddress, setBusyAddress] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [lastScanned, setLastScanned] = useState<string>("not scanned yet");
   const busyRef = useRef(false);
@@ -60,10 +61,10 @@ export function HomeScreen({ onConnected }: Props) {
     return () => clearInterval(id);
   }, [scan]);
 
-  async function connect(body: Parameters<typeof api.createSession>[0], recent: RecentEntry, address: string | null) {
+  async function connect(body: Parameters<typeof api.createSession>[0], recent: RecentEntry, key: string | null) {
     setBusy(true);
     busyRef.current = true;
-    setBusyAddress(address);
+    setBusyKey(key);
     setActionError(null);
     try {
       const session = await api.createSession(body);
@@ -74,16 +75,16 @@ export function HomeScreen({ onConnected }: Props) {
     } finally {
       setBusy(false);
       busyRef.current = false;
-      setBusyAddress(null);
+      setBusyKey(null);
     }
   }
 
-  const onConnectDevice = (d: DiscoveredDevice) => connect({ address: d.address ?? undefined, label: d.model }, { address: d.address, label: d.model, kind: d.kind, model: d.model, mock: false }, d.address);
+  const onConnectDevice = (d: DiscoveredDevice) => connect({ address: d.address ?? undefined, label: d.model }, { address: d.address, label: d.model, kind: d.kind, model: d.model, mock: false }, deviceKey(d));
   const onOpenDevice = async (d: DiscoveredDevice) => {
     if (!d.session_id) return;
     setBusy(true);
     busyRef.current = true;
-    setBusyAddress(d.address);
+    setBusyKey(deviceKey(d));
     setActionError(null);
     try {
       const session = await api.getSession(d.session_id);
@@ -94,7 +95,7 @@ export function HomeScreen({ onConnected }: Props) {
     } finally {
       setBusy(false);
       busyRef.current = false;
-      setBusyAddress(null);
+      setBusyKey(null);
     }
   };
   const onReconnect = (e: RecentEntry) => (e.mock ? connect({ mock: true }, e, null) : connect({ address: e.address ?? undefined, label: e.label }, e, e.address));
@@ -108,7 +109,7 @@ export function HomeScreen({ onConnected }: Props) {
         <div style={{ flex: 3, display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
           <RecentBar onReconnect={onReconnect} />
           {actionError && <div role="alert" style={{ padding: "8px 10px", borderRadius: "var(--radius-sm)", background: "color-mix(in srgb, var(--danger) 12%, transparent)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>{actionError}</div>}
-          <InstrumentDashboard devices={devices} scanning={scanning} error={error} busyAddress={busyAddress} onConnect={onConnectDevice} onOpen={onOpenDevice} />
+          <InstrumentDashboard devices={devices} scanning={scanning} error={error} busyKey={busyKey} onConnect={onConnectDevice} onOpen={onOpenDevice} />
         </div>
         <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "var(--space-2)", minWidth: 220 }}>
           <GroupBox title="Connect manually"><ManualConnect busy={busy} onConnectAddress={onConnectAddress} onConnectMock={onConnectMock} /></GroupBox>

--- a/webapp/app/src/features/home/InstrumentDashboard.test.tsx
+++ b/webapp/app/src/features/home/InstrumentDashboard.test.tsx
@@ -13,7 +13,7 @@ const DEVICES = [
 ];
 
 function renderDash(over = {}) {
-  return render(<InstrumentDashboard devices={DEVICES} scanning={false} error={null} busyAddress={null} onConnect={vi.fn()} onOpen={vi.fn()} {...over} />);
+  return render(<InstrumentDashboard devices={DEVICES} scanning={false} error={null} busyKey={null} onConnect={vi.fn()} onOpen={vi.fn()} {...over} />);
 }
 
 describe("InstrumentDashboard", () => {
@@ -48,5 +48,26 @@ describe("InstrumentDashboard", () => {
   it("shows an empty nudge when idle with no devices", () => {
     renderDash({ devices: [] });
     expect(screen.getByText(/no instruments found/i)).toBeInTheDocument();
+  });
+
+  it("disables a held card by its device key (works for address-less mock sessions)", () => {
+    const mockHeld = dev({ address: null, model: "Mock", connected: true, session_id: "m1", viewers: 0 });
+    render(<InstrumentDashboard devices={[mockHeld]} scanning={false} error={null} busyKey="m1" onConnect={vi.fn()} onOpen={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Open Mock" })).toBeDisabled();
+  });
+
+  it("gives distinct Open buttons for two address-less mock sessions", () => {
+    const m1 = dev({ address: null, model: "Mock", connected: true, session_id: "m1", viewers: 0 });
+    const m2 = dev({ address: null, model: "Mock", connected: true, session_id: "m2", viewers: 0 });
+    render(<InstrumentDashboard devices={[m1, m2]} scanning={false} error={null} busyKey={null} onConnect={vi.fn()} onOpen={vi.fn()} />);
+    expect(screen.getAllByRole("button", { name: "Open Mock" })).toHaveLength(2);
+  });
+
+  it("shows a no-match message and a filtered count when the search matches nothing", async () => {
+    renderDash();
+    await userEvent.type(screen.getByLabelText("Filter instruments"), "zzz-no-such-device");
+    expect(screen.getByText(/no instruments match/i)).toHaveTextContent("zzz-no-such-device");
+    // available header count reflects the filter (0 of 2)
+    expect(screen.getByText(/0 of 2/)).toBeInTheDocument();
   });
 });

--- a/webapp/app/src/features/home/InstrumentDashboard.tsx
+++ b/webapp/app/src/features/home/InstrumentDashboard.tsx
@@ -1,13 +1,14 @@
 import { useState } from "react";
 import type { DiscoveredDevice } from "../../api/types";
 import { DeviceCard } from "./DeviceCard";
+import { deviceKey } from "./deviceKey";
 import { KIND_META, KIND_ORDER, type Kind } from "./kinds";
 
 export type DashboardProps = {
   devices: DiscoveredDevice[];
   scanning: boolean;
   error: string | null;
-  busyAddress: string | null;
+  busyKey: string | null;
   onConnect: (device: DiscoveredDevice) => void;
   onOpen: (device: DiscoveredDevice) => void;
 };
@@ -15,7 +16,7 @@ export type DashboardProps = {
 const zoneHeading = { fontSize: "var(--text-xs)", textTransform: "uppercase" as const, letterSpacing: "0.05em", color: "var(--lc-text-2)", fontWeight: 700, margin: "0 0 var(--space-2)" };
 const grid = { display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", gap: "var(--space-2)" };
 
-export function InstrumentDashboard({ devices, scanning, error, busyAddress, onConnect, onOpen }: DashboardProps) {
+export function InstrumentDashboard({ devices, scanning, error, busyKey, onConnect, onOpen }: DashboardProps) {
   const [query, setQuery] = useState("");
   const held = devices.filter((d) => d.connected);
   const available = devices.filter((d) => !d.connected);
@@ -24,7 +25,7 @@ export function InstrumentDashboard({ devices, scanning, error, busyAddress, onC
   const filtered = q ? available.filter((d) => `${d.model} ${d.address ?? ""} ${d.kind}`.toLowerCase().includes(q)) : available;
 
   function cardFor(device: DiscoveredDevice, variant: "available" | "session") {
-    return <DeviceCard key={`${device.address}-${device.model}`} device={device} variant={variant} busy={busyAddress !== null && busyAddress === device.address} onConnect={onConnect} onOpen={onOpen} />;
+    return <DeviceCard key={deviceKey(device)} device={device} variant={variant} busy={busyKey !== null && busyKey === deviceKey(device)} onConnect={onConnect} onOpen={onOpen} />;
   }
 
   return (
@@ -37,7 +38,7 @@ export function InstrumentDashboard({ devices, scanning, error, busyAddress, onC
       )}
 
       <section>
-        <h2 style={zoneHeading}>Available on the network <span style={{ color: "var(--lc-muted)" }}>{available.length}</span></h2>
+        <h2 style={zoneHeading}>Available on the network <span style={{ color: "var(--lc-muted)" }}>{q ? `${filtered.length} of ${available.length}` : available.length}</span></h2>
         <input
           aria-label="Filter instruments"
           value={query}
@@ -51,6 +52,7 @@ export function InstrumentDashboard({ devices, scanning, error, busyAddress, onC
         {!scanning && !error && devices.length === 0 && (
           <p style={{ color: "var(--lc-muted)" }}>No instruments found on your network. Check the instrument's LAN settings, enter an IP manually, or start a Mock scope.</p>
         )}
+        {q && filtered.length === 0 && available.length > 0 && <p style={{ color: "var(--lc-muted)" }}>No instruments match &ldquo;{query.trim()}&rdquo;.</p>}
 
         {KIND_ORDER.map((kind: Kind) => {
           const inKind = filtered.filter((d) => (d.kind as Kind) === kind || (kind === "unknown" && !(d.kind in KIND_META)));

--- a/webapp/app/src/features/home/deviceKey.test.ts
+++ b/webapp/app/src/features/home/deviceKey.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { deviceKey } from "./deviceKey";
+
+describe("deviceKey", () => {
+  it("prefers session_id (two mock sessions stay distinct)", () => {
+    const a = deviceKey({ session_id: "s1", address: null, model: "Mock" });
+    const b = deviceKey({ session_id: "s2", address: null, model: "Mock" });
+    expect(a).toBe("s1");
+    expect(b).toBe("s2");
+    expect(a).not.toBe(b);
+  });
+
+  it("falls back to address when there is no session", () => {
+    expect(deviceKey({ address: "192.168.1.50", model: "SDS824X HD" })).toBe("192.168.1.50");
+  });
+
+  it("falls back to model when address is null and there is no session", () => {
+    expect(deviceKey({ address: null, model: "Mock" })).toBe("Mock");
+  });
+});

--- a/webapp/app/src/features/home/deviceKey.ts
+++ b/webapp/app/src/features/home/deviceKey.ts
@@ -1,0 +1,11 @@
+import type { DiscoveredDevice } from "../../api/types";
+
+/**
+ * Stable identity for a device across React keys and busy tracking.
+ * A held session is identified by its session_id (so two mock sessions —
+ * both address-less, same model — stay distinct); a free device by its
+ * address; and anything else falls back to the model.
+ */
+export function deviceKey(device: Pick<DiscoveredDevice, "session_id" | "address" | "model">): string {
+  return device.session_id ?? device.address ?? device.model;
+}


### PR DESCRIPTION
## Description

Two follow-up fixes from the home-screen review (PR #53).

**Stable device keys.** Cards and busy-tracking were keyed on `${address}-${model}`, which collides for two address-less mock sessions (identical React keys) and can't identify a mock during Open (its address is null, so the busy state never showed). Introduces `deviceKey(d) = session_id ?? address ?? model` used for both React keys and busy tracking, so held sessions are always distinct and a held mock's card correctly shows its busy/disabled state while opening.

**Search feedback.** When the search filtered out every available device, the dashboard showed nothing. Now it shows a "No instruments match …" message, and the Available zone header count reflects the active filter (e.g. "0 of 2").

## Related Issues

Follow-up to #53.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test coverage improvement
- [ ] CI/CD improvement

## Changes Made

- New `features/home/deviceKey.ts` (`session_id ?? address ?? model`) + unit tests
- `InstrumentDashboard`: `busyAddress` prop → `busyKey`; cards keyed and busy-matched by `deviceKey`; a no-match message and a filtered "N of M" header count
- `HomeScreen`: tracks `busyKey` (set from `deviceKey`) instead of `busyAddress`

## Testing

- [x] Tests pass locally (`npm test` in `webapp/app/`)
- [x] Added tests for the fixes (deviceKey precedence; held-mock disabled by key; two mock sessions get distinct Open buttons; search no-match message + filtered count)

### Test Details

**Test results:**

```
Frontend: 88 passed
Build: clean
```

## Code Quality

- [x] Code follows the project style guidelines
- [x] Code is formatted (Prettier + `tsc --noEmit`)
- [x] Self-reviewed the code
- [x] No new linting warnings introduced

## Additional Notes

Frontend-only; no backend or Python changes. Remaining home-screen follow-ups (hardening `getRecent` against corrupt localStorage; adding `kind` to the session type to drop the two `"scope"` hardcodes when a non-scope instrument view lands) are unaffected and still tracked.