### PR TITLE
feat: scope command expansion - screenshot, waveform JSON, math channels, measurements sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,6 +608,10 @@ built-in mock (`mock: true`) for hardware-free use. The API is documented at
 - `GET /api/discover` scans the gateway's subnet (or `?cidr=…`) for SCPI
   instruments on port 5025 and lists them with model and dialect — handy when
   DHCP moves your instruments around.
+- `GET .../scope/screenshot.png` — the instrument's display as a PNG
+- `GET .../scope/waveform?channels=1,2&max_points=N` — waveform data as JSON
+- `GET/PATCH .../scope/math/{1,2}` — software math channels (streamed as M1/M2 traces)
+- `GET .../scope/measurements` — the current measurement selection
 
 ### Browser UI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ gui = [
 web = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
+    "Pillow>=10.0",
 ]
 fun = [
     "shapely>=2.0.0",

--- a/scpi_control/connection/mock.py
+++ b/scpi_control/connection/mock.py
@@ -20,6 +20,16 @@ def _format_nr3(value: float) -> str:
     return f"{value:.2E}"
 
 
+def _build_ieee_block(payload: bytes) -> bytes:
+    """Wrap payload in an IEEE-488.2 definite-length block: #<ndigits><length><payload>."""
+    length_str = str(len(payload)).encode()
+    return b"#" + str(len(length_str)).encode() + length_str + payload
+
+
+# Minimal valid 1x1 24bpp BMP, so a mock SCDP? screenshot decodes as a real image.
+MOCK_SCREENSHOT_BMP = bytes.fromhex("424d3a000000000000003600000028000000010000000100000001001800000000000400000000000000000000000000000000000000ffffff00")
+
+
 # Canonical PAVA? measurement values for the legacy dialect (mirrors real
 # hardware where PAVA? is legacy-only; the modern dialect has no equivalent).
 _MOCK_PAVA_VALUES: Dict[str, Tuple[str, str]] = {
@@ -779,15 +789,17 @@ class MockConnection(BaseConnection):
 
     def _build_waveform_block(self, payload: bytes) -> bytes:
         """Construct a minimal Siglent-style block response."""
-        length = len(payload)
-        length_str = str(length).encode()
-        header = b"DESC,#" + str(len(length_str)).encode() + length_str
-        return header + payload
+        return b"DESC," + _build_ieee_block(payload)
 
     def read_raw(self, size: Optional[int] = None) -> bytes:
-        """Return deterministic raw waveform data."""
+        """Return deterministic raw waveform data (or a mock screenshot BMP after SCDP?)."""
         if not self._connected:
             raise exceptions.ConnectionError(f"Not connected to oscilloscope at {self.host}:{self.port}")
+
+        if self.writes and self.writes[-1].upper() == "SCDP?":
+            # Bare IEEE 488.2 block (no "DESC," prefix), matching how a real
+            # scope's SCDP? reply is parsed in screen_capture.py.
+            return _build_ieee_block(MOCK_SCREENSHOT_BMP)
 
         channel = self._last_waveform_channel or next(iter(self._waveform_payloads.keys()))
         payload = self._waveform_payloads.get(channel, bytes())

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -3,7 +3,7 @@ import asyncio
 from typing import Any, Callable, List
 
 from fastapi import APIRouter, Request
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import PlainTextResponse, Response
 
 from scpi_control.exceptions import InvalidParameterError
 from scpi_control.server.api.sessions import require_session
@@ -142,6 +142,23 @@ async def capture_csv(session_id: str, request: Request, channels: str = "1"):
     csv_text = _build_csv(captures)
     filename = "capture_{0}_C{1}.csv".format(session.id, "-".join(str(c) for c in channel_list))
     return PlainTextResponse(csv_text, media_type="text/csv", headers={"Content-Disposition": 'attachment; filename="{0}"'.format(filename)})
+
+
+@router.get("/sessions/{session_id}/scope/screenshot.png")
+async def screenshot(session_id: str, request: Request):
+    session = require_session(request, session_id)
+
+    def grab(scope):
+        import io
+
+        image = scope.screen_capture.get_screenshot_pil()
+        buf = io.BytesIO()
+        image.save(buf, "PNG")
+        return buf.getvalue()
+
+    png = await run_job(session, grab)
+    filename = "screenshot_{0}.png".format(session.id)
+    return Response(content=png, media_type="image/png", headers={"Content-Disposition": 'attachment; filename="{0}"'.format(filename)})
 
 
 # NOTE: run_op's {op} path is a catch-all for POST /scope/*; any new specific

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -7,7 +7,7 @@ from fastapi.responses import PlainTextResponse, Response
 
 from scpi_control.exceptions import InvalidParameterError
 from scpi_control.server.api.sessions import require_session
-from scpi_control.server.schemas import ALLOWED_COUPLING, ALLOWED_MEASUREMENTS, ChannelPatch, CommandIn, MeasurementItem, TimebasePatch, TriggerPatch
+from scpi_control.server.schemas import ALLOWED_COUPLING, ALLOWED_MEASUREMENTS, ChannelPatch, CommandIn, MathPatch, MeasurementItem, TimebasePatch, TriggerPatch
 from scpi_control.server.sessions import InstrumentSession, read_state
 
 router = APIRouter(tags=["scope"])
@@ -197,6 +197,35 @@ async def waveform_json(session_id: str, request: Request, channels: str = "1", 
     captures = await run_job(session, capture)
     cap = max_points if max_points > 0 else None
     return {"channels": [_waveform_json(c, data, cap) for c, data in captures]}
+
+
+def _math_state(scope):
+    return [{"n": n, "expression": m.expression, "enabled": m.enabled} for n, m in ((1, scope.math1), (2, scope.math2))]
+
+
+@router.get("/sessions/{session_id}/scope/math")
+async def get_math(session_id: str, request: Request):
+    session = require_session(request, session_id)
+    return await run_job(session, _math_state)
+
+
+@router.patch("/sessions/{session_id}/scope/math/{n}")
+async def patch_math(session_id: str, n: int, body: MathPatch, request: Request):
+    session = require_session(request, session_id)
+    if n not in (1, 2):
+        raise InvalidParameterError("math channel must be 1 or 2")
+    if body.expression is not None and not body.expression.strip():
+        raise InvalidParameterError("expression must not be empty")
+
+    def apply(scope):
+        math = scope.math1 if n == 1 else scope.math2
+        if body.expression is not None:
+            math.set_expression(body.expression)
+        if body.enabled is not None:
+            math.enable() if body.enabled else math.disable()
+        return _math_state(scope)
+
+    return await run_job(session, apply)
 
 
 # NOTE: run_op's {op} path is a catch-all for POST /scope/*; any new specific

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -114,6 +114,12 @@ async def put_measurements(session_id: str, body: List[MeasurementItem], request
     return {"measurements": [{"channel": c, "mtype": m} for c, m in session.measurements]}
 
 
+@router.get("/sessions/{session_id}/scope/measurements")
+async def get_measurements(session_id: str, request: Request):
+    session = require_session(request, session_id)
+    return {"measurements": [{"channel": c, "mtype": m} for c, m in session.measurements]}
+
+
 def _build_csv(captures) -> str:
     """captures: list of (channel:int, WaveformData). Align to the shortest."""
     n = min(len(w.voltage) for _, w in captures)

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -161,6 +161,44 @@ async def screenshot(session_id: str, request: Request):
     return Response(content=png, media_type="image/png", headers={"Content-Disposition": 'attachment; filename="{0}"'.format(filename)})
 
 
+def _waveform_json(channel, data, max_points):
+    voltage = data.voltage
+    time_axis = data.time
+    step = 1
+    if max_points is not None and max_points > 0 and len(voltage) > max_points:
+        step = -(-len(voltage) // max_points)  # ceiling division keeps len <= max_points
+    points = [float(v) for v in voltage[::step]]
+    t0 = float(time_axis[0]) if len(time_axis) else 0.0
+    dt = float(time_axis[1] - time_axis[0]) * step if len(time_axis) > 1 else 1.0
+    return {
+        "channel": channel,
+        "t0": t0,
+        "dt": dt,
+        "sample_rate": data.sample_rate,
+        "voltage_scale": data.voltage_scale,
+        "voltage_offset": data.voltage_offset,
+        "points": points,
+    }
+
+
+@router.get("/sessions/{session_id}/scope/waveform")
+async def waveform_json(session_id: str, request: Request, channels: str = "1", max_points: int = 0):
+    session = require_session(request, session_id)
+    try:
+        channel_list = sorted({int(c) for c in channels.split(",") if c.strip()})
+    except ValueError:
+        raise InvalidParameterError("channels must be a comma-separated list of integers")
+    if not channel_list:
+        raise InvalidParameterError("no channels requested")
+
+    def capture(scope):
+        return [(c, scope.get_waveform(c)) for c in channel_list]
+
+    captures = await run_job(session, capture)
+    cap = max_points if max_points > 0 else None
+    return {"channels": [_waveform_json(c, data, cap) for c, data in captures]}
+
+
 # NOTE: run_op's {op} path is a catch-all for POST /scope/*; any new specific
 # POST route under /scope must be registered ABOVE it or it will be shadowed.
 _RUN_OPS = {

--- a/scpi_control/server/schemas.py
+++ b/scpi_control/server/schemas.py
@@ -58,6 +58,11 @@ class CommandIn(BaseModel):
     command: str
 
 
+class MathPatch(BaseModel):
+    expression: Optional[str] = None
+    enabled: Optional[bool] = None
+
+
 class ModelOut(BaseModel):
     model_name: str
     series: str

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -54,14 +54,17 @@ def read_state(scope: Oscilloscope) -> Dict[str, Any]:
     }
 
 
-def _waveform_frame(scope: Oscilloscope, channel: int) -> Dict[str, Any]:
-    data = scope.get_waveform(channel)
-    voltage = data.voltage
+def _decimate_frame(channel, time_axis, voltage) -> Dict[str, Any]:
     step = max(1, -(-len(voltage) // MAX_FRAME_POINTS))  # ceiling division keeps len(points) <= cap
     points = voltage[::step]
-    t0 = float(data.time[0]) if len(data.time) else 0.0
-    dt = float(data.time[1] - data.time[0]) * step if len(data.time) > 1 else 1.0
+    t0 = float(time_axis[0]) if len(time_axis) else 0.0
+    dt = float(time_axis[1] - time_axis[0]) * step if len(time_axis) > 1 else 1.0
     return {"type": "waveform", "channel": channel, "t0": t0, "dt": dt, "points": [float(v) for v in points]}
+
+
+def _waveform_frame(scope: Oscilloscope, channel: int) -> Dict[str, Any]:
+    data = scope.get_waveform(channel)
+    return _decimate_frame(channel, data.time, data.voltage)
 
 
 _STOP = object()
@@ -247,10 +250,18 @@ class InstrumentSession:
         self._poll_count += 1
         scope = self._scope
         try:
+            acquired = {}
             for n in scope.supported_channels:
                 ch = scope.get_channel(n)
                 if ch is not None and _safe(lambda: ch.enabled, default=False):
-                    self.publish(_waveform_frame(scope, n))
+                    data = scope.get_waveform(n)
+                    acquired["C{0}".format(n)] = data
+                    self.publish(_decimate_frame(n, data.time, data.voltage))
+            for label, math in (("M1", scope.math1), ("M2", scope.math2)):
+                if math is not None and _safe(lambda: math.enabled, default=False):
+                    result = _safe(lambda: math.compute(acquired))
+                    if result is not None:
+                        self.publish(_decimate_frame(label, result.time, result.voltage))
             if self.measurements and self._poll_count % MEASUREMENT_EVERY_N_POLLS == 0:
                 values = []
                 for channel, mtype in self.measurements:

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -103,6 +103,7 @@ class InstrumentSession:
         self._subscribers_lock = threading.Lock()
         self.measurements: List[Tuple[int, str]] = []
         self._poll_count = 0
+        self._math_shown: set = set()  # math labels with a live trace on subscribers' canvases; worker-thread-only
 
     @classmethod
     def open(
@@ -258,11 +259,17 @@ class InstrumentSession:
                     data = scope.get_waveform(n)
                     acquired["C{0}".format(n)] = data
                     self.publish(_decimate_frame(n, data.time, data.voltage))
+            shown_now = set()
             for label, math in (("M1", scope.math1), ("M2", scope.math2)):
+                result = None
                 if math is not None and _safe(lambda: math.enabled, default=False):
                     result = _safe(lambda: math.compute(acquired))
-                    if result is not None:
-                        self.publish(_decimate_frame(label, result.time, result.voltage))
+                if result is not None:
+                    self.publish(_decimate_frame(label, result.time, result.voltage))
+                    shown_now.add(label)
+                elif label in self._math_shown:
+                    self.publish(_decimate_frame(label, [], []))  # one-shot clear on transition
+            self._math_shown = shown_now
             if self.measurements and self._poll_count % MEASUREMENT_EVERY_N_POLLS == 0:
                 values = []
                 for channel, mtype in self.measurements:

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -192,6 +192,7 @@ class InstrumentSession:
 
     def set_measurements(self, items: List[Tuple[int, str]]) -> None:
         self.measurements = list(items)
+        self.publish({"type": "measurements_config", "items": [{"channel": c, "mtype": m} for c, m in self.measurements]})
 
     def _enter_error_state(self, detail: str) -> None:
         """Flip to the terminal error state and tell the streams once."""

--- a/tests/test_mock_dialects.py
+++ b/tests/test_mock_dialects.py
@@ -109,3 +109,24 @@ def test_modern_mock_still_times_out_on_pava():
             scope.measurement.measure("PKPK", 1)
     finally:
         scope.disconnect()
+
+
+def test_mock_answers_scdp_with_a_valid_image():
+    import io
+
+    from PIL import Image
+
+    from scpi_control import Oscilloscope
+    from scpi_control.connection.mock import MockConnection
+
+    conn = MockConnection("mock", idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0")
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    try:
+        image = scope.screen_capture.get_screenshot_pil()  # BMP → PIL
+        assert image.size[0] >= 1 and image.size[1] >= 1
+        buf = io.BytesIO()
+        image.save(buf, "PNG")
+        assert buf.getvalue().startswith(b"\x89PNG\r\n\x1a\n")
+    finally:
+        scope.disconnect()

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -351,3 +351,29 @@ class TestWaveformJson:
     def test_waveform_json_bad_channels_is_400(self, client):
         sid = create_mock_session(client)["id"]
         assert client.get("/api/sessions/{0}/scope/waveform?channels=banana".format(sid)).status_code == 400
+
+
+class TestMath:
+    def test_patch_math_sets_expression_and_enabled(self, client):
+        sid = create_mock_session(client)["id"]
+        response = client.patch("/api/sessions/{0}/scope/math/1".format(sid), json={"expression": "C1 - C2", "enabled": True})
+        assert response.status_code == 200
+        entry = [m for m in response.json() if m["n"] == 1][0]
+        assert entry["expression"] == "C1 - C2"
+        assert entry["enabled"] is True
+
+    def test_get_math_returns_both_channels(self, client):
+        sid = create_mock_session(client)["id"]
+        client.patch("/api/sessions/{0}/scope/math/2".format(sid), json={"expression": "INTG(C1)", "enabled": True})
+        body = client.get("/api/sessions/{0}/scope/math".format(sid)).json()
+        assert {m["n"] for m in body} == {1, 2}
+        m2 = [m for m in body if m["n"] == 2][0]
+        assert m2["expression"] == "INTG(C1)" and m2["enabled"] is True
+
+    def test_patch_math_bad_index_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.patch("/api/sessions/{0}/scope/math/3".format(sid), json={"enabled": True}).status_code == 400
+
+    def test_patch_math_empty_expression_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.patch("/api/sessions/{0}/scope/math/1".format(sid), json={"expression": "   "}).status_code == 400

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -186,6 +186,14 @@ class TestTerminalAndMeasurements:
         assert bad_channel.status_code == 400
 
 
+class TestMeasurementsSync:
+    def test_get_measurements_returns_selection(self, client):
+        sid = create_mock_session(client)["id"]
+        client.put("/api/sessions/{0}/scope/measurements".format(sid), json=[{"channel": 1, "mtype": "PKPK"}])
+        body = client.get("/api/sessions/{0}/scope/measurements".format(sid)).json()
+        assert body["measurements"] == [{"channel": 1, "mtype": "PKPK"}]
+
+
 class TestCapture:
     def test_capture_csv_single_channel(self, client):
         sid = create_mock_session(client)["id"]

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -326,3 +326,28 @@ class TestScreenshot:
         assert response.headers["content-type"] == "image/png"
         assert response.content.startswith(b"\x89PNG\r\n\x1a\n")
         assert "attachment" in response.headers.get("content-disposition", "")
+
+
+class TestWaveformJson:
+    def test_waveform_json_full_resolution(self, client):
+        sid = create_mock_session(client)["id"]
+        response = client.get("/api/sessions/{0}/scope/waveform?channels=1".format(sid))
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["channels"]) == 1
+        ch = body["channels"][0]
+        assert ch["channel"] == 1
+        assert isinstance(ch["points"], list) and len(ch["points"]) > 0
+        assert isinstance(ch["points"][0], float)
+        assert ch["dt"] > 0
+
+    def test_waveform_json_decimates_to_max_points(self, client):
+        sid = create_mock_session(client)["id"]
+        full = client.get("/api/sessions/{0}/scope/waveform?channels=1".format(sid)).json()["channels"][0]["points"]
+        capped = client.get("/api/sessions/{0}/scope/waveform?channels=1&max_points=10".format(sid)).json()["channels"][0]["points"]
+        assert len(capped) <= 10
+        assert len(capped) <= len(full)
+
+    def test_waveform_json_bad_channels_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.get("/api/sessions/{0}/scope/waveform?channels=banana".format(sid)).status_code == 400

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -316,3 +316,13 @@ def test_cli_parses_defaults(monkeypatch):
     assert captured == {"host": "127.0.0.1", "port": 8765}
     cli.main(["--host", "0.0.0.0", "--port", "9000"])
     assert captured == {"host": "0.0.0.0", "port": 9000}
+
+
+class TestScreenshot:
+    def test_screenshot_returns_png(self, client):
+        sid = create_mock_session(client)["id"]
+        response = client.get("/api/sessions/{0}/scope/screenshot.png".format(sid))
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/png"
+        assert response.content.startswith(b"\x89PNG\r\n\x1a\n")
+        assert "attachment" in response.headers.get("content-disposition", "")

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -154,6 +154,43 @@ def test_poll_publishes_math_frame_when_enabled():
         session.close()
 
 
+def test_poll_clears_math_frame_when_disabled():
+    session = make_session()  # mock scope, channel 1 enabled
+    try:
+        # configure math1 = C1 (identity) and enable it
+        session.submit(lambda scope: scope.math1.set_expression("C1")).result(timeout=5)
+        session.submit(lambda scope: scope.math1.enable()).result(timeout=5)
+
+        got = []
+
+        def cb(msg):
+            if msg["type"] == "waveform" and msg["channel"] == "M1":
+                got.append(msg)
+
+        unsubscribe = session.subscribe(cb)
+        deadline = time.time() + 8.0
+        while not any(len(f["points"]) > 0 for f in got) and time.time() < deadline:
+            time.sleep(0.02)
+        assert any(len(f["points"]) > 0 for f in got), "expected a non-empty M1 frame before disabling"
+
+        session.submit(lambda scope: scope.math1.disable()).result(timeout=5)
+
+        # give it a generous window (poll_interval=0.05 -> many ticks) to observe the clear
+        # frame and confirm no further M1 frames arrive afterward.
+        time.sleep(0.5)
+        unsubscribe()
+
+        # find the index of the first empty-points M1 frame after the disable call
+        empty_indices = [i for i, f in enumerate(got) if len(f["points"]) == 0]
+        assert empty_indices, "expected exactly one clear (empty-points) M1 frame after disabling"
+        assert len(empty_indices) == 1, "expected exactly ONE clear frame, not repeated clears"
+        clear_index = empty_indices[0]
+        # nothing after the clear frame should be another M1 frame at all
+        assert len(got) - 1 == clear_index, "no further M1 frames should be published after the clear"
+    finally:
+        session.close()
+
+
 def test_set_measurements_broadcasts_config():
     session = make_session()
     try:

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -138,3 +138,17 @@ def test_raising_subscriber_does_not_kill_worker():
         unsubscribe_good()
     finally:
         session.close()
+
+
+def test_poll_publishes_math_frame_when_enabled():
+    session = make_session()  # mock scope, channel 1 enabled
+    try:
+        # configure math1 = C1 (identity) and enable it
+        session.submit(lambda scope: scope.math1.set_expression("C1")).result(timeout=5)
+        session.submit(lambda scope: scope.math1.enable()).result(timeout=5)
+        frames = collect(session, "waveform", n=4, timeout=8.0)
+        math_frames = [f for f in frames if f["channel"] == "M1"]
+        assert math_frames, "expected an M1 math frame"
+        assert 0 < len(math_frames[0]["points"]) <= 2000
+    finally:
+        session.close()

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -152,3 +152,20 @@ def test_poll_publishes_math_frame_when_enabled():
         assert 0 < len(math_frames[0]["points"]) <= 2000
     finally:
         session.close()
+
+
+def test_set_measurements_broadcasts_config():
+    session = make_session()
+    try:
+        got = []
+
+        def cb(msg):
+            if msg["type"] == "measurements_config":
+                got.append(msg)
+
+        unsubscribe = session.subscribe(cb)
+        session.set_measurements([(1, "PKPK"), (2, "FREQ")])
+        unsubscribe()
+        assert got and got[0]["items"] == [{"channel": 1, "mtype": "PKPK"}, {"channel": 2, "mtype": "FREQ"}]
+    finally:
+        session.close()

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { ChannelsPanel } from "./features/controls/ChannelsPanel";
+import { MathPanel } from "./features/controls/MathPanel";
 import { ScopeToolbar } from "./features/controls/ScopeToolbar";
 import { TriggerPanel } from "./features/controls/TriggerPanel";
 import { HomeScreen } from "./features/home/HomeScreen";
@@ -12,7 +13,7 @@ import { Tabs } from "./ds/Tabs";
 import { useStream } from "./stream/useStream";
 import { useSession } from "./store/session";
 
-const RAIL_TABS = ["Channels", "Trigger", "Measure", "Terminal"];
+const RAIL_TABS = ["Channels", "Trigger", "Math", "Measure", "Terminal"];
 
 export default function App() {
   const status = useSession((s) => s.status);
@@ -37,6 +38,7 @@ export default function App() {
               <Tabs tabs={RAIL_TABS} value={railTab} onChange={setRailTab}>
                 {railTab === "Channels" && <ChannelsPanel />}
                 {railTab === "Trigger" && <TriggerPanel />}
+                {railTab === "Math" && <MathPanel />}
                 {railTab === "Measure" && <MeasurePanel />}
                 {railTab === "Terminal" && <TerminalPanel />}
               </Tabs>

--- a/webapp/app/src/api/client.ts
+++ b/webapp/app/src/api/client.ts
@@ -52,6 +52,8 @@ export const api = {
   runOp: (id: string, op: RunOp) => request<ScopeState>(`${scope(id)}/${op}`, { method: "POST" }),
   command: (id: string, command: string) => request<{ command: string; response: string | null }>(`${scope(id)}/command`, json("POST", { command })),
   setMeasurements: (id: string, items: { channel: number; mtype: string }[]) => request<{ measurements: { channel: number; mtype: string }[] }>(`${scope(id)}/measurements`, json("PUT", items)),
+  getMath: (id: string) => request<{ n: number; expression: string; enabled: boolean }[]>(`${scope(id)}/math`),
+  patchMath: (id: string, n: number, body: { expression?: string; enabled?: boolean }) => request<{ n: number; expression: string; enabled: boolean }[]>(`${scope(id)}/math/${n}`, json("PATCH", body)),
   captureUrl: (id: string, channels: number[]) => `${scope(id)}/capture.csv?channels=${channels.join(",")}`,
 };
 

--- a/webapp/app/src/api/client.ts
+++ b/webapp/app/src/api/client.ts
@@ -52,6 +52,7 @@ export const api = {
   runOp: (id: string, op: RunOp) => request<ScopeState>(`${scope(id)}/${op}`, { method: "POST" }),
   command: (id: string, command: string) => request<{ command: string; response: string | null }>(`${scope(id)}/command`, json("POST", { command })),
   setMeasurements: (id: string, items: { channel: number; mtype: string }[]) => request<{ measurements: { channel: number; mtype: string }[] }>(`${scope(id)}/measurements`, json("PUT", items)),
+  getMeasurements: (id: string) => request<{ measurements: { channel: number; mtype: string }[] }>(`${scope(id)}/measurements`),
   getMath: (id: string) => request<{ n: number; expression: string; enabled: boolean }[]>(`${scope(id)}/math`),
   patchMath: (id: string, n: number, body: { expression?: string; enabled?: boolean }) => request<{ n: number; expression: string; enabled: boolean }[]>(`${scope(id)}/math/${n}`, json("PATCH", body)),
   captureUrl: (id: string, channels: number[]) => `${scope(id)}/capture.csv?channels=${channels.join(",")}`,

--- a/webapp/app/src/api/client.ts
+++ b/webapp/app/src/api/client.ts
@@ -55,6 +55,8 @@ export const api = {
   getMath: (id: string) => request<{ n: number; expression: string; enabled: boolean }[]>(`${scope(id)}/math`),
   patchMath: (id: string, n: number, body: { expression?: string; enabled?: boolean }) => request<{ n: number; expression: string; enabled: boolean }[]>(`${scope(id)}/math/${n}`, json("PATCH", body)),
   captureUrl: (id: string, channels: number[]) => `${scope(id)}/capture.csv?channels=${channels.join(",")}`,
+  screenshotUrl: (id: string) => `${scope(id)}/screenshot.png`,
+  waveformJsonUrl: (id: string, channels: number[]) => `${scope(id)}/waveform?channels=${channels.join(",")}`,
 };
 
 export type { MeasurementValue };

--- a/webapp/app/src/api/types.ts
+++ b/webapp/app/src/api/types.ts
@@ -59,8 +59,9 @@ export type MeasurementValue = { channel: number; mtype: string; value: number |
 
 export type StreamMessage =
   | { type: "state"; state: ScopeState }
-  | { type: "waveform"; channel: number; t0: number; dt: number; points: number[] }
+  | { type: "waveform"; channel: number | string; t0: number; dt: number; points: number[] }
   | { type: "measurements"; values: MeasurementValue[] }
+  | { type: "measurements_config"; items: { channel: number; mtype: string }[] }
   | { type: "error"; detail: string }
   | { type: "closed" };
 

--- a/webapp/app/src/features/controls/MathPanel.test.tsx
+++ b/webapp/app/src/features/controls/MathPanel.test.tsx
@@ -1,0 +1,33 @@
+// webapp/app/src/features/controls/MathPanel.test.tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MathPanel } from "./MathPanel";
+import { api } from "../../api/client";
+import { useSession } from "../../store/session";
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("MathPanel", () => {
+  it("loads current math state and PATCHes an expression change", async () => {
+    vi.spyOn(api, "getMath").mockResolvedValue([{ n: 1, expression: "", enabled: false }, { n: 2, expression: "", enabled: false }]);
+    const patchMath = vi.spyOn(api, "patchMath").mockResolvedValue([{ n: 1, expression: "C1 - C2", enabled: false }, { n: 2, expression: "", enabled: false }]);
+    render(<MathPanel />);
+    const field = await screen.findByLabelText("Math 1 expression");
+    await userEvent.type(field, "C1 - C2");
+    await userEvent.tab();
+    await waitFor(() => expect(patchMath).toHaveBeenCalledWith("abc", 1, { expression: "C1 - C2" }));
+  });
+
+  it("toggles enable", async () => {
+    vi.spyOn(api, "getMath").mockResolvedValue([{ n: 1, expression: "C1", enabled: false }, { n: 2, expression: "", enabled: false }]);
+    const patchMath = vi.spyOn(api, "patchMath").mockResolvedValue([{ n: 1, expression: "C1", enabled: true }, { n: 2, expression: "", enabled: false }]);
+    render(<MathPanel />);
+    await userEvent.click(await screen.findByLabelText("Enable math 1"));
+    await waitFor(() => expect(patchMath).toHaveBeenCalledWith("abc", 1, { enabled: true }));
+  });
+});

--- a/webapp/app/src/features/controls/MathPanel.tsx
+++ b/webapp/app/src/features/controls/MathPanel.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { ApiError, api } from "../../api/client";
+import { GroupBox } from "../../ds/GroupBox";
+import { useSession } from "../../store/session";
+
+type MathState = { n: number; expression: string; enabled: boolean };
+
+export function MathPanel() {
+  const session = useSession((s) => s.session);
+  const [math, setMath] = useState<MathState[]>([]);
+  const [drafts, setDrafts] = useState<Record<number, string>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!session) return;
+    api.getMath(session.id).then((state) => {
+      setMath(state);
+      setDrafts(Object.fromEntries(state.map((m) => [m.n, m.expression])));
+    }).catch(() => setMath([{ n: 1, expression: "", enabled: false }, { n: 2, expression: "", enabled: false }]));
+  }, [session]);
+
+  async function patch(n: number, body: { expression?: string; enabled?: boolean }) {
+    if (!session) return;
+    setError(null);
+    try {
+      setMath(await api.patchMath(session.id, n, body));
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+      {math.map((m) => (
+        <GroupBox key={m.n} title={`Math ${m.n}`}>
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--text-sm)", color: "var(--lc-text)" }}>
+              <input type="checkbox" aria-label={`Enable math ${m.n}`} checked={m.enabled} onChange={(e) => patch(m.n, { enabled: e.target.checked })} />
+              Enabled
+            </label>
+            <input
+              aria-label={`Math ${m.n} expression`}
+              value={drafts[m.n] ?? ""}
+              placeholder="e.g. C1 - C2, INTG(C1)"
+              onChange={(e) => setDrafts((d) => ({ ...d, [m.n]: e.target.value }))}
+              onBlur={(e) => e.target.value.trim() && e.target.value !== m.expression && patch(m.n, { expression: e.target.value.trim() })}
+              style={{ padding: "6px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--text-sm)", border: "1px solid var(--lc-border-strong)", borderRadius: "var(--lc-radius-sm)", background: "var(--lc-control)", color: "var(--lc-text)" }}
+            />
+          </div>
+        </GroupBox>
+      ))}
+      {error && <div role="alert" style={{ color: "var(--danger)", fontSize: "var(--text-sm)" }}>{error}</div>}
+    </div>
+  );
+}

--- a/webapp/app/src/features/controls/ScopeToolbar.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.tsx
@@ -1,15 +1,28 @@
 import { useState } from "react";
 import { ApiError, api } from "../../api/client";
-import type { RunOp } from "../../api/types";
+import type { ChannelState, RunOp } from "../../api/types";
 import { Button } from "../../ds/Button";
 import { Toolbar, ToolbarSeparator } from "../../ds/Toolbar";
 import { useSession } from "../../store/session";
 import { ExportButton } from "../export/ExportButton";
+import { ScreenshotButton } from "../export/ScreenshotButton";
+
+// Stable reference: zustand v5 hands the selector straight to useSyncExternalStore
+// with no memoization, so a fresh `{}` per snapshot would loop forever while scope is null.
+const NO_CHANNELS: Record<string, ChannelState> = {};
 
 export function ScopeToolbar() {
   const session = useSession((s) => s.session);
   const runState = useSession((s) => s.scope?.run_state);
+  const channels = useSession((s) => s.scope?.channels ?? NO_CHANNELS);
+  const enabled = Object.entries(channels)
+    .filter(([, channel]) => channel.enabled)
+    .map(([key]) => Number(key))
+    .sort((a, b) => a - b);
   const [error, setError] = useState<string | null>(null);
+
+  const linkStyle = { fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "6px 12px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", textDecoration: "none" } as const;
+  const disabledLinkStyle = { ...linkStyle, color: "var(--lc-muted)", opacity: 0.6 };
 
   async function op(next: RunOp) {
     if (!session) return;
@@ -39,6 +52,14 @@ export function ScopeToolbar() {
         right={
           <>
             <ExportButton />
+            {!session || enabled.length === 0 ? (
+              <span style={disabledLinkStyle}>JSON</span>
+            ) : (
+              <a href={api.waveformJsonUrl(session.id, enabled)} download style={linkStyle}>
+                JSON
+              </a>
+            )}
+            <ScreenshotButton />
             <Button variant="danger" onClick={disconnect}>Disconnect</Button>
           </>
         }

--- a/webapp/app/src/features/export/ScreenshotButton.test.tsx
+++ b/webapp/app/src/features/export/ScreenshotButton.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ScreenshotButton } from "./ScreenshotButton";
+import { useSession } from "../../store/session";
+
+beforeEach(() => useSession.getState().clearSession());
+
+describe("ScreenshotButton", () => {
+  it("links to the screenshot URL when connected", () => {
+    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+    render(<ScreenshotButton />);
+    expect(screen.getByRole("link", { name: /screenshot/i })).toHaveAttribute("href", "/api/sessions/abc/scope/screenshot.png");
+  });
+
+  it("is not a link with no session", () => {
+    render(<ScreenshotButton />);
+    expect(screen.getByText(/screenshot/i).closest("a")).toBeNull();
+  });
+});

--- a/webapp/app/src/features/export/ScreenshotButton.tsx
+++ b/webapp/app/src/features/export/ScreenshotButton.tsx
@@ -1,0 +1,14 @@
+import { api } from "../../api/client";
+import { useSession } from "../../store/session";
+
+const style = { fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "6px 12px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", textDecoration: "none" } as const;
+
+export function ScreenshotButton() {
+  const session = useSession((s) => s.session);
+  if (!session) return <span style={{ ...style, color: "var(--lc-muted)", opacity: 0.6 }}>Screenshot</span>;
+  return (
+    <a href={api.screenshotUrl(session.id)} download style={style}>
+      Screenshot
+    </a>
+  );
+}

--- a/webapp/app/src/features/measure/MeasurePanel.test.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.test.tsx
@@ -166,11 +166,28 @@ describe("MeasurePanel", () => {
   });
 
   it("reconciles a measurements_config broadcast into the selection", async () => {
+    // this covers the broadcast-BEFORE-GET-settles path: the broadcast lands while the mocked
+    // GET is still in flight, so the noBroadcastSince guard must block the GET from clobbering it.
     vi.spyOn(api, "getMeasurements").mockResolvedValue({ measurements: [] });
     render(<MeasurePanel />);
     act(() => useSession.getState().applyMeasurementConfig([{ channel: 1, mtype: "FREQ" }]));
     const setMeasurements = vi.spyOn(api, "setMeasurements").mockResolvedValue({ measurements: [] });
     await userEvent.click(await screen.findByLabelText("FREQ C1")); // config made it selected → unchecking PUTs []
+    await waitFor(() => expect(setMeasurements).toHaveBeenLastCalledWith("abc", []));
+  });
+
+  it("reflects a measurements_config broadcast that arrives after the mount GET settled (live cross-tab sync)", async () => {
+    vi.spyOn(api, "getMeasurements").mockResolvedValue({ measurements: [{ channel: 1, mtype: "PKPK" }] });
+    render(<MeasurePanel />);
+    // GET settles FIRST — PKPK is the acknowledged selection (this is steady state, not the race window)
+    await waitFor(() => expect(api.getMeasurements).toHaveBeenCalledWith("abc"));
+    await screen.findByLabelText("PKPK C1");
+    // a broadcast from another tab now changes the selection to FREQ, AFTER the GET already settled
+    act(() => useSession.getState().applyMeasurementConfig([{ channel: 1, mtype: "FREQ" }]));
+    // the panel must reflect FREQ live: clicking the now-selected FREQ unchecks it → PUT [].
+    // (Old acked-mask design would still show PKPK selected, so clicking FREQ would PUT [PKPK, FREQ].)
+    const setMeasurements = vi.spyOn(api, "setMeasurements").mockResolvedValue({ measurements: [] });
+    await userEvent.click(await screen.findByLabelText("FREQ C1"));
     await waitFor(() => expect(setMeasurements).toHaveBeenLastCalledWith("abc", []));
   });
 });

--- a/webapp/app/src/features/measure/MeasurePanel.test.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.test.tsx
@@ -25,6 +25,12 @@ describe("MeasurePanel", () => {
   });
 
   it("renders streamed values and shows -- for nulls", () => {
+    // values stream only supplies readouts now — the row is only shown for a SELECTED
+    // measurement, so the selection must also be seeded via measurementConfig.
+    useSession.getState().applyMeasurementConfig([
+      { channel: 1, mtype: "PKPK" },
+      { channel: 1, mtype: "FREQ" },
+    ]);
     useSession.getState().applyMeasurements([
       { channel: 1, mtype: "PKPK", value: 2.5 },
       { channel: 1, mtype: "FREQ", value: null },
@@ -37,7 +43,9 @@ describe("MeasurePanel", () => {
 
   it("keeps the server's selection after a remount instead of re-seeding stale local state", async () => {
     const setMeasurements = vi.spyOn(api, "setMeasurements").mockResolvedValue({ measurements: [] });
-    // server truth: PKPK C1 is already active and streaming
+    // server truth: PKPK C1 is already active and streaming (measurementConfig carries the
+    // selection; measurements carries the streamed value alongside it)
+    useSession.getState().applyMeasurementConfig([{ channel: 1, mtype: "PKPK" }]);
     useSession.getState().applyMeasurements([{ channel: 1, mtype: "PKPK", value: 2.5 }]);
 
     const view = render(<MeasurePanel />);
@@ -65,8 +73,12 @@ describe("MeasurePanel", () => {
     const setMeasurements = vi.spyOn(api, "setMeasurements").mockResolvedValue({ measurements: [] });
     render(<MeasurePanel />); // store starts with no measurements
 
-    // server truth arrives on the stream after mount (restored session / another client / late broadcast)
-    act(() => useSession.getState().applyMeasurements([{ channel: 1, mtype: "PKPK", value: 2.5 }]));
+    // server truth arrives after mount (restored session / another client / late broadcast) —
+    // a measurements_config broadcast is what actually changes the selection.
+    act(() => {
+      useSession.getState().applyMeasurementConfig([{ channel: 1, mtype: "PKPK" }]);
+      useSession.getState().applyMeasurements([{ channel: 1, mtype: "PKPK", value: 2.5 }]);
+    });
 
     await userEvent.click(screen.getByLabelText("FREQ C1"));
 
@@ -141,5 +153,24 @@ describe("MeasurePanel", () => {
         { channel: 1, mtype: "MEAN" },
       ]),
     );
+  });
+
+  it("loads the current selection from the server on mount", async () => {
+    vi.spyOn(api, "getMeasurements").mockResolvedValue({ measurements: [{ channel: 1, mtype: "PKPK" }] });
+    render(<MeasurePanel />);
+    // PKPK C1 shows as checked once the GET resolves (query the checkbox by name and assert the PUT would drop it)
+    const setMeasurements = vi.spyOn(api, "setMeasurements").mockResolvedValue({ measurements: [] });
+    await waitFor(() => expect(api.getMeasurements).toHaveBeenCalledWith("abc"));
+    await userEvent.click(await screen.findByLabelText("PKPK C1")); // was selected → unchecking PUTs []
+    await waitFor(() => expect(setMeasurements).toHaveBeenLastCalledWith("abc", []));
+  });
+
+  it("reconciles a measurements_config broadcast into the selection", async () => {
+    vi.spyOn(api, "getMeasurements").mockResolvedValue({ measurements: [] });
+    render(<MeasurePanel />);
+    act(() => useSession.getState().applyMeasurementConfig([{ channel: 1, mtype: "FREQ" }]));
+    const setMeasurements = vi.spyOn(api, "setMeasurements").mockResolvedValue({ measurements: [] });
+    await userEvent.click(await screen.findByLabelText("FREQ C1")); // config made it selected → unchecking PUTs []
+    await waitFor(() => expect(setMeasurements).toHaveBeenLastCalledWith("abc", []));
   });
 });

--- a/webapp/app/src/features/measure/MeasurePanel.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.tsx
@@ -24,16 +24,14 @@ export function MeasurePanel() {
   const measurements = useSession((s) => s.measurements);
   const measurementConfig = useSession((s) => s.measurementConfig);
   const [error, setError] = useState<string | null>(null);
-  // No local mirror of the selection — the server owns it. The backend only broadcasts
-  // measurement VALUES while the list is NON-empty (sessions.py: `if self.measurements and
-  // self._poll_count % N == 0`), so the config broadcast (and the mount GET) are the only
-  // durable sources for an empty selection — falling back to stale streamed values there
-  // would re-check the box and resurrect the measurement on the next full-replacement PUT.
+  // No local mirror of the acknowledged selection — the STORE's measurementConfig is the single
+  // acknowledged-truth source. The mount GET, each PUT response, and every measurements_config
+  // broadcast all write it (via applyMeasurementConfig), so an already-mounted panel — this rail,
+  // or another tab that receives the broadcast — always reflects the live selection, even in
+  // steady state (no remount required).
   //
-  // The PUT response IS server truth (scope.py echoes the stored list), so we settle to it.
-  // Precedence: in-flight optimistic > last acknowledged (PUT/GET) > synced config broadcast.
+  // Precedence: in-flight optimistic (`pending`) > acknowledged truth (`measurementConfig`).
   const [pending, setPending] = useState<Selection[] | null>(null);
-  const [acked, setAcked] = useState<Selection[] | null>(null);
   // Monotonic request id: a slow PUT must never settle the selection after a newer toggle
   // superseded it, or both boxes flap to unchecked and the next click drops them server-side.
   const requestId = useRef(0);
@@ -41,10 +39,11 @@ export function MeasurePanel() {
   // Seed the selection from the server on mount — the store's measurementConfig may still be
   // stale/empty at first render (it only updates via broadcast), so we GET it directly once per
   // session. This GET is slow relative to everything else that can happen after mount (a user
-  // toggle settling its own acked, or a real measurements_config broadcast arriving) — applying
-  // it unconditionally on resolve would let a stale response clobber fresher local truth. So we
-  // snapshot "nothing has happened yet" at the moment the request goes out and only apply the
-  // result if that's still true when it comes back; otherwise the newer source already won.
+  // toggle settling its own acknowledged truth, or a real measurements_config broadcast arriving)
+  // — applying it unconditionally on resolve would let a stale response clobber fresher truth
+  // that already landed in the store. So we snapshot "nothing has happened yet" at the moment the
+  // request goes out and only apply the result if that's still true when it comes back;
+  // otherwise the newer source (a toggle's PUT response, or a broadcast) already won.
   useEffect(() => {
     if (!session) return;
     let cancelled = false;
@@ -53,7 +52,9 @@ export function MeasurePanel() {
     api.getMeasurements(session.id).then((result) => {
       const noToggleSince = requestId.current === requestIdAtStart;
       const noBroadcastSince = useSession.getState().measurementConfig === configAtStart;
-      if (!cancelled && noToggleSince && noBroadcastSince) setAcked(result.measurements);
+      if (!cancelled && noToggleSince && noBroadcastSince) {
+        useSession.getState().applyMeasurementConfig(result.measurements);
+      }
     }).catch(() => {
       // no server truth available yet (e.g. modern-dialect scope) — fall through to the
       // measurementConfig broadcast / default-empty precedence below.
@@ -61,7 +62,7 @@ export function MeasurePanel() {
     return () => { cancelled = true; };
   }, [session?.id]);
 
-  const selected: Selection[] = pending ?? acked ?? measurementConfig;
+  const selected: Selection[] = pending ?? measurementConfig;
   const isChecked = (channel: number, mtype: string) =>
     selected.some((s) => s.channel === channel && s.mtype === mtype);
 
@@ -81,7 +82,7 @@ export function MeasurePanel() {
     try {
       const result = await api.setMeasurements(session.id, next);
       if (id === requestId.current) {
-        setAcked(result.measurements); // durable across the empty-list broadcast gap
+        useSession.getState().applyMeasurementConfig(result.measurements); // durable across the empty-list broadcast gap
         setPending(null);
       }
       // else: stale response, a newer toggle is in flight — it will settle the selection

--- a/webapp/app/src/features/measure/MeasurePanel.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ApiError, api } from "../../api/client";
 import type { ChannelState } from "../../api/types";
 import { Checkbox } from "../../ds/Checkbox";
@@ -19,23 +19,49 @@ export function MeasurePanel() {
   const channels = useSession((s) => s.scope?.channels ?? NO_CHANNELS);
   // s.measurements is already a stable array reference in the store — select it
   // directly (no `?? []` fallback, which would fabricate a new array every render).
+  // It now carries only VALUES for display; the SELECTION lives in s.measurementConfig
+  // (seeded via GET on mount, kept current via the measurements_config broadcast).
   const measurements = useSession((s) => s.measurements);
+  const measurementConfig = useSession((s) => s.measurementConfig);
   const [error, setError] = useState<string | null>(null);
-  // No local mirror of the selection — the server owns it. But the stream alone cannot carry it:
-  // the backend only broadcasts measurements while its list is NON-empty
-  // (sessions.py: `if self.measurements and self._poll_count % N == 0`), so once you deselect the
-  // last one the store keeps the final streamed values forever. Falling back to the store there
+  // No local mirror of the selection — the server owns it. The backend only broadcasts
+  // measurement VALUES while the list is NON-empty (sessions.py: `if self.measurements and
+  // self._poll_count % N == 0`), so the config broadcast (and the mount GET) are the only
+  // durable sources for an empty selection — falling back to stale streamed values there
   // would re-check the box and resurrect the measurement on the next full-replacement PUT.
   //
   // The PUT response IS server truth (scope.py echoes the stored list), so we settle to it.
-  // Precedence: in-flight optimistic > last acknowledged > streamed values.
+  // Precedence: in-flight optimistic > last acknowledged (PUT/GET) > synced config broadcast.
   const [pending, setPending] = useState<Selection[] | null>(null);
   const [acked, setAcked] = useState<Selection[] | null>(null);
   // Monotonic request id: a slow PUT must never settle the selection after a newer toggle
   // superseded it, or both boxes flap to unchecked and the next click drops them server-side.
   const requestId = useRef(0);
 
-  const selected: Selection[] = pending ?? acked ?? measurements.map((m) => ({ channel: m.channel, mtype: m.mtype }));
+  // Seed the selection from the server on mount — the store's measurementConfig may still be
+  // stale/empty at first render (it only updates via broadcast), so we GET it directly once per
+  // session. This GET is slow relative to everything else that can happen after mount (a user
+  // toggle settling its own acked, or a real measurements_config broadcast arriving) — applying
+  // it unconditionally on resolve would let a stale response clobber fresher local truth. So we
+  // snapshot "nothing has happened yet" at the moment the request goes out and only apply the
+  // result if that's still true when it comes back; otherwise the newer source already won.
+  useEffect(() => {
+    if (!session) return;
+    let cancelled = false;
+    const requestIdAtStart = requestId.current;
+    const configAtStart = useSession.getState().measurementConfig;
+    api.getMeasurements(session.id).then((result) => {
+      const noToggleSince = requestId.current === requestIdAtStart;
+      const noBroadcastSince = useSession.getState().measurementConfig === configAtStart;
+      if (!cancelled && noToggleSince && noBroadcastSince) setAcked(result.measurements);
+    }).catch(() => {
+      // no server truth available yet (e.g. modern-dialect scope) — fall through to the
+      // measurementConfig broadcast / default-empty precedence below.
+    });
+    return () => { cancelled = true; };
+  }, [session?.id]);
+
+  const selected: Selection[] = pending ?? acked ?? measurementConfig;
   const isChecked = (channel: number, mtype: string) =>
     selected.some((s) => s.channel === channel && s.mtype === mtype);
 

--- a/webapp/app/src/features/waveform/WaveformCanvas.mapping.test.ts
+++ b/webapp/app/src/features/waveform/WaveformCanvas.mapping.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { mathTracePixels } from "./WaveformCanvas";
+
+describe("mathTracePixels", () => {
+  it("returns [] for no points", () => {
+    expect(mathTracePixels([], 100, 100, 8)).toEqual([]);
+  });
+
+  it("draws a flat trace at the vertical center with no NaN", () => {
+    const px = mathTracePixels([5, 5, 5], 100, 100, 8);
+    expect(px).toHaveLength(3);
+    px.forEach((p) => {
+      expect(Number.isFinite(p.x)).toBe(true);
+      expect(Number.isFinite(p.y)).toBe(true);
+      expect(p.y).toBeCloseTo(8 + 100 / 2); // pad + gh/2, the mid-line
+    });
+  });
+
+  it("maps a symmetric trace above and below center, all finite", () => {
+    const px = mathTracePixels([-1, 0, 1], 100, 100, 8);
+    const center = 8 + 100 / 2;
+    expect(px[1].y).toBeCloseTo(center); // 0 → center
+    expect(px[0].y).toBeGreaterThan(center); // -1 below (y grows downward)
+    expect(px[2].y).toBeLessThan(center); // +1 above
+    px.forEach((p) => expect(Number.isFinite(p.y)).toBe(true));
+  });
+});

--- a/webapp/app/src/features/waveform/WaveformCanvas.test.tsx
+++ b/webapp/app/src/features/waveform/WaveformCanvas.test.tsx
@@ -2,6 +2,7 @@ import { render } from "@testing-library/react";
 import { StrictMode } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { WaveformCanvas } from "./WaveformCanvas";
+import { setFrame, clearFrames } from "./frames";
 import { useSession } from "../../store/session";
 
 beforeEach(() => useSession.getState().clearSession());
@@ -19,5 +20,13 @@ describe("WaveformCanvas", () => {
         </StrictMode>,
       ),
     ).not.toThrow();
+  });
+
+  it("renders with a math frame present without throwing", () => {
+    // seed a math frame in the buffer, then render
+    clearFrames();
+    setFrame("M1", { t0: 0, dt: 1, points: [0, 1, 0, -1] });
+    expect(() => render(<WaveformCanvas />)).not.toThrow();
+    clearFrames();
   });
 });

--- a/webapp/app/src/features/waveform/WaveformCanvas.tsx
+++ b/webapp/app/src/features/waveform/WaveformCanvas.tsx
@@ -4,6 +4,9 @@ import type { ChannelState } from "../../api/types";
 import { useSession } from "../../store/session";
 
 const TRACE = ["#FFDC32", "#40E0D0", "#FF69B4", "#32FF64"];
+// Resolved to concrete hex (canvas 2D can't read CSS vars) — matches
+// --trace-reference / --trace-difference in webapp/design/tokens/colors.css.
+const MATH_TRACES: Record<string, string> = { M1: "#FFA500", M2: "#FF1493" };
 const DIVS_X = 14;
 const DIVS_Y = 10;
 const PAD = 8;
@@ -99,6 +102,27 @@ export function WaveformCanvas() {
         frame.points.forEach((volts, index) => {
           const x = PAD + (gw * index) / Math.max(1, frame.points.length - 1);
           const y = PAD + gh / 2 - (volts / fullScale) * gh;
+          if (index === 0) ctx.moveTo(x, y);
+          else ctx.lineTo(x, y);
+        });
+        ctx.stroke();
+        drew = true;
+      });
+
+      ["M1", "M2"].forEach((label) => {
+        const frame = getFrame(label);
+        if (!frame || frame.points.length === 0) return;
+        const min = Math.min(...frame.points);
+        const max = Math.max(...frame.points);
+        const mid = (min + max) / 2;
+        const halfSpan = (max - min) / 2;
+        ctx.strokeStyle = MATH_TRACES[label];
+        ctx.lineWidth = 2;
+        ctx.lineJoin = "round";
+        ctx.beginPath();
+        frame.points.forEach((volts, index) => {
+          const x = PAD + (gw * index) / Math.max(1, frame.points.length - 1);
+          const y = PAD + gh / 2 - ((volts - mid) / (halfSpan || 1)) * (gh / 2 * 0.9);
           if (index === 0) ctx.moveTo(x, y);
           else ctx.lineTo(x, y);
         });

--- a/webapp/app/src/features/waveform/WaveformCanvas.tsx
+++ b/webapp/app/src/features/waveform/WaveformCanvas.tsx
@@ -4,9 +4,10 @@ import type { ChannelState } from "../../api/types";
 import { useSession } from "../../store/session";
 
 const TRACE = ["#FFDC32", "#40E0D0", "#FF69B4", "#32FF64"];
-// Resolved to concrete hex (canvas 2D can't read CSS vars) — matches
-// --trace-reference / --trace-difference in webapp/design/tokens/colors.css.
-const MATH_TRACES: Record<string, string> = { M1: "#FFA500", M2: "#FF1493" };
+// Concrete hex (canvas 2D can't read CSS vars). Chosen far in hue from all four
+// channel traces (gold/cyan/hotpink/green) so math traces stay distinguishable;
+// they're also dashed below to read as "computed".
+const MATH_TRACES: Record<string, string> = { M1: "#FFFFFF", M2: "#B18CFF" }; // white + light violet, distinct from channel traces
 const DIVS_X = 14;
 const DIVS_Y = 10;
 const PAD = 8;
@@ -14,6 +15,21 @@ const PAD = 8;
 // Stable reference: zustand v5 hands the selector straight to useSyncExternalStore
 // with no memoization, so a fresh `{}` per snapshot would loop forever while scope is null.
 const NO_CHANNELS: Record<string, ChannelState> = {};
+
+// Pure trace-point mapping for math channels (no voltage_scale): auto-fit each
+// trace to its own min/max so it's visible at any amplitude. Extracted so the
+// risky min/max/NaN math is unit-testable without a canvas 2D context.
+export function mathTracePixels(points: number[], gw: number, gh: number, pad: number): { x: number; y: number }[] {
+  if (points.length === 0) return [];
+  const min = Math.min(...points);
+  const max = Math.max(...points);
+  const mid = (min + max) / 2;
+  const halfSpan = (max - min) / 2 || 1; // flat trace → draw the mid-line, no divide-by-zero
+  return points.map((v, i) => ({
+    x: pad + (gw * i) / Math.max(1, points.length - 1),
+    y: pad + gh / 2 - ((v - mid) / halfSpan) * ((gh / 2) * 0.9),
+  }));
+}
 
 export function WaveformCanvas() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -112,21 +128,19 @@ export function WaveformCanvas() {
       ["M1", "M2"].forEach((label) => {
         const frame = getFrame(label);
         if (!frame || frame.points.length === 0) return;
-        const min = Math.min(...frame.points);
-        const max = Math.max(...frame.points);
-        const mid = (min + max) / 2;
-        const halfSpan = (max - min) / 2;
+        const pixels = mathTracePixels(frame.points, gw, gh, PAD);
+        ctx.save();
+        ctx.setLineDash([5, 3]); // dashed → unmistakably a computed math trace
         ctx.strokeStyle = MATH_TRACES[label];
         ctx.lineWidth = 2;
         ctx.lineJoin = "round";
         ctx.beginPath();
-        frame.points.forEach((volts, index) => {
-          const x = PAD + (gw * index) / Math.max(1, frame.points.length - 1);
-          const y = PAD + gh / 2 - ((volts - mid) / (halfSpan || 1)) * (gh / 2 * 0.9);
+        pixels.forEach(({ x, y }, index) => {
           if (index === 0) ctx.moveTo(x, y);
           else ctx.lineTo(x, y);
         });
         ctx.stroke();
+        ctx.restore();
         drew = true;
       });
       ctx.restore();

--- a/webapp/app/src/features/waveform/frames.test.ts
+++ b/webapp/app/src/features/waveform/frames.test.ts
@@ -27,4 +27,9 @@ describe("frame buffer", () => {
     clearFrames();
     expect(getFrame(1)).toBeUndefined();
   });
+
+  it("stores frames under string keys (math channels)", () => {
+    setFrame("M1", { t0: 0, dt: 1, points: [1, 2] });
+    expect(getFrame("M1")?.points).toEqual([1, 2]);
+  });
 });

--- a/webapp/app/src/features/waveform/frames.ts
+++ b/webapp/app/src/features/waveform/frames.ts
@@ -1,14 +1,14 @@
 export type Frame = { t0: number; dt: number; points: number[] };
 
-const frames = new Map<number, Frame>();
+const frames = new Map<number | string, Frame>();
 const listeners = new Set<() => void>();
 
-export function setFrame(channel: number, frame: Frame): void {
+export function setFrame(channel: number | string, frame: Frame): void {
   frames.set(channel, frame);
   listeners.forEach((listener) => listener());
 }
 
-export function getFrame(channel: number): Frame | undefined {
+export function getFrame(channel: number | string): Frame | undefined {
   return frames.get(channel);
 }
 

--- a/webapp/app/src/store/session.ts
+++ b/webapp/app/src/store/session.ts
@@ -9,10 +9,12 @@ type SessionStore = {
   status: ConnStatus;
   error: string | null;
   measurements: MeasurementValue[];
+  measurementConfig: { channel: number; mtype: string }[];
   setSession: (session: SessionInfo) => void;
   clearSession: () => void;
   applyState: (state: ScopeState) => void;
   applyMeasurements: (values: MeasurementValue[]) => void;
+  applyMeasurementConfig: (items: { channel: number; mtype: string }[]) => void;
   setStatus: (status: ConnStatus) => void;
   setError: (error: string | null) => void;
 };
@@ -23,10 +25,12 @@ export const useSession = create<SessionStore>((set) => ({
   status: "disconnected",
   error: null,
   measurements: [],
+  measurementConfig: [],
   setSession: (session) => set({ session, status: "connected", error: null }),
-  clearSession: () => set({ session: null, scope: null, status: "disconnected", error: null, measurements: [] }),
+  clearSession: () => set({ session: null, scope: null, status: "disconnected", error: null, measurements: [], measurementConfig: [] }),
   applyState: (scope) => set({ scope }),
   applyMeasurements: (measurements) => set({ measurements }),
+  applyMeasurementConfig: (measurementConfig) => set({ measurementConfig }),
   setStatus: (status) => set({ status }),
   setError: (error) => set({ error, status: error ? "error" : "connected" }),
 }));

--- a/webapp/app/src/stream/useStream.test.ts
+++ b/webapp/app/src/stream/useStream.test.ts
@@ -65,6 +65,18 @@ describe("useStream", () => {
     await waitFor(() => expect(useSession.getState().measurements[0].value).toBe(2));
   });
 
+  it("applies a measurements_config message to the store", async () => {
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({ type: "measurements_config", items: [{ channel: 1, mtype: "PKPK" }] });
+    await waitFor(() => expect(useSession.getState().measurementConfig).toEqual([{ channel: 1, mtype: "PKPK" }]));
+  });
+
+  it("routes a math (M1) waveform frame to the frame buffer", async () => {
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({ type: "waveform", channel: "M1", t0: 0, dt: 1e-6, points: [0, 1] });
+    await waitFor(() => expect(getFrame("M1")?.points).toEqual([0, 1]));
+  });
+
   it("treats a closed message as a clean session end", async () => {
     useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
     renderHook(() => useStream("abc"));

--- a/webapp/app/src/stream/useStream.ts
+++ b/webapp/app/src/stream/useStream.ts
@@ -19,6 +19,7 @@ export function useStream(sessionId: string | null): void {
       if (message.type === "state") store.applyState(message.state);
       else if (message.type === "waveform") setFrame(message.channel, { t0: message.t0, dt: message.dt, points: message.points });
       else if (message.type === "measurements") store.applyMeasurements(message.values);
+      else if (message.type === "measurements_config") store.applyMeasurementConfig(message.items);
       else if (message.type === "error") store.setError(message.detail);
       else if (message.type === "closed") {
         ended = true;


### PR DESCRIPTION
## Scope command expansion (gateway sub-project 1)

Exposes four oscilloscope capabilities the `scpi_control` library already implemented but the gateway didn't — each wired **backend and UI**, with the mock kept first-class so everything is exercisable hardware-free.

### What's new

**Screen capture** — `GET /api/sessions/{id}/scope/screenshot.png`
The worker captures the scope's native BMP and Pillow transcodes it to PNG (`Pillow` added to the `[web]` extra). The mock answers `SCDP?` with a minimal valid BMP (a bare IEEE-488.2 block, distinct from the waveform's `DESC,`-prefixed block), so the endpoint returns a real PNG under mock. UI: a **Screenshot** button in the scope toolbar downloads the PNG.

**Waveform as JSON** — `GET /api/sessions/{id}/scope/waveform?channels=1,2&max_points=N`
Full-resolution capture per requested channel, with optional ceiling-division stride decimation to `≤ max_points`. UI: a **JSON** export link beside the CSV export.

**Software math channels** — `GET/PATCH /api/sessions/{id}/scope/math/{1,2}`
Numpy-backed math (`+ - * /`, scalars, `INTG/DIFF/ABS/INV`; no FFT). The poll loop computes each enabled math channel from the already-acquired channel waveforms and streams `{type:"waveform", channel:"M1"|"M2", ...}` frames, rendered on the canvas as distinct **dashed** traces (white / light-violet, chosen far in hue from the channel traces). UI: a **Math** rail panel (expression + enable per channel).

**Measurements sync** — `GET /api/sessions/{id}/scope/measurements` + a `measurements_config` broadcast on `set_measurements`
`MeasurePanel` seeds its selection from the server on mount and treats the store's `measurementConfig` as the single acknowledged-truth source, so a selection change made in one tab syncs live to others.

### Notes

- All instrument I/O runs on the session worker thread via the existing job queue; the new specific routes are registered above the `{op}` catch-all. Streaming frames and the config broadcast are published onto the event loop via `call_soon_threadsafe`; the bounded outbox never evicts control frames.
- Frame-buffer keys widened from `number` to `number | string` to carry `M1`/`M2` traces alongside numeric channels.

### Testing

- Python: 574 passed / 19 skipped. New coverage for the screenshot endpoint + mock BMP, waveform JSON shape / decimation / multi-channel, math PATCH + streamed M1 frame, math-trace clear-on-disable, measurements GET + config broadcast.
- Frontend: 102 passed. New coverage for the Screenshot button, Math panel, string-keyed frames + `mathTracePixels`, and MeasurePanel mount-load + live steady-state config sync.
- Builds clean; `make webapp-build` produces the static bundle; mock-session curl smokes for all four endpoints pass.

### Final-review fixes included

- Disabled/uncomputable math channels published nothing, leaving a frozen ghost trace; the poll loop now emits a single empty-points clear frame on the producing→not-producing transition.
- Live cross-tab measurement sync previously only worked across a remount (a local `acked` mirror masked later broadcasts); acknowledged truth now lives in the store so broadcasts reflect in steady state.

### Follow-ups (non-blocking)

Waveform-JSON `Content-Disposition`/download filename; shared channel-parse helper (dedup with CSV export); clean error mapping when a real-hardware screenshot capture fails; MathPanel expression-clear + draft re-sync; a couple of small test-coverage gaps (JSON link, GET-measurements-before-PUT).
