### PR TITLE
feat: waveform analysis - spectrum view, filter traces, reference waveforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,9 @@ built-in mock (`mock: true`) for hardware-free use. The API is documented at
 - `GET .../scope/waveform?channels=1,2&max_points=N` — waveform data as JSON
 - `GET/PATCH .../scope/math/{1,2}` — software math channels (streamed as M1/M2 traces)
 - `GET .../scope/measurements` — the current measurement selection
+- `GET/PATCH .../scope/spectrum` — server-computed FFT spectrum (streamed as `spectrum` frames)
+- `GET/PATCH .../scope/filters/{1,2}` — software Butterworth filters (streamed as F1/F2 traces)
+- `GET/POST/DELETE .../scope/references` + `GET/PUT .../scope/reference` — saved reference waveforms and the live overlay
 
 ### Browser UI
 

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ built-in mock (`mock: true`) for hardware-free use. The API is documented at
 - `GET/PATCH .../scope/math/{1,2}` — software math channels (streamed as M1/M2 traces)
 - `GET .../scope/measurements` — the current measurement selection
 - `GET/PATCH .../scope/spectrum` — server-computed FFT spectrum (streamed as `spectrum` frames)
-- `GET/PATCH .../scope/filters/{1,2}` — software Butterworth filters (streamed as F1/F2 traces)
+- `GET .../scope/filters` + `PATCH .../scope/filters/{1,2}` — software Butterworth filters (streamed as F1/F2 traces)
 - `GET/POST/DELETE .../scope/references` + `GET/PUT .../scope/reference` — saved reference waveforms and the live overlay
 
 ### Browser UI

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -1,8 +1,10 @@
 # scpi_control/server/api/scope.py
 import asyncio
+from dataclasses import replace
 from typing import Any, Callable, List
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import PlainTextResponse, Response
 
 from scpi_control.exceptions import InvalidParameterError
@@ -17,6 +19,8 @@ from scpi_control.server.schemas import (
     FilterPatch,
     MathPatch,
     MeasurementItem,
+    ReferenceCreate,
+    ReferencePut,
     SpectrumPatch,
     TimebasePatch,
     TriggerPatch,
@@ -305,6 +309,93 @@ async def patch_filter(session_id: str, n: int, body: FilterPatch, request: Requ
                 raise InvalidParameterError("cutoff_low must be below cutoff_high")
     session.filters = {**session.filters, n: merged}
     return _filter_state(session)
+
+
+def _reference_store(request: Request):
+    if request.app.state.references is None:
+        from scpi_control.reference_waveform import ReferenceWaveform
+
+        request.app.state.references = ReferenceWaveform(request.app.state.references_dir)
+    return request.app.state.references
+
+
+def _ref_channel(value):
+    """Normalize a stored channel value (int, '1', or 'C1') to an int, else None."""
+    if isinstance(value, int):
+        return value
+    digits = "".join(ch for ch in str(value) if ch.isdigit())
+    return int(digits) if digits else None
+
+
+def _reference_list(store):
+    return [{"name": r["name"], "channel": _ref_channel(r["channel"]), "timestamp": r["timestamp"], "num_samples": r["num_samples"], "time_span": r["time_span"]} for r in store.list_references()]
+
+
+@router.get("/sessions/{session_id}/scope/references")
+async def list_references(session_id: str, request: Request):
+    require_session(request, session_id)
+    store = _reference_store(request)
+    return await run_in_threadpool(_reference_list, store)
+
+
+@router.post("/sessions/{session_id}/scope/references", status_code=201)
+async def save_reference(session_id: str, body: ReferenceCreate, request: Request):
+    session = require_session(request, session_id)
+    name = body.name.strip()
+    if not name:
+        raise InvalidParameterError("reference name must not be empty")
+    if not 1 <= body.channel <= max(1, session.num_channels):
+        raise InvalidParameterError("channel {0} out of range".format(body.channel))
+    data = await run_job(session, lambda scope: scope.get_waveform(body.channel))
+    data = replace(data, channel=body.channel)  # normalize: list/activate read the channel from NPZ metadata
+    store = _reference_store(request)
+
+    def persist():
+        while store.delete_reference(name):  # replace-on-save, incl. legacy timestamped duplicates
+            pass
+        store.save_reference(data, name)
+        return _reference_list(store)
+
+    return await run_in_threadpool(persist)
+
+
+@router.delete("/sessions/{session_id}/scope/references/{name}", status_code=204)
+async def delete_reference(session_id: str, name: str, request: Request):
+    session = require_session(request, session_id)
+    store = _reference_store(request)
+
+    def remove():
+        deleted = store.delete_reference(name)
+        while store.delete_reference(name):
+            pass
+        return deleted
+
+    if not await run_in_threadpool(remove):
+        raise HTTPException(status_code=404, detail="unknown reference {0}".format(name))
+    active = session.active_reference
+    if active is not None and active["name"] == name:
+        session.set_active_reference(None, None, None)
+
+
+@router.get("/sessions/{session_id}/scope/reference")
+async def get_reference(session_id: str, request: Request):
+    session = require_session(request, session_id)
+    return session.reference_overlay()
+
+
+@router.put("/sessions/{session_id}/scope/reference")
+async def put_reference(session_id: str, body: ReferencePut, request: Request):
+    session = require_session(request, session_id)
+    if body.name is None:
+        session.set_active_reference(None, None, None)
+        return session.reference_overlay()
+    store = _reference_store(request)
+    loaded = await run_in_threadpool(store.load_reference, body.name)
+    if loaded is None:
+        raise HTTPException(status_code=404, detail="unknown reference {0}".format(body.name))
+    metadata = loaded.get("metadata", {})
+    session.set_active_reference(metadata.get("name", body.name), _ref_channel(metadata.get("channel")), loaded)
+    return session.reference_overlay()
 
 
 # NOTE: run_op's {op} path is a catch-all for POST /scope/*; any new specific

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -7,7 +7,20 @@ from fastapi.responses import PlainTextResponse, Response
 
 from scpi_control.exceptions import InvalidParameterError
 from scpi_control.server.api.sessions import require_session
-from scpi_control.server.schemas import ALLOWED_COUPLING, ALLOWED_MEASUREMENTS, ChannelPatch, CommandIn, MathPatch, MeasurementItem, TimebasePatch, TriggerPatch
+from scpi_control.server.schemas import (
+    ALLOWED_COUPLING,
+    ALLOWED_FILTER_KINDS,
+    ALLOWED_MEASUREMENTS,
+    ALLOWED_WINDOWS,
+    ChannelPatch,
+    CommandIn,
+    FilterPatch,
+    MathPatch,
+    MeasurementItem,
+    SpectrumPatch,
+    TimebasePatch,
+    TriggerPatch,
+)
 from scpi_control.server.sessions import InstrumentSession, read_state
 
 router = APIRouter(tags=["scope"])
@@ -232,6 +245,66 @@ async def patch_math(session_id: str, n: int, body: MathPatch, request: Request)
         return _math_state(scope)
 
     return await run_job(session, apply)
+
+
+@router.get("/sessions/{session_id}/scope/spectrum")
+async def get_spectrum(session_id: str, request: Request):
+    session = require_session(request, session_id)
+    return dict(session.spectrum_config)
+
+
+@router.patch("/sessions/{session_id}/scope/spectrum")
+async def patch_spectrum(session_id: str, body: SpectrumPatch, request: Request):
+    session = require_session(request, session_id)
+    updates = {k: v for k, v in body.model_dump().items() if v is not None}
+    if "window" in updates and updates["window"] not in ALLOWED_WINDOWS:
+        raise InvalidParameterError("unknown window: {0}".format(updates["window"]))
+    if "channel" in updates and not 1 <= updates["channel"] <= max(1, session.num_channels):
+        raise InvalidParameterError("channel {0} out of range".format(updates["channel"]))
+    session.spectrum_config = {**session.spectrum_config, **updates}
+    return dict(session.spectrum_config)
+
+
+def _filter_state(session):
+    return [{"n": n, **session.filters[n]} for n in sorted(session.filters)]
+
+
+@router.get("/sessions/{session_id}/scope/filters")
+async def get_filters(session_id: str, request: Request):
+    session = require_session(request, session_id)
+    return _filter_state(session)
+
+
+@router.patch("/sessions/{session_id}/scope/filters/{n}")
+async def patch_filter(session_id: str, n: int, body: FilterPatch, request: Request):
+    session = require_session(request, session_id)
+    if n not in (1, 2):
+        raise InvalidParameterError("filter must be 1 or 2")
+    updates = {k: v for k, v in body.model_dump().items() if v is not None}
+    if "kind" in updates and updates["kind"] not in ALLOWED_FILTER_KINDS:
+        raise InvalidParameterError("unknown filter kind: {0}".format(updates["kind"]))
+    if "source" in updates and not 1 <= updates["source"] <= max(1, session.num_channels):
+        raise InvalidParameterError("channel {0} out of range".format(updates["source"]))
+    if "order" in updates and not 1 <= updates["order"] <= 10:
+        raise InvalidParameterError("order must be between 1 and 10")
+    for key in ("cutoff_low", "cutoff_high"):
+        if key in updates and updates[key] <= 0:
+            raise InvalidParameterError("{0} must be positive".format(key))
+    merged = {**session.filters[n], **updates}
+    if merged["enabled"]:
+        # completeness is only enforced when the merged config is enabled, so
+        # partial configuration while disabled stays a valid workflow
+        if merged["kind"] == "lowpass" and merged["cutoff_high"] is None:
+            raise InvalidParameterError("lowpass requires cutoff_high")
+        if merged["kind"] == "highpass" and merged["cutoff_low"] is None:
+            raise InvalidParameterError("highpass requires cutoff_low")
+        if merged["kind"] == "bandpass":
+            if merged["cutoff_low"] is None or merged["cutoff_high"] is None:
+                raise InvalidParameterError("bandpass requires cutoff_low and cutoff_high")
+            if not merged["cutoff_low"] < merged["cutoff_high"]:
+                raise InvalidParameterError("cutoff_low must be below cutoff_high")
+    session.filters = {**session.filters, n: merged}
+    return _filter_state(session)
 
 
 # NOTE: run_op's {op} path is a catch-all for POST /scope/*; any new specific

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -19,7 +19,7 @@ def _error_response(status: int, exc: BaseException) -> JSONResponse:
     return JSONResponse(status_code=status, content={"error": type(exc).__name__, "detail": str(exc)})
 
 
-def create_app(manager: Optional[SessionManager] = None) -> FastAPI:
+def create_app(manager: Optional[SessionManager] = None, references_dir: Optional[str] = None) -> FastAPI:
     manager = manager if manager is not None else SessionManager()
 
     @asynccontextmanager
@@ -30,6 +30,10 @@ def create_app(manager: Optional[SessionManager] = None) -> FastAPI:
 
     app = FastAPI(title="SCPI Instrument Control Gateway", lifespan=lifespan)
     app.state.manager = manager
+    # Reference store is created lazily on first use: ReferenceWaveform.__init__
+    # mkdirs its storage directory, and most requests never need it.
+    app.state.references_dir = references_dir
+    app.state.references = None
 
     from scpi_control.server.api import discovery as discovery_api
     from scpi_control.server.api import scope as scope_api

--- a/scpi_control/server/compute.py
+++ b/scpi_control/server/compute.py
@@ -1,0 +1,65 @@
+"""Pure analysis computations for the session poll loop.
+
+Everything here operates on already-acquired WaveformData (no instrument
+I/O) and returns stream-frame dicts or None when uncomputable. The poll
+loop turns None into a one-shot cleared frame (the `_shown` pattern).
+"""
+
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+from scpi_control.analysis import FFTAnalyzer
+
+MAX_FFT_POINTS = 65536  # truncation bounds per-tick compute without aliasing (costs only resolution)
+MAX_SPECTRUM_BINS = 2000
+
+_analyzer = FFTAnalyzer()
+
+
+def _max_pool(values: np.ndarray, cap: int):
+    """Decimate a spectrum preserving peaks: max over ceil(n/cap)-sized groups.
+
+    Stride decimation would drop narrow peaks — the whole point of a spectrum.
+    Returns (pooled_values, pool_size).
+    """
+    n = len(values)
+    if n <= cap:
+        return values, 1
+    pool = -(-n // cap)  # ceiling division keeps len <= cap
+    pad = (-n) % pool
+    padded = np.pad(values, (0, pad), constant_values=-np.inf)
+    return padded.reshape(-1, pool).max(axis=1), pool
+
+
+def empty_spectrum_frame(config: Dict[str, Any]) -> Dict[str, Any]:
+    return {"type": "spectrum", "channel": config["channel"], "f0": 0.0, "df": 1.0, "points": [], "db": config["db"], "window": config["window"], "peaks": [], "thd": None}
+
+
+def spectrum_frame(config: Dict[str, Any], acquired: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    data = acquired.get("C{0}".format(config["channel"]))
+    if data is None or len(data.voltage) < 2:
+        return None
+    if len(data.voltage) > MAX_FFT_POINTS:
+        data = type(data)(time=data.time[:MAX_FFT_POINTS], voltage=data.voltage[:MAX_FFT_POINTS], channel=data.channel)
+    result = _analyzer.compute_fft(data, window=config["window"], output_db=config["db"])
+    if result is None:
+        return None
+    peaks = [[float(f), float(m)] for f, m in result.get_peak_frequency(5)]
+    thd = None
+    if peaks:
+        thd_value = FFTAnalyzer.calculate_thd(result, peaks[0][0])
+        thd = float(thd_value) if thd_value is not None else None
+    df = float(result.frequency[1] - result.frequency[0]) if len(result.frequency) > 1 else 1.0
+    pooled, pool = _max_pool(result.magnitude, MAX_SPECTRUM_BINS)
+    return {
+        "type": "spectrum",
+        "channel": config["channel"],
+        "f0": 0.0,
+        "df": df * pool,
+        "points": [float(v) for v in pooled],
+        "db": config["db"],
+        "window": config["window"],
+        "peaks": peaks,
+        "thd": thd,
+    }

--- a/scpi_control/server/compute.py
+++ b/scpi_control/server/compute.py
@@ -63,3 +63,47 @@ def spectrum_frame(config: Dict[str, Any], acquired: Dict[str, Any]) -> Optional
         "peaks": peaks,
         "thd": thd,
     }
+
+
+def filtered_waveform(config: Dict[str, Any], acquired: Dict[str, Any]):
+    """Apply the configured Butterworth filter to its source channel's waveform."""
+    data = acquired.get("C{0}".format(config["source"]))
+    if data is None or len(data.voltage) < 2:
+        return None
+    kind = config["kind"]
+    low = config["cutoff_low"]
+    high = config["cutoff_high"]
+    order = config["order"]
+    if kind == "lowpass" and high is not None:
+        return _analyzer.apply_lowpass_filter(data, high, order)
+    if kind == "highpass" and low is not None:
+        return _analyzer.apply_highpass_filter(data, low, order)
+    if kind == "bandpass" and low is not None and high is not None:
+        return _analyzer.apply_bandpass_filter(data, low, high, order)
+    return None
+
+
+def reference_stats(reference: Dict[str, Any], acquired: Dict[str, Any]) -> Dict[str, Any]:
+    """Correlation + max deviation of the live source-channel trace vs the reference.
+
+    Mirrors ReferenceWaveform.calculate_correlation/_difference semantics
+    (interpolate onto the live grid when lengths differ) without instantiating
+    the store. Degrades every failure to nulls — never raises.
+    """
+    stats: Dict[str, Any] = {"type": "reference_stats", "correlation": None, "max_deviation": None}
+    channel = reference.get("channel")
+    data = acquired.get("C{0}".format(channel)) if channel else None
+    if data is None or len(data.voltage) < 2:
+        return stats
+    try:
+        ref_voltage = np.asarray(reference["data"]["voltage"], dtype=float)
+        if len(data.voltage) != len(ref_voltage):
+            ref_time = np.asarray(reference["data"]["time"], dtype=float)
+            ref_voltage = np.interp(data.time, ref_time, ref_voltage)
+        stats["max_deviation"] = float(np.max(np.abs(data.voltage - ref_voltage)))
+        with np.errstate(divide="ignore", invalid="ignore"):
+            correlation = float(np.corrcoef(data.voltage, ref_voltage)[0, 1])
+        stats["correlation"] = correlation if np.isfinite(correlation) else None
+    except Exception:
+        return {"type": "reference_stats", "correlation": None, "max_deviation": None}
+    return stats

--- a/scpi_control/server/schemas.py
+++ b/scpi_control/server/schemas.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel
 
 ALLOWED_MEASUREMENTS = frozenset({"PKPK", "MAX", "MIN", "AMPL", "TOP", "BASE", "CMEAN", "MEAN", "RMS", "CRMS", "FREQ", "PER", "RISE", "FALL", "WID", "NWID", "DUTY"})
 ALLOWED_COUPLING = frozenset({"DC", "AC", "GND"})
+ALLOWED_WINDOWS = frozenset({"rectangular", "hanning", "hamming", "blackman", "bartlett", "flattop"})
+ALLOWED_FILTER_KINDS = frozenset({"lowpass", "highpass", "bandpass"})
 
 
 class SessionCreate(BaseModel):
@@ -61,6 +63,22 @@ class CommandIn(BaseModel):
 class MathPatch(BaseModel):
     expression: Optional[str] = None
     enabled: Optional[bool] = None
+
+
+class SpectrumPatch(BaseModel):
+    enabled: Optional[bool] = None
+    channel: Optional[int] = None
+    window: Optional[str] = None
+    db: Optional[bool] = None
+
+
+class FilterPatch(BaseModel):
+    enabled: Optional[bool] = None
+    source: Optional[int] = None
+    kind: Optional[str] = None
+    cutoff_low: Optional[float] = None
+    cutoff_high: Optional[float] = None
+    order: Optional[int] = None
 
 
 class ModelOut(BaseModel):

--- a/scpi_control/server/schemas.py
+++ b/scpi_control/server/schemas.py
@@ -81,6 +81,15 @@ class FilterPatch(BaseModel):
     order: Optional[int] = None
 
 
+class ReferenceCreate(BaseModel):
+    name: str
+    channel: int
+
+
+class ReferencePut(BaseModel):
+    name: Optional[str] = None
+
+
 class ModelOut(BaseModel):
     model_name: str
     series: str

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -29,6 +29,18 @@ def _safe(fn, default=None):
         return default
 
 
+def _quiet(fn, default=None):
+    """Like _safe, but for analysis compute: ANY exception degrades to default.
+
+    The poll tick is the session heartbeat; a numpy edge case in analysis
+    must never kill the worker thread.
+    """
+    try:
+        return fn()
+    except Exception:
+        return default
+
+
 def read_state(scope: Oscilloscope) -> Dict[str, Any]:
     channels: Dict[int, Dict[str, Any]] = {}
     for n in scope.supported_channels:
@@ -289,14 +301,14 @@ class InstrumentSession:
             for n in sorted(self.filters):
                 config = self.filters[n]
                 label = "F{0}".format(n)
-                result = compute.filtered_waveform(config, acquired) if config["enabled"] else None
+                result = _quiet(lambda: compute.filtered_waveform(config, acquired)) if config["enabled"] else None
                 if result is not None:
                     self.publish(_decimate_frame(label, result.time, result.voltage))
                     shown_now.add(label)
                 elif label in self._shown:
                     self.publish(_decimate_frame(label, [], []))
             spectrum_config = self.spectrum_config  # snapshot: request threads swap the dict atomically
-            frame = compute.spectrum_frame(spectrum_config, acquired) if spectrum_config["enabled"] else None
+            frame = _quiet(lambda: compute.spectrum_frame(spectrum_config, acquired)) if spectrum_config["enabled"] else None
             if frame is not None:
                 self.publish(frame)
                 shown_now.add("SPEC")

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from scpi_control import Oscilloscope
 from scpi_control.connection.mock import MockConnection
 from scpi_control.exceptions import SiglentConnectionError, SiglentError
+from scpi_control.server import compute
 
 MAX_FRAME_POINTS = 2000
 MEASUREMENT_EVERY_N_POLLS = 4
@@ -103,7 +104,12 @@ class InstrumentSession:
         self._subscribers_lock = threading.Lock()
         self.measurements: List[Tuple[int, str]] = []
         self._poll_count = 0
-        self._math_shown: set = set()  # math labels with a live trace on subscribers' canvases; worker-thread-only
+        # Server-owned analysis config. Request coroutines swap these whole
+        # dicts atomically (never mutate in place); the worker thread only reads.
+        self.spectrum_config: Dict[str, Any] = {"enabled": False, "channel": 1, "window": "hanning", "db": True}
+        self.filters: Dict[int, Dict[str, Any]] = {n: {"source": 1, "kind": "lowpass", "cutoff_low": None, "cutoff_high": None, "order": 5, "enabled": False} for n in (1, 2)}
+        self.active_reference: Optional[Dict[str, Any]] = None  # {"name", "channel", "data": {"time","voltage",...}}
+        self._shown: set = set()  # trace keys (M1/M2/F1/F2/SPEC) live on subscribers' canvases; worker-thread-only
 
     @classmethod
     def open(
@@ -195,6 +201,17 @@ class InstrumentSession:
         self.measurements = list(items)
         self.publish({"type": "measurements_config", "items": [{"channel": c, "mtype": m} for c, m in self.measurements]})
 
+    def reference_overlay(self) -> Dict[str, Any]:
+        active = self.active_reference
+        if active is None:
+            return {"name": None, "channel": None, "t0": 0.0, "dt": 1.0, "points": []}
+        frame = _decimate_frame(active["channel"], active["data"]["time"], active["data"]["voltage"])
+        return {"name": active["name"], "channel": active["channel"], "t0": frame["t0"], "dt": frame["dt"], "points": frame["points"]}
+
+    def set_active_reference(self, name: Optional[str], channel: Optional[int], data: Optional[Dict[str, Any]]) -> None:
+        self.active_reference = None if name is None else {"name": name, "channel": channel, "data": data}
+        self.publish({"type": "reference", **self.reference_overlay()})
+
     def _enter_error_state(self, detail: str) -> None:
         """Flip to the terminal error state and tell the streams once."""
         self.state = "error"
@@ -267,15 +284,35 @@ class InstrumentSession:
                 if result is not None:
                     self.publish(_decimate_frame(label, result.time, result.voltage))
                     shown_now.add(label)
-                elif label in self._math_shown:
+                elif label in self._shown:
                     self.publish(_decimate_frame(label, [], []))  # one-shot clear on transition
-            self._math_shown = shown_now
-            if self.measurements and self._poll_count % MEASUREMENT_EVERY_N_POLLS == 0:
-                values = []
-                for channel, mtype in self.measurements:
-                    value = _safe(lambda: scope.measurement.measure(mtype, channel))
-                    values.append({"channel": channel, "mtype": mtype, "value": value})
-                self.publish({"type": "measurements", "values": values})
+            for n in sorted(self.filters):
+                config = self.filters[n]
+                label = "F{0}".format(n)
+                result = compute.filtered_waveform(config, acquired) if config["enabled"] else None
+                if result is not None:
+                    self.publish(_decimate_frame(label, result.time, result.voltage))
+                    shown_now.add(label)
+                elif label in self._shown:
+                    self.publish(_decimate_frame(label, [], []))
+            spectrum_config = self.spectrum_config  # snapshot: request threads swap the dict atomically
+            frame = compute.spectrum_frame(spectrum_config, acquired) if spectrum_config["enabled"] else None
+            if frame is not None:
+                self.publish(frame)
+                shown_now.add("SPEC")
+            elif "SPEC" in self._shown:
+                self.publish(compute.empty_spectrum_frame(spectrum_config))
+            self._shown = shown_now
+            if self._poll_count % MEASUREMENT_EVERY_N_POLLS == 0:
+                if self.measurements:
+                    values = []
+                    for channel, mtype in self.measurements:
+                        value = _safe(lambda: scope.measurement.measure(mtype, channel))
+                        values.append({"channel": channel, "mtype": mtype, "value": value})
+                    self.publish({"type": "measurements", "values": values})
+                reference = self.active_reference  # snapshot for thread safety
+                if reference is not None:
+                    self.publish(compute.reference_stats(reference, acquired))
         except SiglentError as exc:
             self.error_detail = str(exc)
             self.publish({"type": "error", "detail": str(exc)})

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -19,6 +19,15 @@ def client():
     manager.close_all()
 
 
+@pytest.fixture()
+def ref_client(tmp_path):
+    manager = SessionManager()
+    app = create_app(manager, references_dir=str(tmp_path))
+    with TestClient(app) as test_client:
+        yield test_client
+    manager.close_all()
+
+
 def test_lists_no_sessions_initially(client):
     response = client.get("/api/sessions")
     assert response.status_code == 200
@@ -458,3 +467,55 @@ class TestFilters:
     def test_bad_source_is_400(self, client):
         sid = create_mock_session(client)["id"]
         assert client.patch("/api/sessions/{0}/scope/filters/1".format(sid), json={"source": 9}).status_code == 400
+
+
+class TestReferences:
+    def test_save_returns_the_list(self, ref_client):
+        sid = create_mock_session(ref_client)["id"]
+        response = ref_client.post("/api/sessions/{0}/scope/references".format(sid), json={"name": "golden", "channel": 1})
+        assert response.status_code == 201
+        refs = response.json()
+        assert len(refs) == 1
+        assert refs[0]["name"] == "golden" and refs[0]["channel"] == 1
+        assert refs[0]["num_samples"] > 0
+
+    def test_saving_an_existing_name_replaces_it(self, ref_client):
+        sid = create_mock_session(ref_client)["id"]
+        ref_client.post("/api/sessions/{0}/scope/references".format(sid), json={"name": "golden", "channel": 1})
+        refs = ref_client.post("/api/sessions/{0}/scope/references".format(sid), json={"name": "golden", "channel": 1}).json()
+        assert len(refs) == 1
+
+    def test_activate_returns_overlay_and_get_matches(self, ref_client):
+        sid = create_mock_session(ref_client)["id"]
+        ref_client.post("/api/sessions/{0}/scope/references".format(sid), json={"name": "golden", "channel": 1})
+        overlay = ref_client.put("/api/sessions/{0}/scope/reference".format(sid), json={"name": "golden"}).json()
+        assert overlay["name"] == "golden" and overlay["channel"] == 1
+        assert 0 < len(overlay["points"]) <= 2000
+        assert ref_client.get("/api/sessions/{0}/scope/reference".format(sid)).json() == overlay
+
+    def test_deactivate_clears_the_overlay(self, ref_client):
+        sid = create_mock_session(ref_client)["id"]
+        ref_client.post("/api/sessions/{0}/scope/references".format(sid), json={"name": "golden", "channel": 1})
+        ref_client.put("/api/sessions/{0}/scope/reference".format(sid), json={"name": "golden"})
+        overlay = ref_client.put("/api/sessions/{0}/scope/reference".format(sid), json={"name": None}).json()
+        assert overlay["name"] is None and overlay["points"] == []
+
+    def test_activate_unknown_is_404(self, ref_client):
+        sid = create_mock_session(ref_client)["id"]
+        assert ref_client.put("/api/sessions/{0}/scope/reference".format(sid), json={"name": "nope"}).status_code == 404
+
+    def test_delete_removes_and_clears_active(self, ref_client):
+        sid = create_mock_session(ref_client)["id"]
+        ref_client.post("/api/sessions/{0}/scope/references".format(sid), json={"name": "golden", "channel": 1})
+        ref_client.put("/api/sessions/{0}/scope/reference".format(sid), json={"name": "golden"})
+        assert ref_client.delete("/api/sessions/{0}/scope/references/golden".format(sid)).status_code == 204
+        assert ref_client.get("/api/sessions/{0}/scope/reference".format(sid)).json()["name"] is None
+        assert ref_client.delete("/api/sessions/{0}/scope/references/golden".format(sid)).status_code == 404
+
+    def test_empty_name_is_400(self, ref_client):
+        sid = create_mock_session(ref_client)["id"]
+        assert ref_client.post("/api/sessions/{0}/scope/references".format(sid), json={"name": "   ", "channel": 1}).status_code == 400
+
+    def test_bad_channel_is_400(self, ref_client):
+        sid = create_mock_session(ref_client)["id"]
+        assert ref_client.post("/api/sessions/{0}/scope/references".format(sid), json={"name": "x", "channel": 9}).status_code == 400

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -385,3 +385,76 @@ class TestMath:
     def test_patch_math_empty_expression_is_400(self, client):
         sid = create_mock_session(client)["id"]
         assert client.patch("/api/sessions/{0}/scope/math/1".format(sid), json={"expression": "   "}).status_code == 400
+
+
+def test_allowed_windows_matches_fft_analyzer():
+    from scpi_control.analysis import FFTAnalyzer
+    from scpi_control.server.schemas import ALLOWED_WINDOWS
+
+    assert ALLOWED_WINDOWS == frozenset(FFTAnalyzer.WINDOW_FUNCTIONS)
+
+
+class TestSpectrumConfig:
+    def test_get_returns_defaults(self, client):
+        sid = create_mock_session(client)["id"]
+        body = client.get("/api/sessions/{0}/scope/spectrum".format(sid)).json()
+        assert body == {"enabled": False, "channel": 1, "window": "hanning", "db": True}
+
+    def test_patch_updates_and_persists(self, client):
+        sid = create_mock_session(client)["id"]
+        response = client.patch("/api/sessions/{0}/scope/spectrum".format(sid), json={"enabled": True, "channel": 2, "window": "flattop", "db": False})
+        assert response.status_code == 200
+        assert response.json() == {"enabled": True, "channel": 2, "window": "flattop", "db": False}
+        assert client.get("/api/sessions/{0}/scope/spectrum".format(sid)).json()["window"] == "flattop"
+
+    def test_patch_unknown_window_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.patch("/api/sessions/{0}/scope/spectrum".format(sid), json={"window": "kaiser"}).status_code == 400
+
+    def test_patch_bad_channel_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.patch("/api/sessions/{0}/scope/spectrum".format(sid), json={"channel": 9}).status_code == 400
+
+
+class TestFilters:
+    def test_get_returns_two_disabled_filters(self, client):
+        sid = create_mock_session(client)["id"]
+        body = client.get("/api/sessions/{0}/scope/filters".format(sid)).json()
+        assert [f["n"] for f in body] == [1, 2]
+        assert all(f["enabled"] is False and f["kind"] == "lowpass" and f["order"] == 5 for f in body)
+
+    def test_patch_configures_and_enables(self, client):
+        sid = create_mock_session(client)["id"]
+        response = client.patch("/api/sessions/{0}/scope/filters/1".format(sid), json={"kind": "bandpass", "cutoff_low": 10, "cutoff_high": 100, "enabled": True})
+        assert response.status_code == 200
+        entry = [f for f in response.json() if f["n"] == 1][0]
+        assert entry["kind"] == "bandpass" and entry["cutoff_low"] == 10 and entry["cutoff_high"] == 100 and entry["enabled"] is True
+
+    def test_patch_bad_index_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.patch("/api/sessions/{0}/scope/filters/3".format(sid), json={"enabled": True}).status_code == 400
+
+    def test_enabling_without_required_cutoff_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.patch("/api/sessions/{0}/scope/filters/1".format(sid), json={"enabled": True}).status_code == 400
+
+    def test_bandpass_cutoff_order_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        body = {"kind": "bandpass", "cutoff_low": 100, "cutoff_high": 10, "enabled": True}
+        assert client.patch("/api/sessions/{0}/scope/filters/1".format(sid), json=body).status_code == 400
+
+    def test_nonpositive_cutoff_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.patch("/api/sessions/{0}/scope/filters/1".format(sid), json={"cutoff_high": 0}).status_code == 400
+
+    def test_bad_kind_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.patch("/api/sessions/{0}/scope/filters/1".format(sid), json={"kind": "notch"}).status_code == 400
+
+    def test_bad_order_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.patch("/api/sessions/{0}/scope/filters/1".format(sid), json={"order": 0}).status_code == 400
+
+    def test_bad_source_is_400(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.patch("/api/sessions/{0}/scope/filters/1".format(sid), json={"source": 9}).status_code == 400

--- a/tests/test_server_compute.py
+++ b/tests/test_server_compute.py
@@ -54,3 +54,83 @@ class TestSpectrumFrame:
         frame = empty_spectrum_frame(SPECTRUM_CONFIG)
         assert frame["type"] == "spectrum" and frame["points"] == [] and frame["peaks"] == [] and frame["thd"] is None
         assert frame["channel"] == 1 and frame["db"] is True and frame["window"] == "hanning"
+
+
+from scpi_control.server.compute import filtered_waveform, reference_stats
+
+
+def _two_tone(n=4096, rate=1000.0):
+    t = np.arange(n) / rate
+    return WaveformData(time=t, voltage=np.sin(2 * np.pi * 10 * t) + np.sin(2 * np.pi * 200 * t), channel=1)
+
+
+def _filter_config(**overrides):
+    config = {"source": 1, "kind": "lowpass", "cutoff_low": None, "cutoff_high": None, "order": 5, "enabled": True}
+    config.update(overrides)
+    return config
+
+
+def _tone_magnitude(waveform, freq, rate=1000.0):
+    spectrum = np.abs(np.fft.rfft(waveform.voltage))
+    bin_index = int(round(freq * len(waveform.voltage) / rate))
+    return float(spectrum[bin_index])
+
+
+class TestFilteredWaveform:
+    def test_lowpass_attenuates_the_high_tone(self):
+        out = filtered_waveform(_filter_config(cutoff_high=50.0), {"C1": _two_tone()})
+        assert out is not None
+        assert _tone_magnitude(out, 200) < 0.1 * _tone_magnitude(out, 10)
+
+    def test_highpass_attenuates_the_low_tone(self):
+        out = filtered_waveform(_filter_config(kind="highpass", cutoff_low=100.0), {"C1": _two_tone()})
+        assert out is not None
+        assert _tone_magnitude(out, 10) < 0.1 * _tone_magnitude(out, 200)
+
+    def test_bandpass_needs_both_cutoffs(self):
+        assert filtered_waveform(_filter_config(kind="bandpass", cutoff_low=5.0), {"C1": _two_tone()}) is None
+
+    def test_nyquist_violation_returns_none(self):
+        # rate 1000 -> Nyquist 500; 600 Hz cutoff is invalid -> library returns None
+        assert filtered_waveform(_filter_config(cutoff_high=600.0), {"C1": _two_tone()}) is None
+
+    def test_missing_source_returns_none(self):
+        assert filtered_waveform(_filter_config(cutoff_high=50.0), {}) is None
+
+    def test_missing_required_cutoff_returns_none(self):
+        assert filtered_waveform(_filter_config(), {"C1": _two_tone()}) is None
+
+
+class TestReferenceStats:
+    def test_identical_trace_correlates_perfectly(self):
+        wf = _sine_waveform()
+        reference = {"name": "golden", "channel": 1, "data": {"time": wf.time, "voltage": wf.voltage}}
+        stats = reference_stats(reference, {"C1": wf})
+        assert stats["type"] == "reference_stats"
+        assert stats["correlation"] == pytest.approx(1.0)
+        assert stats["max_deviation"] == pytest.approx(0.0)
+
+    def test_interpolates_when_lengths_differ(self):
+        # Both over the same time span (0 to 4s), different sample densities
+        t_live = np.linspace(0, 4.0, 4096)
+        v_live = np.sin(2 * np.pi * 50 * t_live)
+        live = WaveformData(time=t_live, voltage=v_live, channel=1)
+
+        t_ref = np.linspace(0, 4.0, 1024)
+        v_ref = np.sin(2 * np.pi * 50 * t_ref)
+        reference = {"name": "golden", "channel": 1, "data": {"time": t_ref, "voltage": v_ref}}
+        stats = reference_stats(reference, {"C1": live})
+        assert stats["correlation"] is not None and stats["correlation"] > 0.99
+
+    def test_missing_channel_degrades_to_null(self):
+        reference = {"name": "golden", "channel": 3, "data": {"time": np.arange(4.0), "voltage": np.ones(4)}}
+        stats = reference_stats(reference, {"C1": _sine_waveform()})
+        assert stats == {"type": "reference_stats", "correlation": None, "max_deviation": None}
+
+    def test_flat_trace_correlation_is_null_not_nan(self):
+        t = np.arange(64) / 1000.0
+        flat = WaveformData(time=t, voltage=np.zeros(64), channel=1)
+        reference = {"name": "golden", "channel": 1, "data": {"time": t, "voltage": np.zeros(64)}}
+        stats = reference_stats(reference, {"C1": flat})
+        assert stats["correlation"] is None
+        assert stats["max_deviation"] == pytest.approx(0.0)

--- a/tests/test_server_compute.py
+++ b/tests/test_server_compute.py
@@ -1,0 +1,56 @@
+"""Pure analysis computations for the poll loop. No FastAPI dependency."""
+
+import numpy as np
+import pytest
+
+from scpi_control.server.compute import MAX_SPECTRUM_BINS, empty_spectrum_frame, spectrum_frame
+from scpi_control.waveform import WaveformData
+
+
+def _sine_waveform(freq=50.0, n=4096, rate=1000.0, amplitude=1.0):
+    t = np.arange(n) / rate
+    return WaveformData(time=t, voltage=amplitude * np.sin(2 * np.pi * freq * t), channel=1)
+
+
+SPECTRUM_CONFIG = {"enabled": True, "channel": 1, "window": "hanning", "db": True}
+
+
+class TestSpectrumFrame:
+    def test_peak_lands_at_the_sine_frequency(self):
+        frame = spectrum_frame(SPECTRUM_CONFIG, {"C1": _sine_waveform()})
+        assert frame is not None and frame["type"] == "spectrum"
+        df_full = 1000.0 / 4096  # rfftfreq bin width before pooling
+        assert abs(frame["peaks"][0][0] - 50.0) <= 2 * df_full
+        assert frame["channel"] == 1 and frame["db"] is True and frame["window"] == "hanning"
+        assert frame["f0"] == 0.0 and frame["df"] > 0
+
+    def test_points_are_capped_and_pooling_preserves_the_peak(self):
+        # n=4096 -> 2049 rfft bins -> pooled by 2; max-pool must keep the exact peak magnitude
+        frame = spectrum_frame(SPECTRUM_CONFIG, {"C1": _sine_waveform()})
+        assert 0 < len(frame["points"]) <= MAX_SPECTRUM_BINS
+        assert max(frame["points"]) == pytest.approx(frame["peaks"][0][1])
+
+    def test_df_scales_with_the_pooling_factor(self):
+        frame = spectrum_frame(SPECTRUM_CONFIG, {"C1": _sine_waveform()})
+        df_full = 1000.0 / 4096
+        assert frame["df"] == pytest.approx(df_full * 2)
+
+    def test_thd_of_a_pure_sine_is_small(self):
+        frame = spectrum_frame(SPECTRUM_CONFIG, {"C1": _sine_waveform()})
+        assert frame["thd"] is not None and frame["thd"] < 5.0
+
+    def test_long_records_are_truncated_not_fatal(self):
+        frame = spectrum_frame(SPECTRUM_CONFIG, {"C1": _sine_waveform(n=200_000)})
+        assert frame is not None and 0 < len(frame["points"]) <= MAX_SPECTRUM_BINS
+
+    def test_missing_source_channel_returns_none(self):
+        assert spectrum_frame(SPECTRUM_CONFIG, {}) is None
+
+    def test_too_short_waveform_returns_none(self):
+        wf = WaveformData(time=np.array([0.0]), voltage=np.array([1.0]), channel=1)
+        assert spectrum_frame(SPECTRUM_CONFIG, {"C1": wf}) is None
+
+    def test_empty_frame_shape(self):
+        frame = empty_spectrum_frame(SPECTRUM_CONFIG)
+        assert frame["type"] == "spectrum" and frame["points"] == [] and frame["peaks"] == [] and frame["thd"] is None
+        assert frame["channel"] == 1 and frame["db"] is True and frame["window"] == "hanning"

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -296,3 +296,28 @@ def test_poll_publishes_reference_stats_for_active_reference():
         assert msgs[0]["max_deviation"] is not None
     finally:
         session.close()
+
+
+def test_poll_survives_unexpected_analysis_exception(monkeypatch):
+    # An unexpected (non-Siglent) error in analysis compute must never kill
+    # the worker: the tick degrades that trace and keeps publishing channels.
+    from scpi_control.server import compute
+
+    def boom(config, acquired):
+        raise RuntimeError("unexpected numpy edge case")
+
+    monkeypatch.setattr(compute, "filtered_waveform", boom)
+    monkeypatch.setattr(compute, "spectrum_frame", boom)
+    session = make_session()
+    try:
+        session.filters = {**session.filters, 1: {**session.filters[1], "enabled": True, "cutoff_high": 100.0}}
+        session.spectrum_config = {**session.spectrum_config, "enabled": True}
+        # n=8: this mock's default enables all 4 channels, so one healthy tick
+        # already yields 4 "waveform" messages; require two full ticks' worth
+        # so the assertion actually distinguishes "died after tick 1" from
+        # "kept polling."
+        frames = collect(session, "waveform", n=8, timeout=8.0)
+        channel_frames = [f for f in frames if f["channel"] == 1]
+        assert len(channel_frames) >= 2, "worker must keep polling after an analysis exception"
+    finally:
+        session.close()

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -206,3 +206,93 @@ def test_set_measurements_broadcasts_config():
         assert got and got[0]["items"] == [{"channel": 1, "mtype": "PKPK"}, {"channel": 2, "mtype": "FREQ"}]
     finally:
         session.close()
+
+
+def test_poll_publishes_spectrum_frame_when_enabled():
+    session = make_session()
+    try:
+        session.spectrum_config = {**session.spectrum_config, "enabled": True}
+        frames = collect(session, "spectrum", n=1, timeout=8.0)
+        assert frames, "expected a spectrum frame"
+        frame = frames[0]
+        assert frame["channel"] == 1 and frame["db"] is True and frame["window"] == "hanning"
+        assert 0 < len(frame["points"]) <= 2000
+        assert frame["df"] > 0
+    finally:
+        session.close()
+
+
+def test_poll_clears_spectrum_frame_when_disabled():
+    session = make_session()
+    try:
+        session.spectrum_config = {**session.spectrum_config, "enabled": True}
+        assert collect(session, "spectrum", n=1, timeout=8.0), "expected a live spectrum frame first"
+        cleared = []
+        unsubscribe = session.subscribe(lambda m: cleared.append(m) if m["type"] == "spectrum" and m["points"] == [] else None)
+        session.spectrum_config = {**session.spectrum_config, "enabled": False}
+        deadline = time.time() + 8.0
+        while not cleared and time.time() < deadline:
+            time.sleep(0.02)
+        unsubscribe()
+        assert cleared, "expected a one-shot empty spectrum frame on disable"
+    finally:
+        session.close()
+
+
+def test_poll_publishes_filtered_trace():
+    session = make_session()
+    try:
+        session.filters = {**session.filters, 1: {**session.filters[1], "enabled": True, "cutoff_high": 100.0}}
+        frames = collect(session, "waveform", n=6, timeout=8.0)
+        f1 = [f for f in frames if f["channel"] == "F1"]
+        assert f1, "expected an F1 filtered frame"
+        assert 0 < len(f1[0]["points"]) <= 2000
+    finally:
+        session.close()
+
+
+def test_poll_clears_filtered_trace_when_disabled():
+    session = make_session()
+    try:
+        session.filters = {**session.filters, 1: {**session.filters[1], "enabled": True, "cutoff_high": 100.0}}
+        assert [f for f in collect(session, "waveform", n=6, timeout=8.0) if f["channel"] == "F1"]
+        cleared = []
+        unsubscribe = session.subscribe(lambda m: cleared.append(m) if m["type"] == "waveform" and m["channel"] == "F1" and m["points"] == [] else None)
+        session.filters = {**session.filters, 1: {**session.filters[1], "enabled": False}}
+        deadline = time.time() + 8.0
+        while not cleared and time.time() < deadline:
+            time.sleep(0.02)
+        unsubscribe()
+        assert cleared, "expected a one-shot empty F1 frame on disable"
+    finally:
+        session.close()
+
+
+def test_set_active_reference_broadcasts_overlay_and_clear():
+    session = make_session()
+    try:
+        got = []
+        unsubscribe = session.subscribe(lambda m: got.append(m) if m["type"] == "reference" else None)
+        data = session.submit(lambda scope: scope.get_waveform(1)).result(timeout=5)
+        session.set_active_reference("golden", 1, {"time": data.time, "voltage": data.voltage})
+        session.set_active_reference(None, None, None)
+        unsubscribe()
+        assert got[0]["name"] == "golden" and got[0]["channel"] == 1
+        assert 0 < len(got[0]["points"]) <= 2000
+        assert got[1]["name"] is None and got[1]["points"] == []
+    finally:
+        session.close()
+
+
+def test_poll_publishes_reference_stats_for_active_reference():
+    session = make_session()
+    try:
+        # the mock replays the same record every tick -> self-compare is deterministic
+        data = session.submit(lambda scope: scope.get_waveform(1)).result(timeout=5)
+        session.set_active_reference("golden", 1, {"time": data.time, "voltage": data.voltage})
+        msgs = collect(session, "reference_stats", n=1, timeout=8.0)
+        assert msgs, "expected a reference_stats message"
+        assert msgs[0]["correlation"] is not None and msgs[0]["correlation"] > 0.99
+        assert msgs[0]["max_deviation"] is not None
+    finally:
+        session.close()

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { AnalysisPanel } from "./features/controls/AnalysisPanel";
 import { ChannelsPanel } from "./features/controls/ChannelsPanel";
 import { MathPanel } from "./features/controls/MathPanel";
 import { ScopeToolbar } from "./features/controls/ScopeToolbar";
@@ -17,7 +18,7 @@ import { Tabs } from "./ds/Tabs";
 import { useStream } from "./stream/useStream";
 import { useSession } from "./store/session";
 
-const RAIL_TABS = ["Channels", "Trigger", "Math", "Measure", "Terminal"];
+const RAIL_TABS = ["Channels", "Trigger", "Math", "Analysis", "Reference", "Measure", "Terminal"];
 
 export default function App() {
   const status = useSession((s) => s.status);
@@ -45,6 +46,8 @@ export default function App() {
                 {railTab === "Channels" && <ChannelsPanel />}
                 {railTab === "Trigger" && <TriggerPanel />}
                 {railTab === "Math" && <MathPanel />}
+                {railTab === "Analysis" && <AnalysisPanel />}
+                {railTab === "Reference" && null}
                 {railTab === "Measure" && <MeasurePanel />}
                 {railTab === "Terminal" && <TerminalPanel />}
               </Tabs>

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -7,6 +7,7 @@ import { TriggerPanel } from "./features/controls/TriggerPanel";
 import { HomeScreen } from "./features/home/HomeScreen";
 import { MeasurePanel } from "./features/measure/MeasurePanel";
 import { ReadoutStrip } from "./features/readout/ReadoutStrip";
+import { ReferencePanel } from "./features/reference/ReferencePanel";
 import { useReferenceSeed } from "./features/reference/useReferenceSeed";
 import { TerminalPanel } from "./features/terminal/TerminalPanel";
 import { SpectrumCanvas } from "./features/waveform/SpectrumCanvas";
@@ -47,7 +48,7 @@ export default function App() {
                 {railTab === "Trigger" && <TriggerPanel />}
                 {railTab === "Math" && <MathPanel />}
                 {railTab === "Analysis" && <AnalysisPanel />}
-                {railTab === "Reference" && null}
+                {railTab === "Reference" && <ReferencePanel />}
                 {railTab === "Measure" && <MeasurePanel />}
                 {railTab === "Terminal" && <TerminalPanel />}
               </Tabs>

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -6,8 +6,12 @@ import { TriggerPanel } from "./features/controls/TriggerPanel";
 import { HomeScreen } from "./features/home/HomeScreen";
 import { MeasurePanel } from "./features/measure/MeasurePanel";
 import { ReadoutStrip } from "./features/readout/ReadoutStrip";
+import { useReferenceSeed } from "./features/reference/useReferenceSeed";
 import { TerminalPanel } from "./features/terminal/TerminalPanel";
+import { SpectrumCanvas } from "./features/waveform/SpectrumCanvas";
 import { WaveformCanvas } from "./features/waveform/WaveformCanvas";
+import type { ViewMode } from "./features/waveform/ViewModeToggle";
+import { ViewModeToggle } from "./features/waveform/ViewModeToggle";
 import { StatusIndicator } from "./ds/StatusIndicator";
 import { Tabs } from "./ds/Tabs";
 import { useStream } from "./stream/useStream";
@@ -19,7 +23,9 @@ export default function App() {
   const status = useSession((s) => s.status);
   const session = useSession((s) => s.session);
   const [railTab, setRailTab] = useState("Channels");
+  const [viewMode, setViewMode] = useState<ViewMode>("Time");
   useStream(session?.id ?? null);
+  useReferenceSeed(session?.id ?? null);
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100vh", background: "var(--lc-bg)", fontFamily: "var(--font-ui)" }}>
       <header style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", padding: "10px 14px", background: "var(--lc-panel)", borderBottom: "1px solid var(--lc-border)" }}>
@@ -44,8 +50,8 @@ export default function App() {
               </Tabs>
             </div>
             <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "var(--space-3)", minWidth: 0 }}>
-              <WaveformCanvas />
-              <ScopeToolbar />
+              {viewMode === "Time" ? <WaveformCanvas /> : <SpectrumCanvas />}
+              <ScopeToolbar viewToggle={<ViewModeToggle value={viewMode} onChange={setViewMode} />} />
             </div>
           </div>
         )}

--- a/webapp/app/src/api/client.ts
+++ b/webapp/app/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { ChannelPatch, DiscoveredDevice, MeasurementValue, ModelInfo, RunOp, ScopeState, SessionCreate, SessionInfo, TriggerPatch } from "./types";
+import type { ChannelPatch, DiscoveredDevice, FilterConfig, MeasurementValue, ModelInfo, ReferenceInfo, ReferenceOverlay, RunOp, ScopeState, SessionCreate, SessionInfo, SpectrumConfig, TriggerPatch } from "./types";
 
 export class ApiError extends Error {
   status: number;
@@ -55,6 +55,15 @@ export const api = {
   getMeasurements: (id: string) => request<{ measurements: { channel: number; mtype: string }[] }>(`${scope(id)}/measurements`),
   getMath: (id: string) => request<{ n: number; expression: string; enabled: boolean }[]>(`${scope(id)}/math`),
   patchMath: (id: string, n: number, body: { expression?: string; enabled?: boolean }) => request<{ n: number; expression: string; enabled: boolean }[]>(`${scope(id)}/math/${n}`, json("PATCH", body)),
+  getSpectrum: (id: string) => request<SpectrumConfig>(`${scope(id)}/spectrum`),
+  patchSpectrum: (id: string, body: Partial<SpectrumConfig>) => request<SpectrumConfig>(`${scope(id)}/spectrum`, json("PATCH", body)),
+  getFilters: (id: string) => request<FilterConfig[]>(`${scope(id)}/filters`),
+  patchFilter: (id: string, n: number, body: Partial<Omit<FilterConfig, "n">>) => request<FilterConfig[]>(`${scope(id)}/filters/${n}`, json("PATCH", body)),
+  listReferences: (id: string) => request<ReferenceInfo[]>(`${scope(id)}/references`),
+  saveReference: (id: string, name: string, channel: number) => request<ReferenceInfo[]>(`${scope(id)}/references`, json("POST", { name, channel })),
+  deleteReference: (id: string, name: string) => request<void>(`${scope(id)}/references/${encodeURIComponent(name)}`, { method: "DELETE" }),
+  getReference: (id: string) => request<ReferenceOverlay>(`${scope(id)}/reference`),
+  putReference: (id: string, name: string | null) => request<ReferenceOverlay>(`${scope(id)}/reference`, json("PUT", { name })),
   captureUrl: (id: string, channels: number[]) => `${scope(id)}/capture.csv?channels=${channels.join(",")}`,
   screenshotUrl: (id: string) => `${scope(id)}/screenshot.png`,
   waveformJsonUrl: (id: string, channels: number[]) => `${scope(id)}/waveform?channels=${channels.join(",")}`,

--- a/webapp/app/src/api/types.ts
+++ b/webapp/app/src/api/types.ts
@@ -57,11 +57,21 @@ export type ModelInfo = {
 
 export type MeasurementValue = { channel: number; mtype: string; value: number | null };
 
+export type SpectrumConfig = { enabled: boolean; channel: number; window: string; db: boolean };
+export type FilterConfig = { n: number; source: number; kind: "lowpass" | "highpass" | "bandpass"; cutoff_low: number | null; cutoff_high: number | null; order: number; enabled: boolean };
+export type ReferenceInfo = { name: string; channel: number | null; timestamp: string; num_samples: number; time_span: number };
+export type ReferenceOverlay = { name: string | null; channel: number | null; t0: number; dt: number; points: number[] };
+export type ReferenceStats = { correlation: number | null; max_deviation: number | null };
+export type SpectrumFrame = { channel: number; f0: number; df: number; points: number[]; db: boolean; window: string; peaks: [number, number][]; thd: number | null };
+
 export type StreamMessage =
   | { type: "state"; state: ScopeState }
   | { type: "waveform"; channel: number | string; t0: number; dt: number; points: number[] }
   | { type: "measurements"; values: MeasurementValue[] }
   | { type: "measurements_config"; items: { channel: number; mtype: string }[] }
+  | ({ type: "spectrum" } & SpectrumFrame)
+  | ({ type: "reference" } & ReferenceOverlay)
+  | ({ type: "reference_stats" } & ReferenceStats)
   | { type: "error"; detail: string }
   | { type: "closed" };
 

--- a/webapp/app/src/features/controls/AnalysisPanel.test.tsx
+++ b/webapp/app/src/features/controls/AnalysisPanel.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AnalysisPanel } from "./AnalysisPanel";
+import { ApiError, api } from "../../api/client";
+import type { FilterConfig, SpectrumConfig } from "../../api/types";
+import { useSession } from "../../store/session";
+
+const SPECTRUM: SpectrumConfig = { enabled: false, channel: 1, window: "hanning", db: true };
+const FILTERS: FilterConfig[] = [
+  { n: 1, source: 1, kind: "lowpass", cutoff_low: null, cutoff_high: null, order: 5, enabled: false },
+  { n: 2, source: 1, kind: "lowpass", cutoff_low: null, cutoff_high: null, order: 5, enabled: false },
+];
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  vi.spyOn(api, "getSpectrum").mockResolvedValue(SPECTRUM);
+  vi.spyOn(api, "getFilters").mockResolvedValue(FILTERS);
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("AnalysisPanel", () => {
+  it("loads config and PATCHes a window change", async () => {
+    const patch = vi.spyOn(api, "patchSpectrum").mockResolvedValue({ ...SPECTRUM, window: "flattop" });
+    render(<AnalysisPanel />);
+    await userEvent.selectOptions(await screen.findByLabelText("Spectrum window"), "flattop");
+    await waitFor(() => expect(patch).toHaveBeenCalledWith("abc", { window: "flattop" }));
+  });
+
+  it("enables the spectrum", async () => {
+    const patch = vi.spyOn(api, "patchSpectrum").mockResolvedValue({ ...SPECTRUM, enabled: true });
+    render(<AnalysisPanel />);
+    await userEvent.click(await screen.findByLabelText("Enable spectrum"));
+    await waitFor(() => expect(patch).toHaveBeenCalledWith("abc", { enabled: true }));
+  });
+
+  it("commits a filter cutoff on blur", async () => {
+    const patch = vi.spyOn(api, "patchFilter").mockResolvedValue(FILTERS);
+    render(<AnalysisPanel />);
+    const field = await screen.findByLabelText("Filter 1 high cutoff (Hz)"); // lowpass shows the high cutoff
+    await userEvent.type(field, "100");
+    await userEvent.tab();
+    await waitFor(() => expect(patch).toHaveBeenCalledWith("abc", 1, { cutoff_high: 100 }));
+  });
+
+  it("toggles a filter", async () => {
+    const patch = vi.spyOn(api, "patchFilter").mockResolvedValue(FILTERS);
+    render(<AnalysisPanel />);
+    await userEvent.click(await screen.findByLabelText("Enable filter 1"));
+    await waitFor(() => expect(patch).toHaveBeenCalledWith("abc", 1, { enabled: true }));
+  });
+
+  it("surfaces a PATCH error", async () => {
+    vi.spyOn(api, "patchFilter").mockRejectedValue(new ApiError(400, "InvalidParameterError", "lowpass requires cutoff_high"));
+    render(<AnalysisPanel />);
+    await userEvent.click(await screen.findByLabelText("Enable filter 1"));
+    expect(await screen.findByRole("alert")).toHaveTextContent("lowpass requires cutoff_high");
+  });
+});

--- a/webapp/app/src/features/controls/AnalysisPanel.tsx
+++ b/webapp/app/src/features/controls/AnalysisPanel.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from "react";
+import { ApiError, api } from "../../api/client";
+import type { FilterConfig, SpectrumConfig } from "../../api/types";
+import { GroupBox } from "../../ds/GroupBox";
+import { useSession } from "../../store/session";
+
+const WINDOWS = ["rectangular", "hanning", "hamming", "blackman", "bartlett", "flattop"];
+const KINDS: FilterConfig["kind"][] = ["lowpass", "highpass", "bandpass"];
+
+const inputStyle = { padding: "6px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--text-sm)", border: "1px solid var(--lc-border-strong)", borderRadius: "var(--lc-radius-sm)", background: "var(--lc-control)", color: "var(--lc-text)", minWidth: 0, flex: 1 } as const;
+const rowStyle = { display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--text-sm)", color: "var(--lc-text)" } as const;
+
+export function AnalysisPanel() {
+  const session = useSession((s) => s.session);
+  const [spectrum, setSpectrumConfig] = useState<SpectrumConfig | null>(null);
+  const [filters, setFilters] = useState<FilterConfig[]>([]);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const channels = Array.from({ length: session?.num_channels ?? 4 }, (_, i) => i + 1);
+
+  useEffect(() => {
+    if (!session) return;
+    api.getSpectrum(session.id).then(setSpectrumConfig).catch(() => {});
+    api.getFilters(session.id).then((state) => {
+      setFilters(state);
+      setDrafts(Object.fromEntries(state.flatMap((f) => [
+        [`low${f.n}`, f.cutoff_low?.toString() ?? ""],
+        [`high${f.n}`, f.cutoff_high?.toString() ?? ""],
+        [`order${f.n}`, String(f.order)],
+      ])));
+    }).catch(() => {});
+  }, [session]);
+
+  async function patchSpectrum(body: Partial<SpectrumConfig>) {
+    if (!session) return;
+    setError(null);
+    try {
+      setSpectrumConfig(await api.patchSpectrum(session.id, body));
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  async function patchFilter(n: number, body: Partial<Omit<FilterConfig, "n">>) {
+    if (!session) return;
+    setError(null);
+    try {
+      setFilters(await api.patchFilter(session.id, n, body));
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  function commitNumber(n: number, key: "cutoff_low" | "cutoff_high" | "order", raw: string) {
+    const value = Number(raw);
+    if (!raw.trim() || !Number.isFinite(value) || value <= 0) return;
+    patchFilter(n, { [key]: value });
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+      {spectrum && (
+        <GroupBox title="Spectrum">
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            <label style={rowStyle}>
+              <input type="checkbox" aria-label="Enable spectrum" checked={spectrum.enabled} onChange={(e) => patchSpectrum({ enabled: e.target.checked })} />
+              Enabled
+            </label>
+            <label style={rowStyle}>
+              Source
+              <select aria-label="Spectrum source" value={spectrum.channel} onChange={(e) => patchSpectrum({ channel: Number(e.target.value) })} style={inputStyle}>
+                {channels.map((c) => (<option key={c} value={c}>C{c}</option>))}
+              </select>
+            </label>
+            <label style={rowStyle}>
+              Window
+              <select aria-label="Spectrum window" value={spectrum.window} onChange={(e) => patchSpectrum({ window: e.target.value })} style={inputStyle}>
+                {WINDOWS.map((w) => (<option key={w} value={w}>{w}</option>))}
+              </select>
+            </label>
+            <label style={rowStyle}>
+              <input type="checkbox" aria-label="Magnitude in dB" checked={spectrum.db} onChange={(e) => patchSpectrum({ db: e.target.checked })} />
+              Magnitude in dB
+            </label>
+          </div>
+        </GroupBox>
+      )}
+      {filters.map((f) => (
+        <GroupBox key={f.n} title={`Filter ${f.n} (F${f.n})`}>
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            <label style={rowStyle}>
+              <input type="checkbox" aria-label={`Enable filter ${f.n}`} checked={f.enabled} onChange={(e) => patchFilter(f.n, { enabled: e.target.checked })} />
+              Enabled
+            </label>
+            <label style={rowStyle}>
+              Source
+              <select aria-label={`Filter ${f.n} source`} value={f.source} onChange={(e) => patchFilter(f.n, { source: Number(e.target.value) })} style={inputStyle}>
+                {channels.map((c) => (<option key={c} value={c}>C{c}</option>))}
+              </select>
+            </label>
+            <label style={rowStyle}>
+              Kind
+              <select aria-label={`Filter ${f.n} kind`} value={f.kind} onChange={(e) => patchFilter(f.n, { kind: e.target.value as FilterConfig["kind"] })} style={inputStyle}>
+                {KINDS.map((k) => (<option key={k} value={k}>{k}</option>))}
+              </select>
+            </label>
+            {f.kind !== "lowpass" && (
+              <label style={rowStyle}>
+                Low (Hz)
+                <input aria-label={`Filter ${f.n} low cutoff (Hz)`} value={drafts[`low${f.n}`] ?? ""} onChange={(e) => setDrafts((d) => ({ ...d, [`low${f.n}`]: e.target.value }))} onBlur={(e) => commitNumber(f.n, "cutoff_low", e.target.value)} style={inputStyle} />
+              </label>
+            )}
+            {f.kind !== "highpass" && (
+              <label style={rowStyle}>
+                High (Hz)
+                <input aria-label={`Filter ${f.n} high cutoff (Hz)`} value={drafts[`high${f.n}`] ?? ""} onChange={(e) => setDrafts((d) => ({ ...d, [`high${f.n}`]: e.target.value }))} onBlur={(e) => commitNumber(f.n, "cutoff_high", e.target.value)} style={inputStyle} />
+              </label>
+            )}
+            <label style={rowStyle}>
+              Order
+              <input aria-label={`Filter ${f.n} order`} value={drafts[`order${f.n}`] ?? ""} onChange={(e) => setDrafts((d) => ({ ...d, [`order${f.n}`]: e.target.value }))} onBlur={(e) => { const v = Number(e.target.value); if (Number.isInteger(v) && v >= 1 && v <= 10) patchFilter(f.n, { order: v }); }} style={inputStyle} />
+            </label>
+          </div>
+        </GroupBox>
+      ))}
+      {error && <div role="alert" style={{ color: "var(--danger)", fontSize: "var(--text-sm)" }}>{error}</div>}
+    </div>
+  );
+}

--- a/webapp/app/src/features/controls/ScopeToolbar.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import type { ReactNode } from "react";
 import { ApiError, api } from "../../api/client";
 import type { ChannelState, RunOp } from "../../api/types";
 import { Button } from "../../ds/Button";
@@ -11,7 +12,7 @@ import { ScreenshotButton } from "../export/ScreenshotButton";
 // with no memoization, so a fresh `{}` per snapshot would loop forever while scope is null.
 const NO_CHANNELS: Record<string, ChannelState> = {};
 
-export function ScopeToolbar() {
+export function ScopeToolbar({ viewToggle }: { viewToggle?: ReactNode }) {
   const session = useSession((s) => s.session);
   const runState = useSession((s) => s.scope?.run_state);
   const channels = useSession((s) => s.scope?.channels ?? NO_CHANNELS);
@@ -69,6 +70,8 @@ export function ScopeToolbar() {
         <Button variant="ghost" onClick={() => op("single")}>Single</Button>
         <Button variant="ghost" onClick={() => op("auto")}>Auto</Button>
         <ToolbarSeparator />
+        {viewToggle}
+        {viewToggle && <ToolbarSeparator />}
         <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-sm)", color: "var(--lc-text-2)" }}>{runState}</span>
       </Toolbar>
       {error && (

--- a/webapp/app/src/features/reference/ReferencePanel.test.tsx
+++ b/webapp/app/src/features/reference/ReferencePanel.test.tsx
@@ -30,10 +30,10 @@ describe("ReferencePanel", () => {
     vi.spyOn(api, "listReferences").mockResolvedValue(REFS);
     const put = vi.spyOn(api, "putReference").mockResolvedValue(OVERLAY);
     render(<ReferencePanel />);
-    await userEvent.click(await screen.findByLabelText("Activate golden"));
+    await userEvent.click(await screen.findByLabelText("Show golden"));
     expect(put).toHaveBeenCalledWith("abc", "golden");
     act(() => useSession.getState().applyReference({ name: "golden", channel: 1 })); // the broadcast lands
-    await userEvent.click(await screen.findByLabelText("Deactivate golden"));
+    await userEvent.click(await screen.findByLabelText("Hide golden"));
     expect(put).toHaveBeenLastCalledWith("abc", null);
   });
 

--- a/webapp/app/src/features/reference/ReferencePanel.test.tsx
+++ b/webapp/app/src/features/reference/ReferencePanel.test.tsx
@@ -1,0 +1,59 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReferencePanel } from "./ReferencePanel";
+import { api } from "../../api/client";
+import type { ReferenceInfo } from "../../api/types";
+import { useSession } from "../../store/session";
+
+const REFS: ReferenceInfo[] = [{ name: "golden", channel: 1, timestamp: "2026-07-15T00:00:00", num_samples: 256, time_span: 0.25 }];
+const OVERLAY = { name: "golden", channel: 1, t0: 0, dt: 1, points: [1] };
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("ReferencePanel", () => {
+  it("saves the current trace as a named reference", async () => {
+    vi.spyOn(api, "listReferences").mockResolvedValue([]);
+    const save = vi.spyOn(api, "saveReference").mockResolvedValue(REFS);
+    render(<ReferencePanel />);
+    await userEvent.type(await screen.findByLabelText("Reference name"), "golden");
+    await userEvent.click(screen.getByRole("button", { name: "Save reference" }));
+    await waitFor(() => expect(save).toHaveBeenCalledWith("abc", "golden", 1));
+    expect(await screen.findByText("golden")).toBeInTheDocument();
+  });
+
+  it("activates and deactivates a reference", async () => {
+    vi.spyOn(api, "listReferences").mockResolvedValue(REFS);
+    const put = vi.spyOn(api, "putReference").mockResolvedValue(OVERLAY);
+    render(<ReferencePanel />);
+    await userEvent.click(await screen.findByLabelText("Activate golden"));
+    expect(put).toHaveBeenCalledWith("abc", "golden");
+    act(() => useSession.getState().applyReference({ name: "golden", channel: 1 })); // the broadcast lands
+    await userEvent.click(await screen.findByLabelText("Deactivate golden"));
+    expect(put).toHaveBeenLastCalledWith("abc", null);
+  });
+
+  it("deletes a reference and refreshes the list", async () => {
+    const list = vi.spyOn(api, "listReferences").mockResolvedValueOnce(REFS).mockResolvedValueOnce([]);
+    const del = vi.spyOn(api, "deleteReference").mockResolvedValue(undefined);
+    render(<ReferencePanel />);
+    await userEvent.click(await screen.findByLabelText("Delete golden"));
+    await waitFor(() => expect(del).toHaveBeenCalledWith("abc", "golden"));
+    await waitFor(() => expect(list).toHaveBeenCalledTimes(2));
+  });
+
+  it("shows comparison stats while a reference is active", async () => {
+    vi.spyOn(api, "listReferences").mockResolvedValue(REFS);
+    render(<ReferencePanel />);
+    act(() => {
+      useSession.getState().applyReference({ name: "golden", channel: 1 });
+      useSession.getState().applyReferenceStats({ correlation: 0.987, max_deviation: 0.05 });
+    });
+    expect(await screen.findByText(/0\.987/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.05/)).toBeInTheDocument();
+  });
+});

--- a/webapp/app/src/features/reference/ReferencePanel.tsx
+++ b/webapp/app/src/features/reference/ReferencePanel.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from "react";
+import { ApiError, api } from "../../api/client";
+import type { ReferenceInfo } from "../../api/types";
+import { Button } from "../../ds/Button";
+import { GroupBox } from "../../ds/GroupBox";
+import { useSession } from "../../store/session";
+
+const inputStyle = { padding: "6px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--text-sm)", border: "1px solid var(--lc-border-strong)", borderRadius: "var(--lc-radius-sm)", background: "var(--lc-control)", color: "var(--lc-text)", minWidth: 0, flex: 1 } as const;
+const rowStyle = { display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--text-sm)", color: "var(--lc-text)" } as const;
+
+export function ReferencePanel() {
+  const session = useSession((s) => s.session);
+  const activeReference = useSession((s) => s.activeReference);
+  const referenceStats = useSession((s) => s.referenceStats);
+  const [refs, setRefs] = useState<ReferenceInfo[]>([]);
+  const [name, setName] = useState("");
+  const [channel, setChannel] = useState(1);
+  const [error, setError] = useState<string | null>(null);
+  const channels = Array.from({ length: session?.num_channels ?? 4 }, (_, i) => i + 1);
+
+  useEffect(() => {
+    if (!session) return;
+    api.listReferences(session.id).then(setRefs).catch(() => {});
+  }, [session]);
+
+  async function guard<T>(fn: () => Promise<T>): Promise<T | null> {
+    setError(null);
+    try {
+      return await fn();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+      return null;
+    }
+  }
+
+  async function save() {
+    if (!session || !name.trim()) return;
+    const updated = await guard(() => api.saveReference(session.id, name.trim(), channel));
+    if (updated) {
+      setRefs(updated);
+      setName("");
+    }
+  }
+
+  async function toggleActive(ref: ReferenceInfo) {
+    if (!session) return;
+    const next = activeReference?.name === ref.name ? null : ref.name;
+    await guard(() => api.putReference(session.id, next));
+    // overlay + store update arrive via the stream broadcast — no local apply
+  }
+
+  async function remove(refName: string) {
+    if (!session) return;
+    const deleted = await guard(() => api.deleteReference(session.id, refName));
+    if (deleted !== null) {
+      const updated = await guard(() => api.listReferences(session.id));
+      if (updated) setRefs(updated);
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+      <GroupBox title="Save reference">
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          <input aria-label="Reference name" placeholder="name" value={name} onChange={(e) => setName(e.target.value)} style={inputStyle} />
+          <label style={rowStyle}>
+            Channel
+            <select aria-label="Reference channel" value={channel} onChange={(e) => setChannel(Number(e.target.value))} style={inputStyle}>
+              {channels.map((c) => (<option key={c} value={c}>C{c}</option>))}
+            </select>
+          </label>
+          <Button onClick={save}>Save reference</Button>
+        </div>
+      </GroupBox>
+      <GroupBox title="Saved references">
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          {refs.length === 0 && <span style={{ color: "var(--lc-muted)", fontSize: "var(--text-sm)" }}>No saved references</span>}
+          {refs.map((ref) => {
+            const active = activeReference?.name === ref.name;
+            return (
+              <div key={ref.name} style={rowStyle}>
+                <span style={{ flex: 1, fontFamily: "var(--font-mono)", overflow: "hidden", textOverflow: "ellipsis" }}>{ref.name}</span>
+                <span style={{ color: "var(--lc-muted)" }}>C{ref.channel ?? "?"}</span>
+                <Button variant="ghost" aria-label={`${active ? "Deactivate" : "Activate"} ${ref.name}`} onClick={() => toggleActive(ref)}>
+                  {active ? "Hide" : "Show"}
+                </Button>
+                <Button variant="ghost" aria-label={`Delete ${ref.name}`} onClick={() => remove(ref.name)}>
+                  ✕
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      </GroupBox>
+      {activeReference && (
+        <GroupBox title="Comparison">
+          <div style={{ display: "flex", flexDirection: "column", gap: "4px", fontSize: "var(--text-sm)", color: "var(--lc-text)", fontFamily: "var(--font-mono)" }}>
+            <span>vs {activeReference.name} (C{activeReference.channel ?? "?"})</span>
+            <span>correlation: {referenceStats?.correlation != null ? referenceStats.correlation.toFixed(3) : "—"}</span>
+            <span>max deviation: {referenceStats?.max_deviation != null ? `${referenceStats.max_deviation.toFixed(3)} V` : "—"}</span>
+          </div>
+        </GroupBox>
+      )}
+      {error && <div role="alert" style={{ color: "var(--danger)", fontSize: "var(--text-sm)" }}>{error}</div>}
+    </div>
+  );
+}

--- a/webapp/app/src/features/reference/ReferencePanel.tsx
+++ b/webapp/app/src/features/reference/ReferencePanel.tsx
@@ -81,7 +81,7 @@ export function ReferencePanel() {
               <div key={ref.name} style={rowStyle}>
                 <span style={{ flex: 1, fontFamily: "var(--font-mono)", overflow: "hidden", textOverflow: "ellipsis" }}>{ref.name}</span>
                 <span style={{ color: "var(--lc-muted)" }}>C{ref.channel ?? "?"}</span>
-                <Button variant="ghost" aria-label={`${active ? "Deactivate" : "Activate"} ${ref.name}`} onClick={() => toggleActive(ref)}>
+                <Button variant="ghost" aria-label={`${active ? "Hide" : "Show"} ${ref.name}`} onClick={() => toggleActive(ref)}>
                   {active ? "Hide" : "Show"}
                 </Button>
                 <Button variant="ghost" aria-label={`Delete ${ref.name}`} onClick={() => remove(ref.name)}>

--- a/webapp/app/src/features/reference/useReferenceSeed.test.ts
+++ b/webapp/app/src/features/reference/useReferenceSeed.test.ts
@@ -1,0 +1,33 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useReferenceSeed } from "./useReferenceSeed";
+import { api } from "../../api/client";
+import type { ReferenceOverlay } from "../../api/types";
+import { clearFrames, getFrame } from "../waveform/frames";
+import { useSession } from "../../store/session";
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+  clearFrames();
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("useReferenceSeed", () => {
+  it("seeds the overlay from the server on mount", async () => {
+    vi.spyOn(api, "getReference").mockResolvedValue({ name: "golden", channel: 1, t0: 0, dt: 1, points: [1, 2] });
+    renderHook(() => useReferenceSeed("abc"));
+    await waitFor(() => expect(getFrame("REF")?.points).toEqual([1, 2]));
+    expect(useSession.getState().activeReference).toEqual({ name: "golden", channel: 1 });
+  });
+
+  it("skips a stale response after a live broadcast landed", async () => {
+    let resolve!: (v: ReferenceOverlay) => void;
+    vi.spyOn(api, "getReference").mockReturnValue(new Promise((r) => { resolve = r; }));
+    renderHook(() => useReferenceSeed("abc"));
+    act(() => useSession.getState().applyReference({ name: "fresh", channel: 2 }));
+    resolve({ name: "stale", channel: 1, t0: 0, dt: 1, points: [9] });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useSession.getState().activeReference).toEqual({ name: "fresh", channel: 2 });
+    expect(getFrame("REF")).toBeUndefined();
+  });
+});

--- a/webapp/app/src/features/reference/useReferenceSeed.ts
+++ b/webapp/app/src/features/reference/useReferenceSeed.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { api } from "../../api/client";
+import { setFrame } from "../waveform/frames";
+import { useSession } from "../../store/session";
+
+/** Seed the reference overlay from the server on session mount, so a ghost
+ *  activated by another tab shows without opening the Reference panel. */
+export function useReferenceSeed(sessionId: string | null): void {
+  useEffect(() => {
+    if (!sessionId) return;
+    let stale = false;
+    const before = useSession.getState().activeReference;
+    api
+      .getReference(sessionId)
+      .then((overlay) => {
+        // Snapshot guard: a live `reference` broadcast that landed while this
+        // GET was in flight is fresher — never clobber it with mount data.
+        if (stale || useSession.getState().activeReference !== before) return;
+        setFrame("REF", { t0: overlay.t0, dt: overlay.dt, points: overlay.points });
+        useSession.getState().applyReference(overlay.name ? { name: overlay.name, channel: overlay.channel } : null);
+      })
+      .catch(() => {});
+    return () => {
+      stale = true;
+    };
+  }, [sessionId]);
+}

--- a/webapp/app/src/features/waveform/SpectrumCanvas.test.tsx
+++ b/webapp/app/src/features/waveform/SpectrumCanvas.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SpectrumCanvas, formatHz, spectrumTracePixels } from "./SpectrumCanvas";
+import { clearSpectrum, setSpectrum } from "./spectrum";
+import { api } from "../../api/client";
+import { useSession } from "../../store/session";
+
+const FRAME = { channel: 1, f0: 0, df: 10, points: [-60, -20, -60, -80], db: true, window: "hanning", peaks: [[10, -20]] as [number, number][], thd: 1.5 };
+
+beforeEach(() => {
+  clearSpectrum();
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("spectrumTracePixels", () => {
+  it("maps min to the bottom margin and max to the top margin", () => {
+    const px = spectrumTracePixels([-80, -20], 100, 100, 0);
+    expect(px[0].y).toBeCloseTo(95);
+    expect(px[1].y).toBeCloseTo(5);
+  });
+
+  it("handles a flat spectrum without dividing by zero", () => {
+    const px = spectrumTracePixels([-30, -30], 100, 100, 0);
+    expect(px.every((p) => Number.isFinite(p.y))).toBe(true);
+  });
+});
+
+describe("formatHz", () => {
+  it("scales units", () => {
+    expect(formatHz(50)).toBe("50.0 Hz");
+    expect(formatHz(1500)).toBe("1.5 kHz");
+    expect(formatHz(20e6)).toBe("20.0 MHz");
+  });
+});
+
+describe("SpectrumCanvas", () => {
+  it("shows the empty state and PATCHes enabled on click", async () => {
+    const patch = vi.spyOn(api, "patchSpectrum").mockResolvedValue({ enabled: true, channel: 1, window: "hanning", db: true });
+    render(<SpectrumCanvas />);
+    await userEvent.click(screen.getByRole("button", { name: /enable spectrum/i }));
+    expect(patch).toHaveBeenCalledWith("abc", { enabled: true });
+  });
+
+  it("renders a canvas without throwing when a frame is present", () => {
+    setSpectrum(FRAME);
+    expect(() => render(<SpectrumCanvas />)).not.toThrow();
+  });
+});

--- a/webapp/app/src/features/waveform/SpectrumCanvas.tsx
+++ b/webapp/app/src/features/waveform/SpectrumCanvas.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState } from "react";
+import { ApiError, api } from "../../api/client";
+import type { SpectrumFrame } from "../../api/types";
+import { getSpectrum, subscribeSpectrum } from "./spectrum";
+import { useSession } from "../../store/session";
+
+const TRACE = ["#FFDC32", "#40E0D0", "#FF69B4", "#32FF64"]; // same channel colors as WaveformCanvas
+const DIVS_X = 14;
+const DIVS_Y = 10;
+const PAD = 8;
+const AXIS_PAD = 18; // strip below the graticule for frequency labels
+
+// Auto-fit the magnitude range with a 5% margin top and bottom. Extracted so
+// the min/max math is unit-testable without a canvas 2D context.
+export function spectrumTracePixels(points: number[], gw: number, gh: number, pad: number): { x: number; y: number }[] {
+  if (points.length === 0) return [];
+  const min = Math.min(...points);
+  const max = Math.max(...points);
+  const span = max - min || 1;
+  return points.map((v, i) => ({
+    x: pad + (gw * i) / Math.max(1, points.length - 1),
+    y: pad + gh - gh * 0.05 - ((v - min) / span) * gh * 0.9,
+  }));
+}
+
+export function formatHz(hz: number): string {
+  if (!Number.isFinite(hz)) return "";
+  if (hz >= 1e9) return `${(hz / 1e9).toFixed(1)} GHz`;
+  if (hz >= 1e6) return `${(hz / 1e6).toFixed(1)} MHz`;
+  if (hz >= 1e3) return `${(hz / 1e3).toFixed(1)} kHz`;
+  return `${hz.toFixed(1)} Hz`;
+}
+
+const BOX = { position: "relative", flex: 1, minHeight: 320, background: "#0d1117", border: "1px solid var(--scope-border-2)", borderRadius: "var(--lc-radius)" } as const;
+
+export function SpectrumCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const session = useSession((s) => s.session);
+  const [frame, setSpectrumFrame] = useState<SpectrumFrame | null>(getSpectrum());
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => subscribeSpectrum(() => setSpectrumFrame(getSpectrum())), []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap || !frame || frame.points.length === 0) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const w = wrap.clientWidth;
+    const h = wrap.clientHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    canvas.style.width = `${w}px`;
+    canvas.style.height = `${h}px`;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.fillStyle = "#0d1117";
+    ctx.fillRect(0, 0, w, h);
+
+    const gw = w - PAD * 2;
+    const gh = h - PAD * 2 - AXIS_PAD;
+
+    ctx.save();
+    ctx.setLineDash([1, 3]);
+    ctx.strokeStyle = "#30363d";
+    ctx.lineWidth = 1;
+    for (let i = 1; i < DIVS_X; i += 1) {
+      const x = PAD + (gw * i) / DIVS_X;
+      ctx.beginPath();
+      ctx.moveTo(x, PAD);
+      ctx.lineTo(x, PAD + gh);
+      ctx.stroke();
+    }
+    for (let i = 1; i < DIVS_Y; i += 1) {
+      const y = PAD + (gh * i) / DIVS_Y;
+      ctx.beginPath();
+      ctx.moveTo(PAD, y);
+      ctx.lineTo(PAD + gw, y);
+      ctx.stroke();
+    }
+    ctx.restore();
+
+    const pixels = spectrumTracePixels(frame.points, gw, gh, PAD);
+    ctx.strokeStyle = TRACE[(frame.channel - 1) % TRACE.length];
+    ctx.lineWidth = 1.5;
+    ctx.lineJoin = "round";
+    ctx.beginPath();
+    pixels.forEach(({ x, y }, index) => {
+      if (index === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+
+    const fmax = frame.df * Math.max(1, frame.points.length - 1);
+    ctx.fillStyle = "#e6edf3";
+    ctx.font = "11px 'Segoe UI', sans-serif";
+    ctx.textAlign = "center";
+    frame.peaks.slice(0, 3).forEach(([freq]) => {
+      const x = PAD + (gw * freq) / (fmax || 1);
+      ctx.fillText(`▼ ${formatHz(freq)}`, x, PAD + 12);
+    });
+
+    ctx.fillStyle = "#8b949e";
+    ctx.textAlign = "left";
+    ctx.fillText("0 Hz", PAD, h - 4);
+    ctx.textAlign = "right";
+    ctx.fillText(formatHz(fmax), PAD + gw, h - 4);
+    const unit = frame.db ? "dB" : "linear";
+    const thd = frame.thd == null ? "" : ` · THD ${frame.thd.toFixed(1)}%`;
+    ctx.fillText(`C${frame.channel} · ${frame.window} · ${unit}${thd}`, PAD + gw, PAD + gh - 6);
+  }, [frame]);
+
+  async function enable() {
+    if (!session) return;
+    setError(null);
+    try {
+      await api.patchSpectrum(session.id, { enabled: true });
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  if (!frame || frame.points.length === 0) {
+    return (
+      <div style={{ ...BOX, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: "var(--space-2)", color: "#8b949e", fontSize: "var(--text-sm)" }}>
+        <span>No spectrum — the source channel must be enabled and acquiring</span>
+        <button onClick={enable} style={{ padding: "6px 14px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", background: "var(--lc-control)", color: "var(--lc-text)", cursor: "pointer" }}>
+          Enable spectrum
+        </button>
+        {error && <span role="alert" style={{ color: "var(--danger)" }}>{error}</span>}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={wrapRef} style={BOX}>
+      <canvas ref={canvasRef} />
+    </div>
+  );
+}

--- a/webapp/app/src/features/waveform/ViewModeToggle.test.tsx
+++ b/webapp/app/src/features/waveform/ViewModeToggle.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ViewModeToggle } from "./ViewModeToggle";
+
+describe("ViewModeToggle", () => {
+  it("marks the current mode pressed and reports changes", async () => {
+    const onChange = vi.fn();
+    render(<ViewModeToggle value="Time" onChange={onChange} />);
+    expect(screen.getByRole("button", { name: "Time" })).toHaveAttribute("aria-pressed", "true");
+    await userEvent.click(screen.getByRole("button", { name: "Spectrum" }));
+    expect(onChange).toHaveBeenCalledWith("Spectrum");
+  });
+});

--- a/webapp/app/src/features/waveform/ViewModeToggle.tsx
+++ b/webapp/app/src/features/waveform/ViewModeToggle.tsx
@@ -1,0 +1,28 @@
+const MODES = ["Time", "Spectrum"] as const;
+export type ViewMode = (typeof MODES)[number];
+
+export function ViewModeToggle({ value, onChange }: { value: ViewMode; onChange: (mode: ViewMode) => void }) {
+  return (
+    <div role="group" aria-label="Canvas view" style={{ display: "inline-flex", gap: 2 }}>
+      {MODES.map((mode) => (
+        <button
+          key={mode}
+          aria-pressed={value === mode}
+          onClick={() => onChange(mode)}
+          style={{
+            padding: "4px 12px",
+            fontSize: "var(--text-sm)",
+            fontFamily: "var(--font-ui)",
+            borderRadius: "var(--lc-radius-sm)",
+            border: "1px solid var(--lc-border-strong)",
+            background: value === mode ? "var(--lc-control)" : "transparent",
+            color: value === mode ? "var(--lc-text)" : "var(--lc-muted)",
+            cursor: "pointer",
+          }}
+        >
+          {mode}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/webapp/app/src/features/waveform/WaveformCanvas.mapping.test.ts
+++ b/webapp/app/src/features/waveform/WaveformCanvas.mapping.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mathTracePixels } from "./WaveformCanvas";
+import { mathTracePixels, refTracePixels } from "./WaveformCanvas";
 
 describe("mathTracePixels", () => {
   it("returns [] for no points", () => {
@@ -23,5 +23,18 @@ describe("mathTracePixels", () => {
     expect(px[0].y).toBeGreaterThan(center); // -1 below (y grows downward)
     expect(px[2].y).toBeLessThan(center); // +1 above
     px.forEach((p) => expect(Number.isFinite(p.y)).toBe(true));
+  });
+});
+
+describe("refTracePixels", () => {
+  it("uses the source channel's voltage scale when provided", () => {
+    // 1 V/div on a 10-division canvas -> full scale 10 V; +5 V lands at the top edge
+    const px = refTracePixels([0, 5], 1, 100, 100, 0);
+    expect(px[0].y).toBeCloseTo(50);
+    expect(px[1].y).toBeCloseTo(0);
+  });
+
+  it("falls back to auto-fit when no scale is available", () => {
+    expect(refTracePixels([0, 1], undefined, 100, 100, 0)).toEqual(mathTracePixels([0, 1], 100, 100, 0));
   });
 });

--- a/webapp/app/src/features/waveform/WaveformCanvas.test.tsx
+++ b/webapp/app/src/features/waveform/WaveformCanvas.test.tsx
@@ -29,4 +29,12 @@ describe("WaveformCanvas", () => {
     expect(() => render(<WaveformCanvas />)).not.toThrow();
     clearFrames();
   });
+
+  it("renders with filtered and reference frames present without throwing", () => {
+    clearFrames();
+    setFrame("F1", { t0: 0, dt: 1, points: [1, -1, 1] });
+    setFrame("REF", { t0: 0, dt: 1, points: [0, 1, 0] });
+    expect(() => render(<WaveformCanvas />)).not.toThrow();
+    clearFrames();
+  });
 });

--- a/webapp/app/src/features/waveform/WaveformCanvas.tsx
+++ b/webapp/app/src/features/waveform/WaveformCanvas.tsx
@@ -4,10 +4,16 @@ import type { ChannelState } from "../../api/types";
 import { useSession } from "../../store/session";
 
 const TRACE = ["#FFDC32", "#40E0D0", "#FF69B4", "#32FF64"];
-// Concrete hex (canvas 2D can't read CSS vars). Chosen far in hue from all four
-// channel traces (gold/cyan/hotpink/green) so math traces stay distinguishable;
-// they're also dashed below to read as "computed".
-const MATH_TRACES: Record<string, string> = { M1: "#FFFFFF", M2: "#B18CFF" }; // white + light violet, distinct from channel traces
+// Computed traces (math + filters): concrete hex (canvas 2D can't read CSS vars),
+// chosen far in hue from the four channel colors. Dashes mark them as computed;
+// filters get a tighter dash than math so the two families stay tellable apart.
+const COMPUTED_TRACES: Record<string, { color: string; dash: number[] }> = {
+  M1: { color: "#FFFFFF", dash: [5, 3] },
+  M2: { color: "#B18CFF", dash: [5, 3] },
+  F1: { color: "#FFA657", dash: [2, 2] },
+  F2: { color: "#FF7B72", dash: [2, 2] },
+};
+const REF_TRACE = { color: "#8B949E", dash: [8, 4] };
 const DIVS_X = 14;
 const DIVS_Y = 10;
 const PAD = 8;
@@ -31,10 +37,22 @@ export function mathTracePixels(points: number[], gw: number, gh: number, pad: n
   }));
 }
 
+// Reference ghost mapping: align with the source channel's volts/div when we
+// know it (honest visual comparison); otherwise auto-fit like a math trace.
+export function refTracePixels(points: number[], voltageScale: number | undefined, gw: number, gh: number, pad: number): { x: number; y: number }[] {
+  if (!voltageScale) return mathTracePixels(points, gw, gh, pad);
+  const fullScale = voltageScale * DIVS_Y;
+  return points.map((volts, i) => ({
+    x: pad + (gw * i) / Math.max(1, points.length - 1),
+    y: pad + gh / 2 - (volts / fullScale) * gh,
+  }));
+}
+
 export function WaveformCanvas() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const channels = useSession((s) => s.scope?.channels ?? NO_CHANNELS);
+  const activeReference = useSession((s) => s.activeReference);
   const enabled = Object.entries(channels)
     .filter(([, channel]) => channel.enabled)
     .map(([key]) => Number(key));
@@ -106,6 +124,26 @@ export function WaveformCanvas() {
       ctx.beginPath();
       ctx.rect(PAD, PAD, gw, gh);
       ctx.clip(); // keep out-of-range traces inside the graticule
+
+      const ref = getFrame("REF");
+      if (ref && ref.points.length > 0) {
+        const scale = activeReference?.channel != null ? channels[String(activeReference.channel)]?.voltage_scale : undefined;
+        const pixels = refTracePixels(ref.points, scale, gw, gh, PAD);
+        ctx.save();
+        ctx.setLineDash(REF_TRACE.dash);
+        ctx.strokeStyle = REF_TRACE.color;
+        ctx.lineWidth = 1.5;
+        ctx.lineJoin = "round";
+        ctx.beginPath();
+        pixels.forEach(({ x, y }, index) => {
+          if (index === 0) ctx.moveTo(x, y);
+          else ctx.lineTo(x, y);
+        });
+        ctx.stroke();
+        ctx.restore();
+        drew = true;
+      }
+
       enabled.forEach((channel) => {
         const frame = getFrame(channel);
         if (!frame || frame.points.length === 0) return;
@@ -125,13 +163,13 @@ export function WaveformCanvas() {
         drew = true;
       });
 
-      ["M1", "M2"].forEach((label) => {
+      Object.keys(COMPUTED_TRACES).forEach((label) => {
         const frame = getFrame(label);
         if (!frame || frame.points.length === 0) return;
         const pixels = mathTracePixels(frame.points, gw, gh, PAD);
         ctx.save();
-        ctx.setLineDash([5, 3]); // dashed → unmistakably a computed math trace
-        ctx.strokeStyle = MATH_TRACES[label];
+        ctx.setLineDash(COMPUTED_TRACES[label].dash);
+        ctx.strokeStyle = COMPUTED_TRACES[label].color;
         ctx.lineWidth = 2;
         ctx.lineJoin = "round";
         ctx.beginPath();
@@ -158,7 +196,7 @@ export function WaveformCanvas() {
       cancelAnimationFrame(raf);
       unsubscribe();
     };
-  }, [enabledKey, channels]);
+  }, [enabledKey, channels, activeReference]);
 
   return (
     <div ref={wrapRef} style={{ position: "relative", flex: 1, minHeight: 320, background: "#0d1117", border: "1px solid var(--scope-border-2)", borderRadius: "var(--lc-radius)" }}>

--- a/webapp/app/src/features/waveform/spectrum.test.ts
+++ b/webapp/app/src/features/waveform/spectrum.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { clearSpectrum, getSpectrum, setSpectrum, subscribeSpectrum } from "./spectrum";
+import type { SpectrumFrame } from "../../api/types";
+
+const FRAME: SpectrumFrame = { channel: 1, f0: 0, df: 10, points: [1, 2], db: true, window: "hanning", peaks: [], thd: null };
+
+beforeEach(() => clearSpectrum());
+
+describe("spectrum buffer", () => {
+  it("stores and clears the latest frame", () => {
+    setSpectrum(FRAME);
+    expect(getSpectrum()?.points).toEqual([1, 2]);
+    clearSpectrum();
+    expect(getSpectrum()).toBeNull();
+  });
+
+  it("notifies subscribers on set", () => {
+    let calls = 0;
+    const unsubscribe = subscribeSpectrum(() => { calls += 1; });
+    setSpectrum(FRAME);
+    setSpectrum(null);
+    unsubscribe();
+    setSpectrum(FRAME);
+    expect(calls).toBe(2);
+  });
+});

--- a/webapp/app/src/features/waveform/spectrum.ts
+++ b/webapp/app/src/features/waveform/spectrum.ts
@@ -1,0 +1,22 @@
+import type { SpectrumFrame } from "../../api/types";
+
+let current: SpectrumFrame | null = null;
+const listeners = new Set<() => void>();
+
+export function setSpectrum(frame: SpectrumFrame | null): void {
+  current = frame;
+  listeners.forEach((listener) => listener());
+}
+
+export function getSpectrum(): SpectrumFrame | null {
+  return current;
+}
+
+export function clearSpectrum(): void {
+  current = null;
+}
+
+export function subscribeSpectrum(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/webapp/app/src/store/session.ts
+++ b/webapp/app/src/store/session.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { MeasurementValue, ScopeState, SessionInfo } from "../api/types";
+import type { MeasurementValue, ReferenceStats, ScopeState, SessionInfo } from "../api/types";
 
 export type ConnStatus = "disconnected" | "connecting" | "connected" | "error";
 
@@ -10,11 +10,15 @@ type SessionStore = {
   error: string | null;
   measurements: MeasurementValue[];
   measurementConfig: { channel: number; mtype: string }[];
+  activeReference: { name: string; channel: number | null } | null;
+  referenceStats: ReferenceStats | null;
   setSession: (session: SessionInfo) => void;
   clearSession: () => void;
   applyState: (state: ScopeState) => void;
   applyMeasurements: (values: MeasurementValue[]) => void;
   applyMeasurementConfig: (items: { channel: number; mtype: string }[]) => void;
+  applyReference: (ref: { name: string; channel: number | null } | null) => void;
+  applyReferenceStats: (stats: ReferenceStats | null) => void;
   setStatus: (status: ConnStatus) => void;
   setError: (error: string | null) => void;
 };
@@ -26,11 +30,15 @@ export const useSession = create<SessionStore>((set) => ({
   error: null,
   measurements: [],
   measurementConfig: [],
+  activeReference: null,
+  referenceStats: null,
   setSession: (session) => set({ session, status: "connected", error: null }),
-  clearSession: () => set({ session: null, scope: null, status: "disconnected", error: null, measurements: [], measurementConfig: [] }),
+  clearSession: () => set({ session: null, scope: null, status: "disconnected", error: null, measurements: [], measurementConfig: [], activeReference: null, referenceStats: null }),
   applyState: (scope) => set({ scope }),
   applyMeasurements: (measurements) => set({ measurements }),
   applyMeasurementConfig: (measurementConfig) => set({ measurementConfig }),
+  applyReference: (activeReference) => set({ activeReference }),
+  applyReferenceStats: (referenceStats) => set({ referenceStats }),
   setStatus: (status) => set({ status }),
   setError: (error) => set({ error, status: error ? "error" : "connected" }),
 }));

--- a/webapp/app/src/stream/useStream.test.ts
+++ b/webapp/app/src/stream/useStream.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useStream } from "./useStream";
 import { useSession } from "../store/session";
 import { getFrame, clearFrames } from "../features/waveform/frames";
+import { getSpectrum, clearSpectrum } from "../features/waveform/spectrum";
 
 class FakeWebSocket {
   static last: FakeWebSocket | null = null;
@@ -38,6 +39,7 @@ beforeEach(() => {
   vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
   useSession.getState().clearSession();
   clearFrames();
+  clearSpectrum();
 });
 
 const STATE = { run_state: "STOP", timebase: 0.001, channels: { "1": { enabled: true, voltage_scale: 0.5, voltage_offset: 0, coupling: "DC", probe_ratio: 10 } }, trigger: { mode: "AUTO", source: "C1", level: 0, slope: "POS", coupling: "DC" } };
@@ -140,5 +142,41 @@ describe("useStream", () => {
     expect(useSession.getState().session).toEqual(SESSION);
     expect(useSession.getState().status).toBe("connected");
     expect(useSession.getState().error).toBeNull();
+  });
+
+  it("routes a spectrum frame to the spectrum buffer", async () => {
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({ type: "spectrum", channel: 1, f0: 0, df: 10, points: [1, 2], db: true, window: "hanning", peaks: [], thd: null });
+    await waitFor(() => expect(getSpectrum()?.points).toEqual([1, 2]));
+  });
+
+  it("clears the spectrum buffer on an empty spectrum frame", async () => {
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({ type: "spectrum", channel: 1, f0: 0, df: 10, points: [1], db: true, window: "hanning", peaks: [], thd: null });
+    await waitFor(() => expect(getSpectrum()).not.toBeNull());
+    FakeWebSocket.last!.emit({ type: "spectrum", channel: 1, f0: 0, df: 1, points: [], db: true, window: "hanning", peaks: [], thd: null });
+    await waitFor(() => expect(getSpectrum()).toBeNull());
+  });
+
+  it("applies a reference broadcast to the frame buffer and store", async () => {
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({ type: "reference", name: "golden", channel: 1, t0: 0, dt: 1, points: [1, 2] });
+    await waitFor(() => expect(getFrame("REF")?.points).toEqual([1, 2]));
+    expect(useSession.getState().activeReference).toEqual({ name: "golden", channel: 1 });
+  });
+
+  it("clears the reference on a null-name broadcast", async () => {
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({ type: "reference", name: "golden", channel: 1, t0: 0, dt: 1, points: [1, 2] });
+    await waitFor(() => expect(useSession.getState().activeReference).not.toBeNull());
+    FakeWebSocket.last!.emit({ type: "reference", name: null, channel: null, t0: 0, dt: 1, points: [] });
+    await waitFor(() => expect(useSession.getState().activeReference).toBeNull());
+    expect(getFrame("REF")?.points).toEqual([]);
+  });
+
+  it("applies reference stats to the store", async () => {
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({ type: "reference_stats", correlation: 0.9, max_deviation: 0.1 });
+    await waitFor(() => expect(useSession.getState().referenceStats).toEqual({ correlation: 0.9, max_deviation: 0.1 }));
   });
 });

--- a/webapp/app/src/stream/useStream.ts
+++ b/webapp/app/src/stream/useStream.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import type { StreamMessage } from "../api/types";
 import { clearFrames, setFrame } from "../features/waveform/frames";
+import { clearSpectrum, setSpectrum } from "../features/waveform/spectrum";
 import { useSession } from "../store/session";
 
 const CLOSE_SESSION_ENDED = 4410;
@@ -20,10 +21,16 @@ export function useStream(sessionId: string | null): void {
       else if (message.type === "waveform") setFrame(message.channel, { t0: message.t0, dt: message.dt, points: message.points });
       else if (message.type === "measurements") store.applyMeasurements(message.values);
       else if (message.type === "measurements_config") store.applyMeasurementConfig(message.items);
+      else if (message.type === "spectrum") setSpectrum(message.points.length ? message : null);
+      else if (message.type === "reference") {
+        setFrame("REF", { t0: message.t0, dt: message.dt, points: message.points });
+        store.applyReference(message.name ? { name: message.name, channel: message.channel } : null);
+      } else if (message.type === "reference_stats") store.applyReferenceStats({ correlation: message.correlation, max_deviation: message.max_deviation });
       else if (message.type === "error") store.setError(message.detail);
       else if (message.type === "closed") {
         ended = true;
         clearFrames();
+        clearSpectrum();
         store.clearSession();
       }
     };
@@ -31,6 +38,7 @@ export function useStream(sessionId: string | null): void {
     socket.onclose = (event: CloseEvent) => {
       if (ended || event.code === CLOSE_SESSION_ENDED) {
         clearFrames();
+        clearSpectrum();
         useSession.getState().clearSession();
         return;
       }
@@ -45,6 +53,7 @@ export function useStream(sessionId: string | null): void {
       socket.onerror = null;
       socket.close();
       clearFrames();
+      clearSpectrum();
     };
   }, [sessionId]);
 }


### PR DESCRIPTION
Brings the library's dormant analysis capabilities into the browser gateway — PR-1 of the waveform-analysis + data-logging sub-project (trend logging follows as PR-2).

## What's new

### Spectrum view (FFT)
- `GET/PATCH /api/sessions/{id}/scope/spectrum` — server-owned config (source channel, window, dB/linear)
- The session poll loop computes an FFT of the source channel's full-resolution waveform via the existing `FFTAnalyzer` (input capped at 65,536 points) and streams `spectrum` frames: ≤2000 bins via **max-pool decimation** (stride would drop narrow peaks), top-5 peak markers and THD computed from the full-resolution FFT
- New `[ Time | Spectrum ]` canvas mode toggle; `SpectrumCanvas` with frequency axis, peak labels, THD readout, and a one-click Enable empty state

### Filter traces (F1/F2)
- `GET /scope/filters` + `PATCH /scope/filters/{1,2}` — two software Butterworth filter slots (lowpass/highpass/bandpass over C1–C4), validated on the merged config, enabled-gated
- Computed in the poll loop on the full-resolution record and streamed as `F1`/`F2` traces through the existing string-keyed frame machinery — drawn dashed alongside math traces

### Reference waveforms
- `GET/POST/DELETE /scope/references` — named snapshots persisted as NPZ via the library store (`~/.siglent/references/`), replace-on-save
- `GET/PUT /scope/reference` — per-session overlay, broadcast to every tab as a ghost trace aligned to the source channel's volts/div; live correlation + max-deviation stats streamed at 1 Hz
- New Analysis and Reference rail panels

### Infrastructure
- New pure-computation module `scpi_control/server/compute.py` (unit-tested against synthetic sine/two-tone signals, including a spectrum-honesty test asserting the peak lands at the input frequency)
- The math-trace transition-clear generalized to a `_shown` set covering M/F/spectrum keys — disabled or uncomputable traces clear once, never ghost
- Poll tick hardened: any unexpected exception in analysis compute degrades that trace instead of killing the session worker (regression-tested)

## Verification
- Python: **621 passed, 19 skipped** (baseline 574) — compute unit tests, streaming tests incl. transition clears and worker survival, API tests for every validation/conflict path
- Frontend: **129 passed** (baseline 102) — stream routing, panels by interaction, pure pixel-mapping helpers for both canvases
- `npm run build` + `make webapp-build` clean; live-server curl smokes green (spectrum/filter PATCH, reference save/activate/delete, disable transitions)
- Final whole-branch review: ready to merge, no Critical/Important findings

Mock sessions exercise everything hardware-free; worth a real-scope pass on the spectrum view when convenient (poll-tick cost on deep-memory records is the one watch-item).
