### PR TITLE
feat: measurement trend logging - server recorder, live trend view, CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,8 @@ built-in mock (`mock: true`) for hardware-free use. The API is documented at
 - `GET/PATCH .../scope/spectrum` — server-computed FFT spectrum (streamed as `spectrum` frames)
 - `GET .../scope/filters` + `PATCH .../scope/filters/{1,2}` — software Butterworth filters (streamed as F1/F2 traces)
 - `GET/POST/DELETE .../scope/references` + `GET/PUT .../scope/reference` — saved reference waveforms and the live overlay
+- `POST .../scope/log/start` / `POST .../scope/log/stop` — record the selected measurements (~1 Hz) server-side
+- `GET .../scope/log`, `GET .../scope/log/data?since=`, `GET .../scope/log.csv` — recording status, rows, and CSV export
 
 ### Browser UI
 

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -1,6 +1,7 @@
 # scpi_control/server/api/scope.py
 import asyncio
 from dataclasses import replace
+from datetime import datetime
 from typing import Any, Callable, List
 
 from fastapi import APIRouter, HTTPException, Request
@@ -25,7 +26,7 @@ from scpi_control.server.schemas import (
     TimebasePatch,
     TriggerPatch,
 )
-from scpi_control.server.sessions import InstrumentSession, read_state
+from scpi_control.server.sessions import InstrumentSession, SessionError, read_state
 
 router = APIRouter(tags=["scope"])
 
@@ -122,6 +123,8 @@ async def send_command(session_id: str, body: CommandIn, request: Request):
 @router.put("/sessions/{session_id}/scope/measurements")
 async def put_measurements(session_id: str, body: List[MeasurementItem], request: Request):
     session = require_session(request, session_id)
+    if session.recorder.state == "recording":
+        raise SessionError("measurement selection is locked while recording")
     for item in body:
         if item.mtype.upper() not in ALLOWED_MEASUREMENTS:
             raise InvalidParameterError("unknown measurement type: {0}".format(item.mtype))
@@ -396,6 +399,53 @@ async def put_reference(session_id: str, body: ReferencePut, request: Request):
     metadata = loaded.get("metadata", {})
     session.set_active_reference(metadata.get("name", body.name), _ref_channel(metadata.get("channel")), loaded)
     return session.reference_overlay()
+
+
+@router.post("/sessions/{session_id}/scope/log/start")
+async def log_start(session_id: str, request: Request):
+    session = require_session(request, session_id)
+    return session.start_recording()
+
+
+@router.post("/sessions/{session_id}/scope/log/stop")
+async def log_stop(session_id: str, request: Request):
+    session = require_session(request, session_id)
+    return session.stop_recording()
+
+
+@router.get("/sessions/{session_id}/scope/log")
+async def log_status(session_id: str, request: Request):
+    session = require_session(request, session_id)
+    return session.recorder.status()
+
+
+@router.get("/sessions/{session_id}/scope/log/data")
+async def log_data(session_id: str, request: Request, since: float = 0.0):
+    session = require_session(request, session_id)
+    status = session.recorder.status()
+    return {"columns": status["columns"], "rows": session.recorder.rows_since(since)}
+
+
+def _build_log_csv(status, rows) -> str:
+    header = "timestamp,elapsed_s," + ",".join("C{0} {1}".format(c["channel"], c["mtype"]) for c in status["columns"])
+    started = status["started_at"] or 0.0
+    lines = [header]
+    for row in rows:
+        ts = row[0]
+        cells = ["" if v is None else "{0:.9g}".format(float(v)) for v in row[1:]]
+        lines.append("{0},{1:.3f},{2}".format(datetime.fromtimestamp(ts).isoformat(), ts - started, ",".join(cells)))
+    return "\n".join(lines) + "\n"
+
+
+@router.get("/sessions/{session_id}/scope/log.csv")
+async def log_csv(session_id: str, request: Request):
+    session = require_session(request, session_id)
+    status = session.recorder.status()
+    if status["started_at"] is None:
+        raise HTTPException(status_code=404, detail="no recording exists")
+    csv_text = _build_log_csv(status, session.recorder.rows_since())
+    filename = "log_{0}.csv".format(session.id)
+    return PlainTextResponse(csv_text, media_type="text/csv", headers={"Content-Disposition": 'attachment; filename="{0}"'.format(filename)})
 
 
 # NOTE: run_op's {op} path is a catch-all for POST /scope/*; any new specific

--- a/scpi_control/server/recorder.py
+++ b/scpi_control/server/recorder.py
@@ -1,0 +1,66 @@
+"""In-memory measurement trend recording for one session.
+
+Thread-safe by a single internal lock: the session worker thread appends
+rows while request coroutines start/stop/read. Columns are frozen at start
+(the API locks the measurement selection while recording, so row values
+always align with them).
+"""
+
+import threading
+from collections import deque
+from typing import Any, Dict, List, Optional, Tuple
+
+MAX_LOG_ROWS = 86400  # 24 h at 1 Hz; a few MB worst case
+
+
+class TrendRecorder:
+    def __init__(self, max_rows: int = MAX_LOG_ROWS):
+        self.max_rows = max_rows
+        self._lock = threading.Lock()
+        self._state = "idle"
+        self._started_at: Optional[float] = None
+        self._columns: List[Tuple[int, str]] = []
+        self._rows: "deque" = deque(maxlen=max_rows)
+
+    @property
+    def state(self) -> str:
+        with self._lock:
+            return self._state
+
+    @property
+    def started_at(self) -> Optional[float]:
+        with self._lock:
+            return self._started_at
+
+    def start(self, columns: List[Tuple[int, str]], started_at: float) -> None:
+        """Freeze columns and begin a fresh recording (clears prior rows)."""
+        with self._lock:
+            self._state = "recording"
+            self._started_at = started_at
+            self._columns = list(columns)
+            self._rows.clear()
+
+    def stop(self) -> None:
+        """Stop appending; recorded rows stay available for export."""
+        with self._lock:
+            self._state = "idle"
+
+    def append(self, timestamp: float, values: List[Optional[float]]) -> None:
+        """Record one sample row; a no-op unless recording."""
+        with self._lock:
+            if self._state == "recording":
+                self._rows.append((timestamp, list(values)))
+
+    def status(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "state": self._state,
+                "started_at": self._started_at,
+                "columns": [{"channel": c, "mtype": m} for c, m in self._columns],
+                "row_count": len(self._rows),
+                "max_rows": self.max_rows,
+            }
+
+    def rows_since(self, since: float = 0.0) -> List[List[Any]]:
+        with self._lock:
+            return [[ts] + list(values) for ts, values in self._rows if ts > since]

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -8,6 +8,7 @@ the API layer adapts the returned concurrent.futures.Future to asyncio.
 
 import queue
 import threading
+import time
 import uuid
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeoutError
@@ -15,8 +16,9 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from scpi_control import Oscilloscope
 from scpi_control.connection.mock import MockConnection
-from scpi_control.exceptions import SiglentConnectionError, SiglentError
+from scpi_control.exceptions import InvalidParameterError, SiglentConnectionError, SiglentError
 from scpi_control.server import compute
+from scpi_control.server.recorder import TrendRecorder
 
 MAX_FRAME_POINTS = 2000
 MEASUREMENT_EVERY_N_POLLS = 4
@@ -122,6 +124,7 @@ class InstrumentSession:
         self.filters: Dict[int, Dict[str, Any]] = {n: {"source": 1, "kind": "lowpass", "cutoff_low": None, "cutoff_high": None, "order": 5, "enabled": False} for n in (1, 2)}
         self.active_reference: Optional[Dict[str, Any]] = None  # {"name", "channel", "data": {"time","voltage",...}}
         self._shown: set = set()  # trace keys (M1/M2/F1/F2/SPEC) live on subscribers' canvases; worker-thread-only
+        self.recorder = TrendRecorder()  # internally locked: worker appends, request threads control/read
 
     @classmethod
     def open(
@@ -212,6 +215,24 @@ class InstrumentSession:
     def set_measurements(self, items: List[Tuple[int, str]]) -> None:
         self.measurements = list(items)
         self.publish({"type": "measurements_config", "items": [{"channel": c, "mtype": m} for c, m in self.measurements]})
+
+    def start_recording(self) -> Dict[str, Any]:
+        if self.recorder.state == "recording":
+            raise SessionError("already recording")
+        if not self.measurements:
+            raise InvalidParameterError("no measurements selected")
+        self.recorder.start(list(self.measurements), time.time())
+        self._publish_log_status()
+        return self.recorder.status()
+
+    def stop_recording(self) -> Dict[str, Any]:
+        self.recorder.stop()
+        self._publish_log_status()
+        return self.recorder.status()
+
+    def _publish_log_status(self) -> None:
+        status = self.recorder.status()
+        self.publish({"type": "log_status", "state": status["state"], "started_at": status["started_at"], "row_count": status["row_count"], "columns": status["columns"]})
 
     def reference_overlay(self) -> Dict[str, Any]:
         active = self.active_reference
@@ -317,11 +338,13 @@ class InstrumentSession:
             self._shown = shown_now
             if self._poll_count % MEASUREMENT_EVERY_N_POLLS == 0:
                 if self.measurements:
+                    now = time.time()
                     values = []
                     for channel, mtype in self.measurements:
                         value = _safe(lambda: scope.measurement.measure(mtype, channel))
                         values.append({"channel": channel, "mtype": mtype, "value": value})
-                    self.publish({"type": "measurements", "values": values})
+                    self.publish({"type": "measurements", "values": values, "timestamp": now})
+                    self.recorder.append(now, [entry["value"] for entry in values])
                 reference = self.active_reference  # snapshot for thread safety
                 if reference is not None:
                     self.publish(compute.reference_stats(reference, acquired))

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -519,3 +519,79 @@ class TestReferences:
     def test_bad_channel_is_400(self, ref_client):
         sid = create_mock_session(ref_client)["id"]
         assert ref_client.post("/api/sessions/{0}/scope/references".format(sid), json={"name": "x", "channel": 9}).status_code == 400
+
+
+@pytest.fixture()
+def managed_client():
+    manager = SessionManager()
+    app = create_app(manager)
+    with TestClient(app) as test_client:
+        yield test_client, manager
+    manager.close_all()
+
+
+class TestTrendLog:
+    def test_start_requires_a_selection(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.post("/api/sessions/{0}/scope/log/start".format(sid)).status_code == 400
+
+    def test_start_returns_status_and_double_start_conflicts(self, client):
+        sid = create_mock_session(client)["id"]
+        client.put("/api/sessions/{0}/scope/measurements".format(sid), json=[{"channel": 1, "mtype": "PKPK"}])
+        response = client.post("/api/sessions/{0}/scope/log/start".format(sid))
+        assert response.status_code == 200
+        body = response.json()
+        assert body["state"] == "recording"
+        assert body["columns"] == [{"channel": 1, "mtype": "PKPK"}]
+        assert body["row_count"] == 0 and body["max_rows"] == 86400
+        assert client.post("/api/sessions/{0}/scope/log/start".format(sid)).status_code == 409
+
+    def test_measurement_selection_is_locked_while_recording(self, client):
+        sid = create_mock_session(client)["id"]
+        client.put("/api/sessions/{0}/scope/measurements".format(sid), json=[{"channel": 1, "mtype": "PKPK"}])
+        client.post("/api/sessions/{0}/scope/log/start".format(sid))
+        assert client.put("/api/sessions/{0}/scope/measurements".format(sid), json=[]).status_code == 409
+        client.post("/api/sessions/{0}/scope/log/stop".format(sid))
+        assert client.put("/api/sessions/{0}/scope/measurements".format(sid), json=[]).status_code == 200
+
+    def test_stop_is_idempotent(self, client):
+        sid = create_mock_session(client)["id"]
+        response = client.post("/api/sessions/{0}/scope/log/stop".format(sid))
+        assert response.status_code == 200
+        assert response.json()["state"] == "idle"
+
+    def test_log_status_defaults(self, client):
+        sid = create_mock_session(client)["id"]
+        body = client.get("/api/sessions/{0}/scope/log".format(sid)).json()
+        assert body == {"state": "idle", "started_at": None, "columns": [], "row_count": 0, "max_rows": 86400}
+
+    def test_log_data_and_csv_from_recorded_rows(self, managed_client):
+        client, manager = managed_client
+        sid = create_mock_session(client)["id"]
+        client.put("/api/sessions/{0}/scope/measurements".format(sid), json=[{"channel": 1, "mtype": "PKPK"}, {"channel": 2, "mtype": "FREQ"}])
+        client.post("/api/sessions/{0}/scope/log/start".format(sid))
+        session = manager.get(sid)
+        started = session.recorder.started_at
+        session.recorder.append(started + 1.0, [1.5, None])
+        session.recorder.append(started + 2.0, [1.25, 50.0])
+
+        data = client.get("/api/sessions/{0}/scope/log/data".format(sid)).json()
+        assert data["columns"] == [{"channel": 1, "mtype": "PKPK"}, {"channel": 2, "mtype": "FREQ"}]
+        assert len(data["rows"]) == 2
+        assert data["rows"][0][1] == 1.5 and data["rows"][0][2] is None
+
+        partial = client.get("/api/sessions/{0}/scope/log/data?since={1}".format(sid, started + 1.0)).json()
+        assert len(partial["rows"]) == 1 and partial["rows"][0][2] == 50.0
+
+        response = client.get("/api/sessions/{0}/scope/log.csv".format(sid))
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert "attachment" in response.headers.get("content-disposition", "")
+        lines = response.text.strip().split("\n")
+        assert lines[0] == "timestamp,elapsed_s,C1 PKPK,C2 FREQ"
+        first = lines[1].split(",")
+        assert first[1] == "1.000" and first[2] == "1.5" and first[3] == ""
+
+    def test_csv_before_any_recording_is_404(self, client):
+        sid = create_mock_session(client)["id"]
+        assert client.get("/api/sessions/{0}/scope/log.csv".format(sid)).status_code == 404

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -7,7 +7,8 @@ import pytest
 
 from scpi_control import Oscilloscope
 from scpi_control.connection.mock import MockConnection
-from scpi_control.server.sessions import MAX_FRAME_POINTS, InstrumentSession, _waveform_frame, read_state
+from scpi_control.exceptions import InvalidParameterError
+from scpi_control.server.sessions import MAX_FRAME_POINTS, InstrumentSession, SessionError, _waveform_frame, read_state
 from scpi_control.waveform import WaveformData
 
 LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
@@ -319,5 +320,80 @@ def test_poll_survives_unexpected_analysis_exception(monkeypatch):
         frames = collect(session, "waveform", n=8, timeout=8.0)
         channel_frames = [f for f in frames if f["channel"] == 1]
         assert len(channel_frames) >= 2, "worker must keep polling after an analysis exception"
+    finally:
+        session.close()
+
+
+def test_measurements_message_carries_timestamp():
+    session = make_session()
+    try:
+        session.set_measurements([(1, "PKPK")])
+        before = time.time()
+        msgs = collect(session, "measurements", n=1, timeout=8.0)
+        assert msgs, "expected a measurements message"
+        assert isinstance(msgs[0]["timestamp"], float)
+        assert before - 1.0 <= msgs[0]["timestamp"] <= time.time() + 1.0
+    finally:
+        session.close()
+
+
+def test_recorder_accumulates_rows_while_recording():
+    session = make_session()
+    try:
+        session.set_measurements([(1, "PKPK")])
+        session.start_recording()
+        msgs = collect(session, "measurements", n=2, timeout=12.0)
+        assert msgs
+        status = session.recorder.status()
+        assert status["row_count"] >= 1
+        rows = session.recorder.rows_since()
+        assert len(rows[0]) == 2  # [timestamp, one column value]
+        assert rows[0][0] == msgs[0]["timestamp"]  # same clock stamp feeds both
+    finally:
+        session.close()
+
+
+def test_recorder_ignores_measurements_when_idle():
+    session = make_session()
+    try:
+        session.set_measurements([(1, "PKPK")])
+        assert collect(session, "measurements", n=1, timeout=8.0)
+        assert session.recorder.status()["row_count"] == 0
+    finally:
+        session.close()
+
+
+def test_start_and_stop_recording_broadcast_log_status():
+    session = make_session()
+    try:
+        got = []
+        unsubscribe = session.subscribe(lambda m: got.append(m) if m["type"] == "log_status" else None)
+        session.set_measurements([(1, "PKPK")])
+        session.start_recording()
+        session.stop_recording()
+        unsubscribe()
+        assert [m["state"] for m in got] == ["recording", "idle"]
+        assert got[0]["started_at"] is not None and got[0]["row_count"] == 0
+        assert got[0]["columns"] == [{"channel": 1, "mtype": "PKPK"}]
+    finally:
+        session.close()
+
+
+def test_start_recording_requires_a_selection():
+    session = make_session()
+    try:
+        with pytest.raises(InvalidParameterError):
+            session.start_recording()
+    finally:
+        session.close()
+
+
+def test_double_start_recording_raises_session_error():
+    session = make_session()
+    try:
+        session.set_measurements([(1, "PKPK")])
+        session.start_recording()
+        with pytest.raises(SessionError):
+            session.start_recording()
     finally:
         session.close()

--- a/tests/test_trend_recorder.py
+++ b/tests/test_trend_recorder.py
@@ -1,0 +1,69 @@
+"""TrendRecorder unit tests. No FastAPI or instrument dependency."""
+
+from scpi_control.server.recorder import MAX_LOG_ROWS, TrendRecorder
+
+
+def test_defaults_are_idle_and_empty():
+    recorder = TrendRecorder()
+    assert recorder.state == "idle"
+    assert recorder.started_at is None
+    assert recorder.status() == {"state": "idle", "started_at": None, "columns": [], "row_count": 0, "max_rows": MAX_LOG_ROWS}
+
+
+def test_start_freezes_columns_and_clears_previous_rows():
+    recorder = TrendRecorder()
+    recorder.start([(1, "PKPK")], 100.0)
+    recorder.append(101.0, [1.0])
+    recorder.start([(2, "FREQ"), (1, "PKPK")], 200.0)
+    status = recorder.status()
+    assert status["state"] == "recording"
+    assert status["started_at"] == 200.0
+    assert status["columns"] == [{"channel": 2, "mtype": "FREQ"}, {"channel": 1, "mtype": "PKPK"}]
+    assert status["row_count"] == 0  # previous rows cleared
+
+
+def test_append_is_gated_by_state():
+    recorder = TrendRecorder()
+    recorder.append(1.0, [1.0])  # idle: ignored
+    assert recorder.status()["row_count"] == 0
+    recorder.start([(1, "PKPK")], 0.0)
+    recorder.append(1.0, [1.0])
+    recorder.stop()
+    recorder.append(2.0, [2.0])  # stopped: ignored
+    assert recorder.status()["row_count"] == 1  # stop keeps recorded data
+
+
+def test_none_values_are_preserved():
+    recorder = TrendRecorder()
+    recorder.start([(1, "PKPK"), (2, "FREQ")], 0.0)
+    recorder.append(1.0, [1.5, None])
+    assert recorder.rows_since() == [[1.0, 1.5, None]]
+
+
+def test_ring_buffer_caps_rows_dropping_oldest():
+    recorder = TrendRecorder(max_rows=3)
+    recorder.start([(1, "PKPK")], 0.0)
+    for i in range(5):
+        recorder.append(float(i), [float(i)])
+    rows = recorder.rows_since()
+    assert len(rows) == 3
+    assert [r[0] for r in rows] == [2.0, 3.0, 4.0]
+    assert recorder.status()["max_rows"] == 3
+
+
+def test_rows_since_filters_strictly_greater():
+    recorder = TrendRecorder()
+    recorder.start([(1, "PKPK")], 0.0)
+    recorder.append(1.0, [1.0])
+    recorder.append(2.0, [2.0])
+    assert [r[0] for r in recorder.rows_since(1.0)] == [2.0]
+    assert [r[0] for r in recorder.rows_since()] == [1.0, 2.0]
+
+
+def test_stop_is_idempotent_and_started_at_survives():
+    recorder = TrendRecorder()
+    recorder.start([(1, "PKPK")], 42.0)
+    recorder.stop()
+    recorder.stop()
+    assert recorder.state == "idle"
+    assert recorder.started_at == 42.0  # export availability marker

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -10,6 +10,7 @@ import { ReadoutStrip } from "./features/readout/ReadoutStrip";
 import { ReferencePanel } from "./features/reference/ReferencePanel";
 import { useReferenceSeed } from "./features/reference/useReferenceSeed";
 import { TerminalPanel } from "./features/terminal/TerminalPanel";
+import { TrendCanvas } from "./features/trend/TrendCanvas";
 import { SpectrumCanvas } from "./features/waveform/SpectrumCanvas";
 import { WaveformCanvas } from "./features/waveform/WaveformCanvas";
 import type { ViewMode } from "./features/waveform/ViewModeToggle";
@@ -54,7 +55,7 @@ export default function App() {
               </Tabs>
             </div>
             <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "var(--space-3)", minWidth: 0 }}>
-              {viewMode === "Time" ? <WaveformCanvas /> : <SpectrumCanvas />}
+              {viewMode === "Time" ? <WaveformCanvas /> : viewMode === "Spectrum" ? <SpectrumCanvas /> : <TrendCanvas />}
               <ScopeToolbar viewToggle={<ViewModeToggle value={viewMode} onChange={setViewMode} />} />
             </div>
           </div>

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -10,6 +10,7 @@ import { ReadoutStrip } from "./features/readout/ReadoutStrip";
 import { ReferencePanel } from "./features/reference/ReferencePanel";
 import { useReferenceSeed } from "./features/reference/useReferenceSeed";
 import { TerminalPanel } from "./features/terminal/TerminalPanel";
+import { LogPanel } from "./features/trend/LogPanel";
 import { TrendCanvas } from "./features/trend/TrendCanvas";
 import { SpectrumCanvas } from "./features/waveform/SpectrumCanvas";
 import { WaveformCanvas } from "./features/waveform/WaveformCanvas";
@@ -20,7 +21,7 @@ import { Tabs } from "./ds/Tabs";
 import { useStream } from "./stream/useStream";
 import { useSession } from "./store/session";
 
-const RAIL_TABS = ["Channels", "Trigger", "Math", "Analysis", "Reference", "Measure", "Terminal"];
+const RAIL_TABS = ["Channels", "Trigger", "Math", "Analysis", "Reference", "Log", "Measure", "Terminal"];
 
 export default function App() {
   const status = useSession((s) => s.status);
@@ -50,6 +51,7 @@ export default function App() {
                 {railTab === "Math" && <MathPanel />}
                 {railTab === "Analysis" && <AnalysisPanel />}
                 {railTab === "Reference" && <ReferencePanel />}
+                {railTab === "Log" && <LogPanel />}
                 {railTab === "Measure" && <MeasurePanel />}
                 {railTab === "Terminal" && <TerminalPanel />}
               </Tabs>

--- a/webapp/app/src/api/client.ts
+++ b/webapp/app/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { ChannelPatch, DiscoveredDevice, FilterConfig, MeasurementValue, ModelInfo, ReferenceInfo, ReferenceOverlay, RunOp, ScopeState, SessionCreate, SessionInfo, SpectrumConfig, TriggerPatch } from "./types";
+import type { ChannelPatch, DiscoveredDevice, FilterConfig, LogData, LogInfo, MeasurementValue, ModelInfo, ReferenceInfo, ReferenceOverlay, RunOp, ScopeState, SessionCreate, SessionInfo, SpectrumConfig, TriggerPatch } from "./types";
 
 export class ApiError extends Error {
   status: number;
@@ -67,6 +67,11 @@ export const api = {
   captureUrl: (id: string, channels: number[]) => `${scope(id)}/capture.csv?channels=${channels.join(",")}`,
   screenshotUrl: (id: string) => `${scope(id)}/screenshot.png`,
   waveformJsonUrl: (id: string, channels: number[]) => `${scope(id)}/waveform?channels=${channels.join(",")}`,
+  logStart: (id: string) => request<LogInfo>(`${scope(id)}/log/start`, { method: "POST" }),
+  logStop: (id: string) => request<LogInfo>(`${scope(id)}/log/stop`, { method: "POST" }),
+  getLog: (id: string) => request<LogInfo>(`${scope(id)}/log`),
+  getLogData: (id: string, since = 0) => request<LogData>(`${scope(id)}/log/data?since=${since}`),
+  logCsvUrl: (id: string) => `${scope(id)}/log.csv`,
 };
 
 export type { MeasurementValue };

--- a/webapp/app/src/api/types.ts
+++ b/webapp/app/src/api/types.ts
@@ -64,16 +64,21 @@ export type ReferenceOverlay = { name: string | null; channel: number | null; t0
 export type ReferenceStats = { correlation: number | null; max_deviation: number | null };
 export type SpectrumFrame = { channel: number; f0: number; df: number; points: number[]; db: boolean; window: string; peaks: [number, number][]; thd: number | null };
 
+export type LogStatus = { state: "idle" | "recording"; started_at: number | null; row_count: number; columns: { channel: number; mtype: string }[] };
+export type LogInfo = LogStatus & { max_rows: number };
+export type LogData = { columns: { channel: number; mtype: string }[]; rows: (number | null)[][] };
+
 export type StreamMessage =
   | { type: "state"; state: ScopeState }
   | { type: "waveform"; channel: number | string; t0: number; dt: number; points: number[] }
-  | { type: "measurements"; values: MeasurementValue[] }
+  | { type: "measurements"; values: MeasurementValue[]; timestamp?: number }
   | { type: "measurements_config"; items: { channel: number; mtype: string }[] }
   | ({ type: "spectrum" } & SpectrumFrame)
   | ({ type: "reference" } & ReferenceOverlay)
   | ({ type: "reference_stats" } & ReferenceStats)
   | { type: "error"; detail: string }
-  | { type: "closed" };
+  | { type: "closed" }
+  | ({ type: "log_status" } & LogStatus);
 
 export type SessionCreate = { label?: string; address?: string; port?: number; mock?: boolean; model?: string };
 export type ChannelPatch = Partial<{ enabled: boolean; voltage_scale: number; voltage_offset: number; coupling: string; probe_ratio: number }>;

--- a/webapp/app/src/features/measure/MeasurePanel.test.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.test.tsx
@@ -190,4 +190,13 @@ describe("MeasurePanel", () => {
     await userEvent.click(await screen.findByLabelText("FREQ C1"));
     await waitFor(() => expect(setMeasurements).toHaveBeenLastCalledWith("abc", []));
   });
+
+  it("locks the selection checkboxes while recording", async () => {
+    const setMeasurements = vi.spyOn(api, "setMeasurements").mockResolvedValue({ measurements: [] });
+    render(<MeasurePanel />);
+    act(() => useSession.getState().applyLogStatus({ state: "recording", started_at: 100, row_count: 0, columns: [{ channel: 1, mtype: "PKPK" }] }));
+    expect(await screen.findByText(/selection locked while recording/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("PKPK C1"));
+    expect(setMeasurements).not.toHaveBeenCalled();
+  });
 });

--- a/webapp/app/src/features/measure/MeasurePanel.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.tsx
@@ -23,6 +23,7 @@ export function MeasurePanel() {
   // (seeded via GET on mount, kept current via the measurements_config broadcast).
   const measurements = useSession((s) => s.measurements);
   const measurementConfig = useSession((s) => s.measurementConfig);
+  const recording = useSession((s) => s.logStatus?.state === "recording");
   const [error, setError] = useState<string | null>(null);
   // No local mirror of the acknowledged selection — the STORE's measurementConfig is the single
   // acknowledged-truth source. The mount GET, each PUT response, and every measurements_config
@@ -73,6 +74,7 @@ export function MeasurePanel() {
 
   async function toggle(channel: number, mtype: string) {
     if (!session) return;
+    if (recording) return;
     const next = isChecked(channel, mtype)
       ? selected.filter((s) => !(s.channel === channel && s.mtype === mtype))
       : [...selected, { channel, mtype }];
@@ -117,6 +119,7 @@ export function MeasurePanel() {
                     aria-label={`${mtype} C${n}`}
                     label={mtype}
                     checked={isChecked(n, mtype)}
+                    disabled={recording}
                     onChange={() => toggle(n, mtype)}
                   />
                 ))}
@@ -124,6 +127,11 @@ export function MeasurePanel() {
             </div>
           ))}
         </div>
+        {recording && (
+          <div style={{ color: "var(--lc-muted)", fontSize: "var(--text-sm)", marginTop: "6px" }}>
+            Selection locked while recording.
+          </div>
+        )}
       </GroupBox>
 
       {selected.length === 0 && (

--- a/webapp/app/src/features/trend/LogPanel.test.tsx
+++ b/webapp/app/src/features/trend/LogPanel.test.tsx
@@ -1,0 +1,56 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LogPanel } from "./LogPanel";
+import { clearTrend } from "./trend";
+import { ApiError, api } from "../../api/client";
+import type { LogInfo } from "../../api/types";
+import { useSession } from "../../store/session";
+
+const IDLE: LogInfo = { state: "idle", started_at: null, row_count: 0, columns: [], max_rows: 86400 };
+const RECORDING: LogInfo = { state: "recording", started_at: 100, row_count: 0, columns: [{ channel: 1, mtype: "PKPK" }], max_rows: 86400 };
+
+beforeEach(() => {
+  clearTrend();
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  vi.spyOn(api, "getLog").mockResolvedValue(IDLE);
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("LogPanel", () => {
+  it("seeds status from the server on mount", async () => {
+    render(<LogPanel />);
+    await waitFor(() => expect(api.getLog).toHaveBeenCalledWith("abc"));
+    await waitFor(() => expect(useSession.getState().logStatus?.state).toBe("idle"));
+  });
+
+  it("starts a recording", async () => {
+    const start = vi.spyOn(api, "logStart").mockResolvedValue(RECORDING);
+    render(<LogPanel />);
+    await userEvent.click(await screen.findByRole("button", { name: "Start recording" }));
+    expect(start).toHaveBeenCalledWith("abc");
+  });
+
+  it("stops a recording", async () => {
+    const stop = vi.spyOn(api, "logStop").mockResolvedValue(IDLE);
+    render(<LogPanel />);
+    act(() => useSession.getState().applyLogStatus(RECORDING)); // broadcast landed
+    await userEvent.click(await screen.findByRole("button", { name: "Stop recording" }));
+    expect(stop).toHaveBeenCalledWith("abc");
+  });
+
+  it("links the CSV export once a recording exists, disabled before", async () => {
+    render(<LogPanel />);
+    expect(screen.getByText("Download CSV").closest("a")).toBeNull(); // no recording yet: not a link
+    act(() => useSession.getState().applyLogStatus(RECORDING));
+    await waitFor(() => expect(screen.getByRole("link", { name: "Download CSV" })).toHaveAttribute("href", "/api/sessions/abc/scope/log.csv"));
+  });
+
+  it("surfaces a start error", async () => {
+    vi.spyOn(api, "logStart").mockRejectedValue(new ApiError(400, "InvalidParameterError", "no measurements selected"));
+    render(<LogPanel />);
+    await userEvent.click(await screen.findByRole("button", { name: "Start recording" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("no measurements selected");
+  });
+});

--- a/webapp/app/src/features/trend/LogPanel.test.tsx
+++ b/webapp/app/src/features/trend/LogPanel.test.tsx
@@ -15,6 +15,7 @@ beforeEach(() => {
   useSession.getState().clearSession();
   useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
   vi.spyOn(api, "getLog").mockResolvedValue(IDLE);
+  vi.spyOn(api, "getLogData").mockResolvedValue({ columns: [], rows: [] });
 });
 afterEach(() => vi.restoreAllMocks());
 
@@ -52,5 +53,12 @@ describe("LogPanel", () => {
     render(<LogPanel />);
     await userEvent.click(await screen.findByRole("button", { name: "Start recording" }));
     expect(await screen.findByRole("alert")).toHaveTextContent("no measurements selected");
+  });
+
+  it("backfills the trend buffer on mount so the row counter is live", async () => {
+    vi.spyOn(api, "getLog").mockResolvedValue({ state: "idle", started_at: 100, row_count: 2, columns: [{ channel: 1, mtype: "PKPK" }], max_rows: 86400 });
+    vi.spyOn(api, "getLogData").mockResolvedValue({ columns: [{ channel: 1, mtype: "PKPK" }], rows: [[100, 1.5], [101, 2.5]] });
+    render(<LogPanel />);
+    expect(await screen.findByText(/2 rows/)).toBeInTheDocument();
   });
 });

--- a/webapp/app/src/features/trend/LogPanel.tsx
+++ b/webapp/app/src/features/trend/LogPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { ApiError, api } from "../../api/client";
-import { getTrend, subscribeTrend } from "./trend";
+import { getTrend, seedTrend, subscribeTrend } from "./trend";
 import { Button } from "../../ds/Button";
 import { GroupBox } from "../../ds/GroupBox";
 import { useSession } from "../../store/session";
@@ -28,6 +28,15 @@ export function LogPanel() {
       .then((info) => {
         if (stale || useSession.getState().logStatus !== before) return;
         useSession.getState().applyLogStatus({ state: info.state, started_at: info.started_at, row_count: info.row_count, columns: info.columns });
+      })
+      .catch(() => {});
+    // Backfill the shared trend buffer too: a tab that missed the start
+    // broadcast (opened mid-recording, or refreshed) otherwise shows 0 rows
+    // and skips live appends until the user enters Trend view.
+    api
+      .getLogData(session.id)
+      .then((data) => {
+        if (!stale) seedTrend(data);
       })
       .catch(() => {});
     return () => {

--- a/webapp/app/src/features/trend/LogPanel.tsx
+++ b/webapp/app/src/features/trend/LogPanel.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { ApiError, api } from "../../api/client";
+import { getTrend, subscribeTrend } from "./trend";
+import { Button } from "../../ds/Button";
+import { GroupBox } from "../../ds/GroupBox";
+import { useSession } from "../../store/session";
+
+const linkStyle = { fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "6px 12px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", textDecoration: "none", alignSelf: "flex-start" } as const;
+const mutedStyle = { color: "var(--lc-muted)", fontSize: "var(--text-sm)" } as const;
+
+export function LogPanel() {
+  const session = useSession((s) => s.session);
+  const logStatus = useSession((s) => s.logStatus);
+  const [rowCount, setRowCount] = useState(getTrend().rows.length);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => subscribeTrend(() => setRowCount(getTrend().rows.length)), []);
+
+  // Seed status from the server on mount. Snapshot guard: a live log_status
+  // broadcast that lands while this GET is in flight is fresher — never
+  // clobber it with mount data (the useReferenceSeed pattern).
+  useEffect(() => {
+    if (!session) return;
+    let stale = false;
+    const before = useSession.getState().logStatus;
+    api
+      .getLog(session.id)
+      .then((info) => {
+        if (stale || useSession.getState().logStatus !== before) return;
+        useSession.getState().applyLogStatus({ state: info.state, started_at: info.started_at, row_count: info.row_count, columns: info.columns });
+      })
+      .catch(() => {});
+    return () => {
+      stale = true;
+    };
+  }, [session?.id]);
+
+  const recording = logStatus?.state === "recording";
+  const hasLog = logStatus?.started_at != null;
+
+  async function toggle() {
+    if (!session) return;
+    setError(null);
+    try {
+      // store update arrives via the log_status broadcast (this tab receives its own publish)
+      if (recording) await api.logStop(session.id);
+      else await api.logStart(session.id);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  const startedText = logStatus?.started_at != null ? new Date(logStatus.started_at * 1000).toLocaleTimeString() : null;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+      <GroupBox title="Recording">
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          <Button onClick={toggle}>{recording ? "Stop recording" : "Start recording"}</Button>
+          <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-sm)", color: "var(--lc-text)" }}>
+            {recording ? `recording · ${rowCount} rows${startedText ? ` · since ${startedText}` : ""}` : hasLog ? `stopped · ${rowCount} rows` : "idle"}
+          </div>
+          <span style={mutedStyle}>Records the selected measurements at ~1 Hz. The selection is locked while recording.</span>
+        </div>
+      </GroupBox>
+      <GroupBox title="Export">
+        {session && hasLog ? (
+          <a href={api.logCsvUrl(session.id)} download style={linkStyle}>
+            Download CSV
+          </a>
+        ) : (
+          <span style={{ ...linkStyle, color: "var(--lc-muted)", opacity: 0.6 }}>Download CSV</span>
+        )}
+      </GroupBox>
+      {error && <div role="alert" style={{ color: "var(--danger)", fontSize: "var(--text-sm)" }}>{error}</div>}
+    </div>
+  );
+}

--- a/webapp/app/src/features/trend/TrendCanvas.test.tsx
+++ b/webapp/app/src/features/trend/TrendCanvas.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TrendCanvas, formatElapsed, seriesStats, trendSeriesPixels } from "./TrendCanvas";
+import { clearTrend } from "./trend";
+import { api } from "../../api/client";
+import { useSession } from "../../store/session";
+
+beforeEach(() => {
+  clearTrend();
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("trendSeriesPixels", () => {
+  it("maps time to x and min/max to the vertical margins, skipping nulls", () => {
+    const rows: (number | null)[][] = [[0, 0], [5, null], [10, 10]];
+    const px = trendSeriesPixels(rows, 0, 100, 100, 0);
+    expect(px).toHaveLength(2); // null sample skipped
+    expect(px[0].x).toBeCloseTo(0);
+    expect(px[1].x).toBeCloseTo(100);
+    expect(px[0].y).toBeCloseTo(95); // min -> bottom margin
+    expect(px[1].y).toBeCloseTo(5); // max -> top margin
+  });
+
+  it("handles a flat series without dividing by zero", () => {
+    const px = trendSeriesPixels([[0, 3], [10, 3]], 0, 100, 100, 0);
+    expect(px.every((p) => Number.isFinite(p.y))).toBe(true);
+  });
+});
+
+describe("seriesStats", () => {
+  it("reports latest, min, and max ignoring nulls", () => {
+    const rows: (number | null)[][] = [[0, 5], [1, null], [2, 1], [3, 3]];
+    expect(seriesStats(rows, 0)).toEqual({ latest: 3, min: 1, max: 5 });
+  });
+
+  it("is all-null for an empty column", () => {
+    expect(seriesStats([[0, null]], 0)).toEqual({ latest: null, min: null, max: null });
+  });
+});
+
+describe("formatElapsed", () => {
+  it("scales units", () => {
+    expect(formatElapsed(45)).toBe("45s");
+    expect(formatElapsed(125)).toBe("2m 05s");
+    expect(formatElapsed(3725)).toBe("1h 02m 05s");
+  });
+});
+
+describe("TrendCanvas", () => {
+  it("shows the empty state and backfills from the server on mount", async () => {
+    const getLogData = vi.spyOn(api, "getLogData").mockResolvedValue({ columns: [], rows: [] });
+    render(<TrendCanvas />);
+    expect(screen.getByText(/no recording yet/i)).toBeInTheDocument();
+    await waitFor(() => expect(getLogData).toHaveBeenCalledWith("abc"));
+  });
+
+  it("renders a canvas and legend without throwing when data exists", async () => {
+    vi.spyOn(api, "getLogData").mockResolvedValue({ columns: [{ channel: 1, mtype: "PKPK" }], rows: [[100, 1.5], [101, 2.5]] });
+    render(<TrendCanvas />);
+    expect(await screen.findByText("C1 PKPK")).toBeInTheDocument(); // legend entry from the seeded data
+  });
+});

--- a/webapp/app/src/features/trend/TrendCanvas.tsx
+++ b/webapp/app/src/features/trend/TrendCanvas.tsx
@@ -65,7 +65,16 @@ export function TrendCanvas() {
   // the live appends only cover samples that arrived while this tab was open.
   useEffect(() => {
     if (!session) return;
-    api.getLogData(session.id).then(seedTrend).catch(() => {});
+    let stale = false;
+    api
+      .getLogData(session.id)
+      .then((data) => {
+        if (!stale) seedTrend(data);
+      })
+      .catch(() => {});
+    return () => {
+      stale = true;
+    };
   }, [session?.id, startedAt]);
 
   useEffect(() => {

--- a/webapp/app/src/features/trend/TrendCanvas.tsx
+++ b/webapp/app/src/features/trend/TrendCanvas.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useRef, useState } from "react";
+import { api } from "../../api/client";
+import { getTrend, seedTrend, subscribeTrend } from "./trend";
+import { useSession } from "../../store/session";
+
+const TRACE = ["#FFDC32", "#40E0D0", "#FF69B4", "#32FF64", "#FFA657", "#B18CFF", "#FF7B72", "#FFFFFF"];
+const DIVS_X = 14;
+const DIVS_Y = 10;
+const PAD = 8;
+
+// Per-series auto-fit (units differ wildly across measurement types): min -> bottom
+// margin, max -> top margin, 5% margins. Null samples are gaps, not zeros.
+export function trendSeriesPixels(rows: (number | null)[][], columnIndex: number, gw: number, gh: number, pad: number): { x: number; y: number }[] {
+  if (rows.length === 0) return [];
+  const t0 = rows[0][0] as number;
+  const t1 = rows[rows.length - 1][0] as number;
+  const span = t1 - t0 || 1;
+  const values = rows.map((row) => row[columnIndex + 1]).filter((v): v is number => v != null);
+  if (values.length === 0) return [];
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const vspan = max - min || 1;
+  const pixels: { x: number; y: number }[] = [];
+  rows.forEach((row) => {
+    const v = row[columnIndex + 1];
+    if (v == null) return;
+    pixels.push({
+      x: pad + (((row[0] as number) - t0) / span) * gw,
+      y: pad + gh - gh * 0.05 - ((v - min) / vspan) * gh * 0.9,
+    });
+  });
+  return pixels;
+}
+
+export function seriesStats(rows: (number | null)[][], columnIndex: number): { latest: number | null; min: number | null; max: number | null } {
+  const values = rows.map((row) => row[columnIndex + 1]).filter((v): v is number => v != null);
+  if (values.length === 0) return { latest: null, min: null, max: null };
+  return { latest: values[values.length - 1], min: Math.min(...values), max: Math.max(...values) };
+}
+
+export function formatElapsed(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(s / 3600);
+  const minutes = Math.floor((s % 3600) / 60);
+  const secs = s % 60;
+  if (hours > 0) return `${hours}h ${String(minutes).padStart(2, "0")}m ${String(secs).padStart(2, "0")}s`;
+  if (minutes > 0) return `${minutes}m ${String(secs).padStart(2, "0")}s`;
+  return `${secs}s`;
+}
+
+const BOX = { position: "relative", flex: 1, minHeight: 320, background: "#0d1117", border: "1px solid var(--scope-border-2)", borderRadius: "var(--lc-radius)", display: "flex", flexDirection: "column" } as const;
+
+const fmt = (v: number | null) => (v == null ? "—" : Math.abs(v) >= 1000 || (v !== 0 && Math.abs(v) < 0.01) ? v.toExponential(2) : v.toFixed(3));
+
+export function TrendCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const session = useSession((s) => s.session);
+  const startedAt = useSession((s) => s.logStatus?.started_at);
+  const [trend, setTrend] = useState(getTrend());
+
+  useEffect(() => subscribeTrend(() => setTrend(getTrend())), []);
+
+  // Backfill from the server on mount and whenever a new recording starts —
+  // the live appends only cover samples that arrived while this tab was open.
+  useEffect(() => {
+    if (!session) return;
+    api.getLogData(session.id).then(seedTrend).catch(() => {});
+  }, [session?.id, startedAt]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap || trend.rows.length === 0) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const w = wrap.clientWidth;
+    const h = wrap.clientHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    canvas.style.width = `${w}px`;
+    canvas.style.height = `${h}px`;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.fillStyle = "#0d1117";
+    ctx.fillRect(0, 0, w, h);
+
+    const gw = w - PAD * 2;
+    const gh = h - PAD * 2;
+
+    ctx.save();
+    ctx.setLineDash([1, 3]);
+    ctx.strokeStyle = "#30363d";
+    ctx.lineWidth = 1;
+    for (let i = 1; i < DIVS_X; i += 1) {
+      const x = PAD + (gw * i) / DIVS_X;
+      ctx.beginPath();
+      ctx.moveTo(x, PAD);
+      ctx.lineTo(x, PAD + gh);
+      ctx.stroke();
+    }
+    for (let i = 1; i < DIVS_Y; i += 1) {
+      const y = PAD + (gh * i) / DIVS_Y;
+      ctx.beginPath();
+      ctx.moveTo(PAD, y);
+      ctx.lineTo(PAD + gw, y);
+      ctx.stroke();
+    }
+    ctx.restore();
+
+    trend.columns.forEach((_, index) => {
+      const pixels = trendSeriesPixels(trend.rows, index, gw, gh, PAD);
+      if (pixels.length === 0) return;
+      ctx.strokeStyle = TRACE[index % TRACE.length];
+      ctx.lineWidth = 1.5;
+      ctx.lineJoin = "round";
+      ctx.beginPath();
+      pixels.forEach(({ x, y }, i) => {
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      });
+      ctx.stroke();
+    });
+
+    const first = trend.rows[0][0] as number;
+    const last = trend.rows[trend.rows.length - 1][0] as number;
+    ctx.fillStyle = "#8b949e";
+    ctx.font = "11px 'Segoe UI', sans-serif";
+    ctx.textAlign = "right";
+    ctx.fillText(`${trend.rows.length} samples · ${formatElapsed(last - first)}`, PAD + gw, PAD + 12);
+  }, [trend]);
+
+  if (trend.rows.length === 0) {
+    return (
+      <div style={{ ...BOX, alignItems: "center", justifyContent: "center", color: "#8b949e", fontSize: "var(--text-sm)" }}>
+        <span>No recording yet — start one in the Log tab.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div style={BOX}>
+      <div ref={wrapRef} style={{ position: "relative", flex: 1, minHeight: 0 }}>
+        <canvas ref={canvasRef} />
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2) var(--space-3)", padding: "6px 10px", borderTop: "1px solid var(--scope-border-2)", fontFamily: "var(--font-mono)", fontSize: "var(--text-xs)", color: "var(--lc-text)" }}>
+        {trend.columns.map((column, index) => {
+          const stats = seriesStats(trend.rows, index);
+          return (
+            <span key={`${column.channel}-${column.mtype}`} style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
+              <span aria-hidden style={{ width: 10, height: 10, borderRadius: 2, background: TRACE[index % TRACE.length] }} />
+              {`C${column.channel} ${column.mtype}`}
+              <span style={{ color: "var(--lc-muted)" }}>{`${fmt(stats.latest)} (min ${fmt(stats.min)} / max ${fmt(stats.max)})`}</span>
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/webapp/app/src/features/trend/trend.test.ts
+++ b/webapp/app/src/features/trend/trend.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { appendTrend, clearTrend, getTrend, seedTrend, subscribeTrend } from "./trend";
+
+beforeEach(() => clearTrend());
+
+describe("trend buffer", () => {
+  it("seeds columns and rows and notifies subscribers", () => {
+    let calls = 0;
+    const unsubscribe = subscribeTrend(() => { calls += 1; });
+    seedTrend({ columns: [{ channel: 1, mtype: "PKPK" }], rows: [[1, 2.5]] });
+    unsubscribe();
+    expect(getTrend().columns).toEqual([{ channel: 1, mtype: "PKPK" }]);
+    expect(getTrend().rows).toEqual([[1, 2.5]]);
+    expect(calls).toBe(1);
+  });
+
+  it("appends rows mapped into column order, null for missing values", () => {
+    seedTrend({ columns: [{ channel: 1, mtype: "PKPK" }, { channel: 2, mtype: "FREQ" }], rows: [] });
+    appendTrend(10, [{ channel: 2, mtype: "FREQ", value: 50 }, { channel: 1, mtype: "PKPK", value: 1.5 }]);
+    appendTrend(11, [{ channel: 1, mtype: "PKPK", value: null }]);
+    expect(getTrend().rows).toEqual([[10, 1.5, 50], [11, null, null]]);
+  });
+
+  it("ignores appends before any seed", () => {
+    appendTrend(10, [{ channel: 1, mtype: "PKPK", value: 1 }]);
+    expect(getTrend().rows).toEqual([]);
+  });
+
+  it("drops out-of-order or duplicate timestamps", () => {
+    seedTrend({ columns: [{ channel: 1, mtype: "PKPK" }], rows: [[10, 1]] });
+    appendTrend(10, [{ channel: 1, mtype: "PKPK", value: 2 }]); // same ts as seeded row: skip
+    appendTrend(9, [{ channel: 1, mtype: "PKPK", value: 3 }]); // older: skip
+    appendTrend(11, [{ channel: 1, mtype: "PKPK", value: 4 }]);
+    expect(getTrend().rows).toEqual([[10, 1], [11, 4]]);
+  });
+});

--- a/webapp/app/src/features/trend/trend.ts
+++ b/webapp/app/src/features/trend/trend.ts
@@ -1,0 +1,44 @@
+import type { LogData, MeasurementValue } from "../../api/types";
+
+export type TrendColumn = { channel: number; mtype: string };
+
+const MAX_CLIENT_ROWS = 86400; // mirror the server ring buffer
+
+let columns: TrendColumn[] = [];
+let rows: (number | null)[][] = [];
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  listeners.forEach((listener) => listener());
+}
+
+export function seedTrend(data: LogData): void {
+  columns = data.columns;
+  rows = data.rows.slice(-MAX_CLIENT_ROWS);
+  notify();
+}
+
+export function appendTrend(timestamp: number, values: MeasurementValue[]): void {
+  if (columns.length === 0) return; // not seeded yet — the next seed backfills from the server
+  const last = rows[rows.length - 1];
+  if (last && (last[0] as number) >= timestamp) return; // duplicate or out-of-order sample
+  const row: (number | null)[] = [timestamp, ...columns.map((c) => values.find((v) => v.channel === c.channel && v.mtype === c.mtype)?.value ?? null)];
+  rows.push(row);
+  if (rows.length > MAX_CLIENT_ROWS) rows = rows.slice(-MAX_CLIENT_ROWS);
+  notify();
+}
+
+export function getTrend(): { columns: TrendColumn[]; rows: (number | null)[][] } {
+  return { columns, rows };
+}
+
+export function clearTrend(): void {
+  columns = [];
+  rows = [];
+  notify();
+}
+
+export function subscribeTrend(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/webapp/app/src/features/waveform/ViewModeToggle.test.tsx
+++ b/webapp/app/src/features/waveform/ViewModeToggle.test.tsx
@@ -11,4 +11,11 @@ describe("ViewModeToggle", () => {
     await userEvent.click(screen.getByRole("button", { name: "Spectrum" }));
     expect(onChange).toHaveBeenCalledWith("Spectrum");
   });
+
+  it("offers the Trend mode", async () => {
+    const onChange = vi.fn();
+    render(<ViewModeToggle value="Time" onChange={onChange} />);
+    await userEvent.click(screen.getByRole("button", { name: "Trend" }));
+    expect(onChange).toHaveBeenCalledWith("Trend");
+  });
 });

--- a/webapp/app/src/features/waveform/ViewModeToggle.tsx
+++ b/webapp/app/src/features/waveform/ViewModeToggle.tsx
@@ -1,4 +1,4 @@
-const MODES = ["Time", "Spectrum"] as const;
+const MODES = ["Time", "Spectrum", "Trend"] as const;
 export type ViewMode = (typeof MODES)[number];
 
 export function ViewModeToggle({ value, onChange }: { value: ViewMode; onChange: (mode: ViewMode) => void }) {

--- a/webapp/app/src/store/session.ts
+++ b/webapp/app/src/store/session.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { MeasurementValue, ReferenceStats, ScopeState, SessionInfo } from "../api/types";
+import type { LogStatus, MeasurementValue, ReferenceStats, ScopeState, SessionInfo } from "../api/types";
 
 export type ConnStatus = "disconnected" | "connecting" | "connected" | "error";
 
@@ -12,6 +12,7 @@ type SessionStore = {
   measurementConfig: { channel: number; mtype: string }[];
   activeReference: { name: string; channel: number | null } | null;
   referenceStats: ReferenceStats | null;
+  logStatus: LogStatus | null;
   setSession: (session: SessionInfo) => void;
   clearSession: () => void;
   applyState: (state: ScopeState) => void;
@@ -19,6 +20,7 @@ type SessionStore = {
   applyMeasurementConfig: (items: { channel: number; mtype: string }[]) => void;
   applyReference: (ref: { name: string; channel: number | null } | null) => void;
   applyReferenceStats: (stats: ReferenceStats | null) => void;
+  applyLogStatus: (status: LogStatus | null) => void;
   setStatus: (status: ConnStatus) => void;
   setError: (error: string | null) => void;
 };
@@ -32,13 +34,15 @@ export const useSession = create<SessionStore>((set) => ({
   measurementConfig: [],
   activeReference: null,
   referenceStats: null,
+  logStatus: null,
   setSession: (session) => set({ session, status: "connected", error: null }),
-  clearSession: () => set({ session: null, scope: null, status: "disconnected", error: null, measurements: [], measurementConfig: [], activeReference: null, referenceStats: null }),
+  clearSession: () => set({ session: null, scope: null, status: "disconnected", error: null, measurements: [], measurementConfig: [], activeReference: null, referenceStats: null, logStatus: null }),
   applyState: (scope) => set({ scope }),
   applyMeasurements: (measurements) => set({ measurements }),
   applyMeasurementConfig: (measurementConfig) => set({ measurementConfig }),
   applyReference: (activeReference) => set({ activeReference }),
   applyReferenceStats: (referenceStats) => set({ referenceStats }),
+  applyLogStatus: (logStatus) => set({ logStatus }),
   setStatus: (status) => set({ status }),
   setError: (error) => set({ error, status: error ? "error" : "connected" }),
 }));

--- a/webapp/app/src/stream/useStream.test.ts
+++ b/webapp/app/src/stream/useStream.test.ts
@@ -4,6 +4,7 @@ import { useStream } from "./useStream";
 import { useSession } from "../store/session";
 import { getFrame, clearFrames } from "../features/waveform/frames";
 import { getSpectrum, clearSpectrum } from "../features/waveform/spectrum";
+import { clearTrend, getTrend, seedTrend } from "../features/trend/trend";
 
 class FakeWebSocket {
   static last: FakeWebSocket | null = null;
@@ -40,6 +41,7 @@ beforeEach(() => {
   useSession.getState().clearSession();
   clearFrames();
   clearSpectrum();
+  clearTrend();
 });
 
 const STATE = { run_state: "STOP", timebase: 0.001, channels: { "1": { enabled: true, voltage_scale: 0.5, voltage_offset: 0, coupling: "DC", probe_ratio: 10 } }, trigger: { mode: "AUTO", source: "C1", level: 0, slope: "POS", coupling: "DC" } };
@@ -178,5 +180,30 @@ describe("useStream", () => {
     renderHook(() => useStream("abc"));
     FakeWebSocket.last!.emit({ type: "reference_stats", correlation: 0.9, max_deviation: 0.1 });
     await waitFor(() => expect(useSession.getState().referenceStats).toEqual({ correlation: 0.9, max_deviation: 0.1 }));
+  });
+
+  it("applies a log_status message to the store and seeds a fresh trend buffer", async () => {
+    renderHook(() => useStream("abc"));
+    seedTrend({ columns: [{ channel: 3, mtype: "MAX" }], rows: [[1, 9]] }); // stale previous recording
+    FakeWebSocket.last!.emit({ type: "log_status", state: "recording", started_at: 100, row_count: 0, columns: [{ channel: 1, mtype: "PKPK" }] });
+    await waitFor(() => expect(useSession.getState().logStatus?.state).toBe("recording"));
+    expect(getTrend().columns).toEqual([{ channel: 1, mtype: "PKPK" }]);
+    expect(getTrend().rows).toEqual([]); // fresh start replaced the stale buffer
+  });
+
+  it("appends timestamped measurements to the trend buffer while recording", async () => {
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({ type: "log_status", state: "recording", started_at: 100, row_count: 0, columns: [{ channel: 1, mtype: "PKPK" }] });
+    FakeWebSocket.last!.emit({ type: "measurements", values: [{ channel: 1, mtype: "PKPK", value: 2 }], timestamp: 101 });
+    await waitFor(() => expect(getTrend().rows).toEqual([[101, 2]]));
+    expect(useSession.getState().measurements[0].value).toBe(2); // display path unaffected
+  });
+
+  it("does not append measurements while idle", async () => {
+    renderHook(() => useStream("abc"));
+    seedTrend({ columns: [{ channel: 1, mtype: "PKPK" }], rows: [] });
+    FakeWebSocket.last!.emit({ type: "measurements", values: [{ channel: 1, mtype: "PKPK", value: 2 }], timestamp: 101 });
+    await waitFor(() => expect(useSession.getState().measurements.length).toBe(1));
+    expect(getTrend().rows).toEqual([]);
   });
 });

--- a/webapp/app/src/stream/useStream.ts
+++ b/webapp/app/src/stream/useStream.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import type { StreamMessage } from "../api/types";
+import { appendTrend, clearTrend, seedTrend } from "../features/trend/trend";
 import { clearFrames, setFrame } from "../features/waveform/frames";
 import { clearSpectrum, setSpectrum } from "../features/waveform/spectrum";
 import { useSession } from "../store/session";
@@ -19,8 +20,15 @@ export function useStream(sessionId: string | null): void {
       const store = useSession.getState();
       if (message.type === "state") store.applyState(message.state);
       else if (message.type === "waveform") setFrame(message.channel, { t0: message.t0, dt: message.dt, points: message.points });
-      else if (message.type === "measurements") store.applyMeasurements(message.values);
+      else if (message.type === "measurements") {
+        store.applyMeasurements(message.values);
+        if (message.timestamp != null && store.logStatus?.state === "recording") appendTrend(message.timestamp, message.values);
+      }
       else if (message.type === "measurements_config") store.applyMeasurementConfig(message.items);
+      else if (message.type === "log_status") {
+        store.applyLogStatus({ state: message.state, started_at: message.started_at, row_count: message.row_count, columns: message.columns });
+        if (message.state === "recording" && message.row_count === 0) seedTrend({ columns: message.columns, rows: [] }); // fresh recording: reset the client buffer
+      }
       else if (message.type === "spectrum") setSpectrum(message.points.length ? message : null);
       else if (message.type === "reference") {
         setFrame("REF", { t0: message.t0, dt: message.dt, points: message.points });
@@ -31,6 +39,7 @@ export function useStream(sessionId: string | null): void {
         ended = true;
         clearFrames();
         clearSpectrum();
+        clearTrend();
         store.clearSession();
       }
     };
@@ -39,6 +48,7 @@ export function useStream(sessionId: string | null): void {
       if (ended || event.code === CLOSE_SESSION_ENDED) {
         clearFrames();
         clearSpectrum();
+        clearTrend();
         useSession.getState().clearSession();
         return;
       }
@@ -54,6 +64,7 @@ export function useStream(sessionId: string | null): void {
       socket.close();
       clearFrames();
       clearSpectrum();
+      clearTrend();
     };
   }, [sessionId]);
 }


### PR DESCRIPTION
Server-side measurement trend recording with a live browser chart and CSV export — PR-2 of the waveform-analysis + data-logging sub-project (spec feature b; PR-1 was #56).

## What's new

### Recording backend
- New `scpi_control/server/recorder.py`: a thread-safe `TrendRecorder` per session — frozen column set, ring buffer (`deque(maxlen=86400)`, 24 h at 1 Hz), internally locked (the session worker appends while request coroutines control/read)
- The existing ~1 Hz measurement tick stamps its `measurements` stream message with a server `timestamp` and appends the same-stamped row to the recorder
- **The measurement selection is locked while recording** (`PUT /scope/measurements` → 409), so recorded rows can never misalign with the frozen columns
- `POST /scope/log/start` (400 empty selection, 409 double start) / `POST /scope/log/stop` (idempotent; data stays exportable), `GET /scope/log`, `GET /scope/log/data?since=`, `GET /scope/log.csv` (ISO timestamps + elapsed seconds, empty cells for failed readings, 404 before any recording)
- Start/stop broadcast `{"type":"log_status", state, started_at, row_count, columns}` so every tab syncs live

### Browser UI
- The canvas toggle gains a third mode: `[ Time | Spectrum | Trend ]` — `TrendCanvas` draws each logged measurement as its own auto-normalized series (units differ wildly across types) with a legend showing latest / min / max, sample count, and span
- New **Log** rail tab: Start/Stop, live row counter, start time, CSV download
- The client trend buffer seeds from the server on Log-tab or Trend-view entry and on every recording start, then appends live from the timestamped measurement stream — a tab that joins mid-recording backfills automatically
- Measure panel checkboxes disable with a "Selection locked while recording" note while a recording runs

## Verification
- Python: **641 passed, 19 skipped** (baseline 621) — recorder unit tests, streaming tests (timestamp alignment, log_status broadcast, idle/recording gating), API tests for every validation/conflict path + exact CSV content
- Frontend: **151 passed** (baseline 129) — trend buffer, stream routing, both panels by interaction, pixel-mapping/stats/elapsed helpers
- Builds clean; live-server smokes green including a real WebSocket-subscriber run that drove the poll loop end-to-end (rows 0→5, CSV content verified)
- Final whole-branch review: ready to merge, no Critical/Important findings; two recommended minors already applied (stale-guarded backfills, Log-tab buffer seeding)

Known accepted quirk: if the instrument connection dies mid-recording, `GET /scope/log` keeps reporting `recording` (no rows accrue; stop/export still work) — noted for the polish backlog.

This completes sub-project 2 (waveform analysis + data logging).
