### PR TITLE
feat: Tektronix and LeCroy oscilloscope support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Tektronix and LeCroy oscilloscope support (core control, waveform
+  acquisition, measurements): two more wire dialects (`tektronix`, `lecroy`)
+  alongside the existing Siglent legacy/modern pair, auto-detected from
+  `*IDN?` via a manufacturer-first routing step. Covers the Tektronix
+  TBS1000C Series and 2 Series MSO, and the LeCroy WaveSurfer 3000z and
+  WaveRunner 8000 series. See the
+  [SCPI Dialects guide](docs/user-guide/scpi-dialects.md) for the full
+  per-vendor command tables and known gaps (e.g. MSO 2-Series automated
+  measurements, LeCroy statistics/cursors/holdoff, Tek 16-bit waveform
+  transfer).
+
 ## [2.0.0] - 2026-07-15
 
 ### ⚠️ Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   measurements, LeCroy statistics/cursors/holdoff, Tek 16-bit waveform
   transfer).
 
+### Changed
+
+- On the Siglent modern dialect, `trigger.holdoff`, measurement statistics,
+  cursors, and `channel.unit` now raise `FeatureNotSupportedError` immediately
+  instead of writing an unsupported command and timing out
+  (`SiglentTimeoutError`). Code that caught the timeout to detect these
+  unsupported operations must now catch `FeatureNotSupportedError` instead.
+- Probe-ratio wire format on the legacy and modern dialects now serializes
+  floats compactly (`10.0` is sent as `10`), matching how real scopes echo the
+  value back.
+- `add_measurement` now validates and case-normalizes its measurement type
+  (unknown types raise instead of being sent verbatim to the instrument).
+
 ## [2.0.0] - 2026-07-15
 
 ### ⚠️ Breaking Changes

--- a/README.md
+++ b/README.md
@@ -803,18 +803,27 @@ See the `examples/` directory for complete working examples:
 
 ## Supported Models
 
-### Fully Tested
+### Siglent (Fully Tested)
 
 - **SDS800X HD Series**: SDS804X HD, SDS824X HD
 - **SDS1000X-E Series**: SDS1102X-E, SDS1104X-E, SDS1202X-E, SDS1204X-E
 - **SDS2000X Plus Series**: SDS2104X+, SDS2204X+, SDS2354X+
 - **SDS5000X Series**: SDS5034X, SDS5054X, SDS5104X
 
+### Tektronix and LeCroy (core control + measurements)
+
+- **Tektronix TBS1000C Series**: TBS1102C
+- **Tektronix 2 Series MSO**: MSO24 (automated measurements not yet supported on this family — see the [SCPI Dialects guide](https://little-did-I-know.github.io/SCPI-Instrument-Control/user-guide/scpi-dialects/) for the full per-vendor gap list)
+- **LeCroy WaveSurfer 3000z Series**: WaveSurfer 3024z
+- **LeCroy WaveRunner 8000 Series**: WaveRunner 8104
+
+Command tables were verified command-by-command against the vendor programmer manuals (Tektronix TBS1000C and 2 Series MSO manuals; the Teledyne LeCroy MAUI Remote Control and Automation Manual) and exercised against a dialect-aware mock; not yet run against real Tektronix or LeCroy hardware.
+
 ### Compatibility
 
-Should work with other Siglent oscilloscopes that support SCPI commands over Ethernet. Model-specific features are auto-detected via the `ModelCapability` registry.
+Should work with other Siglent oscilloscopes that support SCPI commands over Ethernet. Model-specific features are auto-detected via the `ModelCapability` registry. Unrecognized Tektronix or LeCroy models fall back to a conservative generic profile for that vendor (with a logged warning) rather than being rejected outright.
 
-**Note**: Some SCPI commands vary between models. The library includes model-specific command variants for HD, X, and Plus series.
+**Note**: Some SCPI commands vary between models. The library includes model-specific command variants for HD, X, and Plus series (Siglent) and for TBS vs. MSO2 (Tektronix).
 
 ## Contributing
 

--- a/docs/getting-started/connection.md
+++ b/docs/getting-started/connection.md
@@ -39,7 +39,10 @@ SCPI Instrument Control communicates with oscilloscopes using the SCPI (Standard
 
 **Oscilloscope:**
 
-- Siglent SDS1000X-E, SDS2000X-E, or SDS5000X series
+- A supported Siglent, Tektronix, or LeCroy oscilloscope (see
+  [Supported Models](https://github.com/little-did-I-know/SCPI-Instrument-Control#supported-models)
+  in the README, and the [SCPI Dialects](../user-guide/scpi-dialects.md)
+  guide for how the wire dialect is detected per vendor)
 - Ethernet port
 - Network connectivity enabled
 

--- a/docs/user-guide/scpi-dialects.md
+++ b/docs/user-guide/scpi-dialects.md
@@ -1,26 +1,51 @@
 # SCPI Dialects
 
-Siglent's oscilloscope line spans two generations of wire protocol, and this
-library speaks both through the exact same Python API.
+This library speaks four oscilloscope wire dialects behind one Python API:
+Siglent legacy, Siglent modern, Tektronix, and LeCroy.
 
 ## Why dialects exist
 
-Older scopes from the SDS1000X-E era speak a **legacy** command set — flat,
-LeCroy-derived commands like `C1:VDIV 500mV`, `TDIV`, and `PAVA?`. Newer
-HD-generation scopes (SDS800X HD and later) speak **modern** colon-form
-SCPI — `:CHANnel1:SCALe 0.5`, `:TIMebase:SCALe`, `:MEASure...`. Whichever
-generation you connect to, you call the same `scope.channel1.voltage_scale`,
-`scope.timebase`, `scope.trigger.mode`, and so on — the library translates
-to the right wire commands underneath.
+Older Siglent scopes from the SDS1000X-E era speak a **legacy** command set —
+flat, LeCroy-derived commands like `C1:VDIV 500mV`, `TDIV`, and `PAVA?`.
+Newer HD-generation Siglent scopes (SDS800X HD and later) speak **modern**
+colon-form SCPI — `:CHANnel1:SCALe 0.5`, `:TIMebase:SCALe`, `:MEASure...`.
+**Tektronix** scopes (TBS1000C, 2 Series MSO) speak a headerless SCPI dialect
+of their own — `CH1:SCAle`, `HORizontal:SCAle`, `TRIGger:A:...`. **LeCroy**
+scopes (WaveSurfer, WaveRunner) speak the MAUI remote-control command set —
+`C1:VDIV`, `TDIV`, `TRIG_MODE`.
+
+Worth calling out explicitly: LeCroy's dialect is the direct ancestor of
+Siglent's legacy dialect. Siglent's early scopes borrowed LeCroy's flat
+command grammar wholesale, which is why the legacy and LeCroy columns in the
+table below look so similar — and why the differences that remain (see
+[Known dialect gaps](#known-dialect-gaps)) are worth knowing about instead of
+assuming the two are interchangeable.
+
+Whichever scope you connect to, you call the same
+`scope.channel1.voltage_scale`, `scope.timebase`, `scope.trigger.mode`, and
+so on — the library translates to the right wire commands underneath.
 
 ## Auto-detection
 
 The dialect is detected automatically from the instrument's `*IDN?` response
-when you call `scope.connect()`. Detection first checks the built-in model
-registry (which pins the dialect for every officially supported model); for
-an unrecognized model it falls back to a heuristic — model names containing
-` HD` (with the space) or ending in `HD`, containing `PLUS`, or containing
-`SDS5`/`SDS6`/`SDS7` are treated as modern, everything else as legacy.
+when you call `scope.connect()`, in two stages:
+
+1. **Vendor routing on the manufacturer field.** A manufacturer field
+   containing `TEKTRONIX` routes detection to the Tektronix registry.
+   `LECROY` (which also matches `TELEDYNE LECROY`) routes to the LeCroy
+   registry. Every other manufacturer string — including all Siglent scopes —
+   takes the historic Siglent detection path unchanged.
+2. **Model matching within that vendor.** Within the routed vendor, the model
+   field is matched against the built-in registry (exact match, then a
+   whitespace/case-insensitive fuzzy match, then a partial/substring match).
+   A recognized model gets its pinned dialect and family variant
+   (`scpi_variant`). An unrecognized model of a *known* vendor (Tektronix or
+   LeCroy) falls back to a conservative generic profile for that vendor —
+   4 channels assumed (2 for TBS1-pattern Tektronix models), a logged
+   warning — rather than guessing wrong. An unrecognized Siglent model falls
+   back to the original heuristic: model names containing ` HD` (with the
+   space) or ending in `HD`, containing `PLUS`, or containing
+   `SDS5`/`SDS6`/`SDS7` are treated as modern, everything else as legacy.
 
 Check what was detected after connecting:
 
@@ -28,7 +53,7 @@ Check what was detected after connecting:
 from scpi_control import Oscilloscope
 
 with Oscilloscope('192.168.1.100') as scope:
-    print(scope.dialect)  # "legacy" or "modern"
+    print(scope.dialect)  # "legacy", "modern", "tektronix", or "lecroy"
 ```
 
 ## Overriding detection
@@ -37,28 +62,28 @@ If detection guesses wrong — an unlisted model that doesn't match the
 heuristic, for instance — force the dialect explicitly:
 
 ```python
-scope = Oscilloscope("192.168.1.100", dialect="modern")   # or dialect="legacy"
+scope = Oscilloscope("192.168.1.100", dialect="modern")
 ```
 
-An explicit `dialect=` always wins over the model registry and the
-fallback heuristic.
+`dialect=` accepts `"legacy"`, `"modern"`, `"tektronix"`, or `"lecroy"`. An
+explicit `dialect=` always wins over the model registry and the fallback
+heuristic.
 
-## Side-by-side: legacy vs. modern wire commands
+## Side-by-side: wire commands across dialects
 
 The library's command tables (`scpi_control/scpi_commands.py`) hold the
-exact strings sent to each dialect. A sample of the underlying wire
-commands (`{ch}` and other braces are template placeholders the library
-fills in):
+exact strings sent to each dialect. A sample of the underlying wire commands
+(`{ch}` and other braces are template placeholders the library fills in):
 
-| Operation | Legacy wire command | Modern wire command |
-|---|---|---|
-| Voltage scale | `C{ch}:VDIV {vdiv}` | `:CHANnel{ch}:SCALe {vdiv}` |
-| Timebase | `TDIV {tdiv}` | `:TIMebase:SCALe {tdiv}` |
-| Trigger mode | `TRIG_MODE {mode}` | `:TRIGger:MODE {mode}` |
-| Run | `TRIG_MODE AUTO` | `:TRIGger:RUN` |
-| Stop | `STOP` | `:TRIGger:STOP` |
-| Waveform fetch | `C{ch}:WF? DAT2` | `C{ch}:WF? DAT2` (unchanged for now) |
-| Sample rate | `SARA?` | `:ACQuire:SRATe?` |
+| Operation | Legacy | Modern | Tektronix | LeCroy |
+|---|---|---|---|---|
+| Voltage scale | `C{ch}:VDIV {vdiv}` | `:CHANnel{ch}:SCALe {vdiv}` | `CH{ch}:SCAle {vdiv}` | `C{ch}:VDIV {vdiv}` |
+| Timebase | `TDIV {tdiv}` | `:TIMebase:SCALe {tdiv}` | `HORizontal:SCAle {tdiv}` | `TDIV {tdiv}` |
+| Trigger mode | `TRIG_MODE {mode}` | `:TRIGger:MODE {mode}` | `TRIGger:A:MODe {mode}` | `TRIG_MODE {mode}` |
+| Run | `TRIG_MODE AUTO` | `:TRIGger:RUN` | `ACQuire:STATE RUN` | `TRIG_MODE AUTO` |
+| Stop | `STOP` | `:TRIGger:STOP` | `ACQuire:STATE STOP` | `STOP` |
+| Waveform fetch | `C{ch}:WF? DAT2` | `C{ch}:WF? DAT2` (unchanged for now) | `CURVe?` | `C{ch}:WF? ALL` |
+| Sample rate | `SARA?` | `:ACQuire:SRATe?` | `HORizontal:SAMPLERate?` | `VBS? 'return=app.Acquisition.Horizontal.SamplingRate'` |
 
 You never need to write these commands yourself for anything the API
 covers — see the [Trigger Control](trigger-control.md) guide for the
@@ -68,23 +93,76 @@ raw commands in whichever dialect the connected scope speaks.
 
 ## Known dialect gaps
 
-Automated measurements (`PAVA?`) are **legacy-only** today. On a
-modern-dialect scope, direct `scope.measurement.measure(...)` calls time out
-and raise `SiglentTimeoutError` (from `scpi_control.exceptions`). The web
-gateway catches this internally and shows measurements as unavailable in its UI.
+Not every dialect implements every feature the public API exposes. Where a
+dialect lacks a command, calling the corresponding property or method raises
+`FeatureNotSupportedError` (or, for the two gaps noted below that involve
+timeouts rather than gating, the appropriate timeout/parse error) —
+`scpi_control.exceptions`.
+
+| Feature | Supported on | Notes |
+|---|---|---|
+| Measurement statistics (`PAST`/`PASTAT`) and cursors (`CRST`/`CRVA?`) | legacy only | Absent from the modern, Tektronix, and LeCroy command tables. |
+| `add_measurement` (`PACU`) | legacy only | LeCroy's `PACU` is slot-first (`PACU <slot>,<measurement>,<qualifier>`) — a different grammar from Siglent's `PACU {mtype},C{ch}`, so it isn't wired up rather than being silently wrong. |
+| `WINDOW` trigger slope | legacy, modern (Siglent) | Tektronix edge trigger only has `RISe`/`FALL`; LeCroy `TRSL` only has `NEG`/`POS`. Neither has a window-slope equivalent. |
+| Trigger holdoff | legacy, tektronix | On legacy, the wire command (`TRIG_DELAY`) is really *trigger delay*, not holdoff — an existing honesty note kept as-is pending a trigger-rework follow-up. Modern has no holdoff command at all. LeCroy holdoff lives in `TRIG_SELECT HT/HV`, a different shape not yet implemented (follow-up). |
+| `GND` channel coupling | legacy, modern, lecroy | Not supported on Tektronix: neither the TBS1000C (`AC`\|`DC`) nor the 2 Series MSO (`AC`\|`DC`\|`DCREJect`) command set has a ground-coupling mode. The MSO2's `DCREJect` coupling readback is normalized to the public `AC` token rather than surfaced as a Tek-specific value. |
+| Channel vertical unit (`C{ch}:UNIT`) | legacy only | No equivalent command in the modern, Tektronix, or LeCroy tables. |
+| `measure()` automated measurements | legacy, lecroy, tektronix (TBS1000C family only) | **Modern:** `measure()` calls still time out and raise `SiglentTimeoutError` — a longstanding, unchanged gap. **Tektronix 2 Series MSO:** `measure()` raises `FeatureNotSupportedError` with a clear message; the MSO2 command set has no `MEASUrement:IMMed` subsystem (badge-based `MEASUrement:MEAS<x>` measurements are a follow-up). |
+| Waveform transfer bit depth | 8-bit only, all dialects | Tektronix's `DATa:WIDth` is pinned to `1` (8-bit) for now; 16-bit transfer is a follow-up. |
+| LeCroy waveform transfer format | lecroy | Uses `C{ch}:WF? ALL` (descriptor + data in one block), scaled from the `WAVEDESC` descriptor's vertical gain/offset and horizontal interval/offset fields, with `CFMT DEF9,{BYTE\|WORD},BIN` and `CORD LO` (LSB-first) pinning the wire encoding — a different transfer path from the Siglent-style `WF? DAT2` used by legacy and modern. |
+| LeCroy bandwidth limit token | lecroy | The public `ON` token maps to the wire value `20MHZ`; LeCroy's `BWL` vocabulary (`OFF`, `20MHZ`, `200MHZ`, ...) has no `ON` token of its own to map onto. |
+
+Automated measurements (`PAVA?`) on **Siglent modern** scopes remain a
+documented, unchanged gap: `scope.measurement.measure(...)` calls time out
+and raise `SiglentTimeoutError`. The web gateway catches this internally and
+shows measurements as unavailable in its UI.
 
 ## Mock sessions
 
-Mock sessions (`mock: true` in the web gateway, or `MockConnection` in
-code) default to a **legacy**-dialect scope. To exercise the modern code
-path against a mock, pass a modern model name:
+Mock sessions (`mock: true` in the web gateway, or `MockConnection` in code)
+default to a **legacy**-dialect Siglent scope. Pass a different `idn` to
+exercise another dialect's code path against a mock:
 
 ```python
 from scpi_control import Oscilloscope
 from scpi_control.connection.mock import MockConnection
 
+# Siglent modern
 idn = "Siglent Technologies,SDS824X HD,MOCK0001,1.0.0.0"
 scope = Oscilloscope("mock", connection=MockConnection("mock", idn=idn))
 scope.connect()
 print(scope.dialect)  # "modern"
+
+# Tektronix (2 Series MSO)
+idn = "TEKTRONIX,MSO24,MOCK0100,CF:91.1CT FV:1.28"
+scope = Oscilloscope("mock", connection=MockConnection("mock", idn=idn))
+scope.connect()
+print(scope.dialect)  # "tektronix"
+
+# LeCroy (WaveSurfer 3000z)
+idn = "LECROY,WAVESURFER3024Z,MOCK0200,8.5.0"
+scope = Oscilloscope("mock", connection=MockConnection("mock", idn=idn))
+scope.connect()
+print(scope.dialect)  # "lecroy"
 ```
+
+Each mock scope only answers its own dialect's commands. Send it a command
+from a different dialect (e.g. `TDIV?` against a Tektronix mock, or
+`:TIMebase:SCALe?` against either vendor mock) and the query still times out
+with `SiglentTimeoutError`, the same as it would against real hardware
+speaking a different command set. Only queries behave this way — an
+unrecognized write is recorded but silently ignored, matching how real
+scopes handle commands they don't understand.
+
+## Manuals
+
+The Tektronix and LeCroy command tables were verified command-by-command
+against the vendor programmer manuals below. The PDFs themselves aren't
+committed to this repo — consult the vendor for the current version:
+
+- *Tektronix TBS1000C Series Programmer Manual* (Tektronix part number
+  077-1691-01) — [tek.com](https://www.tek.com/)
+- *Tektronix 2 Series MSO Programmer Manual* (Tektronix part number
+  077-1776-07) — [tek.com](https://www.tek.com/)
+- *Teledyne LeCroy MAUI Oscilloscopes Remote Control and Automation Manual* —
+  [teledynelecroy.com](https://www.teledynelecroy.com/)

--- a/scpi_control/channel.py
+++ b/scpi_control/channel.py
@@ -31,7 +31,6 @@ class Channel:
         """
         self._scope = oscilloscope
         self._channel = channel_number
-        self._prefix = f"C{channel_number}"
 
         if not 1 <= channel_number <= 4:
             raise exceptions.InvalidParameterError(f"Invalid channel number: {channel_number}. Must be 1-4.")

--- a/scpi_control/channel.py
+++ b/scpi_control/channel.py
@@ -206,6 +206,13 @@ class Channel:
         Returns:
             Bandwidth limit: 'ON', 'OFF', or frequency limit
         """
+        if self._dialect == "lecroy":
+            # BWL? is global: "C1,OFF,C2,ON,..." (MAUI remote manual)
+            tokens = [t.strip().upper() for t in self._scope.query(self._cmd("get_bandwidth_limit")).split(",")]
+            try:
+                return tokens[tokens.index(f"C{self._channel}") + 1]
+            except (ValueError, IndexError):
+                return "OFF"
         response = self._scope.query(self._cmd("get_bandwidth_limit", ch=self._channel)).strip().upper()
         if self._dialect in ("modern", "tektronix"):
             # Modern wire tokens are FULL/20M/200M; Tek's are FULl/TWENty (or

--- a/scpi_control/channel.py
+++ b/scpi_control/channel.py
@@ -172,6 +172,11 @@ class Channel:
         Returns:
             Probe ratio (e.g., 1.0 for 1X, 10.0 for 10X)
         """
+        # Probe commands are family-split on Tek (tek_tbs/tek_mso) and absent
+        # from the plain base table; gate before querying so a forced-dialect
+        # variant fallback raises cleanly instead of a raw KeyError.
+        if not self._scope._has_command("get_probe_ratio"):
+            raise exceptions.FeatureNotSupportedError(f"probe ratio is not supported on the {self._dialect} dialect")
         response = self._scope.query(self._cmd("get_probe_ratio", ch=self._channel))
         # Response may include echo like "C1:ATTN 10"
         if ":" in response:
@@ -191,6 +196,8 @@ class Channel:
         """
         if ratio <= 0:
             raise exceptions.InvalidParameterError(f"Probe ratio must be positive: {ratio}")
+        if not self._scope._has_command("set_probe_ratio"):
+            raise exceptions.FeatureNotSupportedError(f"probe ratio is not supported on the {self._dialect} dialect")
         if self._dialect == "tektronix":
             # Tek speaks probe attenuation as a gain factor (1/ratio); the
             # tek_tbs/tek_mso family templates use the {gain} placeholder
@@ -237,7 +244,16 @@ class Channel:
         if self._dialect == "modern":
             wire = "FULL" if limit in ("OFF", "FULL") else "20M"
         elif self._dialect == "tektronix":
-            wire = "FULL" if limit in ("OFF", "FULL") else "TWENty"
+            if limit in ("OFF", "FULL"):
+                wire = "FULL"
+            elif getattr(getattr(self._scope, "model_capability", None), "scpi_variant", None) == "tek_mso":
+                # MSO 2-Series bandwidth vocabulary is {<NR3>|FULl} -- it has no
+                # TWENty keyword, so send 20 MHz as an explicit hertz value
+                # (2 Series MSO PM 077-1776-07 p.2-183).
+                wire = "20E6"
+            else:
+                # TBS1000C accepts the TWEnty keyword (TBS PM 077-1691-01 p.53).
+                wire = "TWENty"
         elif self._dialect == "lecroy":
             # LeCroy BWL <mode> vocabulary has no "ON" token -- {OFF,20MHZ,
             # 200MHZ,...} (MAUI p.7-18). Map public ON to the 20MHz limit.
@@ -294,9 +310,12 @@ class Channel:
             "coupling": self.coupling,
             "voltage_scale": self.voltage_scale,
             "voltage_offset": self.voltage_offset,
-            "probe_ratio": self.probe_ratio,
-            "bandwidth_limit": self.bandwidth_limit,
         }
+        try:
+            config["probe_ratio"] = self.probe_ratio
+        except exceptions.FeatureNotSupportedError:
+            config["probe_ratio"] = None
+        config["bandwidth_limit"] = self.bandwidth_limit
         try:
             config["unit"] = self.unit
         except exceptions.FeatureNotSupportedError:

--- a/scpi_control/channel.py
+++ b/scpi_control/channel.py
@@ -230,8 +230,9 @@ class Channel:
         Returns:
             Unit string (typically 'V' for volts)
         """
-        # legacy-only command; not routed
-        response = self._scope.query(f"{self._prefix}:UNIT?")
+        if not self._scope._has_command("get_channel_unit"):
+            raise exceptions.FeatureNotSupportedError(f"channel unit is not supported on the {self._dialect} dialect")
+        response = self._scope.query(self._cmd("get_channel_unit", ch=self._channel))
         return response.strip()
 
     @unit.setter
@@ -241,7 +242,9 @@ class Channel:
         Args:
             unit: Unit string ('V' for volts, 'A' for amps)
         """
-        self._scope.write(f"{self._prefix}:UNIT {unit}")
+        if not self._scope._has_command("set_channel_unit"):
+            raise exceptions.FeatureNotSupportedError(f"channel unit is not supported on the {self._dialect} dialect")
+        self._scope.write(self._cmd("set_channel_unit", ch=self._channel, unit=unit))
         logger.info(f"Channel {self._channel} unit set to {unit}")
 
     def auto_scale(self) -> None:
@@ -261,7 +264,7 @@ class Channel:
         Returns:
             Dictionary with all channel settings
         """
-        return {
+        config = {
             "channel": self._channel,
             "enabled": self.enabled,
             "coupling": self.coupling,
@@ -269,8 +272,12 @@ class Channel:
             "voltage_offset": self.voltage_offset,
             "probe_ratio": self.probe_ratio,
             "bandwidth_limit": self.bandwidth_limit,
-            "unit": self.unit,
         }
+        try:
+            config["unit"] = self.unit
+        except exceptions.FeatureNotSupportedError:
+            config["unit"] = None
+        return config
 
     def __repr__(self) -> str:
         """String representation."""

--- a/scpi_control/channel.py
+++ b/scpi_control/channel.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Literal, Optional
 
 from scpi_control import exceptions
-from scpi_control.scpi_commands import coupling_from_wire, coupling_to_wire
+from scpi_control.scpi_commands import coupling_from_wire, coupling_to_wire, probe_from_wire, probe_to_wire
 
 if TYPE_CHECKING:
     from scpi_control.oscilloscope import Oscilloscope
@@ -51,9 +51,10 @@ class Channel:
             True if channel is displayed, False otherwise
         """
         response = self._scope.query(self._cmd("get_channel_display", ch=self._channel))
-        # Response format: "C1:TRA ON" or "C1:TRA OFF"
-        # Extract the last word
-        return "ON" in response.upper()
+        # Response format: "C1:TRA ON"/"C1:TRA OFF" (legacy/modern) or a bare
+        # "1"/"0" numeric select (tektronix SELect:CH<x>? -- TBS p.144)
+        token = response.strip().split()[-1].upper() if response.strip() else ""
+        return token in ("ON", "1")
 
     @enabled.setter
     def enabled(self, value: bool) -> None:
@@ -177,7 +178,7 @@ class Channel:
             response = response.split(":", 1)[1]
         if " " in response:
             response = response.split(" ", 1)[1]
-        return float(response.strip())
+        return probe_from_wire(self._dialect, response.strip())
 
     @probe_ratio.setter
     def probe_ratio(self, ratio: float) -> None:
@@ -190,7 +191,12 @@ class Channel:
         """
         if ratio <= 0:
             raise exceptions.InvalidParameterError(f"Probe ratio must be positive: {ratio}")
-        self._scope.write(self._cmd("set_probe_ratio", ch=self._channel, ratio=ratio))
+        if self._dialect == "tektronix":
+            # Tek speaks probe attenuation as a gain factor (1/ratio); the
+            # tek_tbs/tek_mso family templates use the {gain} placeholder
+            self._scope.write(self._cmd("set_probe_ratio", ch=self._channel, gain=probe_to_wire(self._dialect, ratio)))
+        else:
+            self._scope.write(self._cmd("set_probe_ratio", ch=self._channel, ratio=probe_to_wire(self._dialect, ratio)))
         logger.info(f"Channel {self._channel} probe ratio set to {ratio}X")
 
     @property
@@ -201,8 +207,9 @@ class Channel:
             Bandwidth limit: 'ON', 'OFF', or frequency limit
         """
         response = self._scope.query(self._cmd("get_bandwidth_limit", ch=self._channel)).strip().upper()
-        if self._dialect == "modern":
-            # Modern wire tokens are FULL/20M/200M; the API speaks ON/OFF
+        if self._dialect in ("modern", "tektronix"):
+            # Modern wire tokens are FULL/20M/200M; Tek's are FULl/TWENty (or
+            # a hertz value on MSO2) -- both speak ON/OFF at the public layer
             return "OFF" if response == "FULL" else "ON"
         return response
 
@@ -218,6 +225,8 @@ class Channel:
             raise exceptions.InvalidParameterError(f"Invalid bandwidth limit: {limit}. Must be ON, OFF, or FULL.")
         if self._dialect == "modern":
             wire = "FULL" if limit in ("OFF", "FULL") else "20M"
+        elif self._dialect == "tektronix":
+            wire = "FULL" if limit in ("OFF", "FULL") else "TWENty"
         else:
             wire = "OFF" if limit == "FULL" else limit
         self._scope.write(self._cmd("set_bandwidth_limit", ch=self._channel, limit=wire))

--- a/scpi_control/channel.py
+++ b/scpi_control/channel.py
@@ -207,12 +207,16 @@ class Channel:
             Bandwidth limit: 'ON', 'OFF', or frequency limit
         """
         if self._dialect == "lecroy":
-            # BWL? is global: "C1,OFF,C2,ON,..." (MAUI remote manual)
+            # BWL? is global: "C1,OFF,C2,20MHZ,..." pairs (MAUI p.7-18). The
+            # real LeCroy <mode> vocabulary is {OFF,20MHZ,200MHZ,...} -- there
+            # is no "ON" token, so any non-OFF wire token maps to the public
+            # "ON" (mirrors the modern/tektronix ON/OFF normalization below).
             tokens = [t.strip().upper() for t in self._scope.query(self._cmd("get_bandwidth_limit")).split(",")]
             try:
-                return tokens[tokens.index(f"C{self._channel}") + 1]
+                wire = tokens[tokens.index(f"C{self._channel}") + 1]
             except (ValueError, IndexError):
                 return "OFF"
+            return "OFF" if wire == "OFF" else "ON"
         response = self._scope.query(self._cmd("get_bandwidth_limit", ch=self._channel)).strip().upper()
         if self._dialect in ("modern", "tektronix"):
             # Modern wire tokens are FULL/20M/200M; Tek's are FULl/TWENty (or
@@ -234,6 +238,10 @@ class Channel:
             wire = "FULL" if limit in ("OFF", "FULL") else "20M"
         elif self._dialect == "tektronix":
             wire = "FULL" if limit in ("OFF", "FULL") else "TWENty"
+        elif self._dialect == "lecroy":
+            # LeCroy BWL <mode> vocabulary has no "ON" token -- {OFF,20MHZ,
+            # 200MHZ,...} (MAUI p.7-18). Map public ON to the 20MHz limit.
+            wire = "OFF" if limit in ("OFF", "FULL") else "20MHZ"
         else:
             wire = "OFF" if limit == "FULL" else limit
         self._scope.write(self._cmd("set_bandwidth_limit", ch=self._channel, limit=wire))

--- a/scpi_control/connection/mock/__init__.py
+++ b/scpi_control/connection/mock/__init__.py
@@ -1,0 +1,5 @@
+"""Mock connection package: shared shell in base, one personality module per vendor."""
+
+from scpi_control.connection.mock.base import MOCK_SCREENSHOT_BMP, MockConnection
+
+__all__ = ["MockConnection", "MOCK_SCREENSHOT_BMP"]

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -1,55 +1,19 @@
-"""Mock connection implementation for deterministic offline SCPI testing."""
+"""Mock connection shell: constructor/state, connect/disconnect, PSU/AWG/DAQ handling,
+and personality dispatch to the vendor-specific scope write/query/waveform modules."""
 
 from __future__ import annotations
 
 import re
-from typing import Dict, Iterable, List, Optional, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Union
 
 from scpi_control import exceptions
 from scpi_control.connection.base import BaseConnection
+from scpi_control.connection.mock.helpers import MOCK_SCREENSHOT_BMP, _build_ieee_block
+from scpi_control.connection.mock import siglent
 from scpi_control.models import detect_model_from_idn
 
-
-def _format_scientific(value: float, unit: str) -> str:
-    """Format a numeric value with a unit using Siglent-style scientific notation."""
-    return f"{value:.2E}{unit}"
-
-
-def _format_nr3(value: float) -> str:
-    """Format a bare NR3 numeric value (no unit) as used by modern-dialect queries."""
-    return f"{value:.2E}"
-
-
-def _build_ieee_block(payload: bytes) -> bytes:
-    """Wrap payload in an IEEE-488.2 definite-length block: #<ndigits><length><payload>."""
-    length_str = str(len(payload)).encode()
-    return b"#" + str(len(length_str)).encode() + length_str + payload
-
-
-# Minimal valid 1x1 24bpp BMP, so a mock SCDP? screenshot decodes as a real image.
-MOCK_SCREENSHOT_BMP = bytes.fromhex("424d3a000000000000003600000028000000010000000100000001001800000000000400000000000000000000000000000000000000ffffff00")
-
-
-# Canonical PAVA? measurement values for the legacy dialect (mirrors real
-# hardware where PAVA? is legacy-only; the modern dialect has no equivalent).
-_MOCK_PAVA_VALUES: Dict[str, Tuple[str, str]] = {
-    "PKPK": ("2.000E+00", "V"),
-    "MAX": ("1.000E+00", "V"),
-    "MIN": ("-1.000E+00", "V"),
-    "AMPL": ("2.000E+00", "V"),
-    "TOP": ("1.000E+00", "V"),
-    "BASE": ("-1.000E+00", "V"),
-    "CMEAN": ("0.000E+00", "V"),
-    "MEAN": ("0.000E+00", "V"),
-    "RMS": ("7.070E-01", "V"),
-    "CRMS": ("7.070E-01", "V"),
-    "FREQ": ("1.000E+03", "HZ"),
-    "PER": ("1.000E-03", "S"),
-    "RISE": ("3.500E-05", "S"),
-    "FALL": ("3.500E-05", "S"),
-    "WID": ("5.000E-04", "S"),
-    "NWID": ("5.000E-04", "S"),
-    "DUTY": ("5.000E+01", "%"),
+_PERSONALITIES = {
+    "siglent": siglent,
 }
 
 
@@ -94,7 +58,9 @@ class MockConnection(BaseConnection):
 
         self.idn = idn
         # Personality: answer only the wire dialect this model actually speaks
-        self.scope_dialect = detect_model_from_idn(idn).dialect
+        capability = detect_model_from_idn(idn)
+        self.scope_dialect = capability.dialect
+        self.scope_vendor = capability.vendor
         self._channel_enabled: Dict[int, bool] = {ch: channel_states.get(ch, True) if channel_states else True for ch in channels}
         self._voltage_scales: Dict[int, float] = {ch: voltage_scales.get(ch, 1.0) if voltage_scales else 1.0 for ch in channels}
         self._voltage_offsets: Dict[int, float] = {ch: voltage_offsets.get(ch, 0.0) if voltage_offsets else 0.0 for ch in channels}
@@ -360,101 +326,17 @@ class MockConnection(BaseConnection):
                     self.awg_channels[ch]["enabled"] = enabled
                 return
 
-        # Oscilloscope commands
-        if self.scope_dialect == "modern":
-            if match := re.match(r":CHANnel(\d+):SWITch\s+(ON|OFF)", command, re.IGNORECASE):
-                self._channel_enabled[int(match.group(1))] = match.group(2).upper() == "ON"
-                return
-            if match := re.match(r":CHANnel(\d+):SCALe\s+(.+)", command, re.IGNORECASE):
-                ch = int(match.group(1))
-                self._voltage_scales[ch] = float(match.group(2))
-                self.scale_updates.setdefault(ch, []).append(float(match.group(2)))
-                return
-            if match := re.match(r":CHANnel(\d+):OFFSet\s+(.+)", command, re.IGNORECASE):
-                self._voltage_offsets[int(match.group(1))] = float(match.group(2))
-                return
-            if match := re.match(r":CHANnel(\d+):COUPling\s+(\w+)", command, re.IGNORECASE):
-                self._channel_coupling[int(match.group(1))] = match.group(2).upper()
-                return
-            if match := re.match(r":TIMebase:SCALe\s+(.+)", command, re.IGNORECASE):
-                self.timebase = float(match.group(1))
-                self.timebase_updates.append(self.timebase)
-                return
-            if match := re.match(r":TRIGger:MODE\s+(\w+)", command, re.IGNORECASE):
-                self.trigger_mode = match.group(1)  # stored as wire token, e.g. "NORMal" (guide p.482)
-                if match.group(1).upper() == "SINGLE" and len(self.trigger_status) <= 1:
-                    # Status vocabulary matches real hardware: Ready while armed, Stop when done (same rule as the legacy ARM handler)
-                    self.trigger_status = ["Ready", "Stop"]
-                return
-            if re.match(r":TRIGger:RUN$", command, re.IGNORECASE):
-                self.trigger_mode = "AUTO"
-                return
-            if re.match(r":TRIGger:STOP$", command, re.IGNORECASE):
-                if len(self.trigger_status) <= 1:
-                    self.trigger_status = ["Stop"]
-                return
-            if match := re.match(r":TRIGger:TYPE\s+(\w+)", command, re.IGNORECASE):
-                self.trigger_type = match.group(1).upper()
-                return
-            if match := re.match(r":TRIGger:EDGE:SOURce\s+(\w+)", command, re.IGNORECASE):
-                self.trigger_source = match.group(1).upper()
-                return
-            if match := re.match(r":TRIGger:EDGE:LEVel\s+(.+)", command, re.IGNORECASE):
-                self.trigger_level[1] = float(match.group(1))
-                return
-            if match := re.match(r":TRIGger:EDGE:SLOPe\s+(\w+)", command, re.IGNORECASE):
-                self.trigger_slope = match.group(1)  # wire token, e.g. "RISing" (guide p.494)
-                return
-            if match := re.match(r":TRIGger:EDGE:COUPling\s+(\w+)", command, re.IGNORECASE):
-                self.trigger_coupling = match.group(1)
-                return
-            # Unknown modern writes fall through and are merely recorded,
-            # mirroring real scopes which silently drop unknown commands
-
-        if command.upper().startswith("TDIV "):
-            value = command.split(" ", 1)[1]
-            try:
-                self.timebase = float(value)
-            except ValueError:
-                self.timebase = self.timebase
-            self.timebase_updates.append(self.timebase)
-        elif match := re.match(r"C(\d+):VDIV\s+(.+)", command, re.IGNORECASE):
-            channel = int(match.group(1))
-            value = float(match.group(2))
-            self._voltage_scales[channel] = value
-            self.scale_updates.setdefault(channel, []).append(value)
-        elif match := re.match(r"C(\d+):OFST\s+(.+)", command, re.IGNORECASE):
-            channel = int(match.group(1))
-            value = float(match.group(2))
-            self._voltage_offsets[channel] = value
-        elif match := re.match(r"C(\d+):TRA\s+(ON|OFF)", command, re.IGNORECASE):
-            channel = int(match.group(1))
-            self._channel_enabled[channel] = match.group(2).upper() == "ON"
-        elif match := re.match(r"C(\d+):CPL\s+(\w+)", command, re.IGNORECASE):
-            self._channel_coupling[int(match.group(1))] = match.group(2).upper()
-        elif command.upper().startswith("TRIG_MODE "):
-            self.trigger_mode = command.split(" ", 1)[1].upper()
-        elif command.upper().startswith("TRIG_SELECT "):
-            _, params = command.split(" ", 1)
-            trig_type, _, source = params.split(",")
-            self.trigger_type = trig_type.strip().upper()
-            self.trigger_source = source.strip().upper()
-        elif match := re.match(r"C(\d+):TRSL\s+(\w+)", command, re.IGNORECASE):
-            self.trigger_slope = match.group(2).upper()
-        elif match := re.match(r"C(\d+):TRCP\s+(\w+)", command, re.IGNORECASE):
-            self.trigger_coupling = match.group(2).upper()
-        elif command.upper() == "ARM":
-            # Simulate an acquisition that will eventually stop when no custom sequence is provided.
-            # Status vocabulary matches real hardware: Ready while armed, Stop when done.
-            if len(self.trigger_status) <= 1:
-                self.trigger_status = ["Ready", "Stop"]
-        elif match := re.match(r"C(\d+):TRLV\s+(.+)", command, re.IGNORECASE):
-            channel = int(match.group(1))
-            self.trigger_level[channel] = float(match.group(2))
-        elif match := re.match(r"C(\d+):WF\?", command, re.IGNORECASE):
+        # Oscilloscope commands: C{n}:WF? channel recording is shared across every
+        # scope dialect/vendor (Tek's CURVe? uses data_source instead - Task 9), so
+        # it is recorded here before personality dispatch rather than inside a
+        # single vendor module's write handler.
+        if match := re.match(r"C(\d+):WF\?", command, re.IGNORECASE):
             channel = int(match.group(1))
             self._last_waveform_channel = channel
             self.waveform_requests.append(channel)
+
+        personality = _PERSONALITIES.get(self.scope_vendor, siglent)
+        personality.handle_write(self, command)
 
     def read(self) -> str:
         """Return an empty response for completeness."""
@@ -693,88 +575,10 @@ class MockConnection(BaseConnection):
                     return "CV"
                 return "CV"
 
-        if self.scope_dialect == "modern":
-            if upper == ":TRIGGER:STATUS?":  # enum Arm|Ready|Auto|Trig'd|Stop|Roll, p.483
-                if len(self.trigger_status) > 1:
-                    return self.trigger_status.pop(0)
-                return self.trigger_status[0]
-            if upper == ":TRIGGER:MODE?":  # mixed-case wire token, e.g. "NORMal", p.482
-                return self.trigger_mode
-            if upper == ":TRIGGER:TYPE?":
-                return self.trigger_type
-            if upper == ":TRIGGER:EDGE:SOURCE?":  # bare token, p.495
-                return self.trigger_source
-            if upper == ":TRIGGER:EDGE:SLOPE?":  # wire token e.g. "RISing", p.494
-                return self.trigger_slope
-            if upper == ":TRIGGER:EDGE:COUPLING?":
-                return self.trigger_coupling
-            if upper == ":TRIGGER:EDGE:LEVEL?":  # bare NR3, p.492
-                return _format_nr3(self.trigger_level.get(1, 0.0))
-            if match := re.match(r":CHANNEL(\d+):SWITCH\?", upper):
-                return "ON" if self._channel_enabled.get(int(match.group(1)), True) else "OFF"
-            if match := re.match(r":CHANNEL(\d+):SCALE\?", upper):  # bare NR3, p.58
-                return _format_nr3(self._voltage_scales.get(int(match.group(1)), 1.0))
-            if match := re.match(r":CHANNEL(\d+):OFFSET\?", upper):  # bare NR3, p.56
-                return _format_nr3(self._voltage_offsets.get(int(match.group(1)), 0.0))
-            if match := re.match(r":CHANNEL(\d+):COUPLING\?", upper):  # DC|AC|GND, p.51
-                return self._channel_coupling.get(int(match.group(1)), "DC")
-            if upper == ":TIMEBASE:SCALE?":  # bare NR3, p.476
-                return _format_nr3(self.timebase)
-            if upper == ":ACQUIRE:SRATE?":  # bare NR3, p.46
-                return _format_nr3(self.sample_rate)
-
-        if self.scope_dialect == "legacy":
-            if match := re.match(r"C(\d+):VDIV\?", command, re.IGNORECASE):
-                channel = int(match.group(1))
-                value = self._voltage_scales.get(channel, 1.0)
-                return _format_scientific(value, "V")
-
-            if match := re.match(r"C(\d+):OFST\?", command, re.IGNORECASE):
-                channel = int(match.group(1))
-                value = self._voltage_offsets.get(channel, 0.0)
-                return _format_scientific(value, "V")
-
-            if match := re.match(r"C(\d+):TRA\?", command, re.IGNORECASE):
-                channel = int(match.group(1))
-                return "ON" if self._channel_enabled.get(channel, True) else "OFF"
-
-            if match := re.match(r"C(\d+):CPL\?", command, re.IGNORECASE):
-                return self._channel_coupling.get(int(match.group(1)), "D1M")
-
-            if match := re.match(r"C(\d+):TRLV\?", command, re.IGNORECASE):
-                channel = int(match.group(1))
-                return _format_scientific(self.trigger_level.get(channel, 0.0), "V")
-
-            if re.match(r"C(\d+):TRSL\?", command, re.IGNORECASE):
-                return self.trigger_slope
-
-            if re.match(r"C(\d+):TRCP\?", command, re.IGNORECASE):
-                return self.trigger_coupling
-
-            if upper == "TDIV?":
-                return _format_scientific(self.timebase, "S")
-
-            if upper == "SARA?":
-                return _format_scientific(self.sample_rate, "Sa/s")
-
-            if upper == "SAST?":
-                if len(self.trigger_status) > 1:
-                    return self.trigger_status.pop(0)
-                return self.trigger_status[0]
-
-            if upper == "TRIG_MODE?":
-                return self.trigger_mode
-
-            if upper == "TRIG_SELECT?":
-                return f"{self.trigger_type},SR,{self.trigger_source}"
-
-            if match := re.match(r"PAVA\?\s*(\w+)\s*,\s*C?(\d+)", command, re.IGNORECASE):
-                mtype = match.group(1).upper()
-                channel = match.group(2)
-                entry = _MOCK_PAVA_VALUES.get(mtype)
-                if entry is not None:
-                    value, unit = entry
-                    return f"PAVA {mtype},C{channel},{value}{unit}"
+        personality = _PERSONALITIES.get(self.scope_vendor, siglent)
+        response = personality.handle_query(self, command)
+        if response is not None:
+            return response
 
         if self.psu_mode or self.awg_mode or self.daq_mode:
             return ""
@@ -787,10 +591,6 @@ class MockConnection(BaseConnection):
         """Convenience helper to query multiple commands sequentially."""
         return [self.query(cmd) for cmd in commands]
 
-    def _build_waveform_block(self, payload: bytes) -> bytes:
-        """Construct a minimal Siglent-style block response."""
-        return b"DESC," + _build_ieee_block(payload)
-
     def read_raw(self, size: Optional[int] = None) -> bytes:
         """Return deterministic raw waveform data (or a mock screenshot BMP after SCDP?)."""
         if not self._connected:
@@ -801,6 +601,5 @@ class MockConnection(BaseConnection):
             # scope's SCDP? reply is parsed in screen_capture.py.
             return _build_ieee_block(MOCK_SCREENSHOT_BMP)
 
-        channel = self._last_waveform_channel or next(iter(self._waveform_payloads.keys()))
-        payload = self._waveform_payloads.get(channel, bytes())
-        return self._build_waveform_block(payload)
+        personality = _PERSONALITIES.get(self.scope_vendor, siglent)
+        return personality.build_waveform_response(self)

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -9,11 +9,12 @@ from typing import Dict, Iterable, List, Optional, Union
 from scpi_control import exceptions
 from scpi_control.connection.base import BaseConnection
 from scpi_control.connection.mock.helpers import MOCK_SCREENSHOT_BMP, _build_ieee_block
-from scpi_control.connection.mock import siglent
+from scpi_control.connection.mock import siglent, tektronix
 from scpi_control.models import detect_model_from_idn
 
 _PERSONALITIES = {
     "siglent": siglent,
+    "tektronix": tektronix,
 }
 
 
@@ -81,6 +82,22 @@ class MockConnection(BaseConnection):
         self.trigger_coupling = "DC"
         self.trigger_level: Dict[int, float] = {ch: 0.0 for ch in channels}
         self.trigger_status: List[str] = trigger_status[:] if trigger_status else ["Stop"]
+
+        # Tektronix wire-vocabulary state (shared across tek_tbs/tek_mso variants)
+        self.tek_stop_after = "RUNSTOP"
+        self.data_source: int = 1
+        self.probe_gains: Dict[int, float] = {ch: 0.1 for ch in channels}
+        self.holdoff_time = 0.0
+        if self.scope_vendor == "tektronix":
+            # Tek vocabulary differs from both Siglent dialects (guide TEKTRONIX_COMMANDS table)
+            self.trigger_mode = "AUTO"
+            self.trigger_slope = "RISE"
+            self.trigger_source = "CH1"
+            self._channel_coupling = {ch: "DC" for ch in channels}
+            if not trigger_status:
+                # "SAVE" is the Tek TRIGger:STATE? token for stopped; the shared
+                # default ["Stop"] is Siglent vocabulary and not a valid Tek state.
+                self.trigger_status = ["SAVE"]
 
         self.custom_responses = custom_responses or {}
         self.writes: List[str] = []

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -9,12 +9,13 @@ from typing import Dict, Iterable, List, Optional, Union
 from scpi_control import exceptions
 from scpi_control.connection.base import BaseConnection
 from scpi_control.connection.mock.helpers import MOCK_SCREENSHOT_BMP, _build_ieee_block
-from scpi_control.connection.mock import siglent, tektronix
+from scpi_control.connection.mock import lecroy, siglent, tektronix
 from scpi_control.models import detect_model_from_idn
 
 _PERSONALITIES = {
     "siglent": siglent,
     "tektronix": tektronix,
+    "lecroy": lecroy,
 }
 
 

--- a/scpi_control/connection/mock/helpers.py
+++ b/scpi_control/connection/mock/helpers.py
@@ -1,0 +1,25 @@
+"""Vendor-neutral formatting helpers shared by the mock connection shell and every
+personality module. Lives separately so personality modules never need to import
+from `base` (which imports these helpers), avoiding an import cycle."""
+
+from __future__ import annotations
+
+
+def _format_scientific(value: float, unit: str) -> str:
+    """Format a numeric value with a unit using Siglent-style scientific notation."""
+    return f"{value:.2E}{unit}"
+
+
+def _format_nr3(value: float) -> str:
+    """Format a bare NR3 numeric value (no unit) as used by modern-dialect queries."""
+    return f"{value:.2E}"
+
+
+def _build_ieee_block(payload: bytes) -> bytes:
+    """Wrap payload in an IEEE-488.2 definite-length block: #<ndigits><length><payload>."""
+    length_str = str(len(payload)).encode()
+    return b"#" + str(len(length_str)).encode() + length_str + payload
+
+
+# Minimal valid 1x1 24bpp BMP, so a mock SCDP? screenshot decodes as a real image.
+MOCK_SCREENSHOT_BMP = bytes.fromhex("424d3a000000000000003600000028000000010000000100000001001800000000000400000000000000000000000000000000000000ffffff00")

--- a/scpi_control/connection/mock/lecroy.py
+++ b/scpi_control/connection/mock/lecroy.py
@@ -83,6 +83,11 @@ def build_waveform_response(conn) -> bytes:
     struct.pack_into("<h", desc, 32, 0)
     struct.pack_into("<i", desc, 36, 346)
     struct.pack_into("<i", desc, 40, 0)
+    # TRIGTIME_ARRAY (offset 48) and RIS_TIME_ARRAY (offset 52) lengths: 0 for
+    # this single-shot mock (the bytearray is already zero-filled; packed
+    # explicitly to document the layout parse_wavedesc now skips).
+    struct.pack_into("<i", desc, 48, 0)
+    struct.pack_into("<i", desc, 52, 0)
     struct.pack_into("<i", desc, 116, len(codes))
     struct.pack_into("<f", desc, 156, gain)
     struct.pack_into("<f", desc, 160, conn._voltage_offsets.get(channel, 0.0))

--- a/scpi_control/connection/mock/lecroy.py
+++ b/scpi_control/connection/mock/lecroy.py
@@ -5,9 +5,10 @@ queries answer in CHDR OFF format: bare values, no unit suffixes.
 """
 
 import re
+import struct
 from typing import Optional
 
-from scpi_control.connection.mock.helpers import _format_nr3
+from scpi_control.connection.mock.helpers import _build_ieee_block, _format_nr3
 from scpi_control.connection.mock.siglent import _MOCK_PAVA_VALUES, handle_write as _legacy_write
 
 _INR_MAP = {"TRIG'D": "1"}  # INR bit 0: new signal acquired
@@ -73,4 +74,18 @@ def handle_query(conn, command: str) -> Optional[str]:
 
 
 def build_waveform_response(conn) -> bytes:
-    raise NotImplementedError  # Task 15
+    """Construct a LeCroy WAVEDESC + sample-array block (WF? ALL, CORD LO)."""
+    channel = conn._last_waveform_channel or next(iter(conn._waveform_payloads))
+    codes = conn._waveform_payloads.get(channel, bytes())
+    gain = conn._voltage_scales.get(channel, 1.0) / 25.0  # mirror Siglent scaling for comparable volts
+    desc = bytearray(346)
+    desc[0:8] = b"WAVEDESC"
+    struct.pack_into("<h", desc, 32, 0)
+    struct.pack_into("<i", desc, 36, 346)
+    struct.pack_into("<i", desc, 40, 0)
+    struct.pack_into("<i", desc, 116, len(codes))
+    struct.pack_into("<f", desc, 156, gain)
+    struct.pack_into("<f", desc, 160, conn._voltage_offsets.get(channel, 0.0))
+    struct.pack_into("<f", desc, 176, 1.0 / conn.sample_rate)
+    struct.pack_into("<d", desc, 180, 0.0)
+    return _build_ieee_block(bytes(desc) + codes)

--- a/scpi_control/connection/mock/lecroy.py
+++ b/scpi_control/connection/mock/lecroy.py
@@ -1,0 +1,76 @@
+"""LeCroy MAUI mock personality.
+
+Writes reuse the Siglent legacy handler (Siglent copied LeCroy's command set);
+queries answer in CHDR OFF format: bare values, no unit suffixes.
+"""
+
+import re
+from typing import Optional
+
+from scpi_control.connection.mock.helpers import _format_nr3
+from scpi_control.connection.mock.siglent import _MOCK_PAVA_VALUES, handle_write as _legacy_write
+
+_INR_MAP = {"TRIG'D": "1"}  # INR bit 0: new signal acquired
+
+
+def handle_write(conn, command: str) -> bool:
+    upper = command.strip().upper()
+    if upper.startswith("CFMT ") or upper.startswith("CORD ") or upper == "CHDR OFF":
+        return True
+    if upper == "STOP":
+        conn.trigger_mode = "STOP"  # TRMD? reports STOP after a STOP command
+        return True
+    if upper.startswith("BWL "):
+        # Legacy chain has no BWL handler; record as a no-op write explicitly
+        # so the fidelity contract (write returns True => consumed) holds.
+        return True
+    # The legacy chain understands TDIV/VDIV/TRA/CPL/TRIG_* — LeCroy originals.
+    # Its modern branch gates on scope_dialect == "modern", which is False here.
+    return _legacy_write(conn, command)
+
+
+def handle_query(conn, command: str) -> Optional[str]:
+    upper = command.strip().upper()
+
+    if match := re.match(r"C(\d+):VDIV\?", upper):
+        return _format_nr3(conn._voltage_scales.get(int(match.group(1)), 1.0))
+    if match := re.match(r"C(\d+):OFST\?", upper):
+        return _format_nr3(conn._voltage_offsets.get(int(match.group(1)), 0.0))
+    if match := re.match(r"C(\d+):TRA\?", upper):
+        return "ON" if conn._channel_enabled.get(int(match.group(1)), True) else "OFF"
+    if match := re.match(r"C(\d+):CPL\?", upper):
+        return conn._channel_coupling.get(int(match.group(1)), "D1M")
+    if match := re.match(r"C(\d+):TRLV\?", upper):
+        return _format_nr3(conn.trigger_level.get(int(match.group(1)), 0.0))
+    if re.match(r"C(\d+):TRSL\?", upper):
+        return conn.trigger_slope
+    if re.match(r"C(\d+):TRCP\?", upper):
+        return conn.trigger_coupling
+    if match := re.match(r"C(\d+):ATTN\?", upper):
+        return "10"
+    if upper == "TDIV?":
+        return _format_nr3(conn.timebase)
+    if upper == "TRIG_MODE?" or upper == "TRMD?":
+        return conn.trigger_mode
+    if upper == "TRIG_SELECT?" or upper == "TRSE?":
+        return f"{conn.trigger_type},SR,{conn.trigger_source}"
+    if upper == "INR?":
+        if len(conn.trigger_status) > 1:
+            return _INR_MAP.get(conn.trigger_status.pop(0).upper(), "0")
+        return _INR_MAP.get(conn.trigger_status[0].upper(), "0")
+    if upper == "BWL?":
+        return ",".join(f"C{ch},OFF" for ch in sorted(conn._channel_enabled))
+    if upper.startswith("VBS? 'RETURN=APP.ACQUISITION.HORIZONTAL.SAMPLINGRATE'"):
+        return _format_nr3(conn.sample_rate)
+    if match := re.match(r"C(\d+):PAVA\?\s*(\w+)", upper):
+        mtype = match.group(2)
+        entry = _MOCK_PAVA_VALUES.get(mtype)
+        if entry is not None:
+            value, _unit = entry
+            # CHDR OFF suppresses units on LeCroy; native shape is <param>,<value>,<state>
+            return f"{mtype},{value},OK"
+    return None
+
+
+def build_waveform_response(conn) -> bytes:
+    raise NotImplementedError  # Task 15

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -1,0 +1,235 @@
+"""Siglent scope personality: legacy (SDS1000/2000-style) and modern (SDS800X HD-style)
+write/query dialects, plus the waveform-response builder."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Optional, Tuple
+
+from scpi_control.connection.mock.helpers import _build_ieee_block, _format_nr3, _format_scientific
+
+# Canonical PAVA? measurement values for the legacy dialect (mirrors real
+# hardware where PAVA? is legacy-only; the modern dialect has no equivalent).
+_MOCK_PAVA_VALUES: Dict[str, Tuple[str, str]] = {
+    "PKPK": ("2.000E+00", "V"),
+    "MAX": ("1.000E+00", "V"),
+    "MIN": ("-1.000E+00", "V"),
+    "AMPL": ("2.000E+00", "V"),
+    "TOP": ("1.000E+00", "V"),
+    "BASE": ("-1.000E+00", "V"),
+    "CMEAN": ("0.000E+00", "V"),
+    "MEAN": ("0.000E+00", "V"),
+    "RMS": ("7.070E-01", "V"),
+    "CRMS": ("7.070E-01", "V"),
+    "FREQ": ("1.000E+03", "HZ"),
+    "PER": ("1.000E-03", "S"),
+    "RISE": ("3.500E-05", "S"),
+    "FALL": ("3.500E-05", "S"),
+    "WID": ("5.000E-04", "S"),
+    "NWID": ("5.000E-04", "S"),
+    "DUTY": ("5.000E+01", "%"),
+}
+
+
+def handle_write(conn, command: str) -> bool:
+    """Handle a Siglent-dialect (legacy or modern) scope write. Returns True if consumed."""
+    if conn.scope_dialect == "modern":
+        if match := re.match(r":CHANnel(\d+):SWITch\s+(ON|OFF)", command, re.IGNORECASE):
+            conn._channel_enabled[int(match.group(1))] = match.group(2).upper() == "ON"
+            return True
+        if match := re.match(r":CHANnel(\d+):SCALe\s+(.+)", command, re.IGNORECASE):
+            ch = int(match.group(1))
+            conn._voltage_scales[ch] = float(match.group(2))
+            conn.scale_updates.setdefault(ch, []).append(float(match.group(2)))
+            return True
+        if match := re.match(r":CHANnel(\d+):OFFSet\s+(.+)", command, re.IGNORECASE):
+            conn._voltage_offsets[int(match.group(1))] = float(match.group(2))
+            return True
+        if match := re.match(r":CHANnel(\d+):COUPling\s+(\w+)", command, re.IGNORECASE):
+            conn._channel_coupling[int(match.group(1))] = match.group(2).upper()
+            return True
+        if match := re.match(r":TIMebase:SCALe\s+(.+)", command, re.IGNORECASE):
+            conn.timebase = float(match.group(1))
+            conn.timebase_updates.append(conn.timebase)
+            return True
+        if match := re.match(r":TRIGger:MODE\s+(\w+)", command, re.IGNORECASE):
+            conn.trigger_mode = match.group(1)  # stored as wire token, e.g. "NORMal" (guide p.482)
+            if match.group(1).upper() == "SINGLE" and len(conn.trigger_status) <= 1:
+                # Status vocabulary matches real hardware: Ready while armed, Stop when done (same rule as the legacy ARM handler)
+                conn.trigger_status = ["Ready", "Stop"]
+            return True
+        if re.match(r":TRIGger:RUN$", command, re.IGNORECASE):
+            conn.trigger_mode = "AUTO"
+            return True
+        if re.match(r":TRIGger:STOP$", command, re.IGNORECASE):
+            if len(conn.trigger_status) <= 1:
+                conn.trigger_status = ["Stop"]
+            return True
+        if match := re.match(r":TRIGger:TYPE\s+(\w+)", command, re.IGNORECASE):
+            conn.trigger_type = match.group(1).upper()
+            return True
+        if match := re.match(r":TRIGger:EDGE:SOURce\s+(\w+)", command, re.IGNORECASE):
+            conn.trigger_source = match.group(1).upper()
+            return True
+        if match := re.match(r":TRIGger:EDGE:LEVel\s+(.+)", command, re.IGNORECASE):
+            conn.trigger_level[1] = float(match.group(1))
+            return True
+        if match := re.match(r":TRIGger:EDGE:SLOPe\s+(\w+)", command, re.IGNORECASE):
+            conn.trigger_slope = match.group(1)  # wire token, e.g. "RISing" (guide p.494)
+            return True
+        if match := re.match(r":TRIGger:EDGE:COUPling\s+(\w+)", command, re.IGNORECASE):
+            conn.trigger_coupling = match.group(1)
+            return True
+        # Unknown modern writes fall through and are merely recorded,
+        # mirroring real scopes which silently drop unknown commands
+
+    if command.upper().startswith("TDIV "):
+        value = command.split(" ", 1)[1]
+        try:
+            conn.timebase = float(value)
+        except ValueError:
+            conn.timebase = conn.timebase
+        conn.timebase_updates.append(conn.timebase)
+        return True
+    elif match := re.match(r"C(\d+):VDIV\s+(.+)", command, re.IGNORECASE):
+        channel = int(match.group(1))
+        value = float(match.group(2))
+        conn._voltage_scales[channel] = value
+        conn.scale_updates.setdefault(channel, []).append(value)
+        return True
+    elif match := re.match(r"C(\d+):OFST\s+(.+)", command, re.IGNORECASE):
+        channel = int(match.group(1))
+        value = float(match.group(2))
+        conn._voltage_offsets[channel] = value
+        return True
+    elif match := re.match(r"C(\d+):TRA\s+(ON|OFF)", command, re.IGNORECASE):
+        channel = int(match.group(1))
+        conn._channel_enabled[channel] = match.group(2).upper() == "ON"
+        return True
+    elif match := re.match(r"C(\d+):CPL\s+(\w+)", command, re.IGNORECASE):
+        conn._channel_coupling[int(match.group(1))] = match.group(2).upper()
+        return True
+    elif command.upper().startswith("TRIG_MODE "):
+        conn.trigger_mode = command.split(" ", 1)[1].upper()
+        return True
+    elif command.upper().startswith("TRIG_SELECT "):
+        _, params = command.split(" ", 1)
+        trig_type, _, source = params.split(",")
+        conn.trigger_type = trig_type.strip().upper()
+        conn.trigger_source = source.strip().upper()
+        return True
+    elif match := re.match(r"C(\d+):TRSL\s+(\w+)", command, re.IGNORECASE):
+        conn.trigger_slope = match.group(2).upper()
+        return True
+    elif match := re.match(r"C(\d+):TRCP\s+(\w+)", command, re.IGNORECASE):
+        conn.trigger_coupling = match.group(2).upper()
+        return True
+    elif command.upper() == "ARM":
+        # Simulate an acquisition that will eventually stop when no custom sequence is provided.
+        # Status vocabulary matches real hardware: Ready while armed, Stop when done.
+        if len(conn.trigger_status) <= 1:
+            conn.trigger_status = ["Ready", "Stop"]
+        return True
+    elif match := re.match(r"C(\d+):TRLV\s+(.+)", command, re.IGNORECASE):
+        channel = int(match.group(1))
+        conn.trigger_level[channel] = float(match.group(2))
+        return True
+
+    return False
+
+
+def handle_query(conn, command: str) -> Optional[str]:
+    """Handle a Siglent-dialect (legacy or modern) scope query. Returns None if unmatched."""
+    upper = command.upper()
+
+    if conn.scope_dialect == "modern":
+        if upper == ":TRIGGER:STATUS?":  # enum Arm|Ready|Auto|Trig'd|Stop|Roll, p.483
+            if len(conn.trigger_status) > 1:
+                return conn.trigger_status.pop(0)
+            return conn.trigger_status[0]
+        if upper == ":TRIGGER:MODE?":  # mixed-case wire token, e.g. "NORMal", p.482
+            return conn.trigger_mode
+        if upper == ":TRIGGER:TYPE?":
+            return conn.trigger_type
+        if upper == ":TRIGGER:EDGE:SOURCE?":  # bare token, p.495
+            return conn.trigger_source
+        if upper == ":TRIGGER:EDGE:SLOPE?":  # wire token e.g. "RISing", p.494
+            return conn.trigger_slope
+        if upper == ":TRIGGER:EDGE:COUPLING?":
+            return conn.trigger_coupling
+        if upper == ":TRIGGER:EDGE:LEVEL?":  # bare NR3, p.492
+            return _format_nr3(conn.trigger_level.get(1, 0.0))
+        if match := re.match(r":CHANNEL(\d+):SWITCH\?", upper):
+            return "ON" if conn._channel_enabled.get(int(match.group(1)), True) else "OFF"
+        if match := re.match(r":CHANNEL(\d+):SCALE\?", upper):  # bare NR3, p.58
+            return _format_nr3(conn._voltage_scales.get(int(match.group(1)), 1.0))
+        if match := re.match(r":CHANNEL(\d+):OFFSET\?", upper):  # bare NR3, p.56
+            return _format_nr3(conn._voltage_offsets.get(int(match.group(1)), 0.0))
+        if match := re.match(r":CHANNEL(\d+):COUPLING\?", upper):  # DC|AC|GND, p.51
+            return conn._channel_coupling.get(int(match.group(1)), "DC")
+        if upper == ":TIMEBASE:SCALE?":  # bare NR3, p.476
+            return _format_nr3(conn.timebase)
+        if upper == ":ACQUIRE:SRATE?":  # bare NR3, p.46
+            return _format_nr3(conn.sample_rate)
+
+    if conn.scope_dialect == "legacy":
+        if match := re.match(r"C(\d+):VDIV\?", command, re.IGNORECASE):
+            channel = int(match.group(1))
+            value = conn._voltage_scales.get(channel, 1.0)
+            return _format_scientific(value, "V")
+
+        if match := re.match(r"C(\d+):OFST\?", command, re.IGNORECASE):
+            channel = int(match.group(1))
+            value = conn._voltage_offsets.get(channel, 0.0)
+            return _format_scientific(value, "V")
+
+        if match := re.match(r"C(\d+):TRA\?", command, re.IGNORECASE):
+            channel = int(match.group(1))
+            return "ON" if conn._channel_enabled.get(channel, True) else "OFF"
+
+        if match := re.match(r"C(\d+):CPL\?", command, re.IGNORECASE):
+            return conn._channel_coupling.get(int(match.group(1)), "D1M")
+
+        if match := re.match(r"C(\d+):TRLV\?", command, re.IGNORECASE):
+            channel = int(match.group(1))
+            return _format_scientific(conn.trigger_level.get(channel, 0.0), "V")
+
+        if re.match(r"C(\d+):TRSL\?", command, re.IGNORECASE):
+            return conn.trigger_slope
+
+        if re.match(r"C(\d+):TRCP\?", command, re.IGNORECASE):
+            return conn.trigger_coupling
+
+        if upper == "TDIV?":
+            return _format_scientific(conn.timebase, "S")
+
+        if upper == "SARA?":
+            return _format_scientific(conn.sample_rate, "Sa/s")
+
+        if upper == "SAST?":
+            if len(conn.trigger_status) > 1:
+                return conn.trigger_status.pop(0)
+            return conn.trigger_status[0]
+
+        if upper == "TRIG_MODE?":
+            return conn.trigger_mode
+
+        if upper == "TRIG_SELECT?":
+            return f"{conn.trigger_type},SR,{conn.trigger_source}"
+
+        if match := re.match(r"PAVA\?\s*(\w+)\s*,\s*C?(\d+)", command, re.IGNORECASE):
+            mtype = match.group(1).upper()
+            channel = match.group(2)
+            entry = _MOCK_PAVA_VALUES.get(mtype)
+            if entry is not None:
+                value, unit = entry
+                return f"PAVA {mtype},C{channel},{value}{unit}"
+
+    return None
+
+
+def build_waveform_response(conn) -> bytes:
+    """Construct a minimal Siglent-style waveform block response."""
+    channel = conn._last_waveform_channel or next(iter(conn._waveform_payloads.keys()))
+    payload = conn._waveform_payloads.get(channel, bytes())
+    return b"DESC," + _build_ieee_block(payload)

--- a/scpi_control/connection/mock/tektronix.py
+++ b/scpi_control/connection/mock/tektronix.py
@@ -12,10 +12,23 @@ from scpi_control.connection.mock.helpers import _build_ieee_block, _format_nr3
 # Immediate-measurement values mirror _MOCK_PAVA_VALUES semantically (same
 # synthetic 1 kHz, 2 Vpp signal) but keyed by Tek IMMed type names.
 _MOCK_IMMED_VALUES = {
-    "PK2PK": "2.0E0", "MAXIMUM": "1.0E0", "MINIMUM": "-1.0E0", "AMPLITUDE": "2.0E0",
-    "HIGH": "1.0E0", "LOW": "-1.0E0", "CMEAN": "0.0E0", "MEAN": "0.0E0",
-    "RMS": "7.07E-1", "CRMS": "7.07E-1", "FREQUENCY": "1.0E3", "PERIOD": "1.0E-3",
-    "RISE": "3.5E-5", "FALL": "3.5E-5", "PWIDTH": "5.0E-4", "NWIDTH": "5.0E-4", "PDUTY": "5.0E1",
+    "PK2PK": "2.0E0",
+    "MAXIMUM": "1.0E0",
+    "MINIMUM": "-1.0E0",
+    "AMPLITUDE": "2.0E0",
+    "HIGH": "1.0E0",
+    "LOW": "-1.0E0",
+    "CMEAN": "0.0E0",
+    "MEAN": "0.0E0",
+    "RMS": "7.07E-1",
+    "CRMS": "7.07E-1",
+    "FREQUENCY": "1.0E3",
+    "PERIOD": "1.0E-3",
+    "RISE": "3.5E-5",
+    "FALL": "3.5E-5",
+    "PWIDTH": "5.0E-4",
+    "NWIDTH": "5.0E-4",
+    "PDUTY": "5.0E1",
 }
 
 

--- a/scpi_control/connection/mock/tektronix.py
+++ b/scpi_control/connection/mock/tektronix.py
@@ -1,0 +1,170 @@
+"""Tektronix mock personality: TBS1000C / MSO 2-Series wire language.
+
+Command spellings mirror the TEKTRONIX_COMMANDS table (scpi_commands.py);
+responses use HEADer OFF format (bare values), matching CONNECT_SETUP.
+"""
+
+import re
+from typing import Optional
+
+from scpi_control.connection.mock.helpers import _build_ieee_block, _format_nr3
+
+# Immediate-measurement values mirror _MOCK_PAVA_VALUES semantically (same
+# synthetic 1 kHz, 2 Vpp signal) but keyed by Tek IMMed type names.
+_MOCK_IMMED_VALUES = {
+    "PK2PK": "2.0E0", "MAXIMUM": "1.0E0", "MINIMUM": "-1.0E0", "AMPLITUDE": "2.0E0",
+    "HIGH": "1.0E0", "LOW": "-1.0E0", "CMEAN": "0.0E0", "MEAN": "0.0E0",
+    "RMS": "7.07E-1", "CRMS": "7.07E-1", "FREQUENCY": "1.0E3", "PERIOD": "1.0E-3",
+    "RISE": "3.5E-5", "FALL": "3.5E-5", "PWIDTH": "5.0E-4", "NWIDTH": "5.0E-4", "PDUTY": "5.0E1",
+}
+
+
+def handle_write(conn, command: str) -> bool:
+    upper = command.upper()
+
+    if upper in ("HEADER OFF", "HEADER ON"):
+        return True
+    if match := re.match(r"(?:SELECT:CH|DISPLAY:GLOBAL:CH)(\d+)(?::STATE)?\s+(ON|OFF|1|0)", upper):
+        conn._channel_enabled[int(match.group(1))] = match.group(2) in ("ON", "1")
+        return True
+    if match := re.match(r"CH(\d+):SCALE\s+(.+)", upper):
+        ch = int(match.group(1))
+        conn._voltage_scales[ch] = float(match.group(2))
+        conn.scale_updates.setdefault(ch, []).append(float(match.group(2)))
+        return True
+    if match := re.match(r"CH(\d+):OFFSET\s+(.+)", upper):
+        conn._voltage_offsets[int(match.group(1))] = float(match.group(2))
+        return True
+    if match := re.match(r"CH(\d+):COUPLING\s+(\w+)", upper):
+        conn._channel_coupling[int(match.group(1))] = match.group(2)
+        return True
+    if match := re.match(r"CH(\d+):PROBE:GAIN\s+(.+)", upper):
+        conn.probe_gains[int(match.group(1))] = float(match.group(2))
+        return True
+    if match := re.match(r"CH(\d+):PROBEFUNC:EXTATTEN\s+(.+)", upper):
+        # tek_mso spelling for the same probe-gain state (tek_tbs uses PRObe:GAIN above).
+        conn.probe_gains[int(match.group(1))] = float(match.group(2))
+        return True
+    if match := re.match(r"CH(\d+):BANDWIDTH\s+(\w+)", upper):
+        return True  # accepted, not modeled
+    if match := re.match(r"HORIZONTAL:SCALE\s+(.+)", upper):
+        conn.timebase = float(match.group(1))
+        conn.timebase_updates.append(conn.timebase)
+        return True
+    if re.match(r"HORIZONTAL:DELAY:TIME\s+", upper):
+        return True
+    if match := re.match(r"TRIGGER:A:MODE\s+(\w+)", upper):
+        conn.trigger_mode = match.group(1)
+        return True
+    if match := re.match(r"ACQUIRE:STOPAFTER\s+(\w+)", upper):
+        conn.tek_stop_after = match.group(1)
+        return True
+    if re.match(r"ACQUIRE:STATE\s+(RUN|ON|1)", upper):
+        if conn.tek_stop_after == "SEQUENCE" and len(conn.trigger_status) <= 1:
+            # Single-shot: Ready while armed, Save when done (Tek vocabulary)
+            conn.trigger_status = ["READY", "SAVE"]
+        return True
+    if re.match(r"ACQUIRE:STATE\s+(STOP|OFF|0)", upper):
+        if len(conn.trigger_status) <= 1:
+            conn.trigger_status = ["SAVE"]
+        return True
+    if re.match(r"TRIGGER\s+FORCE", upper):
+        return True
+    if match := re.match(r"TRIGGER:A:TYPE\s+(\w+)", upper):
+        conn.trigger_type = match.group(1)
+        return True
+    if match := re.match(r"TRIGGER:A:EDGE:SOURCE\s+(\w+)", upper):
+        conn.trigger_source = match.group(1)
+        return True
+    if match := re.match(r"TRIGGER:A:LEVEL:CH(\d+)\s+(.+)", upper):
+        conn.trigger_level[int(match.group(1))] = float(match.group(2))
+        return True
+    if match := re.match(r"TRIGGER:A:EDGE:SLOPE\s+(\w+)", upper):
+        conn.trigger_slope = match.group(1)
+        return True
+    if match := re.match(r"TRIGGER:A:EDGE:COUPLING\s+(\w+)", upper):
+        conn.trigger_coupling = match.group(1)
+        return True
+    if match := re.match(r"TRIGGER:A:HOLDOFF:TIME\s+(.+)", upper):
+        conn.holdoff_time = float(match.group(1))
+        return True
+    if re.match(r"AUTOSET\s+EXECUTE", upper):
+        return True
+    if match := re.match(r"DATA:SOURCE\s+CH(\d+)", upper):
+        conn.data_source = int(match.group(1))
+        conn._last_waveform_channel = conn.data_source
+        return True
+    if re.match(r"DATA:(ENCDG|WIDTH|START|STOP)\s+", upper):
+        return True
+    if upper == "CURVE?":
+        conn.waveform_requests.append(conn.data_source)
+        return True
+    if re.match(r"MEASUREMENT:IMMED:(TYPE|SOURCE1)\s+", upper):
+        if match := re.match(r"MEASUREMENT:IMMED:TYPE\s+(\w+)", upper):
+            conn.meas_immed_type = match.group(1)
+        return True
+    return False
+
+
+def handle_query(conn, command: str) -> Optional[str]:
+    upper = command.strip().upper()
+
+    if match := re.match(r"(?:SELECT:CH|DISPLAY:GLOBAL:CH)(\d+)(?::STATE)?\?", upper):
+        return "1" if conn._channel_enabled.get(int(match.group(1)), True) else "0"
+    if match := re.match(r"CH(\d+):SCALE\?", upper):
+        return _format_nr3(conn._voltage_scales.get(int(match.group(1)), 1.0))
+    if match := re.match(r"CH(\d+):OFFSET\?", upper):
+        return _format_nr3(conn._voltage_offsets.get(int(match.group(1)), 0.0))
+    if match := re.match(r"CH(\d+):COUPLING\?", upper):
+        return conn._channel_coupling.get(int(match.group(1)), "DC")
+    if match := re.match(r"CH(\d+):PROBE:GAIN\?", upper):
+        return _format_nr3(conn.probe_gains.get(int(match.group(1)), 0.1))
+    if match := re.match(r"CH(\d+):PROBEFUNC:EXTATTEN\?", upper):
+        return _format_nr3(conn.probe_gains.get(int(match.group(1)), 0.1))
+    if re.match(r"CH(\d+):BANDWIDTH\?", upper):
+        return "FULL"
+    if upper == "HORIZONTAL:SCALE?":
+        return _format_nr3(conn.timebase)
+    if upper == "HORIZONTAL:SAMPLERATE?":
+        return _format_nr3(conn.sample_rate)
+    if upper == "TRIGGER:STATE?":
+        if len(conn.trigger_status) > 1:
+            return conn.trigger_status.pop(0).upper()
+        return conn.trigger_status[0].upper()
+    if upper == "TRIGGER:A:MODE?":
+        return conn.trigger_mode.upper()
+    if upper == "TRIGGER:A:TYPE?":
+        return conn.trigger_type.upper()
+    if upper == "TRIGGER:A:EDGE:SOURCE?":
+        return conn.trigger_source
+    if match := re.match(r"TRIGGER:A:LEVEL:CH(\d+)\?", upper):
+        return _format_nr3(conn.trigger_level.get(int(match.group(1)), 0.0))
+    if upper == "TRIGGER:A:EDGE:SLOPE?":
+        return conn.trigger_slope.upper()
+    if upper == "TRIGGER:A:EDGE:COUPLING?":
+        return conn.trigger_coupling.upper()
+    if upper == "TRIGGER:A:HOLDOFF:TIME?":
+        return _format_nr3(conn.holdoff_time)
+    if upper == "WFMOUTPRE:NR_PT?":
+        return str(len(conn._waveform_payloads.get(conn.data_source, b"")))
+    if upper == "WFMOUTPRE:XINCR?":
+        return _format_nr3(1.0 / conn.sample_rate)
+    if upper == "WFMOUTPRE:XZERO?":
+        return "0.0E0"
+    if upper == "WFMOUTPRE:PT_OFF?":
+        return "0"
+    if upper == "WFMOUTPRE:YMULT?":
+        # Mirror the Siglent 25-codes-per-division scale so end-to-end volts match
+        return _format_nr3(conn._voltage_scales.get(conn.data_source, 1.0) / 25.0)
+    if upper == "WFMOUTPRE:YZERO?":
+        return "0.0E0"
+    if upper == "WFMOUTPRE:YOFF?":
+        return "0.0E0"
+    if upper == "MEASUREMENT:IMMED:VALUE?":
+        return _MOCK_IMMED_VALUES.get(getattr(conn, "meas_immed_type", ""), "0.0E0")
+    return None
+
+
+def build_waveform_response(conn) -> bytes:
+    payload = conn._waveform_payloads.get(conn.data_source, bytes())
+    return _build_ieee_block(payload)  # CURVe? responses are a bare IEEE block

--- a/scpi_control/exceptions.py
+++ b/scpi_control/exceptions.py
@@ -31,6 +31,12 @@ class InvalidParameterError(SiglentError):
     pass
 
 
+class FeatureNotSupportedError(SiglentError):
+    """Raised when an operation is not supported by the connected instrument's dialect."""
+
+    pass
+
+
 # Backward compatibility aliases (deprecated in 0.3.0)
 # These will be removed in a future version
 ConnectionError = SiglentConnectionError

--- a/scpi_control/measurement.py
+++ b/scpi_control/measurement.py
@@ -78,7 +78,7 @@ class Measurement:
         if self._dialect == "tektronix":
             if not self._scope._has_command("set_meas_immed_type"):
                 raise exceptions.FeatureNotSupportedError(
-                    f"measure({mtype!r}) is not supported: this Tektronix family lacks the "
+                    f"measure({mtype!r}) is not supported: this Tektronix family/configuration lacks the "
                     "MEASUrement:IMMed subsystem (badge-based measurements are a follow-up)"
                 )
             # Immediate measurement: configure type+source, then read the value

--- a/scpi_control/measurement.py
+++ b/scpi_control/measurement.py
@@ -93,6 +93,16 @@ class Measurement:
         # Query parameter value
         response = self._scope.query(self._scope._get_command("get_parameter_value", ch=channel, param=wire_type))
 
+        if self._dialect == "lecroy":
+            # LeCroy's PAVA? answers its own native shape "<param>,<value>,
+            # <state>" (3 fields; CHDR OFF strips the unit suffix) -- MAUI
+            # remote manual p.7-70. Value is the 2nd field (parts[1]).
+            try:
+                parts = response.split(",")
+                return float(parts[1].strip())
+            except (ValueError, IndexError) as e:
+                raise exceptions.CommandError(f"Failed to parse measurement: {e}")
+
         # Parse response (format typically: "PAVA PKPK,C1,1.23V")
         try:
             # Extract value from response

--- a/scpi_control/measurement.py
+++ b/scpi_control/measurement.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional
 
 from scpi_control import exceptions
+from scpi_control.scpi_commands import measurement_to_wire
 
 if TYPE_CHECKING:
     from scpi_control.oscilloscope import Oscilloscope
@@ -46,6 +47,15 @@ class Measurement:
         """
         self._scope = oscilloscope
 
+    @property
+    def _dialect(self) -> str:
+        """Wire dialect of the parent scope; defaults to legacy before connect."""
+        return getattr(self._scope, "dialect", None) or "legacy"
+
+    def _require(self, command_name: str) -> None:
+        if not self._scope._has_command(command_name):
+            raise exceptions.FeatureNotSupportedError(f"{command_name} is not supported on the {self._dialect} dialect")
+
     def measure(self, mtype: MeasurementType, channel: int) -> float:
         """Perform a measurement on a channel.
 
@@ -63,10 +73,10 @@ class Measurement:
             raise exceptions.InvalidParameterError(f"Invalid channel number: {channel}. Must be 1-4.")
 
         mtype = mtype.upper()
-        ch = f"C{channel}"
+        wire_type = measurement_to_wire(self._dialect, mtype)
 
         # Query parameter value
-        response = self._scope.query(f"PAVA? {mtype},{ch}")
+        response = self._scope.query(self._scope._get_command("get_parameter_value", ch=channel, param=wire_type))
 
         # Parse response (format typically: "PAVA PKPK,C1,1.23V")
         try:
@@ -275,35 +285,41 @@ class Measurement:
         if not 1 <= channel <= 4:
             raise exceptions.InvalidParameterError(f"Invalid channel number: {channel}. Must be 1-4.")
 
+        self._require("add_measurement")
+        wire_type = measurement_to_wire(self._dialect, mtype.upper())
         ch = f"C{channel}"
-        stat_flag = "ON" if stat else "OFF"
 
         # Add measurement (command format may vary by model)
-        self._scope.write(f"PACU {mtype},{ch}")
+        self._scope.write(self._scope._get_command("add_measurement", mtype=wire_type, ch=channel))
 
         if stat:
-            self._scope.write(f"PAST {stat_flag}")
+            self._require("set_statistics")
+            self._scope.write(self._scope._get_command("set_statistics", state="ON"))
 
         logger.info(f"Added measurement {mtype} for {ch}")
 
     def clear_measurements(self) -> None:
         """Clear all measurements from the measurement table."""
-        self._scope.write("PACL")
+        self._require("clear_measurements")
+        self._scope.write(self._scope._get_command("clear_measurements"))
         logger.info("Cleared all measurements")
 
     def enable_statistics(self) -> None:
         """Enable measurement statistics."""
-        self._scope.write("PAST ON")
+        self._require("set_statistics")
+        self._scope.write(self._scope._get_command("set_statistics", state="ON"))
         logger.info("Measurement statistics enabled")
 
     def disable_statistics(self) -> None:
         """Disable measurement statistics."""
-        self._scope.write("PAST OFF")
+        self._require("set_statistics")
+        self._scope.write(self._scope._get_command("set_statistics", state="OFF"))
         logger.info("Measurement statistics disabled")
 
     def reset_statistics(self) -> None:
         """Reset measurement statistics."""
-        self._scope.write("PASTAT RESET")
+        self._require("reset_statistics")
+        self._scope.write(self._scope._get_command("reset_statistics"))
         logger.info("Measurement statistics reset")
 
     def set_cursor_type(self, cursor_type: str) -> None:
@@ -322,7 +338,8 @@ class Measurement:
         if cursor_type not in valid_types:
             raise exceptions.InvalidParameterError(f"Invalid cursor type: {cursor_type}. Must be one of {valid_types}.")
 
-        self._scope.write(f"CRST {cursor_type}")
+        self._require("set_cursor_type")
+        self._scope.write(self._scope._get_command("set_cursor_type", type=cursor_type))
         logger.info(f"Cursor type set to {cursor_type}")
 
     def get_cursor_value(self) -> Dict[str, Any]:
@@ -331,7 +348,8 @@ class Measurement:
         Returns:
             Dictionary with cursor measurements
         """
-        response = self._scope.query("CRVA?")
+        self._require("get_cursor_value")
+        response = self._scope.query(self._scope._get_command("get_cursor_value"))
 
         # Parse cursor values
         # Response format varies by cursor type

--- a/scpi_control/measurement.py
+++ b/scpi_control/measurement.py
@@ -78,8 +78,7 @@ class Measurement:
         if self._dialect == "tektronix":
             if not self._scope._has_command("set_meas_immed_type"):
                 raise exceptions.FeatureNotSupportedError(
-                    f"measure({mtype!r}) is not supported: this Tektronix family/configuration lacks the "
-                    "MEASUrement:IMMed subsystem (badge-based measurements are a follow-up)"
+                    f"measure({mtype!r}) is not supported: this Tektronix family/configuration lacks the " "MEASUrement:IMMed subsystem (badge-based measurements are a follow-up)"
                 )
             # Immediate measurement: configure type+source, then read the value
             self._scope.write(self._scope._get_command("set_meas_immed_type", type=wire_type))

--- a/scpi_control/measurement.py
+++ b/scpi_control/measurement.py
@@ -75,6 +75,21 @@ class Measurement:
         mtype = mtype.upper()
         wire_type = measurement_to_wire(self._dialect, mtype)
 
+        if self._dialect == "tektronix":
+            if not self._scope._has_command("set_meas_immed_type"):
+                raise exceptions.FeatureNotSupportedError(
+                    f"measure({mtype!r}) is not supported: this Tektronix family lacks the "
+                    "MEASUrement:IMMed subsystem (badge-based measurements are a follow-up)"
+                )
+            # Immediate measurement: configure type+source, then read the value
+            self._scope.write(self._scope._get_command("set_meas_immed_type", type=wire_type))
+            self._scope.write(self._scope._get_command("set_meas_immed_source", ch=channel))
+            response = self._scope.query(self._scope._get_command("get_meas_immed_value"))
+            try:
+                return float(response.strip())
+            except ValueError as e:
+                raise exceptions.CommandError(f"Failed to parse measurement: {e}")
+
         # Query parameter value
         response = self._scope.query(self._scope._get_command("get_parameter_value", ch=channel, param=wire_type))
 

--- a/scpi_control/models.py
+++ b/scpi_control/models.py
@@ -27,7 +27,10 @@ class ModelCapability:
     has_protocol_decode: bool  # Supports protocol decode
     supported_decode_types: List[str]  # Supported protocol types (I2C, SPI, UART, CAN, etc.)
     scpi_variant: str  # SCPI command variant ("standard", "hd_series", "x_series", "plus_series")
-    dialect: str = "legacy"  # Wire dialect: "legacy" (TRIG_SELECT/TDIV era) or "modern" (colon-form :TRIGger/:TIMebase)
+    dialect: str = "legacy"  # Wire dialect: "legacy", "modern", "tektronix", or "lecroy"
+    vendor: str = "siglent"  # Instrument vendor: "siglent", "tektronix", or "lecroy"
+    horiz_divisions: int = 14  # Screen grid width in divisions (Siglent scopes use 14)
+    vert_divisions: int = 8  # Screen grid height in divisions
 
     def __str__(self) -> str:
         """String representation of model capability."""
@@ -194,11 +197,145 @@ MODEL_REGISTRY = {
         scpi_variant="x_series",
         dialect="modern",
     ),
+    # Tektronix TBS1000C Series (datasheet: 2 ch, 1 GSa/s, 20 kpts, 15x8 grid)
+    "TBS1102C": ModelCapability(
+        model_name="TBS1102C",
+        series="TBS1000C",
+        num_channels=2,
+        max_sample_rate=1.0,
+        memory_depth=20_000,
+        bandwidth_mhz=100,
+        has_math_channels=True,
+        has_fft=True,
+        has_protocol_decode=False,
+        supported_decode_types=[],
+        scpi_variant="tek_tbs",
+        dialect="tektronix",
+        vendor="tektronix",
+        horiz_divisions=15,
+        vert_divisions=8,
+    ),
+    # Tektronix 2 Series MSO (datasheet: 4 ch, 2.5 GSa/s, 10 Mpts, 10x10 grid)
+    "MSO24": ModelCapability(
+        model_name="MSO24",
+        series="MSO2",
+        num_channels=4,
+        max_sample_rate=2.5,
+        memory_depth=10_000_000,
+        bandwidth_mhz=200,
+        has_math_channels=True,
+        has_fft=True,
+        has_protocol_decode=False,
+        supported_decode_types=[],
+        scpi_variant="tek_mso",
+        dialect="tektronix",
+        vendor="tektronix",
+        horiz_divisions=10,
+        vert_divisions=10,
+    ),
+    # LeCroy WaveSurfer 3000z (datasheet: 4 ch, 4 GSa/s, 10 Mpts, 10x8 grid)
+    "WaveSurfer 3024z": ModelCapability(
+        model_name="WaveSurfer 3024z",
+        series="WaveSurfer3000z",
+        num_channels=4,
+        max_sample_rate=4.0,
+        memory_depth=10_000_000,
+        bandwidth_mhz=200,
+        has_math_channels=True,
+        has_fft=True,
+        has_protocol_decode=False,
+        supported_decode_types=[],
+        scpi_variant="lecroy_maui",
+        dialect="lecroy",
+        vendor="lecroy",
+        horiz_divisions=10,
+        vert_divisions=8,
+    ),
+    # LeCroy WaveRunner 8000 (datasheet: 4 ch, 10 GSa/s, 16 Mpts, 10x8 grid)
+    "WaveRunner 8104": ModelCapability(
+        model_name="WaveRunner 8104",
+        series="WaveRunner8000",
+        num_channels=4,
+        max_sample_rate=10.0,
+        memory_depth=16_000_000,
+        bandwidth_mhz=1000,
+        has_math_channels=True,
+        has_fft=True,
+        has_protocol_decode=False,
+        supported_decode_types=[],
+        scpi_variant="lecroy_maui",
+        dialect="lecroy",
+        vendor="lecroy",
+        horiz_divisions=10,
+        vert_divisions=8,
+    ),
 }
+
+
+def _match_registry(model_from_idn: str, vendor: Optional[str] = None) -> Optional[ModelCapability]:
+    """Exact -> fuzzy -> partial registry match, optionally filtered by vendor."""
+    candidates = {name: cap for name, cap in MODEL_REGISTRY.items() if vendor is None or cap.vendor == vendor}
+
+    if model_from_idn in candidates:
+        logger.info(f"Exact match found: {model_from_idn}")
+        return candidates[model_from_idn]
+
+    normalized_model = re.sub(r"[\s\-_]", "", model_from_idn).upper()
+    for registered_model, capability in candidates.items():
+        if re.sub(r"[\s\-_]", "", registered_model).upper() == normalized_model:
+            logger.info(f"Fuzzy match found: {model_from_idn} -> {registered_model}")
+            return capability
+
+    for registered_model, capability in candidates.items():
+        if registered_model.replace(" ", "").upper() in model_from_idn.replace(" ", "").upper():
+            logger.info(f"Partial match found: {model_from_idn} -> {registered_model}")
+            return capability
+
+    return None
+
+
+def _generic_vendor_capability(model_from_idn: str, vendor: str) -> ModelCapability:
+    """Conservative fallback for an unrecognized model of a known vendor."""
+    upper = model_from_idn.upper()
+    if vendor == "tektronix":
+        # TBS1000-pattern models are 2-channel; everything else defaults to 4
+        num_channels = 2 if re.match(r"TBS1\d", upper) else 4
+        scpi_variant = "tek_tbs" if upper.startswith("TBS") else "tek_mso"
+        dialect = "tektronix"
+        horiz, vert = (15, 8) if upper.startswith("TBS1") else (10, 10)
+    else:  # lecroy
+        num_channels = 4
+        scpi_variant = "lecroy_maui"
+        dialect = "lecroy"
+        horiz, vert = 10, 8
+
+    logger.warning(f"Model '{model_from_idn}' not in registry, using generic {vendor} fallback")
+    return ModelCapability(
+        model_name=model_from_idn,
+        series="Unknown",
+        num_channels=num_channels,
+        max_sample_rate=1.0,
+        memory_depth=10_000_000,
+        bandwidth_mhz=100,
+        has_math_channels=True,
+        has_fft=True,
+        has_protocol_decode=False,
+        supported_decode_types=[],
+        scpi_variant=scpi_variant,
+        dialect=dialect,
+        vendor=vendor,
+        horiz_divisions=horiz,
+        vert_divisions=vert,
+    )
 
 
 def detect_model_from_idn(idn_string: str) -> ModelCapability:
     """Detect oscilloscope model and return its capability profile.
+
+    Routes on the manufacturer field: Tektronix and LeCroy IDNs are matched
+    against their vendor-scoped registry entries (falling back to a generic
+    vendor capability), while every other manufacturer takes the historical
+    Siglent detection path unchanged.
 
     Args:
         idn_string: The response from *IDN? command
@@ -211,36 +348,33 @@ def detect_model_from_idn(idn_string: str) -> ModelCapability:
     Raises:
         ValueError: If model cannot be detected from IDN string
     """
-    # Parse the model name from IDN string
+    # Parse the manufacturer and model name from IDN string
     parts = idn_string.split(",")
     if len(parts) < 2:
         raise ValueError(f"Invalid *IDN? response format: {idn_string}")
 
+    manufacturer = parts[0].strip().upper()
     model_from_idn = parts[1].strip()
-    logger.info(f"Detecting model from IDN: {model_from_idn}")
+    logger.info(f"Detecting model from IDN: {manufacturer} / {model_from_idn}")
 
-    # Try exact match first
-    if model_from_idn in MODEL_REGISTRY:
-        logger.info(f"Exact match found: {model_from_idn}")
-        return MODEL_REGISTRY[model_from_idn]
+    if "TEKTRONIX" in manufacturer:
+        return _match_registry(model_from_idn, "tektronix") or _generic_vendor_capability(model_from_idn, "tektronix")
+    if "LECROY" in manufacturer:  # covers both "LECROY" and "TELEDYNE LECROY"
+        return _match_registry(model_from_idn, "lecroy") or _generic_vendor_capability(model_from_idn, "lecroy")
 
-    # Try fuzzy matching - handle variations in model name format
-    # Remove spaces, dashes, underscores for comparison
-    normalized_model = re.sub(r"[\s\-_]", "", model_from_idn).upper()
+    # Everything else takes the historical Siglent path, byte-for-byte
+    matched = _match_registry(model_from_idn)
+    if matched is not None:
+        return matched
+    return _detect_siglent(model_from_idn)
 
-    for registered_model, capability in MODEL_REGISTRY.items():
-        normalized_registered = re.sub(r"[\s\-_]", "", registered_model).upper()
-        if normalized_model == normalized_registered:
-            logger.info(f"Fuzzy match found: {model_from_idn} -> {registered_model}")
-            return capability
 
-    # Try partial matching - check if registry key is contained in model name
-    for registered_model, capability in MODEL_REGISTRY.items():
-        # Remove spaces from both for comparison
-        if registered_model.replace(" ", "").upper() in model_from_idn.replace(" ", "").upper():
-            logger.info(f"Partial match found: {model_from_idn} -> {registered_model}")
-            return capability
+def _detect_siglent(model_from_idn: str) -> ModelCapability:
+    """Generic Siglent fallback when no registry match is found.
 
+    Historical behavior, unchanged: infer series/channel count/dialect from
+    the model name pattern when the model isn't in the registry.
+    """
     # Model not found - create a generic fallback capability
     logger.warning(f"Model '{model_from_idn}' not in registry, using generic fallback")
 

--- a/scpi_control/oscilloscope.py
+++ b/scpi_control/oscilloscope.py
@@ -14,7 +14,7 @@ from scpi_control.connection import BaseConnection, SocketConnection
 from scpi_control.math_channel import MathChannel
 from scpi_control.measurement import Measurement
 from scpi_control.models import ModelCapability, detect_model_from_idn
-from scpi_control.scpi_commands import SCPICommandSet, normalize_status
+from scpi_control.scpi_commands import CONNECT_SETUP, SUPPORTED_DIALECTS, SCPICommandSet, normalize_status
 from scpi_control.screen_capture import ScreenCapture
 from scpi_control.trigger import Trigger
 from scpi_control.waveform import Waveform, WaveformData
@@ -72,8 +72,8 @@ class Oscilloscope:
         self.port = port
         self.timeout = timeout
 
-        if dialect not in (None, "legacy", "modern"):
-            raise exceptions.InvalidParameterError(f"Invalid dialect: {dialect}. Must be 'legacy', 'modern', or None for auto-detect.")
+        if dialect is not None and dialect not in SUPPORTED_DIALECTS:
+            raise exceptions.InvalidParameterError(f"Invalid dialect: {dialect}. Must be one of {SUPPORTED_DIALECTS} or None for auto-detect.")
         self._dialect_override = dialect
         self.dialect: Optional[str] = None
 
@@ -171,10 +171,9 @@ class Oscilloscope:
             self._scpi_commands = SCPICommandSet(self.dialect, self.model_capability.scpi_variant)
             logger.info(f"Using SCPI dialect: {self.dialect} (variant: {self.model_capability.scpi_variant})")
 
-            # Legacy scopes echo command headers by default; turn that off so
-            # every response arrives as a bare value
-            if self.dialect == "legacy":
-                self.write("CHDR OFF")
+            # Per-dialect connect-time setup (e.g. response-header suppression)
+            for setup_command in CONNECT_SETUP.get(self.dialect, []):
+                self.write(setup_command)
 
             # Create channels dynamically based on model capability
             self._create_channels()

--- a/scpi_control/oscilloscope.py
+++ b/scpi_control/oscilloscope.py
@@ -331,6 +331,16 @@ class Oscilloscope:
         Returns:
             One of 'ARM', 'READY', 'AUTO', 'TRIGD', 'STOP', 'ROLL'.
         """
+        if self.dialect == "lecroy":
+            # LeCroy has no SAST-style status query. TRIG_MODE? exposes STOP;
+            # INR? bit 0 reports "new signal acquired" (MAUI remote manual).
+            mode = self.query(self._get_command("get_trigger_mode")).strip().upper()
+            if mode.endswith("STOP"):
+                return "STOP"
+            inr = int(self.query(self._get_command("get_acq_status")).strip().split()[-1])
+            if inr & 1:
+                return "TRIGD"
+            return "AUTO" if mode.endswith("AUTO") else "READY"
         return normalize_status(self.query(self._get_command("get_acq_status")))
 
     @property

--- a/scpi_control/oscilloscope.py
+++ b/scpi_control/oscilloscope.py
@@ -300,7 +300,10 @@ class Oscilloscope:
 
     def trigger_single(self) -> None:
         """Arm a one-shot (single) acquisition."""
-        if self.dialect == "modern":
+        if self.dialect == "tektronix":
+            self.write(self._get_command("set_stop_after", mode="SEQuence"))
+            self.write(self._get_command("run"))
+        elif self.dialect == "modern":
             # SINGle self-arms on the modern dialect; there is no ARM command (guide p.482)
             self.write(self._get_command("set_trigger_mode", mode="SINGle"))
         else:
@@ -313,6 +316,9 @@ class Oscilloscope:
 
     def run(self) -> None:
         """Start acquisition."""
+        if self.dialect == "tektronix":
+            # A prior single-shot leaves STOPAfter latched to SEQuence
+            self.write(self._get_command("set_stop_after", mode="RUNSTop"))
         self.write(self._get_command("run"))
 
     def stop(self) -> None:

--- a/scpi_control/oscilloscope.py
+++ b/scpi_control/oscilloscope.py
@@ -472,6 +472,10 @@ class Oscilloscope:
 
         return self._scpi_commands.get_command(command_name, **kwargs)
 
+    def _has_command(self, command_name: str) -> bool:
+        """True if the active dialect/variant defines this command."""
+        return self._scpi_commands is not None and self._scpi_commands.has_command(command_name)
+
     def __enter__(self):
         """Context manager entry."""
         self.connect()

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -1,10 +1,13 @@
-"""SCPI command abstraction layer for different Siglent oscilloscope models.
+"""SCPI command abstraction layer for the supported oscilloscope dialects.
 
-Two wire dialects exist across Siglent scope generations:
+Wire dialects with a command table:
 - "legacy": the LeCroy-derived flat dialect (TRIG_SELECT, TDIV, C1:VDIV) spoken
-  by SDS1000X-E era scopes.
+  by Siglent SDS1000X-E era scopes.
 - "modern": colon-form SCPI (:TRIGger:EDGE:SOURce, :TIMebase:SCALe) documented
   in the SDS Series Programming Guide EN11G for HD/Plus/SDS5000X+ scopes.
+- "tektronix": Tek-style headerless SCPI (CH1:SCAle, HORizontal:SCAle) shared
+  by the TBS1000C and 2 Series MSO families, with family differences captured
+  in VARIANT_OVERRIDES ("tek_tbs" / "tek_mso").
 
 This module holds the per-dialect command tables and the enum conversions
 between the library's public vocabulary and each dialect's wire tokens.
@@ -14,7 +17,7 @@ import re
 from typing import Dict
 
 # Wire dialects with a command table. Grows as vendor tables land.
-SUPPORTED_DIALECTS = ("legacy", "modern")
+SUPPORTED_DIALECTS = ("legacy", "modern", "tektronix")
 
 # IEEE-488.2 mandated common commands, identical on every instrument.
 IEEE488_BASE = {
@@ -27,9 +30,12 @@ IEEE488_BASE = {
 # Commands written once right after connect-time dialect resolution.
 # legacy: response headers off (Siglent legacy echoes headers by default)
 # modern: nothing needed
+# tektronix: HEADer OFF so queries return bare values (no "CH1:SCALE " prefix)
+#            -- TBS1000C PM 077-1691-01 p.96 / 2 Series MSO PM 077-1776-07 p.2-340
 CONNECT_SETUP = {
     "legacy": ["CHDR OFF"],
     "modern": [],
+    "tektronix": ["HEADer OFF"],
 }
 
 
@@ -165,10 +171,87 @@ class SCPICommandSet:
         "hardcopy_print": "HCSU PRINT",
     }
 
-    # Dialect base tables, keyed by dialect name. Tek/LeCroy tables added later.
+    # Tektronix dialect, verified command-by-command against the TBS1000C
+    # Programmer Manual 077-1691-01 (current edition, supersedes 077-1430-xx;
+    # cited below as "TBS p.N") and the 2 Series MSO (MSO22/MSO24) Programmer
+    # Manual 077-1776-07 (cited as "MSO2 p.2-N"); both printed page numbers.
+    # Family differences live in VARIANT_OVERRIDES["tek_tbs"/"tek_mso"]:
+    # channel display, probe attenuation, PT_Off, and immediate measurements
+    # diverge between the families.
+    TEKTRONIX_COMMANDS = {
+        # Acquisition control
+        "set_trigger_mode": "TRIGger:A:MODe {mode}",  # AUTO|NORMal -- TBS p.155 / MSO2 p.2-684
+        "get_trigger_mode": "TRIGger:A:MODe?",  # TBS p.155 / MSO2 p.2-684
+        "force_trigger": "TRIGger FORCe",  # TBS p.149 / MSO2 p.2-626
+        "run": "ACQuire:STATE RUN",  # TBS p.42 / MSO2 p.2-78
+        "stop": "ACQuire:STATE STOP",  # TBS p.42 / MSO2 p.2-78
+        "set_stop_after": "ACQuire:STOPAfter {mode}",  # RUNSTop|SEQuence -- TBS p.43 / MSO2 p.2-80
+        "get_acq_status": "TRIGger:STATE?",  # ARMED|AUTO|READY|SAVE|TRIGGER -- TBS p.162 / MSO2 p.2-686
+        "auto_setup": "AUTOSet EXECute",  # TBS p.47 / MSO2 p.2-113
+        # Channel control
+        "set_channel_display": "SELect:CH{ch} {state}",  # ON|OFF|<NR1> -- TBS p.144 (MSO2: tek_mso override)
+        "get_channel_display": "SELect:CH{ch}?",  # returns 1|0 -- TBS p.144
+        "set_voltage_div": "CH{ch}:SCAle {vdiv}",  # TBS p.58 / MSO2 p.2-184
+        "get_voltage_div": "CH{ch}:SCAle?",  # TBS p.58 / MSO2 p.2-184
+        "set_voltage_offset": "CH{ch}:OFFSet {offset}",  # TBS p.55 / MSO2 p.2-191
+        "get_voltage_offset": "CH{ch}:OFFSet?",  # TBS p.55 / MSO2 p.2-191
+        # Coupling: TBS {AC|DC} only, MSO2 {AC|DC|DCREJect}; neither family
+        # has GND coupling -- TBS p.53 / MSO2 p.2-184
+        "set_coupling": "CH{ch}:COUPling {coupling}",
+        "get_coupling": "CH{ch}:COUPling?",  # TBS p.53 / MSO2 p.2-184
+        # Bandwidth: TBS {TWEnty|FULl|<NR3>} p.53; MSO2 {<NR3>|FULl} p.2-183
+        # (no TWEnty token on MSO2 -- send FULl or a hertz value for portability)
+        "set_bandwidth_limit": "CH{ch}:BANdwidth {limit}",
+        "get_bandwidth_limit": "CH{ch}:BANdwidth?",  # TBS p.53 / MSO2 p.2-183
+        # Timebase
+        "set_time_div": "HORizontal:SCAle {tdiv}",  # TBS p.104 / MSO2 p.2-349
+        "get_time_div": "HORizontal:SCAle?",  # TBS p.104 / MSO2 p.2-349
+        "set_time_offset": "HORizontal:DELay:TIMe {offset}",  # TBS p.103 / MSO2 p.2-343
+        "get_time_offset": "HORizontal:DELay:TIMe?",  # TBS p.103 / MSO2 p.2-343
+        "get_sample_rate": "HORizontal:SAMPLERate?",  # TBS p.104 (query only) / MSO2 p.2-348
+        # Edge trigger
+        "set_trigger_type": "TRIGger:A:TYPe {type}",  # TBS {EDGe|PULSe} p.161 / MSO2 {EDGE|WIDth|...} p.2-682
+        "get_trigger_type": "TRIGger:A:TYPe?",  # TBS p.161 / MSO2 p.2-682
+        "set_trigger_source": "TRIGger:A:EDGE:SOUrce {src}",  # TBS p.152 / MSO2 p.2-662
+        "get_trigger_source": "TRIGger:A:EDGE:SOUrce?",  # TBS p.152 / MSO2 p.2-662
+        "set_trigger_level": "TRIGger:A:LEVel:CH{ch} {level}",  # TBS p.154 / MSO2 p.2-663
+        "get_trigger_level": "TRIGger:A:LEVel:CH{ch}?",  # TBS p.154 / MSO2 p.2-663
+        "set_trigger_slope": "TRIGger:A:EDGE:SLOpe {slope}",  # TBS {RISe|FALL} p.151 / MSO2 adds EITher p.2-662
+        "get_trigger_slope": "TRIGger:A:EDGE:SLOpe?",  # TBS p.151 / MSO2 p.2-662
+        "set_trigger_coupling": "TRIGger:A:EDGE:COUPling {coupling}",  # DC|HFRej|LFRej|NOISErej -- TBS p.151 / MSO2 p.2-661
+        "get_trigger_coupling": "TRIGger:A:EDGE:COUPling?",  # TBS p.151 / MSO2 p.2-661
+        # Holdoff (TBS prints the keyword as HOLDOff, MSO2 as HOLDoff; the
+        # full spelling below is identical on both -- SCPI is case-insensitive)
+        "set_trigger_holdoff": "TRIGger:A:HOLDoff:TIMe {t}",  # TBS p.153 / MSO2 p.2-684
+        "get_trigger_holdoff": "TRIGger:A:HOLDoff:TIMe?",  # TBS p.153 / MSO2 p.2-684
+        # Waveform transfer (CURVe protocol)
+        "set_data_source": "DATa:SOUrce CH{ch}",  # TBS p.71 / MSO2 p.2-208
+        # DATa:ENCdg has no D-section entry in the TBS manual but is used by
+        # its own transfer procedure (p.38) and echoed by DATa? (p.70);
+        # RIBinary = signed int, MSB first on both families -- MSO2 p.2-205
+        "set_data_encoding": "DATa:ENCdg RIBinary",
+        "set_data_width": "DATa:WIDth 1",  # 8-bit for this project (16-bit is a follow-up) -- TBS p.72 / MSO2 p.2-211
+        "set_data_start": "DATa:STARt {start}",  # TBS p.71 / MSO2 p.2-209
+        "set_data_stop": "DATa:STOP {stop}",  # TBS p.72 / MSO2 p.2-210
+        "get_wfm_nr_pt": "WFMOutpre:NR_Pt?",  # TBS p.174 / MSO2 p.2-204
+        "get_wfm_xincr": "WFMOutpre:XINcr?",  # TBS p.175 / MSO2 p.2-706
+        "get_wfm_xzero": "WFMOutpre:XZEro?",  # TBS p.176 / MSO2 p.2-702
+        # NOTE: no WFMOutpre:PT_Off? on TBS1000C (leaf absent from its
+        # WFMOutpre subsystem, pp.172-177) -- MSO2-only, see tek_mso override
+        "get_wfm_ymult": "WFMOutpre:YMUlt?",  # TBS p.176 / MSO2 p.2-707
+        "get_wfm_yzero": "WFMOutpre:YZEro?",  # TBS p.177 / MSO2 p.2-709
+        "get_wfm_yoff": "WFMOutpre:YOFf?",  # TBS p.176 / MSO2 p.2-708
+        "get_waveform": "CURVe?",  # TBS p.68 / MSO2 p.2-77
+        # Immediate measurements (MEASUrement:IMMed) are TBS-only: the MSO2
+        # manual has no IMMed:TYPe/SOUrce1/VALue commands (badge-based
+        # MEASUrement:MEAS<x> instead) -- see tek_tbs override.
+    }
+
+    # Dialect base tables, keyed by dialect name. LeCroy table added later.
     DIALECT_TABLES = {
         "legacy": LEGACY_COMMANDS,
         "modern": MODERN_COMMANDS,
+        "tektronix": TEKTRONIX_COMMANDS,
     }
 
     # Family overrides applied on top of the dialect base table.
@@ -177,6 +260,29 @@ class SCPICommandSet:
         "hd_series": {},
         "x_series": {},  # HCSU? screen-dump override removed: it was a hardcopy SETUP query, not a dump
         "plus_series": {},
+        "tek_tbs": {
+            # Probe attenuation as gain factor: "a common 10x probe has a
+            # gain of 0.1" -- TBS p.56 (no PRObe:GAIN on MSO2)
+            "set_probe_ratio": "CH{ch}:PRObe:GAIN {gain}",
+            "get_probe_ratio": "CH{ch}:PRObe:GAIN?",
+            # Immediate measurements -- TBS pp.117-121 (absent from the MSO2
+            # command set, so MSO models gate with FeatureNotSupportedError)
+            "set_meas_immed_type": "MEASUrement:IMMed:TYPe {type}",  # TBS p.119
+            "set_meas_immed_source": "MEASUrement:IMMed:SOUrce1 CH{ch}",  # TBS p.117
+            "get_meas_immed_value": "MEASUrement:IMMed:VALue?",  # TBS p.121
+        },
+        "tek_mso": {
+            # MSO2 has no SELect subsystem; display is per-channel global
+            # state {<NR1>|OFF|ON} -- MSO2 p.2-225
+            "set_channel_display": "DISplay:GLObal:CH{ch}:STATE {state}",
+            "get_channel_display": "DISplay:GLObal:CH{ch}:STATE?",
+            # External attenuation "as a multiplier" (gain form, e.g.
+            # 167.00E-3) -- MSO2 p.2-192; closest equivalent of TBS PRObe:GAIN
+            "set_probe_ratio": "CH{ch}:PROBEFunc:EXTAtten {gain}",
+            "get_probe_ratio": "CH{ch}:PROBEFunc:EXTAtten?",
+            # Preamble trigger-point offset, MSO2-only -- MSO2 p.2-701
+            "get_wfm_pt_off": "WFMOutpre:PT_Off?",
+        },
     }
 
     def __init__(self, dialect: str = "legacy", scpi_variant: str = "standard"):
@@ -286,7 +392,7 @@ from scpi_control import exceptions
 FLAT_TRIGGER_DIALECTS = frozenset({"legacy"})
 
 # Dialects whose numeric queries return a bare NR3 value with no unit suffix.
-BARE_NR3_DIALECTS = frozenset({"modern"})
+BARE_NR3_DIALECTS = frozenset({"modern", "tektronix"})
 
 
 def is_flat_trigger(dialect: str) -> bool:
@@ -296,26 +402,37 @@ def is_flat_trigger(dialect: str) -> bool:
 _MODE_TO_WIRE = {
     "legacy": {"AUTO": "AUTO", "NORM": "NORM", "SINGLE": "SINGLE", "STOP": "STOP"},
     "modern": {"AUTO": "AUTO", "NORM": "NORMal", "SINGLE": "SINGle"},
+    # AUTO|NORMal (TBS p.155 / MSO2 p.2-684); SINGLE/STOP are command sequences
+    "tektronix": {"AUTO": "AUTO", "NORM": "NORMal"},
 }
 _MODE_FROM_WIRE = {
     "legacy": {"AUTO": "AUTO", "NORM": "NORM", "SINGLE": "SINGLE", "STOP": "STOP"},
     "modern": {"AUTO": "AUTO", "NORMAL": "NORM", "SINGLE": "SINGLE", "FTRIG": "AUTO"},
+    "tektronix": {"AUTO": "AUTO", "NORMAL": "NORM", "NORM": "NORM"},
 }
 _SLOPE_TO_WIRE = {
     "legacy": {"POS": "POS", "NEG": "NEG", "WINDOW": "WINDOW"},
     "modern": {"POS": "RISing", "NEG": "FALLing", "WINDOW": "ALTernate"},
+    # RISe|FALL (TBS p.151 / MSO2 p.2-662); WINDOW has no Tek edge equivalent
+    # (MSO2's third token is EITher, which is absent on TBS)
+    "tektronix": {"POS": "RISe", "NEG": "FALL"},
 }
 _SLOPE_FROM_WIRE = {
     "legacy": {"POS": "POS", "NEG": "NEG", "WINDOW": "WINDOW"},
     "modern": {"RISING": "POS", "FALLING": "NEG", "ALTERNATE": "WINDOW"},
+    "tektronix": {"RISE": "POS", "FALL": "NEG"},
 }
 _COUPLING_TO_WIRE = {
     "legacy": {"DC": "D1M", "AC": "A1M", "GND": "GND"},
     "modern": {"DC": "DC", "AC": "AC", "GND": "GND"},
+    # No GND coupling on either Tek family: TBS is {AC|DC} (p.53), MSO2 is
+    # {AC|DC|DCREJect} (p.2-184) -- GND gates as FeatureNotSupportedError
+    "tektronix": {"DC": "DC", "AC": "AC"},
 }
 _COUPLING_FROM_WIRE = {
     "legacy": {"D1M": "DC", "A1M": "AC", "D50": "DC", "A50": "AC", "GND": "GND"},
     "modern": {"DC": "DC", "AC": "AC", "GND": "GND"},
+    "tektronix": {"DC": "DC", "AC": "AC"},
 }
 
 _PUBLIC_MODES = {"AUTO", "NORM", "SINGLE", "STOP"}
@@ -323,7 +440,9 @@ _PUBLIC_SLOPES = {"POS", "NEG", "WINDOW"}
 _PUBLIC_COUPLINGS = {"DC", "AC", "GND"}
 
 # Acquisition-status vocabulary shared by every dialect's status query.
-_STATUS_MAP = {"ARM": "ARM", "ARMED": "ARM", "READY": "READY", "AUTO": "AUTO", "TRIG'D": "TRIGD", "STOP": "STOP", "ROLL": "ROLL"}
+# TRIGGER/SAVE are the Tek TRIGger:STATE? vocabulary (SAVE == acquisition
+# stopped) -- TBS p.162 / MSO2 p.2-686.
+_STATUS_MAP = {"ARM": "ARM", "ARMED": "ARM", "READY": "READY", "AUTO": "AUTO", "TRIG'D": "TRIGD", "TRIGGER": "TRIGD", "STOP": "STOP", "SAVE": "STOP", "ROLL": "ROLL"}
 
 
 def _last_token(raw: str) -> str:
@@ -354,6 +473,15 @@ _MEASUREMENT_TYPES = {"PKPK", "MAX", "MIN", "AMPL", "TOP", "BASE", "CMEAN", "MEA
 _MEASUREMENT_TO_WIRE = {
     "legacy": {m: m for m in _MEASUREMENT_TYPES},
     "modern": {m: m for m in _MEASUREMENT_TYPES},
+    # Tek MEASUrement:IMMed:TYPe vocabulary, verbatim from TBS p.119 (the
+    # IMMed subsystem is TBS-only; MSO2's MEAS<x> badge vocabulary differs
+    # and is a follow-up when badge measurements land).
+    "tektronix": {
+        "PKPK": "PK2Pk", "MAX": "MAXimum", "MIN": "MINImum", "AMPL": "AMPlitude",
+        "TOP": "HIGH", "BASE": "LOW", "CMEAN": "CMEan", "MEAN": "MEAN",
+        "RMS": "RMS", "CRMS": "CRMs", "FREQ": "FREQuency", "PER": "PERIod",
+        "RISE": "RISe", "FALL": "FALL", "WID": "PWIdth", "NWID": "NWIdth", "DUTY": "PDUty",
+    },
 }
 
 
@@ -420,3 +548,23 @@ def normalize_status(raw: str) -> str:
     if token not in _STATUS_MAP:
         raise ValueError(f"Unrecognized acquisition status response: {raw!r}")
     return _STATUS_MAP[token]
+
+
+def probe_to_wire(dialect: str, ratio: float) -> str:
+    """Convert a probe attenuation ratio to the wire value (Tek speaks gain = 1/ratio).
+
+    TBS PRObe:GAIN: "a common 10x probe has a gain of 0.1" (TBS p.56);
+    MSO2 PROBEFunc:EXTAtten takes the same multiplier form (MSO2 p.2-192).
+    """
+    if dialect == "tektronix":
+        return f"{1.0 / ratio:g}"
+    return f"{ratio:g}"
+
+
+def probe_from_wire(dialect: str, raw: str) -> float:
+    """Convert a probe query response back to an attenuation ratio."""
+    token = _last_token(raw).replace("X", "")
+    value = float(token)
+    if dialect == "tektronix":
+        return 1.0 / value if value else 0.0
+    return value

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -12,16 +12,30 @@ between the library's public vocabulary and each dialect's wire tokens.
 
 from typing import Dict
 
+# Wire dialects with a command table. Grows as vendor tables land.
+SUPPORTED_DIALECTS = ("legacy", "modern")
+
+# IEEE-488.2 mandated common commands, identical on every instrument.
+IEEE488_BASE = {
+    "identify": "*IDN?",
+    "reset": "*RST",
+    "clear_status": "*CLS",
+    "operation_complete": "*OPC?",
+}
+
+# Commands written once right after connect-time dialect resolution.
+# legacy: response headers off (Siglent legacy echoes headers by default)
+# modern: nothing needed
+CONNECT_SETUP = {
+    "legacy": ["CHDR OFF"],
+    "modern": [],
+}
+
 
 class SCPICommandSet:
     """Per-model SCPI command table (dialect base + family overrides)."""
 
     LEGACY_COMMANDS = {
-        # Identification and system
-        "identify": "*IDN?",
-        "reset": "*RST",
-        "clear_status": "*CLS",
-        "operation_complete": "*OPC?",
         # Trigger control
         "set_trigger_mode": "TRIG_MODE {mode}",  # mode: AUTO, NORM, SINGLE, STOP
         "get_trigger_mode": "TRIG_MODE?",
@@ -83,11 +97,6 @@ class SCPICommandSet:
     # Modern colon-form dialect, verbatim from the SDS Series Programming
     # Guide EN11G (page references in the design spec's command table).
     MODERN_COMMANDS = {
-        # Identification and system
-        "identify": "*IDN?",
-        "reset": "*RST",
-        "clear_status": "*CLS",
-        "operation_complete": "*OPC?",
         # Trigger control (p.482-484; no standalone ARM/force — FTRIG forces)
         "set_trigger_mode": ":TRIGger:MODE {mode}",  # wire modes: AUTO, NORMal, SINGle, FTRIG
         "get_trigger_mode": ":TRIGger:MODE?",
@@ -139,34 +148,37 @@ class SCPICommandSet:
         "hardcopy_print": "HCSU PRINT",
     }
 
+    # Dialect base tables, keyed by dialect name. Tek/LeCroy tables added later.
+    DIALECT_TABLES = {
+        "legacy": LEGACY_COMMANDS,
+        "modern": MODERN_COMMANDS,
+    }
+
     # Family overrides applied on top of the dialect base table.
-    HD_SERIES_OVERRIDES: Dict[str, str] = {}
-    X_SERIES_OVERRIDES: Dict[str, str] = {}  # HCSU? screen-dump override removed: it was a hardcopy SETUP query, not a dump
-    PLUS_SERIES_OVERRIDES: Dict[str, str] = {}
-    STANDARD_OVERRIDES: Dict[str, str] = {}
+    VARIANT_OVERRIDES: Dict[str, Dict[str, str]] = {
+        "standard": {},
+        "hd_series": {},
+        "x_series": {},  # HCSU? screen-dump override removed: it was a hardcopy SETUP query, not a dump
+        "plus_series": {},
+    }
 
     def __init__(self, dialect: str = "legacy", scpi_variant: str = "standard"):
         """Build the command set for a dialect + model family.
 
         Args:
-            dialect: "legacy" or "modern" — selects the base table
+            dialect: wire dialect (one of SUPPORTED_DIALECTS) — selects the base table
             scpi_variant: family identifier ("standard", "hd_series", "x_series", "plus_series") for overrides
         """
-        if dialect not in ("legacy", "modern"):
-            raise ValueError(f"Unknown SCPI dialect: {dialect}. Must be 'legacy' or 'modern'.")
+        if dialect not in SUPPORTED_DIALECTS:
+            raise ValueError(f"Unknown SCPI dialect: {dialect}. Must be one of {SUPPORTED_DIALECTS}.")
         self.dialect = dialect
         self.scpi_variant = scpi_variant
         self._command_set = self._build_command_set(dialect, scpi_variant)
 
     def _build_command_set(self, dialect: str, variant: str) -> Dict[str, str]:
-        command_set = (self.LEGACY_COMMANDS if dialect == "legacy" else self.MODERN_COMMANDS).copy()
-        overrides = {
-            "hd_series": self.HD_SERIES_OVERRIDES,
-            "x_series": self.X_SERIES_OVERRIDES,
-            "plus_series": self.PLUS_SERIES_OVERRIDES,
-            "standard": self.STANDARD_OVERRIDES,
-        }.get(variant, {})
-        command_set.update(overrides)
+        command_set = dict(IEEE488_BASE)
+        command_set.update(self.DIALECT_TABLES[dialect])
+        command_set.update(self.VARIANT_OVERRIDES.get(variant, {}))
         return command_set
 
     def get_command(self, command_name: str, **kwargs) -> str:

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -281,10 +281,10 @@ class SCPICommandSet:
         "get_probe_ratio": "C{ch}:ATTN?",  # MAUI p.7-17
         # Bandwidth limit differs from legacy: BWL is global, ch/mode pairs.
         # NOTE: LeCroy <mode> is {OFF,20MHZ,200MHZ,...} -- there is NO "ON"
-        # token; channel.py's public "ON" sends a literal "ON" a real LeCroy
-        # rejects (map ON->20MHZ in a follow-up; see task-13 report).
+        # token; channel.py maps public ON->20MHZ (and any non-OFF wire
+        # token back to public ON on the getter) -- see task-16 report.
         "set_bandwidth_limit": "BWL C{ch},{limit}",  # BANDWIDTH_LIMIT (BWL) -- MAUI p.7-18
-        "get_bandwidth_limit": "BWL?",  # returns "C1,OFF,C2,ON,..." pairs -- MAUI p.7-18
+        "get_bandwidth_limit": "BWL?",  # returns "C1,OFF,C2,20MHZ,..." pairs -- MAUI p.7-18
         # Timebase control
         "set_time_div": "TDIV {tdiv}",  # TIME_DIV (TDIV) -- MAUI p.7-29
         "get_time_div": "TDIV?",  # MAUI p.7-29
@@ -315,8 +315,8 @@ class SCPICommandSet:
         # "C{ch}:PAVA? {param}" (MAUI p.7-70), NOT the Siglent "PAVA? p,C{ch}"
         # form. LeCroy's PAVA? response is "<param>,<value>,<state>" (3 fields);
         # measurement.py's parser reads parts[2] (=value on Siglent, =state on
-        # LeCroy), so measure() needs a lecroy branch (parts[1]) -- documented
-        # gap for Tasks 14-16 (see task-13 report). Vocabulary = PARAMETER_VALUE.
+        # LeCroy), so measure() has a lecroy branch reading parts[1] instead
+        # (see task-16 report). Vocabulary = PARAMETER_VALUE.
         "get_parameter_value": "C{ch}:PAVA? {param}",  # PARAMETER_VALUE? (PAVA?) -- MAUI p.7-70
         "clear_measurements": "PACL",  # PARAMETER_CLR (PACL / PARAMETER_CLEAR), no args -- MAUI p.7-58
         # add_measurement OMITTED: LeCroy PACU is "PACU <slot>,<measurement>,

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -259,9 +259,12 @@ class SCPICommandSet:
         "get_wfm_yzero": "WFMOutpre:YZEro?",  # TBS p.177 / MSO2 p.2-709
         "get_wfm_yoff": "WFMOutpre:YOFf?",  # TBS p.176 / MSO2 p.2-708
         "get_waveform": "CURVe?",  # TBS p.68 / MSO2 p.2-77
-        # Immediate measurements (MEASUrement:IMMed) are TBS-only: the MSO2
-        # manual has no IMMed:TYPe/SOUrce1/VALue commands (badge-based
-        # MEASUrement:MEAS<x> instead) -- see tek_tbs override.
+        # Immediate measurements (MEASUrement:IMMed) are wired for TBS only
+        # (see tek_tbs override); MSO2 gates with FeatureNotSupportedError and
+        # steers callers at its badge-based MEASUrement:MEAS<x> subsystem.
+        # NOTE: the MSO2 PM's programming-examples appendix (p.3-12/3-13) and
+        # factory-defaults table (p.C-11) do show IMMed:TYPe/SOURCE/VALue
+        # working, so this gate is deliberately conservative, not manual-contradicted.
     }
 
     # LeCroy MAUI dialect, per the MAUI Oscilloscopes Remote Control and
@@ -359,7 +362,7 @@ class SCPICommandSet:
     }
 
     # Dialect base tables, keyed by dialect name.
-    DIALECT_TABLES = {
+    DIALECT_TABLES: Dict[str, Dict[str, str]] = {
         "legacy": LEGACY_COMMANDS,
         "modern": MODERN_COMMANDS,
         "tektronix": TEKTRONIX_COMMANDS,
@@ -704,7 +707,21 @@ def source_from_wire(dialect: str, raw: str) -> str:
 
 
 def normalize_status(raw: str) -> str:
-    """Normalize an acquisition-status response to ARM|READY|AUTO|TRIGD|STOP|ROLL."""
+    """Normalize an acquisition-status response to ARM|READY|AUTO|TRIGD|STOP|ROLL.
+
+    Reads the last whitespace-separated token of the response (tolerating a
+    residual header echo such as a leading "SAST") and maps it from whichever
+    dialect produced it:
+
+    - Siglent legacy (SAST?) / modern (:TRIGger:STATus?): ARM, READY, AUTO,
+      TRIG'D, STOP, ROLL.
+    - Tektronix (TRIGger:STATE?): ARMED, AUTO, READY, SAVE, TRIGGER, where SAVE
+      means acquisition stopped and TRIGGER is the triggered state
+      (TBS p.162 / MSO2 p.2-686).
+
+    Raises:
+        ValueError: If the token is not a recognized status in any dialect.
+    """
     token = _last_token(raw)
     if token not in _STATUS_MAP:
         raise ValueError(f"Unrecognized acquisition status response: {raw!r}")

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -10,6 +10,7 @@ This module holds the per-dialect command tables and the enum conversions
 between the library's public vocabulary and each dialect's wire tokens.
 """
 
+import re
 from typing import Dict
 
 # Wire dialects with a command table. Grows as vendor tables land.
@@ -256,96 +257,136 @@ class SCPICommandSet:
 
 # ---- Public-vocabulary <-> wire-token conversions -------------------------
 # The library's public API always speaks: modes AUTO|NORM|SINGLE|STOP,
-# slopes POS|NEG|WINDOW, coupling DC|AC|GND. These helpers convert at the
-# dialect boundary and are the only place wire enums are spelled out.
+# slopes POS|NEG|WINDOW, coupling DC|AC|GND, sources C1..C4|EX|EX5|LINE.
+# These tables convert at the dialect boundary and are the only place wire
+# enums are spelled out. A missing (dialect, token) pair means the dialect
+# cannot express that public token -> FeatureNotSupportedError.
 
-_MODE_TO_MODERN = {"AUTO": "AUTO", "NORM": "NORMal", "SINGLE": "SINGle"}
-_MODE_FROM_MODERN = {"AUTO": "AUTO", "NORMAL": "NORM", "SINGLE": "SINGLE", "FTRIG": "AUTO"}
-_LEGACY_MODES = {"AUTO", "NORM", "SINGLE", "STOP"}
+from scpi_control import exceptions
 
-_SLOPE_TO_MODERN = {"POS": "RISing", "NEG": "FALLing", "WINDOW": "ALTernate"}
-_SLOPE_FROM_MODERN = {"RISING": "POS", "FALLING": "NEG", "ALTERNATE": "WINDOW"}
-_LEGACY_SLOPES = {"POS", "NEG", "WINDOW"}
+# Dialects whose trigger commands are per-source-prefixed (C1:TRLV ...) rather
+# than global (:TRIGger:EDGE:LEVel ...). These also have a STOP trigger-mode
+# wire token; the global-style dialects detect STOP via acquisition status.
+FLAT_TRIGGER_DIALECTS = frozenset({"legacy"})
 
-_COUPLING_TO_LEGACY = {"DC": "D1M", "AC": "A1M", "GND": "GND"}
-_COUPLING_FROM_LEGACY = {"D1M": "DC", "A1M": "AC", "D50": "DC", "A50": "AC", "GND": "GND"}
-_MODERN_COUPLINGS = {"DC", "AC", "GND"}
+# Dialects whose numeric queries return a bare NR3 value with no unit suffix.
+BARE_NR3_DIALECTS = frozenset({"modern"})
 
-# :TRIGger:STATus? enum (guide p.483) plus legacy SAST? responses share this space
+
+def is_flat_trigger(dialect: str) -> bool:
+    return dialect in FLAT_TRIGGER_DIALECTS
+
+
+_MODE_TO_WIRE = {
+    "legacy": {"AUTO": "AUTO", "NORM": "NORM", "SINGLE": "SINGLE", "STOP": "STOP"},
+    "modern": {"AUTO": "AUTO", "NORM": "NORMal", "SINGLE": "SINGle"},
+}
+_MODE_FROM_WIRE = {
+    "legacy": {"AUTO": "AUTO", "NORM": "NORM", "SINGLE": "SINGLE", "STOP": "STOP"},
+    "modern": {"AUTO": "AUTO", "NORMAL": "NORM", "SINGLE": "SINGLE", "FTRIG": "AUTO"},
+}
+_SLOPE_TO_WIRE = {
+    "legacy": {"POS": "POS", "NEG": "NEG", "WINDOW": "WINDOW"},
+    "modern": {"POS": "RISing", "NEG": "FALLing", "WINDOW": "ALTernate"},
+}
+_SLOPE_FROM_WIRE = {
+    "legacy": {"POS": "POS", "NEG": "NEG", "WINDOW": "WINDOW"},
+    "modern": {"RISING": "POS", "FALLING": "NEG", "ALTERNATE": "WINDOW"},
+}
+_COUPLING_TO_WIRE = {
+    "legacy": {"DC": "D1M", "AC": "A1M", "GND": "GND"},
+    "modern": {"DC": "DC", "AC": "AC", "GND": "GND"},
+}
+_COUPLING_FROM_WIRE = {
+    "legacy": {"D1M": "DC", "A1M": "AC", "D50": "DC", "A50": "AC", "GND": "GND"},
+    "modern": {"DC": "DC", "AC": "AC", "GND": "GND"},
+}
+
+_PUBLIC_MODES = {"AUTO", "NORM", "SINGLE", "STOP"}
+_PUBLIC_SLOPES = {"POS", "NEG", "WINDOW"}
+_PUBLIC_COUPLINGS = {"DC", "AC", "GND"}
+
+# Acquisition-status vocabulary shared by every dialect's status query.
 _STATUS_MAP = {"ARM": "ARM", "ARMED": "ARM", "READY": "READY", "AUTO": "AUTO", "TRIG'D": "TRIGD", "STOP": "STOP", "ROLL": "ROLL"}
 
 
-def mode_to_wire(dialect: str, mode: str) -> str:
-    """Convert a public trigger mode (AUTO|NORM|SINGLE) to the wire token.
+def _last_token(raw: str) -> str:
+    return raw.strip().split()[-1].upper() if raw.strip() else ""
 
-    STOP is not a wire mode on the modern dialect (it is the :TRIGger:STOP
-    command); callers handle it before converting.
+
+def _to_wire(table, public_values, dialect: str, token: str, what: str) -> str:
+    token = token.upper()
+    if token not in public_values:
+        raise ValueError(f"Invalid {what}: {token}. Must be one of {sorted(public_values)}.")
+    try:
+        return table[dialect][token]
+    except KeyError:
+        raise exceptions.FeatureNotSupportedError(f"{what} {token} is not supported on the {dialect} dialect")
+
+
+def _from_wire(table, dialect: str, raw: str, what: str) -> str:
+    token = _last_token(raw)
+    try:
+        return table[dialect][token]
+    except KeyError:
+        raise ValueError(f"Unrecognized {dialect} {what} response: {raw!r}")
+
+
+def mode_to_wire(dialect: str, mode: str) -> str:
+    """Convert a public trigger mode to the wire token.
+
+    STOP is only a wire mode on flat-trigger dialects; global-style dialects
+    implement it via their stop command, and callers handle it before converting.
     """
-    mode = mode.upper()
-    if dialect == "legacy":
-        if mode not in _LEGACY_MODES:
-            raise ValueError(f"Invalid trigger mode: {mode}")
-        return mode
-    if mode not in _MODE_TO_MODERN:
-        raise ValueError(f"Invalid trigger mode for modern dialect: {mode}")
-    return _MODE_TO_MODERN[mode]
+    return _to_wire(_MODE_TO_WIRE, _PUBLIC_MODES, dialect, mode, "trigger mode")
 
 
 def mode_from_wire(dialect: str, raw: str) -> str:
     """Normalize a trigger-mode query response to AUTO|NORM|SINGLE|STOP."""
-    token = raw.strip().split()[-1].upper() if raw.strip() else ""
-    if dialect == "legacy":
-        if token not in _LEGACY_MODES:
-            raise ValueError(f"Unrecognized legacy trigger mode response: {raw!r}")
-        return token
-    if token not in _MODE_FROM_MODERN:
-        raise ValueError(f"Unrecognized modern trigger mode response: {raw!r}")
-    return _MODE_FROM_MODERN[token]
+    return _from_wire(_MODE_FROM_WIRE, dialect, raw, "trigger mode")
 
 
 def slope_to_wire(dialect: str, slope: str) -> str:
-    slope = slope.upper()
-    if slope not in _LEGACY_SLOPES:
-        raise ValueError(f"Invalid trigger slope: {slope}. Must be POS, NEG, or WINDOW.")
-    return slope if dialect == "legacy" else _SLOPE_TO_MODERN[slope]
+    return _to_wire(_SLOPE_TO_WIRE, _PUBLIC_SLOPES, dialect, slope, "trigger slope")
 
 
 def slope_from_wire(dialect: str, raw: str) -> str:
-    token = raw.strip().split()[-1].upper() if raw.strip() else ""
-    if dialect == "legacy":
-        if token not in _LEGACY_SLOPES:
-            raise ValueError(f"Unrecognized legacy slope response: {raw!r}")
-        return token
-    if token not in _SLOPE_FROM_MODERN:
-        raise ValueError(f"Unrecognized modern slope response: {raw!r}")
-    return _SLOPE_FROM_MODERN[token]
+    return _from_wire(_SLOPE_FROM_WIRE, dialect, raw, "trigger slope")
 
 
 def coupling_to_wire(dialect: str, coupling: str) -> str:
-    coupling = coupling.upper()
-    if coupling not in _MODERN_COUPLINGS:
-        raise ValueError(f"Invalid coupling mode: {coupling}. Must be DC, AC, or GND.")
-    return _COUPLING_TO_LEGACY[coupling] if dialect == "legacy" else coupling
+    return _to_wire(_COUPLING_TO_WIRE, _PUBLIC_COUPLINGS, dialect, coupling, "coupling mode")
 
 
 def coupling_from_wire(dialect: str, raw: str) -> str:
-    token = raw.strip().split()[-1].upper() if raw.strip() else ""
-    if dialect == "legacy":
-        if token not in _COUPLING_FROM_LEGACY:
-            raise ValueError(f"Unrecognized legacy coupling response: {raw!r}")
-        return _COUPLING_FROM_LEGACY[token]
-    if token not in _MODERN_COUPLINGS:
-        raise ValueError(f"Unrecognized modern coupling response: {raw!r}")
+    return _from_wire(_COUPLING_FROM_WIRE, dialect, raw, "coupling mode")
+
+
+def channel_token(dialect: str, source) -> str:
+    """Convert a public channel source (int, 'C2', 'EX', 'LINE') to the wire token."""
+    if isinstance(source, int):
+        number = source
+    else:
+        token = str(source).strip().upper()
+        match = re.fullmatch(r"C(?:H)?(\d+)", token)
+        if not match:
+            return token  # EX, EX5, LINE and friends pass through
+        number = int(match.group(1))
+    return f"CH{number}" if dialect == "tektronix" else f"C{number}"
+
+
+def source_from_wire(dialect: str, raw: str) -> str:
+    """Normalize a trigger-source query response to the public vocabulary."""
+    token = raw.strip().upper()
+    match = re.fullmatch(r"C(?:H)?(\d+)", token)
+    if match:
+        return f"C{int(match.group(1))}"
     return token
 
 
 def normalize_status(raw: str) -> str:
-    """Normalize an acquisition-status response to ARM|READY|AUTO|TRIGD|STOP|ROLL.
-
-    Accepts modern ':TRIGger:STATus?' responses (Arm|Ready|Auto|Trig'd|Stop|Roll,
-    guide p.483) and legacy 'SAST?' responses, with or without the 'SAST ' echo.
-    """
-    token = raw.strip().split()[-1].upper() if raw.strip() else ""
+    """Normalize an acquisition-status response to ARM|READY|AUTO|TRIGD|STOP|ROLL."""
+    token = _last_token(raw)
     if token not in _STATUS_MAP:
         raise ValueError(f"Unrecognized acquisition status response: {raw!r}")
     return _STATUS_MAP[token]

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -79,13 +79,28 @@ class SCPICommandSet:
         # sub-project; the DAT2 path works on both scope generations)
         "get_waveform": "C{ch}:WF? DAT2",
         "get_waveform_preamble": "C{ch}:WF? DESC",
-        # Measurements (routing deferred to the waveform/measurement sub-project)
-        "get_parameter_value": "C{ch}:PAVA? {param}",
-        "clear_measurements": "PACU CLEAR",
+        # Measurements
+        # NOTE: get_parameter_value's wire form is "PAVA? {param},C{ch}" (mtype
+        # first, then a C-prefixed channel) -- this is what measurement.py
+        # actually sent pre-refactor and what the legacy mock's PAVA? regex
+        # parses; do not "correct" it to "C{ch}:PAVA? {param}".
+        "get_parameter_value": "PAVA? {param},C{ch}",
+        "add_measurement": "PACU {mtype},C{ch}",
+        "set_statistics": "PAST {state}",
+        "clear_measurements": "PACL",
+        "reset_statistics": "PASTAT RESET",
         # Cursor control
         "set_cursor_type": "CRST {type}",
         "get_cursor_type": "CRST?",
-        "get_cursor_value": "CRVA? {cursor}",
+        # NOTE: bare query -- no cursor id is ever passed by measurement.py.
+        "get_cursor_value": "CRVA?",
+        # Trigger holdoff (AUDIT M4: TRIG_DELAY is really trigger delay, not
+        # holdoff; legacy-only, routing deferred to a trigger-rework follow-up)
+        "set_trigger_holdoff": "TRIG_DELAY {t}",
+        "get_trigger_holdoff": "TRIG_DELAY?",
+        # Channel vertical unit (legacy-only)
+        "set_channel_unit": "C{ch}:UNIT {unit}",
+        "get_channel_unit": "C{ch}:UNIT?",
         # Math operations (basic)
         "set_math_display": "MATH{n}:TRA {state}",
         "get_math_display": "MATH{n}:TRA?",
@@ -140,9 +155,10 @@ class SCPICommandSet:
         # Waveform acquisition — unchanged until the waveform sub-project
         "get_waveform": "C{ch}:WF? DAT2",
         "get_waveform_preamble": "C{ch}:WF? DESC",
-        # Measurements — routing deferred to the waveform/measurement sub-project
+        # Measurements — get_parameter_value stays available (measure() keeps
+        # working on modern, a documented gap); statistics/cursors/holdoff/unit
+        # are legacy-only and intentionally absent so they gate cleanly.
         "get_parameter_value": "C{ch}:PAVA? {param}",
-        "clear_measurements": "PACU CLEAR",
         # Screen capture (legacy strings accepted on modern scopes today; revisit with screen-capture overhaul)
         "screen_dump": "SCDP",
         "set_hardcopy_format": "HCSU DEV,FORMAT,{format}",
@@ -330,6 +346,20 @@ def _from_wire(table, dialect: str, raw: str, what: str) -> str:
         return table[dialect][token]
     except KeyError:
         raise ValueError(f"Unrecognized {dialect} {what} response: {raw!r}")
+
+
+# Public measurement vocabulary (PAVA parameter names). Identity for Siglent
+# dialects; vendor dialects map or reject per their manuals.
+_MEASUREMENT_TYPES = {"PKPK", "MAX", "MIN", "AMPL", "TOP", "BASE", "CMEAN", "MEAN", "RMS", "CRMS", "FREQ", "PER", "RISE", "FALL", "WID", "NWID", "DUTY"}
+_MEASUREMENT_TO_WIRE = {
+    "legacy": {m: m for m in _MEASUREMENT_TYPES},
+    "modern": {m: m for m in _MEASUREMENT_TYPES},
+}
+
+
+def measurement_to_wire(dialect: str, mtype: str) -> str:
+    """Convert a public measurement type to the dialect's wire token."""
+    return _to_wire(_MEASUREMENT_TO_WIRE, _MEASUREMENT_TYPES, dialect, mtype, "measurement type")
 
 
 def mode_to_wire(dialect: str, mode: str) -> str:

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -17,7 +17,7 @@ import re
 from typing import Dict
 
 # Wire dialects with a command table. Grows as vendor tables land.
-SUPPORTED_DIALECTS = ("legacy", "modern", "tektronix")
+SUPPORTED_DIALECTS = ("legacy", "modern", "tektronix", "lecroy")
 
 # IEEE-488.2 mandated common commands, identical on every instrument.
 IEEE488_BASE = {
@@ -36,6 +36,9 @@ CONNECT_SETUP = {
     "legacy": ["CHDR OFF"],
     "modern": [],
     "tektronix": ["HEADer OFF"],
+    # CHDR is LeCroy's own short form of COMM_HEADER; OFF omits response
+    # headers AND suppresses unit suffixes (MAUI p.7-46). Siglent inherited CHDR.
+    "lecroy": ["CHDR OFF"],
 }
 
 
@@ -247,11 +250,106 @@ class SCPICommandSet:
         # MEASUrement:MEAS<x> instead) -- see tek_tbs override.
     }
 
-    # Dialect base tables, keyed by dialect name. LeCroy table added later.
+    # LeCroy MAUI dialect, per the MAUI Oscilloscopes Remote Control and
+    # Automation Manual (cited "MAUI p.<part>-<section>" by printed page number;
+    # command reference is Part 7, VBS?/automation wrapper is Part 2). Every
+    # entry was verified against that manual (see task-13 report). Siglent's
+    # legacy dialect is derived from this one; entries below are the LeCroy
+    # originals.
+    LECROY_COMMANDS = {
+        # Trigger control -- all page cites are printed "Part-Section" numbers
+        # from Part 7 (IEEE 488.2 Command Reference) unless noted.
+        "set_trigger_mode": "TRIG_MODE {mode}",  # TRIG_MODE (TRMD) {AUTO,NORM,SINGLE,STOP} -- MAUI p.7-34
+        "get_trigger_mode": "TRIG_MODE?",  # resp "TRIG_MODE <mode>" -- MAUI p.7-34
+        "arm_trigger": "ARM",  # ARM_ACQUISITION (ARM) -- MAUI p.7-15
+        "force_trigger": "FRTR",  # FORCE_TRIGGER (FRTR) -- MAUI p.7-21
+        "stop": "STOP",  # STOP: sets Stopped trigger mode -- MAUI p.7-28
+        "run": "TRIG_MODE AUTO",  # continuous acquisition via TRIG_MODE -- MAUI p.7-34
+        "get_acq_status": "INR?",  # INR? reads+clears INTERNAL_STATE_CHANGE reg (p.7-132); bit0="new signal acquired" (p.7-133). Siglent invented SAST.
+        # Auto setup: bare ASET performs a normal auto-setup (channel prefix optional) -- MAUI p.7-16
+        "auto_setup": "ASET",  # AUTO_SETUP (ASET) -- MAUI p.7-16
+        # Channel control
+        "set_channel_display": "C{ch}:TRA {state}",  # TRACE (TRA) {ON,OFF} -- MAUI p.7-88
+        "get_channel_display": "C{ch}:TRA?",  # MAUI p.7-88
+        "set_voltage_div": "C{ch}:VDIV {vdiv}",  # VOLT_DIV (VDIV) -- MAUI p.7-41
+        "get_voltage_div": "C{ch}:VDIV?",  # MAUI p.7-41
+        "set_voltage_offset": "C{ch}:OFST {offset}",  # OFFSET (OFST) -- MAUI p.7-24
+        "get_voltage_offset": "C{ch}:OFST?",  # MAUI p.7-24
+        "set_coupling": "C{ch}:CPL {coupling}",  # COUPLING (CPL) {A1M,D1M,D50,GND} -- MAUI p.7-20
+        "get_coupling": "C{ch}:CPL?",  # query may also return OVL (overload) -- MAUI p.7-20
+        "set_probe_ratio": "C{ch}:ATTN {ratio}",  # ATTENUATION (ATTN) {1..10000} -- MAUI p.7-17
+        "get_probe_ratio": "C{ch}:ATTN?",  # MAUI p.7-17
+        # Bandwidth limit differs from legacy: BWL is global, ch/mode pairs.
+        # NOTE: LeCroy <mode> is {OFF,20MHZ,200MHZ,...} -- there is NO "ON"
+        # token; channel.py's public "ON" sends a literal "ON" a real LeCroy
+        # rejects (map ON->20MHZ in a follow-up; see task-13 report).
+        "set_bandwidth_limit": "BWL C{ch},{limit}",  # BANDWIDTH_LIMIT (BWL) -- MAUI p.7-18
+        "get_bandwidth_limit": "BWL?",  # returns "C1,OFF,C2,ON,..." pairs -- MAUI p.7-18
+        # Timebase control
+        "set_time_div": "TDIV {tdiv}",  # TIME_DIV (TDIV) -- MAUI p.7-29
+        "get_time_div": "TDIV?",  # MAUI p.7-29
+        "set_time_offset": "TRDL {offset}",  # TRIG_DELAY (TRDL) = horizontal delay -- MAUI p.7-31
+        "get_time_offset": "TRDL?",  # MAUI p.7-31
+        # Sample rate: no legacy-style query on LeCroy -- read via the MAUI
+        # automation (VBS?) object model. The VBS? 'return=app...' wrapper is
+        # documented at MAUI p.2-12..2-18; the exact cvar SamplingRate is NOT
+        # enumerated in this manual's Part 4 reference (UNVERIFIED, see report).
+        "get_sample_rate": "VBS? 'return=app.Acquisition.Horizontal.SamplingRate'",  # VBS? wrapper -- MAUI p.2-13
+        # Trigger settings
+        "set_trigger_select": "TRIG_SELECT {type},SR,{src}",  # TRIG_SELECT (TRSE); SR=Trigger Source param, EDGE type -- MAUI p.7-36
+        "get_trigger_select": "TRIG_SELECT?",  # MAUI p.7-36
+        "set_trigger_level": "{src}:TRLV {level}",  # TRIG_LEVEL (TRLV) -- MAUI p.7-33
+        "get_trigger_level": "{src}:TRLV?",  # MAUI p.7-33
+        "set_trigger_slope": "{src}:TRSL {slope}",  # TRIG_SLOPE (TRSL) {NEG,POS} -- MAUI p.7-40
+        "get_trigger_slope": "{src}:TRSL?",  # MAUI p.7-40
+        "set_trigger_coupling": "{src}:TRCP {coupling}",  # TRIG_COUPLING (TRCP) {AC,DC,HFREJ,LFREJ} -- MAUI p.7-30
+        "get_trigger_coupling": "{src}:TRCP?",  # MAUI p.7-30
+        # Waveform acquisition: WF? ALL returns descriptor+data in one block;
+        # CFMT/CORD pin the binary block encoding for the transfer sub-project.
+        "get_waveform": "C{ch}:WF? ALL",  # WAVEFORM (WF) ALL block -- MAUI p.7-150
+        "get_waveform_preamble": "C{ch}:WF? DESC",  # WAVEFORM (WF) DESC block -- MAUI p.7-150
+        "set_comm_format": "CFMT DEF9,{fmt},BIN",  # COMM_FORMAT (CFMT) DEF9,{BYTE,WORD},BIN -- MAUI p.7-44
+        "set_comm_order": "CORD LO",  # COMM_ORDER (CORD) {HI,LO}, LO=LSB first -- MAUI p.7-49
+        # Measurements
+        # PAVA-form decision: use the LeCroy-native trace-prefix form
+        # "C{ch}:PAVA? {param}" (MAUI p.7-70), NOT the Siglent "PAVA? p,C{ch}"
+        # form. LeCroy's PAVA? response is "<param>,<value>,<state>" (3 fields);
+        # measurement.py's parser reads parts[2] (=value on Siglent, =state on
+        # LeCroy), so measure() needs a lecroy branch (parts[1]) -- documented
+        # gap for Tasks 14-16 (see task-13 report). Vocabulary = PARAMETER_VALUE.
+        "get_parameter_value": "C{ch}:PAVA? {param}",  # PARAMETER_VALUE? (PAVA?) -- MAUI p.7-70
+        "clear_measurements": "PACL",  # PARAMETER_CLR (PACL / PARAMETER_CLEAR), no args -- MAUI p.7-58
+        # add_measurement OMITTED: LeCroy PACU is "PACU <slot>,<measurement>,
+        #   <qualifier>" (slot number first, MAUI p.7-59), NOT the Siglent
+        #   "PACU {mtype},C{ch}" form -> FeatureNotSupportedError until a
+        #   slot-aware implementation lands.
+        # set_statistics/reset_statistics OMITTED: PAST/PASTAT are Siglent
+        #   spellings, not LeCroy commands -> FeatureNotSupportedError.
+        # set_cursor_type/get_cursor_value OMITTED: LeCroy CRST is CURSOR_SET
+        #   (positioning) and CRVA? is trace-prefixed with {HABS,HREL,VABS,VREL}
+        #   modes (MAUI p.7-55) -- neither matches the Siglent cursor path.
+        # set_trigger_holdoff/get_trigger_holdoff OMITTED: TRDL is trigger delay,
+        #   not holdoff; LeCroy holdoff lives in TRIG_SELECT HT/HV (MAUI p.7-36).
+        # set_channel_unit/get_channel_unit OMITTED: no LeCroy C<n>:UNIT command.
+        # Math operations: LeCroy math traces are F1..Fn (TRACE, MAUI p.7-88),
+        # NOT Siglent's MATH<n> (math module out of scope; corrected for honesty)
+        "set_math_display": "F{n}:TRA {state}",  # TRACE (TRA) on F<n> -- MAUI p.7-88
+        "get_math_display": "F{n}:TRA?",  # MAUI p.7-88
+        # Screen capture -- keep (LeCroy-origin; screen module out of scope).
+        # NOTE: HCSU arg grammar below is the Siglent-adapted form; LeCroy HCSU
+        # uses "DEV,<device>,FORMAT,<format>,..." pairs and has no PRINT keyword
+        # (print = SCDP to a PRINTER destination) -- rework with the screen module.
+        "screen_dump": "SCDP",  # SCREEN_DUMP (SCDP) -- MAUI p.7-104
+        "set_hardcopy_format": "HCSU DEV,FORMAT,{format}",  # HARDCOPY_SETUP (HCSU) -- MAUI p.7-102
+        "hardcopy_print": "HCSU PRINT",  # HARDCOPY_SETUP (HCSU) -- MAUI p.7-102
+    }
+
+    # Dialect base tables, keyed by dialect name.
     DIALECT_TABLES = {
         "legacy": LEGACY_COMMANDS,
         "modern": MODERN_COMMANDS,
         "tektronix": TEKTRONIX_COMMANDS,
+        "lecroy": LECROY_COMMANDS,
     }
 
     # Family overrides applied on top of the dialect base table.
@@ -283,6 +381,10 @@ class SCPICommandSet:
             # Preamble trigger-point offset, MSO2-only -- MSO2 p.2-701
             "get_wfm_pt_off": "WFMOutpre:PT_Off?",
         },
+        # LeCroy MAUI family: the base table is already MAUI-correct, so no
+        # per-family overrides are needed today (placeholder for future splits
+        # between WaveRunner/HDO/WaveSurfer generations).
+        "lecroy_maui": {},
     }
 
     def __init__(self, dialect: str = "legacy", scpi_variant: str = "standard"):
@@ -389,10 +491,13 @@ from scpi_control import exceptions
 # Dialects whose trigger commands are per-source-prefixed (C1:TRLV ...) rather
 # than global (:TRIGger:EDGE:LEVel ...). These also have a STOP trigger-mode
 # wire token; the global-style dialects detect STOP via acquisition status.
-FLAT_TRIGGER_DIALECTS = frozenset({"legacy"})
+FLAT_TRIGGER_DIALECTS = frozenset({"legacy", "lecroy"})
 
 # Dialects whose numeric queries return a bare NR3 value with no unit suffix.
-BARE_NR3_DIALECTS = frozenset({"modern", "tektronix"})
+# LeCroy joins because CHDR OFF also suppresses the trailing unit token on
+# LeCroy responses -- e.g. C1:VDIV? returns "200E-3", not "200E-3 V" (MAUI
+# p.7-46) -- unlike Siglent legacy, which keeps the unit.
+BARE_NR3_DIALECTS = frozenset({"modern", "tektronix", "lecroy"})
 
 
 def is_flat_trigger(dialect: str) -> bool:
@@ -404,11 +509,14 @@ _MODE_TO_WIRE = {
     "modern": {"AUTO": "AUTO", "NORM": "NORMal", "SINGLE": "SINGle"},
     # AUTO|NORMal (TBS p.155 / MSO2 p.2-684); SINGLE/STOP are command sequences
     "tektronix": {"AUTO": "AUTO", "NORM": "NORMal"},
+    # LeCroy TRIG_MODE {AUTO,NORM,SINGLE,STOP} -- ancestor of legacy tokens (MAUI p.7-34)
+    "lecroy": {"AUTO": "AUTO", "NORM": "NORM", "SINGLE": "SINGLE", "STOP": "STOP"},
 }
 _MODE_FROM_WIRE = {
     "legacy": {"AUTO": "AUTO", "NORM": "NORM", "SINGLE": "SINGLE", "STOP": "STOP"},
     "modern": {"AUTO": "AUTO", "NORMAL": "NORM", "SINGLE": "SINGLE", "FTRIG": "AUTO"},
     "tektronix": {"AUTO": "AUTO", "NORMAL": "NORM", "NORM": "NORM"},
+    "lecroy": {"AUTO": "AUTO", "NORM": "NORM", "SINGLE": "SINGLE", "STOP": "STOP"},
 }
 _SLOPE_TO_WIRE = {
     "legacy": {"POS": "POS", "NEG": "NEG", "WINDOW": "WINDOW"},
@@ -416,11 +524,15 @@ _SLOPE_TO_WIRE = {
     # RISe|FALL (TBS p.151 / MSO2 p.2-662); WINDOW has no Tek edge equivalent
     # (MSO2's third token is EITher, which is absent on TBS)
     "tektronix": {"POS": "RISe", "NEG": "FALL"},
+    # LeCroy TRIG_SLOPE is {NEG, POS} only (MAUI p.7-40) -- no WINDOW edge slope,
+    # so WINDOW gates as FeatureNotSupportedError (mirrors the Tek GND removal).
+    "lecroy": {"POS": "POS", "NEG": "NEG"},
 }
 _SLOPE_FROM_WIRE = {
     "legacy": {"POS": "POS", "NEG": "NEG", "WINDOW": "WINDOW"},
     "modern": {"RISING": "POS", "FALLING": "NEG", "ALTERNATE": "WINDOW"},
     "tektronix": {"RISE": "POS", "FALL": "NEG"},
+    "lecroy": {"POS": "POS", "NEG": "NEG"},
 }
 _COUPLING_TO_WIRE = {
     "legacy": {"DC": "D1M", "AC": "A1M", "GND": "GND"},
@@ -428,6 +540,8 @@ _COUPLING_TO_WIRE = {
     # No GND coupling on either Tek family: TBS is {AC|DC} (p.53), MSO2 is
     # {AC|DC|DCREJect} (p.2-184) -- GND gates as FeatureNotSupportedError
     "tektronix": {"DC": "DC", "AC": "AC"},
+    # LeCroy COUPLING {A1M,D1M,D50,GND} (MAUI p.7-20) -- ancestor of legacy tokens
+    "lecroy": {"DC": "D1M", "AC": "A1M", "GND": "GND"},
 }
 _COUPLING_FROM_WIRE = {
     "legacy": {"D1M": "DC", "A1M": "AC", "D50": "DC", "A50": "AC", "GND": "GND"},
@@ -435,6 +549,10 @@ _COUPLING_FROM_WIRE = {
     # DCREJect (MSO2 PM 077-1776-07 p.2-184) passes AC only -- normalize to
     # the public AC token rather than surfacing the Tek-specific spelling.
     "tektronix": {"DC": "DC", "AC": "AC", "DCREJ": "AC", "DCREJECT": "AC"},
+    # LeCroy CPL? returns {A1M,D1M,D50,GND} (D50=DC 50 ohm; also OVL on overload,
+    # which is intentionally unmapped -> ValueError). A50 is not a LeCroy token
+    # but is kept as a harmless superset. -- MAUI p.7-20
+    "lecroy": {"D1M": "DC", "A1M": "AC", "D50": "DC", "A50": "AC", "GND": "GND"},
 }
 
 _PUBLIC_MODES = {"AUTO", "NORM", "SINGLE", "STOP"}
@@ -475,6 +593,9 @@ _MEASUREMENT_TYPES = {"PKPK", "MAX", "MIN", "AMPL", "TOP", "BASE", "CMEAN", "MEA
 _MEASUREMENT_TO_WIRE = {
     "legacy": {m: m for m in _MEASUREMENT_TYPES},
     "modern": {m: m for m in _MEASUREMENT_TYPES},
+    # LeCroy PARAMETER_VALUE (PAVA) parameter names -- identity, the ancestor
+    # of the Siglent legacy vocabulary (MAUI p.7-70).
+    "lecroy": {m: m for m in _MEASUREMENT_TYPES},
     # Tek MEASUrement:IMMed:TYPe vocabulary, verbatim from TBS p.119 (the
     # IMMed subsystem is TBS-only; MSO2's MEAS<x> badge vocabulary differs
     # and is a follow-up when badge measurements land).

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -427,8 +427,7 @@ class SCPICommandSet:
         # table. Fall back to the plain base table instead.
         if variant not in DIALECT_VARIANTS[dialect]:
             logger.warning(
-                "SCPI variant %r does not belong to the %r dialect; ignoring "
-                "family overrides and using the plain base table.",
+                "SCPI variant %r does not belong to the %r dialect; ignoring " "family overrides and using the plain base table.",
                 variant,
                 dialect,
             )
@@ -630,10 +629,23 @@ _MEASUREMENT_TO_WIRE = {
     # IMMed subsystem is TBS-only; MSO2's MEAS<x> badge vocabulary differs
     # and is a follow-up when badge measurements land).
     "tektronix": {
-        "PKPK": "PK2Pk", "MAX": "MAXimum", "MIN": "MINImum", "AMPL": "AMPlitude",
-        "TOP": "HIGH", "BASE": "LOW", "CMEAN": "CMEan", "MEAN": "MEAN",
-        "RMS": "RMS", "CRMS": "CRMs", "FREQ": "FREQuency", "PER": "PERIod",
-        "RISE": "RISe", "FALL": "FALL", "WID": "PWIdth", "NWID": "NWIdth", "DUTY": "PDUty",
+        "PKPK": "PK2Pk",
+        "MAX": "MAXimum",
+        "MIN": "MINImum",
+        "AMPL": "AMPlitude",
+        "TOP": "HIGH",
+        "BASE": "LOW",
+        "CMEAN": "CMEan",
+        "MEAN": "MEAN",
+        "RMS": "RMS",
+        "CRMS": "CRMs",
+        "FREQ": "FREQuency",
+        "PER": "PERIod",
+        "RISE": "RISe",
+        "FALL": "FALL",
+        "WID": "PWIdth",
+        "NWID": "NWIdth",
+        "DUTY": "PDUty",
     },
 }
 

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -432,7 +432,9 @@ _COUPLING_TO_WIRE = {
 _COUPLING_FROM_WIRE = {
     "legacy": {"D1M": "DC", "A1M": "AC", "D50": "DC", "A50": "AC", "GND": "GND"},
     "modern": {"DC": "DC", "AC": "AC", "GND": "GND"},
-    "tektronix": {"DC": "DC", "AC": "AC"},
+    # DCREJect (MSO2 PM 077-1776-07 p.2-184) passes AC only -- normalize to
+    # the public AC token rather than surfacing the Tek-specific spelling.
+    "tektronix": {"DC": "DC", "AC": "AC", "DCREJ": "AC", "DCREJECT": "AC"},
 }
 
 _PUBLIC_MODES = {"AUTO", "NORM", "SINGLE", "STOP"}

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -13,8 +13,11 @@ This module holds the per-dialect command tables and the enum conversions
 between the library's public vocabulary and each dialect's wire tokens.
 """
 
+import logging
 import re
 from typing import Dict
+
+logger = logging.getLogger(__name__)
 
 # Wire dialects with a command table. Grows as vendor tables land.
 SUPPORTED_DIALECTS = ("legacy", "modern", "tektronix", "lecroy")
@@ -39,6 +42,17 @@ CONNECT_SETUP = {
     # CHDR is LeCroy's own short form of COMM_HEADER; OFF omits response
     # headers AND suppresses unit suffixes (MAUI p.7-46). Siglent inherited CHDR.
     "lecroy": ["CHDR OFF"],
+}
+
+# Which model families (scpi_variant) belong to which dialect. Variants only
+# apply to their own dialect; a forced-dialect override (e.g. a Tek-detected
+# scope run with dialect="modern") on a mismatched instrument falls back to the
+# plain base table instead of contaminating it with the wrong family overrides.
+DIALECT_VARIANTS = {
+    "legacy": frozenset({"standard", "hd_series", "x_series", "plus_series"}),
+    "modern": frozenset({"standard", "hd_series", "x_series", "plus_series"}),
+    "tektronix": frozenset({"standard", "tek_tbs", "tek_mso"}),
+    "lecroy": frozenset({"standard", "lecroy_maui"}),
 }
 
 
@@ -403,6 +417,19 @@ class SCPICommandSet:
     def _build_command_set(self, dialect: str, variant: str) -> Dict[str, str]:
         command_set = dict(IEEE488_BASE)
         command_set.update(self.DIALECT_TABLES[dialect])
+        # Only apply family overrides that belong to this dialect. A forced
+        # dialect override can pair a variant with the wrong base table (e.g.
+        # dialect="modern" over an MSO24-detected scope, variant "tek_mso");
+        # applying those overrides would write Tek commands onto the modern
+        # table. Fall back to the plain base table instead.
+        if variant not in DIALECT_VARIANTS[dialect]:
+            logger.warning(
+                "SCPI variant %r does not belong to the %r dialect; ignoring "
+                "family overrides and using the plain base table.",
+                variant,
+                dialect,
+            )
+            variant = "standard"
         command_set.update(self.VARIANT_OVERRIDES.get(variant, {}))
         return command_set
 
@@ -651,6 +678,17 @@ def channel_token(dialect: str, source) -> str:
         token = str(source).strip().upper()
         match = re.fullmatch(r"C(?:H)?(\d+)", token)
         if not match:
+            if dialect == "tektronix":
+                # Both Tek families expose a single external ("Aux In") trigger
+                # and accept the SCPI short form AUX for it -- TBS1000C PM
+                # 077-1691-01 p.152 {CH1|CH2|LINE|AUX}; 2 Series MSO PM
+                # 077-1776-07 p.2-663 {CH<x>|DCH<x>_D<x>|INTernal|AUXiliary}.
+                if token == "EX":
+                    return "AUX"
+                # EX5 (external /5) has no Tek token, and LINE is a TBS-only
+                # source (absent from the MSO2 edge-source vocabulary), so
+                # neither is expressible portably across the Tek families.
+                raise exceptions.FeatureNotSupportedError(f"trigger source {token} is not supported on the tektronix dialect")
             return token  # EX, EX5, LINE and friends pass through
         number = int(match.group(1))
     return f"CH{number}" if dialect == "tektronix" else f"C{number}"

--- a/scpi_control/trigger.py
+++ b/scpi_control/trigger.py
@@ -324,12 +324,13 @@ class Trigger:
         Returns:
             Holdoff time in seconds
         """
-        response = self._scope.query("TRIG_DELAY?")
+        if not self._scope._has_command("get_trigger_holdoff"):
+            raise exceptions.FeatureNotSupportedError(f"trigger holdoff is not supported on the {self._dialect} dialect")
+        response = self._scope.query(self._cmd("get_trigger_holdoff"))
         # Response may include echo like "TRIG_DELAY 0.0E+00S"
         if " " in response:
             response = response.split(" ", 1)[1]
-        value = response.replace("S", "").strip()
-        return float(value)
+        return float(response.replace("S", "").strip())
 
     @holdoff.setter
     def holdoff(self, time_seconds: float) -> None:
@@ -340,8 +341,9 @@ class Trigger:
         """
         if time_seconds < 0:
             raise exceptions.InvalidParameterError(f"Holdoff time must be non-negative: {time_seconds}")
-
-        self._scope.write(f"TRIG_DELAY {time_seconds}")
+        if not self._scope._has_command("set_trigger_holdoff"):
+            raise exceptions.FeatureNotSupportedError(f"trigger holdoff is not supported on the {self._dialect} dialect")
+        self._scope.write(self._cmd("set_trigger_holdoff", t=time_seconds))
         logger.info(f"Trigger holdoff set to {time_seconds}s")
 
     def get_configuration(self) -> dict:
@@ -350,15 +352,19 @@ class Trigger:
         Returns:
             Dictionary with all trigger settings
         """
-        return {
+        config = {
             "mode": self.mode,
             "type": self.trigger_type,
             "source": self.source,
             "level": self.level,
             "slope": self.slope,
             "coupling": self.coupling,
-            "holdoff": self.holdoff,
         }
+        try:
+            config["holdoff"] = self.holdoff
+        except exceptions.FeatureNotSupportedError:
+            config["holdoff"] = None
+        return config
 
     def __repr__(self) -> str:
         """String representation."""

--- a/scpi_control/trigger.py
+++ b/scpi_control/trigger.py
@@ -4,7 +4,16 @@ import logging
 from typing import TYPE_CHECKING, Literal, Optional, Union
 
 from scpi_control import exceptions
-from scpi_control.scpi_commands import mode_from_wire, mode_to_wire, normalize_status, slope_from_wire, slope_to_wire
+from scpi_control.scpi_commands import (
+    channel_token,
+    is_flat_trigger,
+    mode_from_wire,
+    mode_to_wire,
+    normalize_status,
+    slope_from_wire,
+    slope_to_wire,
+    source_from_wire,
+)
 
 if TYPE_CHECKING:
     from scpi_control.oscilloscope import Oscilloscope
@@ -63,9 +72,10 @@ class Trigger:
         Returns:
             Trigger mode: 'AUTO', 'NORM', 'SINGLE', or 'STOP'
         """
-        if self._dialect == "modern":
-            # Modern scopes have no STOP mode token; a stopped scope is
-            # detected via the acquisition status (guide p.483)
+        if not is_flat_trigger(self._dialect):
+            # Global-style dialects (modern, tektronix) have no STOP mode
+            # token; a stopped scope is detected via the acquisition status
+            # (guide p.483 / TBS p.162, MSO2 p.2-686)
             status = normalize_status(self._scope.query(self._cmd("get_acq_status")))
             if status == "STOP":
                 return "STOP"
@@ -89,7 +99,13 @@ class Trigger:
 
         if mode == "STOP":
             self._scope.write(self._cmd("stop"))
+        elif self._dialect == "tektronix" and mode == "SINGLE":
+            # Single-shot is a stop-after sequence, not a trigger mode (Tek PM)
+            self._scope.write(self._cmd("set_stop_after", mode="SEQuence"))
+            self._scope.write(self._cmd("run"))
         else:
+            if self._dialect == "tektronix":
+                self._scope.write(self._cmd("set_stop_after", mode="RUNSTop"))
             self._scope.write(self._cmd("set_trigger_mode", mode=mode_to_wire(self._dialect, mode)))
         logger.info(f"Trigger mode set to {mode}")
 
@@ -125,8 +141,8 @@ class Trigger:
         Returns:
             Trigger source (e.g., 'C1', 'C2', 'C3', 'C4', 'EX', 'EX5', 'LINE')
         """
-        if self._dialect == "modern":
-            return self._scope.query(self._cmd("get_trigger_source")).strip()
+        if not is_flat_trigger(self._dialect):
+            return source_from_wire(self._dialect, self._scope.query(self._cmd("get_trigger_source")).strip())
         response = self._scope.query(self._cmd("get_trigger_select"))
         # Response format typically: "EDGE,SR,C1,..."
         parts = response.split(",")
@@ -147,8 +163,8 @@ class Trigger:
         if channel not in valid_sources:
             raise exceptions.InvalidParameterError(f"Invalid trigger source: {channel}. Must be one of {valid_sources}.")
 
-        if self._dialect == "modern":
-            self._scope.write(self._cmd("set_trigger_source", src=channel))
+        if not is_flat_trigger(self._dialect):
+            self._scope.write(self._cmd("set_trigger_source", src=channel_token(self._dialect, channel)))
         else:
             # Get current trigger type to preserve it
             current_type = self.trigger_type
@@ -166,7 +182,7 @@ class Trigger:
         Returns:
             Trigger type: 'EDGE', 'SLEW', 'GLIT', 'INTV', 'RUNT', 'PATTERN', etc.
         """
-        if self._dialect == "modern":
+        if not is_flat_trigger(self._dialect):
             return self._scope.query(self._cmd("get_trigger_type")).strip().upper()
         response = self._scope.query(self._cmd("get_trigger_select"))
         # Response format: "EDGE,SR,C1,..."
@@ -188,7 +204,7 @@ class Trigger:
         if trig_type not in valid_types:
             raise exceptions.InvalidParameterError(f"Invalid trigger type: {trig_type}. Must be one of {valid_types}.")
 
-        if self._dialect == "modern":
+        if not is_flat_trigger(self._dialect):
             self._scope.write(self._cmd("set_trigger_type", type=trig_type))
         else:
             # Get current source to preserve it
@@ -204,9 +220,9 @@ class Trigger:
             slope: Trigger slope - 'POS' (rising), 'NEG' (falling) (default: 'POS')
         """
         source = source.upper()
-        if self._dialect == "modern":
+        if not is_flat_trigger(self._dialect):
             self._scope.write(self._cmd("set_trigger_type", type="EDGE"))
-            self._scope.write(self._cmd("set_trigger_source", src=source))
+            self._scope.write(self._cmd("set_trigger_source", src=channel_token(self._dialect, source)))
         else:
             self._scope.write(self._cmd("set_trigger_select", type="EDGE", src=source))
         self.slope = slope
@@ -219,7 +235,13 @@ class Trigger:
         Returns:
             Trigger level in volts
         """
-        if self._dialect == "modern":
+        if not is_flat_trigger(self._dialect):
+            if self._dialect == "tektronix":
+                source = self.source  # public token like "C3"
+                if not source.startswith("C") or not source[1:].isdigit():
+                    logger.warning(f"Cannot get trigger level for source {source}")
+                    return 0.0
+                return self._parse_float_response(self._scope.query(self._cmd("get_trigger_level", ch=int(source[1:]))))
             return self._parse_float_response(self._scope.query(self._cmd("get_trigger_level")))
         source = self.source
         if source.startswith("C"):
@@ -233,8 +255,15 @@ class Trigger:
         Args:
             voltage: Trigger level in volts
         """
-        if self._dialect == "modern":
-            self._scope.write(self._cmd("set_trigger_level", level=voltage))
+        if not is_flat_trigger(self._dialect):
+            if self._dialect == "tektronix":
+                source = self.source  # public token like "C3"
+                if not source.startswith("C") or not source[1:].isdigit():
+                    logger.warning(f"Cannot set trigger level for source {source}")
+                    return
+                self._scope.write(self._cmd("set_trigger_level", ch=int(source[1:]), level=voltage))
+            else:
+                self._scope.write(self._cmd("set_trigger_level", level=voltage))
             logger.info(f"Trigger level set to {voltage}V")
             return
         source = self.source
@@ -256,10 +285,10 @@ class Trigger:
         Returns:
             Trigger slope: 'POS', 'NEG', or 'WINDOW'
         """
-        if self._dialect == "modern":
-            return slope_from_wire("modern", self._scope.query(self._cmd("get_trigger_slope")))
+        if not is_flat_trigger(self._dialect):
+            return slope_from_wire(self._dialect, self._scope.query(self._cmd("get_trigger_slope")))
         source = self.source
-        return slope_from_wire("legacy", self._scope.query(self._cmd("get_trigger_slope", src=source)))
+        return slope_from_wire(self._dialect, self._scope.query(self._cmd("get_trigger_slope", src=source)))
 
     @slope.setter
     def slope(self, slope: TriggerSlopeType) -> None:
@@ -271,7 +300,7 @@ class Trigger:
         # NOTE: WINDOW maps to the modern ALTernate slope, which triggers on
         # alternating edges rather than either edge - approximate parity only
         wire = slope_to_wire(self._dialect, slope)
-        if self._dialect == "modern":
+        if not is_flat_trigger(self._dialect):
             self._scope.write(self._cmd("set_trigger_slope", slope=wire))
         else:
             source = self.source
@@ -289,10 +318,14 @@ class Trigger:
         Returns:
             Coupling: 'DC', 'AC', 'HFREJ', 'LFREJ'
         """
-        if self._dialect == "modern":
+        if not is_flat_trigger(self._dialect):
             token = self._scope.query(self._cmd("get_trigger_coupling")).strip().upper()
-            # Reverse of the setter's HFREJ->HFREJect mapping (guide p.486)
-            return {"HFREJECT": "HFREJ", "LFREJECT": "LFREJ"}.get(token, token)
+            if self._dialect == "modern":
+                # Reverse of the setter's HFREJ->HFREJect mapping (guide p.486)
+                return {"HFREJECT": "HFREJ", "LFREJECT": "LFREJ"}.get(token, token)
+            # tektronix wire tokens (HFRej/LFRej) already match the public
+            # vocabulary uppercased -- TBS p.151 / MSO2 p.2-661
+            return token
         source = self.source
         return self._scope.query(self._cmd("get_trigger_coupling", src=source)).strip().split()[-1].upper()
 
@@ -307,9 +340,13 @@ class Trigger:
         if coupling not in ["DC", "AC", "HFREJ", "LFREJ"]:
             raise exceptions.InvalidParameterError(f"Invalid trigger coupling: {coupling}. Must be DC, AC, HFREJ, or LFREJ.")
 
-        if self._dialect == "modern":
-            # Modern wire tokens spell out the reject modes (guide p.486)
-            wire = {"HFREJ": "HFREJect", "LFREJ": "LFREJect"}.get(coupling, coupling)
+        if not is_flat_trigger(self._dialect):
+            if self._dialect == "modern":
+                # Modern wire tokens spell out the reject modes (guide p.486)
+                wire = {"HFREJ": "HFREJect", "LFREJ": "LFREJect"}.get(coupling, coupling)
+            else:
+                # tektronix wire tokens: DC|HFRej|LFRej|NOISErej -- TBS p.151 / MSO2 p.2-661
+                wire = {"HFREJ": "HFRej", "LFREJ": "LFRej"}.get(coupling, coupling)
             self._scope.write(self._cmd("set_trigger_coupling", coupling=wire))
         else:
             source = self.source

--- a/scpi_control/waveform.py
+++ b/scpi_control/waveform.py
@@ -1,7 +1,6 @@
 """Waveform acquisition and data processing for Siglent oscilloscopes."""
 
 import logging
-import re
 import struct
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Tuple, Union
@@ -68,7 +67,8 @@ class WaveformData:
             if dt > 0:
                 self.sample_rate = 1.0 / dt
 
-        # Estimate timebase using standard 14 horizontal divisions if possible
+        # generic fallback; real acquisitions carry explicit timebase --
+        # per-model grids live in ModelCapability
         if self.timebase is None and self.sample_rate:
             total_time = self.record_length / self.sample_rate
             self.timebase = total_time / 14.0
@@ -122,44 +122,9 @@ class Waveform:
 
         logger.info(f"Acquiring waveform from channel {channel}")
 
-        # Get channel configuration
-        ch = f"C{channel}"
-        voltage_scale = self._get_voltage_scale(ch)
-        voltage_offset = self._get_voltage_offset(ch)
-        timebase = self._get_timebase()
-        sample_rate = self._get_sample_rate()
+        from scpi_control.waveform_transfer import make_transfer
 
-        # Request waveform data; hold the connection lock so no other thread
-        # can slip a query between the command and its binary response
-        waveform_command = f"{ch}:WF? DAT2"  # DAT2 is binary format
-        with self._scope._connection.lock:
-            self._scope.write(waveform_command)
-            raw_data = self._scope.read_raw()
-
-        # Parse waveform data
-        voltage_data = self._parse_waveform(raw_data, format, waveform_command)
-        record_length = len(voltage_data)
-
-        # Convert to voltage using scale and offset
-        # Formula: Voltage = (code - code_offset) * code_scale + voltage_offset
-        # For 8-bit data: typically code_offset = 127 (or 128), code_scale = voltage_scale / 25
-        voltage = self._convert_to_voltage(voltage_data, voltage_scale, voltage_offset)
-
-        # Generate time axis
-        time = self._generate_time_axis(record_length, sample_rate, timebase)
-
-        logger.info(f"Acquired {record_length} samples from channel {channel}")
-
-        return WaveformData(
-            time=time,
-            voltage=voltage,
-            channel=channel,
-            sample_rate=sample_rate,
-            record_length=record_length,
-            timebase=timebase,
-            voltage_scale=voltage_scale,
-            voltage_offset=voltage_offset,
-        )
+        return make_transfer(self._scope).acquire(channel, format)
 
     def _get_voltage_scale(self, channel: str) -> float:
         """Get voltage scale for channel.
@@ -226,133 +191,29 @@ class Waveform:
     def _parse_waveform(self, raw_data: bytes, format: str = "BYTE", command: Optional[str] = None) -> np.ndarray:
         """Parse waveform data from oscilloscope.
 
+        Compatibility wrapper around waveform_transfer.parse_ieee_block, kept
+        for callers (internal and external) that still use the format-string
+        + command-string signature.
+
         Args:
             raw_data: Raw binary data from oscilloscope
             format: Data format - 'BYTE' or 'WORD'
+            command: Command that produced raw_data (used for error context)
 
         Returns:
             Numpy array of raw data codes
         """
-        # Siglent waveform format:
-        # Header: DESC,#9000000346...
-        # Find the start of binary data (after header)
+        from scpi_control.waveform_transfer import parse_ieee_block
 
-        if not raw_data:
-            raise exceptions.CommandError(self._format_scope_error("Invalid waveform format: empty response", command))
-
-        # Look for the # character indicating block data
-        header_end = raw_data.find(b"#")
-        if header_end == -1:
-            raise exceptions.CommandError(self._format_scope_error("Invalid waveform format: no # found in block header", command))
-
-        if header_end + 2 > len(raw_data):
-            raise exceptions.CommandError(self._format_scope_error("Invalid waveform format: truncated block header", command))
-
-        # Parse IEEE 488.2 definite length block
-        # Format: #<n><length><data>
-        # where n is number of digits in length
-        n_digit_char = chr(raw_data[header_end + 1])
-        if not n_digit_char.isdigit():
-            raise exceptions.CommandError(self._format_scope_error(f"Invalid waveform format: non-numeric length digit '{n_digit_char}'", command))
-
-        n_digits = int(n_digit_char)
-        if n_digits <= 0:
-            raise exceptions.CommandError(
-                self._format_scope_error(
-                    f"Invalid waveform format: length digit must be positive (got {n_digits})",
-                    command,
-                )
-            )
-
-        length_field_start = header_end + 2
-        length_field_end = length_field_start + n_digits
-        if length_field_end > len(raw_data):
-            raise exceptions.CommandError(self._format_scope_error("Invalid waveform format: truncated length field", command))
-
-        length_field = raw_data[length_field_start:length_field_end]
-        if not re.fullmatch(rb"\d+", length_field):
-            raise exceptions.CommandError(
-                self._format_scope_error(
-                    f"Invalid waveform format: non-numeric length field '{length_field.decode(errors='ignore')}'",
-                    command,
-                )
-            )
-
-        data_length = int(length_field)
-        data_start = length_field_end
-        data_end = data_start + data_length
-
-        if data_end > len(raw_data):
-            raise exceptions.CommandError(self._format_scope_error("Invalid waveform format: declared data length exceeds available data", command))
-
-        # Extract binary data
-        binary_data = raw_data[data_start:data_end]
-
-        # Convert to numpy array
         if format == "BYTE":
-            # 8-bit signed data
-            data = np.frombuffer(binary_data, dtype=np.int8)
+            dtype = np.int8
         elif format == "WORD":
-            # 16-bit signed data
-            if data_length % 2:
-                raise exceptions.CommandError(self._format_scope_error("Invalid waveform format: WORD data length must be even", command))
-            data = np.frombuffer(binary_data, dtype=np.int16)
+            dtype = np.int16
         else:
             raise exceptions.InvalidParameterError(f"Invalid format: {format}")
 
-        return data
-
-    def _convert_to_voltage(self, codes: np.ndarray, voltage_scale: float, voltage_offset: float) -> np.ndarray:
-        """Convert raw ADC codes to voltage values.
-
-        Uses conversion formula from Siglent SCPI programming manual:
-        voltage = (code - code_center) * (voltage_scale / code_per_div) - voltage_offset
-
-        For 8-bit ADC:  25 codes per vertical division
-        For 16-bit ADC: 6400 codes per vertical division
-
-        Args:
-            codes: Raw ADC code values (signed int8 or int16)
-            voltage_scale: Voltage scale in volts/division
-            voltage_offset: Voltage offset in volts
-
-        Returns:
-            Voltage array in volts
-        """
-        # Select conversion constants based on ADC resolution
-        if codes.dtype == np.int8:
-            code_per_div = WAVEFORM_CODE_PER_DIV_8BIT
-        else:  # 16-bit data
-            code_per_div = WAVEFORM_CODE_PER_DIV_16BIT
-
-        # Convert codes to voltage using Siglent formula
-        # Since we use signed integers, center code is 0
-        voltage = (codes.astype(np.float64) - WAVEFORM_CODE_CENTER) * (voltage_scale / code_per_div) - voltage_offset
-
-        return voltage
-
-    def _generate_time_axis(self, num_samples: int, sample_rate: float, timebase: float) -> np.ndarray:
-        """Generate time axis for waveform.
-
-        Args:
-            num_samples: Number of samples
-            sample_rate: Sample rate in Sa/s
-            timebase: Timebase in s/div
-
-        Returns:
-            Time array in seconds
-        """
-        # Calculate time interval
-        dt = 1.0 / sample_rate
-
-        # Generate time axis (centered at trigger point)
-        # Typically trigger is at center of screen (14 divisions total, 7 left of trigger)
-        total_time = num_samples * dt
-        trigger_position = total_time / 2  # Assume trigger at center
-
-        time = np.arange(num_samples) * dt - trigger_position
-
-        return time
+        context = f"host {self._scope.host}:{self._scope.port}" + (f", command '{command}'" if command else "")
+        return parse_ieee_block(raw_data, dtype, error_context=context)
 
     def _parse_value_with_units(
         self,

--- a/scpi_control/waveform.py
+++ b/scpi_control/waveform.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Optional, Tuple, Union
 import numpy as np
 
 from scpi_control import exceptions
+from scpi_control.scpi_commands import BARE_NR3_DIALECTS
 
 if TYPE_CHECKING:
     from scpi_control.oscilloscope import Oscilloscope
@@ -399,15 +400,17 @@ class Waveform:
                 except ValueError as exc:
                     raise exceptions.CommandError(self._format_scope_error(f"Invalid {quantity} response: '{response}'", command)) from exc
 
-        # Modern-dialect numeric queries (:CHANnel:SCALe?, :CHANnel:OFFSet?,
-        # :TIMebase:SCALe?, :ACQuire:SRATe?) return a bare NR3 value with no
-        # unit suffix at all (guide pp.46,56,58,476); legacy always echoes a
-        # unit and keeps the strict check above (audit-pinned, see
+        # Bare-NR3 dialects return a numeric value with no unit suffix at
+        # all: modern Siglent (:CHANnel:SCALe?, :CHANnel:OFFSet?,
+        # :TIMebase:SCALe?, :ACQuire:SRATe? -- guide pp.46,56,58,476),
+        # Tektronix (HEADer OFF strips the echo, leaving a bare NR3), and
+        # LeCroy (CHDR OFF). Legacy Siglent always echoes a unit and keeps
+        # the strict check above (audit-pinned, see
         # test_value_parsing_requires_units).
-        if self._dialect == "modern":
+        if self._dialect in BARE_NR3_DIALECTS:
             try:
                 value = float(cleaned)
-                logger.debug(f"Parsed {quantity}: {value} (bare NR3, modern dialect)")
+                logger.debug(f"Parsed {quantity}: {value} (bare NR3, {self._dialect} dialect)")
                 return value
             except ValueError:
                 pass

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -1,0 +1,276 @@
+"""Per-dialect waveform transfer strategies.
+
+Siglent (both dialects) speaks WF? DAT2 with fixed code-per-division scaling;
+Tektronix speaks the CURVe protocol scaled by the WFMOutpre preamble; LeCroy
+(Task 15) speaks WF? ALL scaled by the WAVEDESC descriptor. The IEEE-488.2
+definite-length block framing is shared by all of them.
+"""
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from scpi_control import exceptions
+from scpi_control.waveform import (
+    WAVEFORM_CODE_CENTER,
+    WAVEFORM_CODE_PER_DIV_8BIT,
+    WAVEFORM_CODE_PER_DIV_16BIT,
+    WaveformData,
+)
+
+if TYPE_CHECKING:
+    from scpi_control.oscilloscope import Oscilloscope
+
+logger = logging.getLogger(__name__)
+
+
+def parse_ieee_block(raw_data: bytes, dtype, *, error_context: str = "") -> np.ndarray:
+    """Parse an IEEE-488.2 definite-length block into a numpy array.
+
+    Args:
+        raw_data: Raw bytes containing a "#<n><length><data>" block (with an
+            optional prefix before the "#", e.g. Siglent's "DESC," header).
+        dtype: numpy dtype of the packed samples (np.int8 or np.int16).
+        error_context: Extra context appended to error messages, e.g.
+            "host 1.2.3.4:5025, command 'C1:WF? DAT2'".
+
+    Returns:
+        Numpy array of raw data codes.
+
+    Raises:
+        exceptions.CommandError: If the block is malformed.
+    """
+
+    def _err(message: str) -> str:
+        return f"{message} ({error_context})" if error_context else message
+
+    if not raw_data:
+        raise exceptions.CommandError(_err("Invalid waveform format: empty response"))
+
+    # Look for the # character indicating block data
+    header_end = raw_data.find(b"#")
+    if header_end == -1:
+        raise exceptions.CommandError(_err("Invalid waveform format: no # found in block header"))
+
+    if header_end + 2 > len(raw_data):
+        raise exceptions.CommandError(_err("Invalid waveform format: truncated block header"))
+
+    # Parse IEEE 488.2 definite length block
+    # Format: #<n><length><data>
+    # where n is number of digits in length
+    n_digit_char = chr(raw_data[header_end + 1])
+    if not n_digit_char.isdigit():
+        raise exceptions.CommandError(_err(f"Invalid waveform format: non-numeric length digit '{n_digit_char}'"))
+
+    n_digits = int(n_digit_char)
+    if n_digits <= 0:
+        raise exceptions.CommandError(_err(f"Invalid waveform format: length digit must be positive (got {n_digits})"))
+
+    length_field_start = header_end + 2
+    length_field_end = length_field_start + n_digits
+    if length_field_end > len(raw_data):
+        raise exceptions.CommandError(_err("Invalid waveform format: truncated length field"))
+
+    length_field = raw_data[length_field_start:length_field_end]
+    if not re.fullmatch(rb"\d+", length_field):
+        raise exceptions.CommandError(_err(f"Invalid waveform format: non-numeric length field '{length_field.decode(errors='ignore')}'"))
+
+    data_length = int(length_field)
+    data_start = length_field_end
+    data_end = data_start + data_length
+
+    if data_end > len(raw_data):
+        raise exceptions.CommandError(_err("Invalid waveform format: declared data length exceeds available data"))
+
+    # Extract binary data
+    binary_data = raw_data[data_start:data_end]
+
+    # Convert to numpy array
+    if dtype == np.int16:
+        # 16-bit signed data
+        if data_length % 2:
+            raise exceptions.CommandError(_err("Invalid waveform format: WORD data length must be even"))
+
+    data = np.frombuffer(binary_data, dtype=dtype)
+
+    return data
+
+
+class SiglentTransfer:
+    """WF? DAT2 transfer with code-per-division scaling (current behavior, moved)."""
+
+    def __init__(self, scope: "Oscilloscope"):
+        self._scope = scope
+
+    def acquire(self, channel: int, format: str = "BYTE") -> WaveformData:
+        """Acquire waveform data from a channel via WF? DAT2.
+
+        Args:
+            channel: Channel number (1-4)
+            format: Data format - 'BYTE' or 'WORD' (default: 'BYTE')
+
+        Returns:
+            WaveformData object with time and voltage arrays
+
+        Raises:
+            CommandError: If acquisition fails
+        """
+        # Get channel configuration
+        ch = f"C{channel}"
+        voltage_scale = self._scope.waveform._get_voltage_scale(ch)
+        voltage_offset = self._scope.waveform._get_voltage_offset(ch)
+        timebase = self._scope.waveform._get_timebase()
+        sample_rate = self._scope.waveform._get_sample_rate()
+
+        # Request waveform data; hold the connection lock so no other thread
+        # can slip a query between the command and its binary response
+        waveform_command = self._scope._get_command("get_waveform", ch=channel)
+        with self._scope._connection.lock:
+            self._scope.write(waveform_command)
+            raw_data = self._scope.read_raw()
+
+        # Parse waveform data
+        if format == "BYTE":
+            dtype = np.int8
+        elif format == "WORD":
+            dtype = np.int16
+        else:
+            raise exceptions.InvalidParameterError(f"Invalid format: {format}")
+
+        error_context = f"host {self._scope.host}:{self._scope.port}, command '{waveform_command}'"
+        voltage_data = parse_ieee_block(raw_data, dtype, error_context=error_context)
+        record_length = len(voltage_data)
+
+        # Convert to voltage using scale and offset
+        # Formula: Voltage = (code - code_offset) * code_scale + voltage_offset
+        # For 8-bit data: typically code_offset = 127 (or 128), code_scale = voltage_scale / 25
+        voltage = self._convert_to_voltage(voltage_data, voltage_scale, voltage_offset)
+
+        # Generate time axis
+        time = self._generate_time_axis(record_length, sample_rate, timebase)
+
+        logger.info(f"Acquired {record_length} samples from channel {channel}")
+
+        return WaveformData(
+            time=time,
+            voltage=voltage,
+            channel=channel,
+            sample_rate=sample_rate,
+            record_length=record_length,
+            timebase=timebase,
+            voltage_scale=voltage_scale,
+            voltage_offset=voltage_offset,
+        )
+
+    def _convert_to_voltage(self, codes: np.ndarray, voltage_scale: float, voltage_offset: float) -> np.ndarray:
+        """Convert raw ADC codes to voltage values.
+
+        Uses conversion formula from Siglent SCPI programming manual:
+        voltage = (code - code_center) * (voltage_scale / code_per_div) - voltage_offset
+
+        For 8-bit ADC:  25 codes per vertical division
+        For 16-bit ADC: 6400 codes per vertical division
+
+        Args:
+            codes: Raw ADC code values (signed int8 or int16)
+            voltage_scale: Voltage scale in volts/division
+            voltage_offset: Voltage offset in volts
+
+        Returns:
+            Voltage array in volts
+        """
+        # Select conversion constants based on ADC resolution
+        if codes.dtype == np.int8:
+            code_per_div = WAVEFORM_CODE_PER_DIV_8BIT
+        else:  # 16-bit data
+            code_per_div = WAVEFORM_CODE_PER_DIV_16BIT
+
+        # Convert codes to voltage using Siglent formula
+        # Since we use signed integers, center code is 0
+        voltage = (codes.astype(np.float64) - WAVEFORM_CODE_CENTER) * (voltage_scale / code_per_div) - voltage_offset
+
+        return voltage
+
+    def _generate_time_axis(self, num_samples: int, sample_rate: float, timebase: float) -> np.ndarray:
+        """Generate time axis for waveform.
+
+        Args:
+            num_samples: Number of samples
+            sample_rate: Sample rate in Sa/s
+            timebase: Timebase in s/div
+
+        Returns:
+            Time array in seconds
+        """
+        # Calculate time interval
+        dt = 1.0 / sample_rate
+
+        # Generate time axis (centered at trigger point)
+        # Typically trigger is at center of screen (14 divisions total, 7 left of trigger)
+        total_time = num_samples * dt
+        trigger_position = total_time / 2  # Assume trigger at center
+
+        time = np.arange(num_samples) * dt - trigger_position
+
+        return time
+
+
+class TektronixTransfer:
+    """CURVe? transfer scaled by the WFMOutpre preamble (Tek PMs, Task 7 citations)."""
+
+    def __init__(self, scope: "Oscilloscope"):
+        self._scope = scope
+
+    def acquire(self, channel: int, format: str = "BYTE") -> WaveformData:
+        if format.upper() != "BYTE":
+            raise exceptions.FeatureNotSupportedError("16-bit waveform transfer on tektronix is not supported yet (DATa:WIDth 1 only)")
+        scope = self._scope
+        scope.write(scope._get_command("set_data_source", ch=channel))
+        scope.write(scope._get_command("set_data_encoding"))
+        scope.write(scope._get_command("set_data_width"))
+        n_points = int(float(scope.query(scope._get_command("get_wfm_nr_pt"))))
+        scope.write(scope._get_command("set_data_start", start=1))
+        scope.write(scope._get_command("set_data_stop", stop=n_points))
+        xincr = float(scope.query(scope._get_command("get_wfm_xincr")))
+        xzero = float(scope.query(scope._get_command("get_wfm_xzero")))
+        # WFMOutpre:PT_Off? is MSO2-only (absent from the TBS1000C WFMOutpre
+        # subsystem, per Task 7's manual audit) -- default to 0 (trigger at
+        # record start) when the active dialect/variant doesn't define it.
+        if scope._has_command("get_wfm_pt_off"):
+            pt_off = float(scope.query(scope._get_command("get_wfm_pt_off")))
+        else:
+            pt_off = 0.0
+        ymult = float(scope.query(scope._get_command("get_wfm_ymult")))
+        yzero = float(scope.query(scope._get_command("get_wfm_yzero")))
+        yoff = float(scope.query(scope._get_command("get_wfm_yoff")))
+
+        command = scope._get_command("get_waveform")
+        with scope._connection.lock:
+            scope.write(command)
+            raw = scope.read_raw()
+        codes = parse_ieee_block(raw, np.int8, error_context=f"host {scope.host}:{scope.port}, command '{command}'")
+
+        voltage = (codes.astype(np.float64) - yoff) * ymult + yzero
+        time = xzero + (np.arange(len(codes)) - pt_off) * xincr
+        voltage_scale = scope.waveform._get_voltage_scale(f"C{channel}")
+        timebase = scope.waveform._get_timebase()
+        logger.info(f"Acquired {len(codes)} samples from channel {channel} (tektronix)")
+        return WaveformData(
+            time=time,
+            voltage=voltage,
+            channel=channel,
+            sample_rate=1.0 / xincr if xincr else None,
+            record_length=len(codes),
+            timebase=timebase,
+            voltage_scale=voltage_scale,
+        )
+
+
+def make_transfer(scope: "Oscilloscope"):
+    """Select the waveform transfer strategy for a connected scope's dialect."""
+    dialect = getattr(scope, "dialect", None) or "legacy"
+    if dialect == "tektronix":
+        return TektronixTransfer(scope)
+    return SiglentTransfer(scope)

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -225,6 +225,21 @@ class TektronixTransfer:
         self._scope = scope
 
     def acquire(self, channel: int, format: str = "BYTE") -> WaveformData:
+        """Acquire waveform data from a channel via the CURVe protocol.
+
+        Args:
+            channel: Channel number (1-4)
+            format: Data format - only 'BYTE' (8-bit, DATa:WIDth 1) is
+                supported today; 'WORD' (16-bit) is a follow-up.
+
+        Returns:
+            WaveformData scaled by the WFMOutpre preamble (ymult/yoff/yzero for
+            volts, xincr/xzero/pt_off for the time axis).
+
+        Raises:
+            FeatureNotSupportedError: If a non-BYTE format is requested.
+            CommandError: If the CURVe block is malformed.
+        """
         if format.upper() != "BYTE":
             raise exceptions.FeatureNotSupportedError("16-bit waveform transfer on tektronix is not supported yet (DATa:WIDth 1 only)")
         scope = self._scope
@@ -286,7 +301,8 @@ def parse_wavedesc(payload: bytes, *, error_context: str = "") -> dict:
     """Parse the WAVEDESC descriptor out of a LeCroy WF? ALL payload (CORD LO)."""
     start = payload.find(b"WAVEDESC")
     if start == -1:
-        raise exceptions.CommandError(f"Invalid LeCroy waveform: no WAVEDESC descriptor found ({error_context})")
+        message = "Invalid LeCroy waveform: no WAVEDESC descriptor found"
+        raise exceptions.CommandError(f"{message} ({error_context})" if error_context else message)
     desc_len = struct.unpack_from("<i", payload, start + _WAVEDESC_DESC_LEN)[0]
     user_text_len = struct.unpack_from("<i", payload, start + _WAVEDESC_USER_TEXT_LEN)[0]
     # Per the WAVEDESC template, DATA_ARRAY_1 follows WAVEDESC + USER_TEXT +

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -285,16 +285,16 @@ class TektronixTransfer:
 
 
 # WAVEDESC field offsets, per the MAUI remote manual's TEMPLATE? definition.
-_WAVEDESC_COMM_TYPE = 32       # int16: 0 = byte, 1 = word
-_WAVEDESC_DESC_LEN = 36        # int32: descriptor block length (typ. 346)
-_WAVEDESC_USER_TEXT_LEN = 40   # int32
-_WAVEDESC_TRIGTIME_LEN = 48    # int32: TRIGTIME_ARRAY byte length (0 unless sequence/segment mode)
-_WAVEDESC_RISTIME_LEN = 52     # int32: RIS_TIME_ARRAY byte length (0 unless RIS mode)
-_WAVEDESC_ARRAY_COUNT = 116    # int32: number of samples
+_WAVEDESC_COMM_TYPE = 32  # int16: 0 = byte, 1 = word
+_WAVEDESC_DESC_LEN = 36  # int32: descriptor block length (typ. 346)
+_WAVEDESC_USER_TEXT_LEN = 40  # int32
+_WAVEDESC_TRIGTIME_LEN = 48  # int32: TRIGTIME_ARRAY byte length (0 unless sequence/segment mode)
+_WAVEDESC_RISTIME_LEN = 52  # int32: RIS_TIME_ARRAY byte length (0 unless RIS mode)
+_WAVEDESC_ARRAY_COUNT = 116  # int32: number of samples
 _WAVEDESC_VERTICAL_GAIN = 156  # float32
 _WAVEDESC_VERTICAL_OFFSET = 160  # float32
-_WAVEDESC_HORIZ_INTERVAL = 176   # float32
-_WAVEDESC_HORIZ_OFFSET = 180     # float64
+_WAVEDESC_HORIZ_INTERVAL = 176  # float32
+_WAVEDESC_HORIZ_OFFSET = 180  # float64
 
 
 def parse_wavedesc(payload: bytes, *, error_context: str = "") -> dict:

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -8,6 +8,7 @@ definite-length block framing is shared by all of them.
 
 import logging
 import re
+import struct
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -268,9 +269,76 @@ class TektronixTransfer:
         )
 
 
+# WAVEDESC field offsets, per the MAUI remote manual's TEMPLATE? definition.
+_WAVEDESC_COMM_TYPE = 32       # int16: 0 = byte, 1 = word
+_WAVEDESC_DESC_LEN = 36        # int32: descriptor block length (typ. 346)
+_WAVEDESC_USER_TEXT_LEN = 40   # int32
+_WAVEDESC_ARRAY_COUNT = 116    # int32: number of samples
+_WAVEDESC_VERTICAL_GAIN = 156  # float32
+_WAVEDESC_VERTICAL_OFFSET = 160  # float32
+_WAVEDESC_HORIZ_INTERVAL = 176   # float32
+_WAVEDESC_HORIZ_OFFSET = 180     # float64
+
+
+def parse_wavedesc(payload: bytes, *, error_context: str = "") -> dict:
+    """Parse the WAVEDESC descriptor out of a LeCroy WF? ALL payload (CORD LO)."""
+    start = payload.find(b"WAVEDESC")
+    if start == -1:
+        raise exceptions.CommandError(f"Invalid LeCroy waveform: no WAVEDESC descriptor found ({error_context})")
+    desc_len = struct.unpack_from("<i", payload, start + _WAVEDESC_DESC_LEN)[0]
+    user_text_len = struct.unpack_from("<i", payload, start + _WAVEDESC_USER_TEXT_LEN)[0]
+    return {
+        "comm_type": struct.unpack_from("<h", payload, start + _WAVEDESC_COMM_TYPE)[0],
+        "desc_len": desc_len,
+        "user_text_len": user_text_len,
+        "wave_array_count": struct.unpack_from("<i", payload, start + _WAVEDESC_ARRAY_COUNT)[0],
+        "vertical_gain": struct.unpack_from("<f", payload, start + _WAVEDESC_VERTICAL_GAIN)[0],
+        "vertical_offset": struct.unpack_from("<f", payload, start + _WAVEDESC_VERTICAL_OFFSET)[0],
+        "horiz_interval": struct.unpack_from("<f", payload, start + _WAVEDESC_HORIZ_INTERVAL)[0],
+        "horiz_offset": struct.unpack_from("<d", payload, start + _WAVEDESC_HORIZ_OFFSET)[0],
+        "data_offset": start + desc_len + user_text_len,
+    }
+
+
+class LeCroyTransfer:
+    """WF? ALL transfer scaled by the WAVEDESC descriptor (MAUI remote manual)."""
+
+    def __init__(self, scope: "Oscilloscope"):
+        self._scope = scope
+
+    def acquire(self, channel: int, format: str = "BYTE") -> WaveformData:
+        scope = self._scope
+        fmt = "WORD" if format.upper() == "WORD" else "BYTE"
+        scope.write(scope._get_command("set_comm_format", fmt=fmt))
+        scope.write(scope._get_command("set_comm_order"))
+        command = scope._get_command("get_waveform", ch=channel)
+        with scope._connection.lock:
+            scope.write(command)
+            raw = scope.read_raw()
+        context = f"host {scope.host}:{scope.port}, command '{command}'"
+        payload = parse_ieee_block(raw, np.uint8, error_context=context).tobytes()
+        meta = parse_wavedesc(payload, error_context=context)
+        dtype = np.int16 if meta["comm_type"] == 1 else np.int8
+        codes = np.frombuffer(payload, dtype=dtype, count=meta["wave_array_count"], offset=meta["data_offset"])
+        voltage = meta["vertical_gain"] * codes.astype(np.float64) - meta["vertical_offset"]
+        time = meta["horiz_offset"] + np.arange(len(codes)) * meta["horiz_interval"]
+        logger.info(f"Acquired {len(codes)} samples from channel {channel} (lecroy)")
+        return WaveformData(
+            time=time,
+            voltage=voltage,
+            channel=channel,
+            sample_rate=1.0 / meta["horiz_interval"] if meta["horiz_interval"] else None,
+            record_length=len(codes),
+            timebase=scope.waveform._get_timebase(),
+            voltage_scale=scope.waveform._get_voltage_scale(f"C{channel}"),
+        )
+
+
 def make_transfer(scope: "Oscilloscope"):
     """Select the waveform transfer strategy for a connected scope's dialect."""
     dialect = getattr(scope, "dialect", None) or "legacy"
     if dialect == "tektronix":
         return TektronixTransfer(scope)
+    if dialect == "lecroy":
+        return LeCroyTransfer(scope)
     return SiglentTransfer(scope)

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -273,6 +273,8 @@ class TektronixTransfer:
 _WAVEDESC_COMM_TYPE = 32       # int16: 0 = byte, 1 = word
 _WAVEDESC_DESC_LEN = 36        # int32: descriptor block length (typ. 346)
 _WAVEDESC_USER_TEXT_LEN = 40   # int32
+_WAVEDESC_TRIGTIME_LEN = 48    # int32: TRIGTIME_ARRAY byte length (0 unless sequence/segment mode)
+_WAVEDESC_RISTIME_LEN = 52     # int32: RIS_TIME_ARRAY byte length (0 unless RIS mode)
 _WAVEDESC_ARRAY_COUNT = 116    # int32: number of samples
 _WAVEDESC_VERTICAL_GAIN = 156  # float32
 _WAVEDESC_VERTICAL_OFFSET = 160  # float32
@@ -287,16 +289,24 @@ def parse_wavedesc(payload: bytes, *, error_context: str = "") -> dict:
         raise exceptions.CommandError(f"Invalid LeCroy waveform: no WAVEDESC descriptor found ({error_context})")
     desc_len = struct.unpack_from("<i", payload, start + _WAVEDESC_DESC_LEN)[0]
     user_text_len = struct.unpack_from("<i", payload, start + _WAVEDESC_USER_TEXT_LEN)[0]
+    # Per the WAVEDESC template, DATA_ARRAY_1 follows WAVEDESC + USER_TEXT +
+    # TRIGTIME_ARRAY + RIS_TIME_ARRAY. The two array lengths are 0 for a plain
+    # single-shot capture but non-zero in sequence/RIS modes, and must be
+    # skipped or the sample data is read from the wrong offset.
+    trigtime_len = struct.unpack_from("<i", payload, start + _WAVEDESC_TRIGTIME_LEN)[0]
+    ristime_len = struct.unpack_from("<i", payload, start + _WAVEDESC_RISTIME_LEN)[0]
     return {
         "comm_type": struct.unpack_from("<h", payload, start + _WAVEDESC_COMM_TYPE)[0],
         "desc_len": desc_len,
         "user_text_len": user_text_len,
+        "trigtime_len": trigtime_len,
+        "ristime_len": ristime_len,
         "wave_array_count": struct.unpack_from("<i", payload, start + _WAVEDESC_ARRAY_COUNT)[0],
         "vertical_gain": struct.unpack_from("<f", payload, start + _WAVEDESC_VERTICAL_GAIN)[0],
         "vertical_offset": struct.unpack_from("<f", payload, start + _WAVEDESC_VERTICAL_OFFSET)[0],
         "horiz_interval": struct.unpack_from("<f", payload, start + _WAVEDESC_HORIZ_INTERVAL)[0],
         "horiz_offset": struct.unpack_from("<d", payload, start + _WAVEDESC_HORIZ_OFFSET)[0],
-        "data_offset": start + desc_len + user_text_len,
+        "data_offset": start + desc_len + user_text_len + trigtime_len + ristime_len,
     }
 
 

--- a/tests/dialect_helpers.py
+++ b/tests/dialect_helpers.py
@@ -9,4 +9,5 @@ def make_dialect_scope(dialect):
     scope = Mock()
     scope.dialect = dialect
     scope._get_command.side_effect = SCPICommandSet(dialect).get_command
+    scope._has_command.side_effect = SCPICommandSet(dialect).has_command
     return scope

--- a/tests/dialect_helpers.py
+++ b/tests/dialect_helpers.py
@@ -5,9 +5,9 @@ from unittest.mock import Mock
 from scpi_control.scpi_commands import SCPICommandSet
 
 
-def make_dialect_scope(dialect):
+def make_dialect_scope(dialect, variant="standard"):
     scope = Mock()
     scope.dialect = dialect
-    scope._get_command.side_effect = SCPICommandSet(dialect).get_command
-    scope._has_command.side_effect = SCPICommandSet(dialect).has_command
+    scope._get_command.side_effect = SCPICommandSet(dialect, variant).get_command
+    scope._has_command.side_effect = SCPICommandSet(dialect, variant).has_command
     return scope

--- a/tests/test_dialect_connect.py
+++ b/tests/test_dialect_connect.py
@@ -62,6 +62,13 @@ def test_dialect_override_accepts_tektronix():
     scope.disconnect()
 
 
+def test_lecroy_scope_resolves_and_sends_chdr_off():
+    scope, conn = make_scope("LECROY,WAVESURFER3024Z,MOCK0200,8.5.0")
+    assert scope.dialect == "lecroy"
+    assert "CHDR OFF" in conn.writes
+    scope.disconnect()
+
+
 def test_datacollector_forwards_dialect_override():
     from scpi_control.automation import DataCollector
 

--- a/tests/test_dialect_connect.py
+++ b/tests/test_dialect_connect.py
@@ -48,6 +48,20 @@ def test_dialect_is_none_before_connect():
     assert scope.dialect is None
 
 
+def test_tektronix_scope_resolves_and_sends_header_off():
+    scope, conn = make_scope("TEKTRONIX,MSO24,MOCK0100,FV:1.28")
+    assert scope.dialect == "tektronix"
+    assert "HEADer OFF" in conn.writes
+    assert "CHDR OFF" not in conn.writes
+    scope.disconnect()
+
+
+def test_dialect_override_accepts_tektronix():
+    scope, conn = make_scope("TEKTRONIX,MSO24,MOCK0100,FV:1.28", dialect="tektronix")
+    assert scope.dialect == "tektronix"
+    scope.disconnect()
+
+
 def test_datacollector_forwards_dialect_override():
     from scpi_control.automation import DataCollector
 

--- a/tests/test_dialect_matrix.py
+++ b/tests/test_dialect_matrix.py
@@ -10,6 +10,7 @@ IDN = {
     "legacy": "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0",
     "modern": "Siglent Technologies,SDS824X HD,MOCK0002,3.8.12",
     "tektronix": "TEKTRONIX,MSO24,MOCK0100,CF:91.1CT FV:1.28",
+    "lecroy": "LECROY,WAVESURFER3024Z,MOCK0200,8.5.0",
 }
 
 WIRE = {
@@ -46,10 +47,21 @@ WIRE = {
         "stop": "ACQuire:STATE STOP",
         "status_q": "TRIGger:STATE?",
     },
+    "lecroy": {
+        "chdr": True,  # CHDR is LeCroy's own COMM_HEADER short form
+        "mode_norm": "TRIG_MODE NORM",
+        "source": "TRIG_SELECT EDGE,SR,C2",
+        "vdiv": "C1:VDIV 0.5",
+        "coupling_ac": "C1:CPL A1M",
+        "tdiv": "TDIV 0.002",
+        "run": "TRIG_MODE AUTO",
+        "stop": "STOP",
+        "status_q": "TRIG_MODE?",  # STOP probe of the lecroy acquisition_status path
+    },
 }
 
 
-@pytest.fixture(params=["legacy", "modern", "tektronix"])
+@pytest.fixture(params=["legacy", "modern", "tektronix", "lecroy"])
 def rig(request):
     dialect = request.param
     conn = MockConnection("mock", idn=IDN[dialect], channel_states={1: True, 2: True}, trigger_status=["Ready", "Trig'd", "Stop"], sample_rate=1_000.0, timebase=1e-3)
@@ -110,10 +122,11 @@ STATUS_SEQ = {
     "legacy": ["Ready", "Ready", "Trig'd"],
     "modern": ["Ready", "Ready", "Trig'd"],
     "tektronix": ["READY", "READY", "TRIGGER"],
+    "lecroy": ["Ready", "Ready", "Trig'd"],  # lecroy mock's INR? maps Trig'd -> "1"
 }
 
 
-@pytest.mark.parametrize("dialect", ["legacy", "modern", "tektronix"])
+@pytest.mark.parametrize("dialect", ["legacy", "modern", "tektronix", "lecroy"])
 def test_wait_for_trigger_normal_mode_both_dialects(monkeypatch, dialect):
     conn = MockConnection("mock", idn=IDN[dialect], channel_states={1: True}, trigger_status=STATUS_SEQ[dialect], sample_rate=1_000.0)
     tc = TriggerWaitCollector("mock", connection=conn)

--- a/tests/test_dialect_matrix.py
+++ b/tests/test_dialect_matrix.py
@@ -9,6 +9,7 @@ from scpi_control.connection.mock import MockConnection
 IDN = {
     "legacy": "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0",
     "modern": "Siglent Technologies,SDS824X HD,MOCK0002,3.8.12",
+    "tektronix": "TEKTRONIX,MSO24,MOCK0100,CF:91.1CT FV:1.28",
 }
 
 WIRE = {
@@ -34,10 +35,21 @@ WIRE = {
         "stop": ":TRIGger:STOP",
         "status_q": ":TRIGger:STATus?",
     },
+    "tektronix": {
+        "chdr": False,
+        "mode_norm": "TRIGger:A:MODe NORMal",
+        "source": "TRIGger:A:EDGE:SOUrce CH2",
+        "vdiv": "CH1:SCAle 0.5",
+        "coupling_ac": "CH1:COUPling AC",
+        "tdiv": "HORizontal:SCAle 0.002",
+        "run": "ACQuire:STATE RUN",
+        "stop": "ACQuire:STATE STOP",
+        "status_q": "TRIGger:STATE?",
+    },
 }
 
 
-@pytest.fixture(params=["legacy", "modern"])
+@pytest.fixture(params=["legacy", "modern", "tektronix"])
 def rig(request):
     dialect = request.param
     conn = MockConnection("mock", idn=IDN[dialect], channel_states={1: True, 2: True}, trigger_status=["Ready", "Trig'd", "Stop"], sample_rate=1_000.0, timebase=1e-3)
@@ -94,9 +106,16 @@ def test_get_waveform_wire_and_value(rig):
     assert len(waveform.voltage) > 0
 
 
-@pytest.mark.parametrize("dialect", ["legacy", "modern"])
+STATUS_SEQ = {
+    "legacy": ["Ready", "Ready", "Trig'd"],
+    "modern": ["Ready", "Ready", "Trig'd"],
+    "tektronix": ["READY", "READY", "TRIGGER"],
+}
+
+
+@pytest.mark.parametrize("dialect", ["legacy", "modern", "tektronix"])
 def test_wait_for_trigger_normal_mode_both_dialects(monkeypatch, dialect):
-    conn = MockConnection("mock", idn=IDN[dialect], channel_states={1: True}, trigger_status=["Ready", "Ready", "Trig'd"], sample_rate=1_000.0)
+    conn = MockConnection("mock", idn=IDN[dialect], channel_states={1: True}, trigger_status=STATUS_SEQ[dialect], sample_rate=1_000.0)
     tc = TriggerWaitCollector("mock", connection=conn)
     tc.collector.connect()
 

--- a/tests/test_measurement_comprehensive.py
+++ b/tests/test_measurement_comprehensive.py
@@ -411,3 +411,33 @@ def test_tektronix_statistics_not_supported():
     with pytest.raises(exceptions.FeatureNotSupportedError):
         scope.measurement.set_cursor_type("HREL")
     scope.disconnect()
+
+
+def test_lecroy_pava_measurement():
+    from scpi_control import Oscilloscope
+    from scpi_control.connection.mock import MockConnection
+
+    conn = MockConnection("mock", idn="LECROY,WAVESURFER3024Z,MOCK0200,8.5.0", channel_states={1: True})
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    assert scope.measurement.measure_vpp(1) == pytest.approx(2.0)
+    assert "C1:PAVA? PKPK" in conn.queries
+    scope.disconnect()
+
+
+def test_lecroy_add_measurement_and_holdoff_not_supported():
+    # LeCroy PACU is slot-addressed ("PACU <slot>,<measurement>,<qualifier>",
+    # MAUI p.7-59) and holdoff lives in TRIG_SELECT HT/HV, not a Siglent-style
+    # PACU/TRDL pair -- both entries were dropped from the lecroy table
+    # (scpi_commands.py LECROY_COMMANDS comments), so both gate cleanly.
+    from scpi_control import Oscilloscope, exceptions
+    from scpi_control.connection.mock import MockConnection
+
+    conn = MockConnection("mock", idn="LECROY,WAVESURFER3024Z,MOCK0200,8.5.0", channel_states={1: True})
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        scope.measurement.add_measurement("PKPK", 1)
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        scope.trigger.holdoff = 0.001
+    scope.disconnect()

--- a/tests/test_measurement_comprehensive.py
+++ b/tests/test_measurement_comprehensive.py
@@ -371,3 +371,43 @@ def test_statistics_raise_cleanly_on_modern_dialect():
     with pytest.raises(exceptions.FeatureNotSupportedError):
         scope.trigger.holdoff = 0.001
     scope.disconnect()
+
+
+def test_tektronix_immediate_measurement():
+    from scpi_control import Oscilloscope
+    from scpi_control.connection.mock import MockConnection
+
+    conn = MockConnection("mock", idn="TEKTRONIX,TBS1102C,MOCK0101,CF:91.1CT FV:1.10", channel_states={1: True})
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    assert scope.measurement.measure_vpp(1) == pytest.approx(2.0)
+    assert scope.measurement.measure_frequency(1) == pytest.approx(1000.0)
+    assert "MEASUrement:IMMed:TYPe PK2Pk" in conn.writes
+    assert "MEASUrement:IMMed:SOUrce1 CH1" in conn.writes
+    scope.disconnect()
+
+
+def test_tektronix_immediate_measurement_not_supported_on_mso():
+    from scpi_control import Oscilloscope, exceptions
+    from scpi_control.connection.mock import MockConnection
+
+    conn = MockConnection("mock", idn="TEKTRONIX,MSO24,MOCK0100,FV:1.28", channel_states={1: True})
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        scope.measurement.measure_vpp(1)
+    scope.disconnect()
+
+
+def test_tektronix_statistics_not_supported():
+    from scpi_control import Oscilloscope, exceptions
+    from scpi_control.connection.mock import MockConnection
+
+    conn = MockConnection("mock", idn="TEKTRONIX,MSO24,MOCK0100,FV:1.28")
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        scope.measurement.enable_statistics()
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        scope.measurement.set_cursor_type("HREL")
+    scope.disconnect()

--- a/tests/test_measurement_comprehensive.py
+++ b/tests/test_measurement_comprehensive.py
@@ -6,15 +6,13 @@ import pytest
 
 from scpi_control.exceptions import CommandError
 from scpi_control.measurement import Measurement
+from tests.dialect_helpers import make_dialect_scope
 
 
 @pytest.fixture
 def mock_scope():
-    """Create a mock oscilloscope for testing."""
-    scope = Mock()
-    scope.write = Mock()
-    scope.query = Mock()
-    return scope
+    """Create a mock oscilloscope for testing (legacy dialect, real command table)."""
+    return make_dialect_scope("legacy")
 
 
 @pytest.fixture
@@ -359,3 +357,17 @@ class TestMeasurementStringRepresentation:
     def test_repr(self, measurement):
         """Test repr."""
         assert "Measurement" in repr(measurement)
+
+
+def test_statistics_raise_cleanly_on_modern_dialect():
+    from scpi_control import Oscilloscope, exceptions
+    from scpi_control.connection.mock import MockConnection
+
+    conn = MockConnection("mock", idn="Siglent Technologies,SDS824X HD,MOCK0002,3.8.12")
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        scope.measurement.enable_statistics()
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        scope.trigger.holdoff = 0.001
+    scope.disconnect()

--- a/tests/test_mock_dialects.py
+++ b/tests/test_mock_dialects.py
@@ -194,3 +194,51 @@ def test_tek_mock_probe_gain_family_split():
     assert conn.query("CH2:PROBEFunc:EXTAtten?") == "1.00E+01"
     assert conn.probe_gains[1] == 0.1
     assert conn.probe_gains[2] == 10.0
+
+
+LECROY_IDN = "LECROY,WAVESURFER3024Z,MOCK0200,8.5.0"
+
+
+def _lecroy_conn(**kwargs):
+    from scpi_control.connection.mock import MockConnection
+
+    conn = MockConnection("mock", idn=LECROY_IDN, **kwargs)
+    conn.connect()
+    return conn
+
+
+def test_lecroy_mock_answers_bare_nr3():
+    conn = _lecroy_conn()
+    conn.write("C1:VDIV 0.5")
+    assert conn.query("C1:VDIV?") == "5.00E-01"  # no V suffix, unlike Siglent legacy
+    conn.write("TDIV 0.002")
+    assert conn.query("TDIV?") == "2.00E-03"
+
+
+def test_lecroy_mock_status_and_vbs():
+    conn = _lecroy_conn()
+    conn.write("TRIG_MODE AUTO")
+    assert conn.query("TRIG_MODE?") == "AUTO"
+    assert conn.query("INR?") in {"0", "1"}
+    assert float(conn.query("VBS? 'return=app.Acquisition.Horizontal.SamplingRate'")) == 1000.0
+
+
+def test_lecroy_mock_times_out_on_wrong_dialect():
+    import pytest
+
+    from scpi_control import exceptions
+
+    conn = _lecroy_conn()
+    with pytest.raises(exceptions.TimeoutError):
+        conn.query("SAST?")
+    with pytest.raises(exceptions.TimeoutError):
+        conn.query(":TIMebase:SCALe?")
+
+
+def test_lecroy_mock_pava():
+    conn = _lecroy_conn()
+    resp = conn.query("C1:PAVA? PKPK")
+    parts = resp.split(",")
+    assert parts[0] == "PKPK"
+    assert float(parts[1]) == 2.0
+    assert parts[2] == "OK"

--- a/tests/test_mock_dialects.py
+++ b/tests/test_mock_dialects.py
@@ -130,3 +130,67 @@ def test_mock_answers_scdp_with_a_valid_image():
         assert buf.getvalue().startswith(b"\x89PNG\r\n\x1a\n")
     finally:
         scope.disconnect()
+
+
+TEK_IDN = "TEKTRONIX,MSO24,MOCK0100,CF:91.1CT FV:1.28"
+
+
+def _tek_conn(**kwargs):
+    from scpi_control.connection.mock import MockConnection
+
+    conn = MockConnection("mock", idn=TEK_IDN, **kwargs)
+    conn.connect()
+    return conn
+
+
+def test_tek_mock_answers_tek_queries():
+    conn = _tek_conn()
+    conn.write("CH1:SCAle 0.5")
+    assert conn.query("CH1:SCAle?") == "5.00E-01"
+    conn.write("HORizontal:SCAle 0.002")
+    assert conn.query("HORizontal:SCAle?") == "2.00E-03"
+    assert conn.query("TRIGger:STATE?") in {"ARMED", "AUTO", "READY", "SAVE", "TRIGGER"}
+
+
+def test_tek_mock_times_out_on_siglent_commands():
+    import pytest
+
+    from scpi_control import exceptions
+
+    conn = _tek_conn()
+    with pytest.raises(exceptions.TimeoutError):
+        conn.query("TDIV?")
+    with pytest.raises(exceptions.TimeoutError):
+        conn.query(":TIMebase:SCALe?")
+
+
+def test_tek_mock_trigger_state_machine():
+    conn = _tek_conn()
+    conn.write("ACQuire:STOPAfter SEQuence")
+    conn.write("ACQuire:STATE RUN")
+    assert conn.tek_stop_after == "SEQUENCE"
+    conn.write("TRIGger:A:EDGE:SOUrce CH2")
+    assert conn.trigger_source == "CH2"
+    conn.write("TRIGger:A:LEVel:CH2 0.5")
+    assert conn.trigger_level[2] == 0.5
+
+
+def test_tek_mock_serves_curve_block():
+    conn = _tek_conn(waveform_payloads={1: bytes([0, 25, 50, 75])})
+    conn.write("DATa:SOUrce CH1")
+    assert conn.query("WFMOutpre:NR_Pt?") == "4"
+    conn.write("CURVe?")
+    raw = conn.read_raw()
+    assert raw.startswith(b"#")  # bare IEEE block, no DESC prefix
+
+
+def test_tek_mock_probe_gain_family_split():
+    """Task 7 correction: tek_tbs writes CH{ch}:PRObe:GAIN, tek_mso writes
+    CH{ch}:PROBEFunc:EXTAtten -- both must land in the same probe_gains state."""
+    conn = _tek_conn()
+    conn.write("CH1:PRObe:GAIN 0.1")
+    assert conn.query("CH1:PRObe:GAIN?") == "1.00E-01"
+    conn.write("CH2:PROBEFunc:EXTAtten 10")
+    assert conn.query("CH2:PROBEFunc:EXTAtten?") == "1.00E+01"
+    assert conn.probe_gains[1] == 0.1
+    assert conn.probe_gains[2] == 10.0

--- a/tests/test_scpi_command_tables.py
+++ b/tests/test_scpi_command_tables.py
@@ -206,3 +206,107 @@ class TestMeasurementRouting:
         assert measurement_to_wire("modern", "FREQ") == "FREQ"
         with pytest.raises(ValueError):
             measurement_to_wire("legacy", "BOGUS")
+
+
+from scpi_control.scpi_commands import probe_from_wire, probe_to_wire
+from scpi_control import exceptions as exc
+
+
+class TestTektronixTable:
+    def setup_method(self):
+        self.cmds = SCPICommandSet("tektronix", "tek_tbs")
+
+    def test_channel_and_timebase(self):
+        assert self.cmds.get_command("set_voltage_div", ch=1, vdiv=0.5) == "CH1:SCAle 0.5"
+        assert self.cmds.get_command("set_voltage_offset", ch=2, offset=-1.0) == "CH2:OFFSet -1.0"
+        assert self.cmds.get_command("set_coupling", ch=1, coupling="AC") == "CH1:COUPling AC"
+        assert self.cmds.get_command("set_time_div", tdiv=0.002) == "HORizontal:SCAle 0.002"
+        assert self.cmds.get_command("get_sample_rate") == "HORizontal:SAMPLERate?"
+        assert self.cmds.get_command("set_channel_display", ch=1, state="ON") == "SELect:CH1 ON"
+
+    def test_mso_display_override(self):
+        mso = SCPICommandSet("tektronix", "tek_mso")
+        assert mso.get_command("set_channel_display", ch=1, state="ON") == "DISplay:GLObal:CH1:STATE ON"
+
+    def test_trigger_commands(self):
+        assert self.cmds.get_command("set_trigger_mode", mode="NORMal") == "TRIGger:A:MODe NORMal"
+        assert self.cmds.get_command("set_trigger_source", src="CH2") == "TRIGger:A:EDGE:SOUrce CH2"
+        assert self.cmds.get_command("set_trigger_level", ch=1, level=0.5) == "TRIGger:A:LEVel:CH1 0.5"
+        assert self.cmds.get_command("set_trigger_slope", slope="RISe") == "TRIGger:A:EDGE:SLOpe RISe"
+        assert self.cmds.get_command("run") == "ACQuire:STATE RUN"
+        assert self.cmds.get_command("stop") == "ACQuire:STATE STOP"
+        assert self.cmds.get_command("set_stop_after", mode="SEQuence") == "ACQuire:STOPAfter SEQuence"
+        assert self.cmds.get_command("get_acq_status") == "TRIGger:STATE?"
+        assert self.cmds.get_command("set_trigger_holdoff", t=0.001) == "TRIGger:A:HOLDoff:TIMe 0.001"
+        assert not self.cmds.has_command("arm_trigger")
+
+    def test_waveform_and_measurement_entries(self):
+        assert self.cmds.get_command("set_data_source", ch=1) == "DATa:SOUrce CH1"
+        assert self.cmds.get_command("get_waveform") == "CURVe?"
+        assert self.cmds.get_command("get_wfm_ymult") == "WFMOutpre:YMUlt?"
+        # PK2Pk spelling per TBS1000C PM 077-1691-01 p.119
+        assert self.cmds.get_command("set_meas_immed_type", type="PK2Pk") == "MEASUrement:IMMed:TYPe PK2Pk"
+
+    def test_family_splits(self):
+        # Manual-verified divergences: IMMed measurements and PRObe:GAIN are
+        # TBS-only; WFMOutpre:PT_Off? and PROBEFunc:EXTAtten are MSO-only.
+        mso = SCPICommandSet("tektronix", "tek_mso")
+        assert self.cmds.has_command("set_meas_immed_type")
+        assert not mso.has_command("set_meas_immed_type")
+        assert not mso.has_command("get_meas_immed_value")
+        assert not self.cmds.has_command("get_wfm_pt_off")
+        assert mso.get_command("get_wfm_pt_off") == "WFMOutpre:PT_Off?"
+        assert self.cmds.get_command("set_probe_ratio", ch=1, gain=0.1) == "CH1:PRObe:GAIN 0.1"
+        assert mso.get_command("set_probe_ratio", ch=1, gain=0.1) == "CH1:PROBEFunc:EXTAtten 0.1"
+
+    def test_connect_setup(self):
+        assert CONNECT_SETUP["tektronix"] == ["HEADer OFF"]
+
+
+class TestTektronixConverters:
+    def test_modes(self):
+        assert mode_to_wire("tektronix", "AUTO") == "AUTO"
+        assert mode_to_wire("tektronix", "NORM") == "NORMal"
+        assert mode_from_wire("tektronix", "NORMAL") == "NORM"
+        with pytest.raises(exc.FeatureNotSupportedError):
+            mode_to_wire("tektronix", "SINGLE")  # single-shot is a command sequence, not a mode
+
+    def test_slopes(self):
+        assert slope_to_wire("tektronix", "POS") == "RISe"
+        assert slope_to_wire("tektronix", "NEG") == "FALL"
+        assert slope_from_wire("tektronix", "RISE") == "POS"
+        with pytest.raises(exc.FeatureNotSupportedError):
+            slope_to_wire("tektronix", "WINDOW")
+
+    def test_coupling_identity(self):
+        assert coupling_to_wire("tektronix", "DC") == "DC"
+        assert coupling_to_wire("tektronix", "AC") == "AC"
+        assert coupling_from_wire("tektronix", "AC") == "AC"
+        # Neither Tek family has GND coupling (TBS1000C PM p.53: {AC|DC};
+        # MSO2 PM p.2-184: {AC|DC|DCREJect}) -- valid public token, so it
+        # gates as FeatureNotSupportedError rather than ValueError.
+        with pytest.raises(exc.FeatureNotSupportedError):
+            coupling_to_wire("tektronix", "GND")
+
+    def test_status_map_covers_tek_states(self):
+        assert normalize_status("TRIGGER") == "TRIGD"
+        assert normalize_status("SAVE") == "STOP"
+        assert normalize_status("ARMED") == "ARM"
+
+    def test_probe_gain_inversion(self):
+        assert probe_to_wire("tektronix", 10.0) == "0.1"
+        assert probe_from_wire("tektronix", "0.1") == pytest.approx(10.0)
+        assert probe_to_wire("legacy", 10.0) == "10"
+        assert probe_from_wire("legacy", "10") == pytest.approx(10.0)
+
+    def test_channel_token_tek(self):
+        assert channel_token("tektronix", 2) == "CH2"
+        assert channel_token("tektronix", "C2") == "CH2"
+        assert source_from_wire("tektronix", "CH2") == "C2"
+
+    def test_measurement_map(self):
+        # Wire spellings verbatim from TBS1000C PM 077-1691-01 p.119
+        assert measurement_to_wire("tektronix", "PKPK") == "PK2Pk"
+        assert measurement_to_wire("tektronix", "FREQ") == "FREQuency"
+        assert measurement_to_wire("tektronix", "TOP") == "HIGH"
+        assert measurement_to_wire("tektronix", "DUTY") == "PDUty"

--- a/tests/test_scpi_command_tables.py
+++ b/tests/test_scpi_command_tables.py
@@ -163,3 +163,13 @@ class TestDialectHelpers:
     def test_bare_nr3_dialects(self):
         assert "modern" in BARE_NR3_DIALECTS
         assert "legacy" not in BARE_NR3_DIALECTS
+
+    def test_valid_public_token_unsupported_on_dialect_raises(self):
+        # STOP is the :TRIGger:STOP command on modern, not a trigger-mode token;
+        # the converter contract maps "valid public token, missing from dialect
+        # table" to FeatureNotSupportedError (ValueError stays reserved for
+        # invalid public tokens).
+        from scpi_control import exceptions
+
+        with pytest.raises(exceptions.FeatureNotSupportedError):
+            mode_to_wire("modern", "STOP")

--- a/tests/test_scpi_command_tables.py
+++ b/tests/test_scpi_command_tables.py
@@ -116,3 +116,26 @@ class TestEnumMappers:
             mode_to_wire("modern", "BOGUS")
         with pytest.raises(ValueError):
             normalize_status("???")
+
+
+from scpi_control.scpi_commands import CONNECT_SETUP, SUPPORTED_DIALECTS
+
+
+class TestDialectInfrastructure:
+    def test_supported_dialects_drive_validation(self):
+        assert "legacy" in SUPPORTED_DIALECTS
+        assert "modern" in SUPPORTED_DIALECTS
+        with pytest.raises(ValueError):
+            SCPICommandSet("klingon")
+
+    def test_connect_setup_per_dialect(self):
+        assert CONNECT_SETUP["legacy"] == ["CHDR OFF"]
+        assert CONNECT_SETUP["modern"] == []
+
+    def test_ieee488_base_present_in_every_dialect(self):
+        for dialect in SUPPORTED_DIALECTS:
+            cmds = SCPICommandSet(dialect)
+            assert cmds.get_command("identify") == "*IDN?"
+            assert cmds.get_command("reset") == "*RST"
+            assert cmds.get_command("clear_status") == "*CLS"
+            assert cmds.get_command("operation_complete") == "*OPC?"

--- a/tests/test_scpi_command_tables.py
+++ b/tests/test_scpi_command_tables.py
@@ -173,3 +173,36 @@ class TestDialectHelpers:
 
         with pytest.raises(exceptions.FeatureNotSupportedError):
             mode_to_wire("modern", "STOP")
+
+
+from scpi_control.scpi_commands import measurement_to_wire
+
+
+class TestMeasurementRouting:
+    def test_legacy_measurement_table_entries(self):
+        cmds = SCPICommandSet("legacy")
+        # NOTE: get_parameter_value's wire form is "PAVA? {param},C{ch}", not
+        # "C{ch}:PAVA? {param}" -- this matches the wire string measurement.py
+        # actually sent pre-refactor (and what the legacy mock's PAVA? regex
+        # parses); the table previously held an unreachable, never-exercised
+        # value here.
+        assert cmds.get_command("get_parameter_value", ch=1, param="PKPK") == "PAVA? PKPK,C1"
+        assert cmds.get_command("add_measurement", mtype="FREQ", ch=2) == "PACU FREQ,C2"
+        assert cmds.get_command("set_statistics", state="ON") == "PAST ON"
+        assert cmds.get_command("clear_measurements") == "PACL"
+        assert cmds.get_command("reset_statistics") == "PASTAT RESET"
+        assert cmds.get_command("set_trigger_holdoff", t=0.001) == "TRIG_DELAY 0.001"
+        assert cmds.get_command("set_channel_unit", ch=1, unit="A") == "C1:UNIT A"
+
+    def test_modern_lacks_statistics_and_holdoff(self):
+        cmds = SCPICommandSet("modern")
+        assert not cmds.has_command("add_measurement")
+        assert not cmds.has_command("set_statistics")
+        assert not cmds.has_command("set_trigger_holdoff")
+        assert not cmds.has_command("set_channel_unit")
+
+    def test_measurement_to_wire_identity_for_siglent(self):
+        assert measurement_to_wire("legacy", "PKPK") == "PKPK"
+        assert measurement_to_wire("modern", "FREQ") == "FREQ"
+        with pytest.raises(ValueError):
+            measurement_to_wire("legacy", "BOGUS")

--- a/tests/test_scpi_command_tables.py
+++ b/tests/test_scpi_command_tables.py
@@ -310,3 +310,42 @@ class TestTektronixConverters:
         assert measurement_to_wire("tektronix", "FREQ") == "FREQuency"
         assert measurement_to_wire("tektronix", "TOP") == "HIGH"
         assert measurement_to_wire("tektronix", "DUTY") == "PDUty"
+
+
+class TestLeCroyTable:
+    def setup_method(self):
+        self.cmds = SCPICommandSet("lecroy", "lecroy_maui")
+
+    def test_inherits_lecroy_flat_syntax(self):
+        assert self.cmds.get_command("set_voltage_div", ch=1, vdiv=0.5) == "C1:VDIV 0.5"
+        assert self.cmds.get_command("set_trigger_select", type="EDGE", src="C2") == "TRIG_SELECT EDGE,SR,C2"
+        assert self.cmds.get_command("set_time_div", tdiv=0.002) == "TDIV 0.002"
+        assert self.cmds.get_command("run") == "TRIG_MODE AUTO"
+        assert self.cmds.get_command("stop") == "STOP"
+        assert self.cmds.get_command("arm_trigger") == "ARM"
+
+    def test_lecroy_specific_diffs(self):
+        assert self.cmds.get_command("get_acq_status") == "INR?"
+        assert self.cmds.get_command("get_waveform", ch=1) == "C1:WF? ALL"
+        assert self.cmds.get_command("set_comm_format", fmt="BYTE") == "CFMT DEF9,BYTE,BIN"
+        assert self.cmds.get_command("set_comm_order") == "CORD LO"
+        assert self.cmds.get_command("set_bandwidth_limit", ch=1, limit="ON") == "BWL C1,ON"
+        assert not self.cmds.has_command("set_statistics")
+        assert not self.cmds.has_command("set_trigger_holdoff")
+        # add_measurement dropped: LeCroy PACU is slot-first (see task-13 report)
+        assert not self.cmds.has_command("add_measurement")
+        # PAVA form: manual mandates the LeCroy-native trace-prefix form
+        # "C{ch}:PAVA? {param}" (MAUI p.7-70), NOT the Siglent "PAVA? p,C{ch}"
+        # form -- decided from the manual (see task-13 report, PAVA-form decision).
+        assert self.cmds.get_command("get_parameter_value", ch=1, param="PKPK") == "C1:PAVA? PKPK"
+
+    def test_lecroy_converters_match_legacy(self):
+        assert mode_to_wire("lecroy", "NORM") == "NORM"
+        assert slope_to_wire("lecroy", "POS") == "POS"
+        assert coupling_to_wire("lecroy", "AC") == "A1M"
+        assert measurement_to_wire("lecroy", "PKPK") == "PKPK"
+        assert is_flat_trigger("lecroy") is True
+        assert "lecroy" in BARE_NR3_DIALECTS
+
+    def test_connect_setup(self):
+        assert CONNECT_SETUP["lecroy"] == ["CHDR OFF"]

--- a/tests/test_scpi_command_tables.py
+++ b/tests/test_scpi_command_tables.py
@@ -139,3 +139,27 @@ class TestDialectInfrastructure:
             assert cmds.get_command("reset") == "*RST"
             assert cmds.get_command("clear_status") == "*CLS"
             assert cmds.get_command("operation_complete") == "*OPC?"
+
+
+from scpi_control.scpi_commands import BARE_NR3_DIALECTS, channel_token, is_flat_trigger, source_from_wire
+
+
+class TestDialectHelpers:
+    def test_channel_token_passthrough_for_siglent(self):
+        assert channel_token("legacy", 2) == "C2"
+        assert channel_token("legacy", "C2") == "C2"
+        assert channel_token("modern", "C1") == "C1"
+        assert channel_token("legacy", "EX") == "EX"
+        assert channel_token("legacy", "LINE") == "LINE"
+
+    def test_source_from_wire_passthrough_for_siglent(self):
+        assert source_from_wire("legacy", "C2") == "C2"
+        assert source_from_wire("modern", " C3 ") == "C3"
+
+    def test_flat_trigger_dialects(self):
+        assert is_flat_trigger("legacy") is True
+        assert is_flat_trigger("modern") is False
+
+    def test_bare_nr3_dialects(self):
+        assert "modern" in BARE_NR3_DIALECTS
+        assert "legacy" not in BARE_NR3_DIALECTS

--- a/tests/test_vendor_detection.py
+++ b/tests/test_vendor_detection.py
@@ -8,3 +8,70 @@ from scpi_control import exceptions
 def test_feature_not_supported_error_exists_and_subclasses_base():
     err = exceptions.FeatureNotSupportedError("holdoff is not supported on the modern dialect")
     assert isinstance(err, exceptions.SiglentError)
+
+
+from scpi_control.models import MODEL_REGISTRY, ModelCapability, detect_model_from_idn
+
+
+def test_existing_siglent_entries_default_to_siglent_vendor():
+    cap = MODEL_REGISTRY["SDS1104X-E"]
+    assert cap.vendor == "siglent"
+    assert cap.horiz_divisions == 14
+    assert cap.vert_divisions == 8
+
+
+def test_siglent_detection_unchanged():
+    cap = detect_model_from_idn("Siglent Technologies,SDS824X HD,SER,1.0")
+    assert cap.vendor == "siglent"
+    assert cap.dialect == "modern"
+
+
+def test_tektronix_registry_model_detected_by_manufacturer():
+    cap = detect_model_from_idn("TEKTRONIX,MSO24,C000001,CF:91.1CT FV:1.28")
+    assert cap.vendor == "tektronix"
+    assert cap.dialect == "tektronix"
+    assert cap.scpi_variant == "tek_mso"
+    assert cap.num_channels == 4
+
+
+def test_tektronix_tbs_detected():
+    cap = detect_model_from_idn("TEKTRONIX,TBS1102C,C000002,CF:91.1CT FV:1.10")
+    assert cap.vendor == "tektronix"
+    assert cap.scpi_variant == "tek_tbs"
+    assert cap.num_channels == 2
+
+
+def test_lecroy_registry_models_detected():
+    cap = detect_model_from_idn("LECROY,WAVESURFER3024Z,LCRY0001,8.5.0")
+    assert cap.vendor == "lecroy"
+    assert cap.dialect == "lecroy"
+    assert cap.scpi_variant == "lecroy_maui"
+
+    cap2 = detect_model_from_idn("TELEDYNE LECROY,WAVERUNNER8104,LCRY0002,9.1.0")
+    assert cap2.vendor == "lecroy"
+    assert cap2.dialect == "lecroy"
+
+
+def test_unknown_tektronix_model_gets_generic_tek_fallback():
+    cap = detect_model_from_idn("TEKTRONIX,MSO58,C000003,FV:2.0")
+    assert cap.vendor == "tektronix"
+    assert cap.dialect == "tektronix"
+    assert cap.has_protocol_decode is False
+
+
+def test_unknown_tbs_pattern_falls_back_to_two_channels():
+    cap = detect_model_from_idn("TEKTRONIX,TBS2104B,C000004,FV:1.0")
+    assert cap.num_channels == 2 or cap.num_channels == 4  # TBS2000B is 4ch-capable; see step 3 rule
+    assert cap.vendor == "tektronix"
+
+
+def test_unknown_lecroy_model_gets_generic_lecroy_fallback():
+    cap = detect_model_from_idn("LECROY,HDO6104A,LCRY0003,9.8")
+    assert cap.vendor == "lecroy"
+    assert cap.dialect == "lecroy"
+
+
+def test_unknown_manufacturer_keeps_siglent_heuristics():
+    cap = detect_model_from_idn("Rigol Technologies,DS1054Z,RIG0001,00.04.04")
+    assert cap.vendor == "siglent"  # legacy fallback path, unchanged behavior
+    assert cap.dialect == "legacy"

--- a/tests/test_vendor_detection.py
+++ b/tests/test_vendor_detection.py
@@ -1,7 +1,5 @@
 """Vendor-aware model detection and vendor-axis primitives."""
 
-import pytest
-
 from scpi_control import exceptions
 
 

--- a/tests/test_vendor_detection.py
+++ b/tests/test_vendor_detection.py
@@ -1,0 +1,10 @@
+"""Vendor-aware model detection and vendor-axis primitives."""
+
+import pytest
+
+from scpi_control import exceptions
+
+
+def test_feature_not_supported_error_exists_and_subclasses_base():
+    err = exceptions.FeatureNotSupportedError("holdoff is not supported on the modern dialect")
+    assert isinstance(err, exceptions.SiglentError)

--- a/tests/test_vendor_scope_ops.py
+++ b/tests/test_vendor_scope_ops.py
@@ -168,15 +168,33 @@ def test_lecroy_acquisition_status_auto_and_ready():
 
 
 def test_lecroy_bandwidth_getter_parses_global_pairs():
+    # Real LeCroy BWL? vocabulary has no "ON" token -- {OFF,20MHZ,200MHZ,...}
+    # (MAUI p.7-18). Any non-OFF wire token maps to the public "ON".
     from scpi_control.channel import Channel
 
     scope = make_dialect_scope("lecroy")
-    scope.query.return_value = "C1,OFF,C2,ON,C3,OFF,C4,OFF"
+    scope.query.return_value = "C1,OFF,C2,20MHZ,C3,OFF,C4,OFF"
     assert Channel(scope, 2).bandwidth_limit == "ON"
     assert Channel(scope, 1).bandwidth_limit == "OFF"
     # Missing channel in the pair list falls back to OFF.
     scope.query.return_value = "C1,OFF"
     assert Channel(scope, 3).bandwidth_limit == "OFF"
+
+
+def test_lecroy_bandwidth_setter_maps_on_to_20mhz():
+    # LeCroy has no "ON" token (MAUI p.7-18): public ON -> wire "20MHZ",
+    # OFF/FULL -> wire "OFF".
+    from scpi_control.channel import Channel
+
+    scope = make_dialect_scope("lecroy")
+    scope._has_command.side_effect = lambda name: True
+    ch = Channel(scope, 1)
+    ch.bandwidth_limit = "ON"
+    scope.write.assert_called_with("BWL C1,20MHZ")
+    ch.bandwidth_limit = "OFF"
+    scope.write.assert_called_with("BWL C1,OFF")
+    ch.bandwidth_limit = "FULL"
+    scope.write.assert_called_with("BWL C1,OFF")
 
 
 def test_lecroy_window_slope_rejected():

--- a/tests/test_vendor_scope_ops.py
+++ b/tests/test_vendor_scope_ops.py
@@ -319,3 +319,27 @@ def test_tek_trigger_source_ex5_raises_before_write(tek_scope):
     with pytest.raises(exceptions.FeatureNotSupportedError):
         Trigger(tek_scope).source = "EX5"
     assert not any("EDGE:SOUrce" in c.args[0] for c in tek_scope.write.call_args_list)
+
+
+# --- B8: tektronix trigger-level getter -----------------------------------
+
+
+def test_tek_trigger_level_getter_queries_source_channel(tek_scope):
+    from scpi_control.trigger import Trigger
+
+    trig = Trigger(tek_scope)
+    # source resolves to CH3, so the level getter targets the per-channel path
+    tek_scope.query.side_effect = ["CH3", "0.25"]
+    assert trig.level == pytest.approx(0.25)
+    assert tek_scope.query.call_args_list[-1].args[0] == "TRIGger:A:LEVel:CH3?"
+
+
+def test_tek_trigger_level_getter_non_channel_source_returns_zero(tek_scope):
+    from scpi_control.trigger import Trigger
+
+    trig = Trigger(tek_scope)
+    # A non-channel source (external AUX/LINE) has no per-channel trigger level;
+    # the getter guards and returns 0.0 without issuing a level query.
+    tek_scope.query.return_value = "AUX"
+    assert trig.level == 0.0
+    assert not any("LEVel" in c.args[0] for c in tek_scope.query.call_args_list)

--- a/tests/test_vendor_scope_ops.py
+++ b/tests/test_vendor_scope_ops.py
@@ -1,0 +1,114 @@
+"""Tektronix wire traffic through the public Oscilloscope API (mock-free unit level)."""
+
+import pytest
+
+from scpi_control import exceptions
+from scpi_control.scpi_commands import coupling_from_wire
+from tests.dialect_helpers import make_dialect_scope
+
+
+@pytest.fixture
+def tek_scope():
+    scope = make_dialect_scope("tektronix")
+    scope._has_command.side_effect = lambda name: True
+    return scope
+
+
+def test_single_shot_is_stopafter_sequence(tek_scope):
+    from scpi_control.trigger import Trigger
+
+    trig = Trigger(tek_scope)
+    trig.mode = "SINGLE"
+    written = [c.args[0] for c in tek_scope.write.call_args_list]
+    assert written == ["ACQuire:STOPAfter SEQuence", "ACQuire:STATE RUN"]
+
+
+def test_auto_mode_restores_runstop(tek_scope):
+    from scpi_control.trigger import Trigger
+
+    trig = Trigger(tek_scope)
+    trig.mode = "AUTO"
+    written = [c.args[0] for c in tek_scope.write.call_args_list]
+    assert written == ["ACQuire:STOPAfter RUNSTop", "TRIGger:A:MODe AUTO"]
+
+
+def test_trigger_source_uses_ch_tokens(tek_scope):
+    from scpi_control.trigger import Trigger
+
+    trig = Trigger(tek_scope)
+    trig.source = "C2"
+    tek_scope.write.assert_called_with("TRIGger:A:EDGE:SOUrce CH2")
+
+    tek_scope.query.return_value = "CH2"
+    assert trig.source == "C2"
+
+
+def test_trigger_level_targets_source_channel(tek_scope):
+    from scpi_control.trigger import Trigger
+
+    trig = Trigger(tek_scope)
+    tek_scope.query.return_value = "CH3"
+    trig.level = 0.25
+    tek_scope.write.assert_called_with("TRIGger:A:LEVel:CH3 0.25")
+
+
+def test_slope_round_trip(tek_scope):
+    from scpi_control.trigger import Trigger
+
+    trig = Trigger(tek_scope)
+    trig.slope = "NEG"
+    tek_scope.write.assert_called_with("TRIGger:A:EDGE:SLOpe FALL")
+    tek_scope.query.return_value = "RISE"
+    assert trig.slope == "POS"
+
+
+def test_window_slope_rejected(tek_scope):
+    from scpi_control.trigger import Trigger
+
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        Trigger(tek_scope).slope = "WINDOW"
+
+
+def test_channel_enabled_parses_numeric_select(tek_scope):
+    from scpi_control.channel import Channel
+
+    ch = Channel(tek_scope, 1)
+    tek_scope.query.return_value = "1"
+    assert ch.enabled is True
+    tek_scope.query.return_value = "0"
+    assert ch.enabled is False
+
+
+def test_probe_ratio_gain_inversion():
+    from scpi_control.channel import Channel
+
+    # Probe commands are family-split (tek_tbs vs tek_mso); the default
+    # "standard" variant has no probe entries at all (Task 7 report,
+    # correction #4), so this test builds a tek_tbs scope explicitly.
+    tek_tbs_scope = make_dialect_scope("tektronix", "tek_tbs")
+    tek_tbs_scope._has_command.side_effect = lambda name: True
+
+    ch = Channel(tek_tbs_scope, 1)
+    ch.probe_ratio = 10.0
+    tek_tbs_scope.write.assert_called_with("CH1:PRObe:GAIN 0.1")
+    tek_tbs_scope.query.return_value = "0.1"
+    assert ch.probe_ratio == pytest.approx(10.0)
+
+
+def test_bandwidth_limit_mapping(tek_scope):
+    from scpi_control.channel import Channel
+
+    ch = Channel(tek_scope, 1)
+    ch.bandwidth_limit = "ON"
+    tek_scope.write.assert_called_with("CH1:BANdwidth TWENty")
+    ch.bandwidth_limit = "OFF"
+    tek_scope.write.assert_called_with("CH1:BANdwidth FULL")
+    tek_scope.query.return_value = "FULL"
+    assert ch.bandwidth_limit == "OFF"
+
+
+def test_dcreject_coupling_normalizes_to_ac():
+    # MSO2 CH<x>:COUPling? can return DCREJect; DCREJect passes AC only, so
+    # it normalizes to the public AC token -- MSO2 PM 077-1776-07 p.2-184.
+    assert coupling_from_wire("tektronix", "DCREJ") == "AC"
+    assert coupling_from_wire("tektronix", "DCREJECT") == "AC"

--- a/tests/test_vendor_scope_ops.py
+++ b/tests/test_vendor_scope_ops.py
@@ -205,3 +205,117 @@ def test_lecroy_window_slope_rejected():
 
     with pytest.raises(exceptions.FeatureNotSupportedError):
         Trigger(scope).slope = "WINDOW"
+
+
+# --- A1: dialect-scoped variant overrides + probe_ratio gating -------------
+
+MSO24_IDN = "TEKTRONIX,MSO24,MOCK0100,CF:91.1CT FV:1.28"
+TBS_IDN = "TEKTRONIX,TBS1102C,MOCK0002,CF:91.1CT FV:1.10"
+SIGLENT_LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+
+
+def _real_scope(idn, dialect=None):
+    from scpi_control.connection.mock import MockConnection
+    from scpi_control.oscilloscope import Oscilloscope
+
+    conn = MockConnection("mock", idn=idn)
+    scope = Oscilloscope("mock", connection=conn, dialect=dialect)
+    scope.connect()
+    return scope, conn
+
+
+def test_forced_tektronix_over_siglent_gates_probe_ratio_not_keyerror():
+    # Forcing dialect="tektronix" onto a non-Tek (Siglent) IDN yields variant
+    # "standard" (x_series does not belong to the tektronix dialect), and the
+    # base Tek table has no probe commands. probe_ratio must raise
+    # FeatureNotSupportedError, never a raw KeyError (never-KeyError contract).
+    scope, conn = _real_scope(SIGLENT_LEGACY_IDN, dialect="tektronix")
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        _ = scope.channel1.probe_ratio
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        scope.channel1.probe_ratio = 10.0
+    scope.disconnect()
+
+
+def test_forced_modern_over_mso24_uses_modern_table_no_tek_contamination():
+    # dialect="modern" over an MSO24 (tek_mso) scope must fall back to the plain
+    # modern base table -- no tek_mso override contaminating it. Use a write-only
+    # path (the tek mock won't answer modern queries).
+    scope, conn = _real_scope(MSO24_IDN, dialect="modern")
+    scope.channel1.enabled = True
+    assert ":CHANnel1:SWITch ON" in conn.writes
+    assert not any("DISplay:GLObal" in w for w in conn.writes)  # tek_mso override absent
+    scope.disconnect()
+
+
+def test_forced_modern_over_tek_mso_variant_unit_level():
+    # Unit-level check of the same fallback: SCPICommandSet drops the mismatched
+    # tek_mso overrides and serves the plain modern channel-display command.
+    from scpi_control.scpi_commands import SCPICommandSet
+
+    cmds = SCPICommandSet("modern", "tek_mso")
+    assert cmds.get_command("set_channel_display", ch=1, state="ON") == ":CHANnel1:SWITch ON"
+
+
+# --- A2: MSO2 bandwidth vocabulary (NR3 hertz vs TBS TWENty) ---------------
+
+
+def test_mso2_bandwidth_on_uses_nr3_hertz():
+    # MSO 2-Series has no TWENty keyword; ON must serialize as a hertz value
+    # (MSO2 PM 077-1776-07 p.2-183).
+    scope, conn = _real_scope(MSO24_IDN)
+    scope.channel1.bandwidth_limit = "ON"
+    assert "CH1:BANdwidth 20E6" in conn.writes
+    scope.channel1.bandwidth_limit = "OFF"
+    assert "CH1:BANdwidth FULL" in conn.writes
+    scope.disconnect()
+
+
+def test_tbs_bandwidth_on_uses_twenty_keyword():
+    # TBS1000C keeps the TWEnty keyword (TBS PM 077-1691-01 p.53).
+    scope, conn = _real_scope(TBS_IDN)
+    scope.channel1.bandwidth_limit = "ON"
+    assert "CH1:BANdwidth TWENty" in conn.writes
+    scope.disconnect()
+
+
+# --- A4: EX/EX5/LINE trigger sources on tektronix --------------------------
+
+
+def test_tek_external_trigger_maps_ex_to_aux():
+    # Both Tek families accept AUX (TBS p.152 / MSO2 p.2-663).
+    from scpi_control.scpi_commands import channel_token
+
+    assert channel_token("tektronix", "EX") == "AUX"
+
+
+def test_tek_external_trigger_gates_ex5_and_line():
+    # EX5 has no Tek token and LINE is TBS-only (absent on MSO2) -- both gate.
+    from scpi_control.scpi_commands import channel_token
+
+    for src in ("EX5", "LINE"):
+        with pytest.raises(exceptions.FeatureNotSupportedError):
+            channel_token("tektronix", src)
+
+
+def test_non_tek_dialects_pass_external_trigger_through():
+    from scpi_control.scpi_commands import channel_token
+
+    assert channel_token("modern", "EX") == "EX"
+    assert channel_token("modern", "EX5") == "EX5"
+    assert channel_token("legacy", "LINE") == "LINE"
+
+
+def test_tek_trigger_source_ex_writes_aux(tek_scope):
+    from scpi_control.trigger import Trigger
+
+    Trigger(tek_scope).source = "EX"
+    tek_scope.write.assert_called_with("TRIGger:A:EDGE:SOUrce AUX")
+
+
+def test_tek_trigger_source_ex5_raises_before_write(tek_scope):
+    from scpi_control.trigger import Trigger
+
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        Trigger(tek_scope).source = "EX5"
+    assert not any("EDGE:SOUrce" in c.args[0] for c in tek_scope.write.call_args_list)

--- a/tests/test_vendor_scope_ops.py
+++ b/tests/test_vendor_scope_ops.py
@@ -112,3 +112,78 @@ def test_dcreject_coupling_normalizes_to_ac():
     # it normalizes to the public AC token -- MSO2 PM 077-1776-07 p.2-184.
     assert coupling_from_wire("tektronix", "DCREJ") == "AC"
     assert coupling_from_wire("tektronix", "DCREJECT") == "AC"
+
+
+def test_lecroy_trigger_wire_matches_legacy_shape():
+    scope = make_dialect_scope("lecroy")
+    scope._has_command.side_effect = lambda name: True
+    from scpi_control.trigger import Trigger
+
+    trig = Trigger(scope)
+    scope.query.return_value = "EDGE,SR,C1"
+    trig.mode = "NORM"
+    scope.write.assert_called_with("TRIG_MODE NORM")
+
+
+def _lecroy_scope():
+    from unittest.mock import Mock
+
+    from scpi_control.oscilloscope import Oscilloscope
+    from scpi_control.scpi_commands import SCPICommandSet
+
+    scope = Oscilloscope("mock", connection=Mock())
+    scope.dialect = "lecroy"
+    scope._scpi_commands = SCPICommandSet("lecroy", "lecroy_maui")
+    return scope
+
+
+def test_lecroy_acquisition_status_stop_via_trig_mode():
+    # TRIG_MODE? ending in STOP short-circuits to STOP without an INR? read.
+    from unittest.mock import Mock
+
+    scope = _lecroy_scope()
+    scope.query = Mock(return_value="STOP")
+    assert scope.acquisition_status() == "STOP"
+    assert scope.query.call_count == 1  # no INR? read once STOP is seen
+
+
+def test_lecroy_acquisition_status_trigd_via_inr_bit0():
+    # TRIG_MODE? -> NORM, then INR? with bit 0 set == a new signal acquired.
+    from unittest.mock import Mock
+
+    scope = _lecroy_scope()
+    scope.query = Mock(side_effect=["NORM", "1"])
+    assert scope.acquisition_status() == "TRIGD"
+
+
+def test_lecroy_acquisition_status_auto_and_ready():
+    from unittest.mock import Mock
+
+    scope = _lecroy_scope()
+    scope.query = Mock(side_effect=["AUTO", "0"])
+    assert scope.acquisition_status() == "AUTO"
+    scope2 = _lecroy_scope()
+    scope2.query = Mock(side_effect=["NORM", "0"])
+    assert scope2.acquisition_status() == "READY"
+
+
+def test_lecroy_bandwidth_getter_parses_global_pairs():
+    from scpi_control.channel import Channel
+
+    scope = make_dialect_scope("lecroy")
+    scope.query.return_value = "C1,OFF,C2,ON,C3,OFF,C4,OFF"
+    assert Channel(scope, 2).bandwidth_limit == "ON"
+    assert Channel(scope, 1).bandwidth_limit == "OFF"
+    # Missing channel in the pair list falls back to OFF.
+    scope.query.return_value = "C1,OFF"
+    assert Channel(scope, 3).bandwidth_limit == "OFF"
+
+
+def test_lecroy_window_slope_rejected():
+    # LeCroy TRIG_SLOPE is {NEG, POS} only (MAUI p.7-40) -- WINDOW gates.
+    scope = make_dialect_scope("lecroy")
+    scope._has_command.side_effect = lambda name: True
+    from scpi_control.trigger import Trigger
+
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        Trigger(scope).slope = "WINDOW"

--- a/tests/test_waveform_comprehensive.py
+++ b/tests/test_waveform_comprehensive.py
@@ -66,8 +66,16 @@ def mock_scope():
 
 @pytest.fixture
 def waveform_handler(mock_scope):
-    """Create a Waveform instance."""
-    return Waveform(mock_scope)
+    """Create a Waveform instance.
+
+    Mirrors real Oscilloscope wiring (self.waveform = Waveform(self)) so
+    that SiglentTransfer's `scope.waveform._get_voltage_scale(...)` calls
+    resolve back to this same handler instead of an unconfigured auto-Mock
+    child of mock_scope.
+    """
+    handler = Waveform(mock_scope)
+    mock_scope.waveform = handler
+    return handler
 
 
 class TestWaveformInitialization:

--- a/tests/test_waveform_transfer.py
+++ b/tests/test_waveform_transfer.py
@@ -1,14 +1,17 @@
 """Waveform transfer strategies: golden-blob parses and wire dispatch."""
 
+import struct
+
 import numpy as np
 import pytest
 
 from scpi_control import Oscilloscope, exceptions
 from scpi_control.connection.mock import MockConnection
-from scpi_control.waveform_transfer import parse_ieee_block
+from scpi_control.waveform_transfer import parse_ieee_block, parse_wavedesc
 
 TEK_IDN = "TEKTRONIX,MSO24,MOCK0100,CF:91.1CT FV:1.28"
 LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+LECROY_IDN = "LECROY,WAVESURFER3024Z,MOCK0200,8.5.0"
 
 
 def _block(payload: bytes) -> bytes:
@@ -74,4 +77,55 @@ class TestSiglentPathUnchanged:
         wf = scope.get_waveform(1)
         assert len(wf.voltage) > 0
         assert any(w.startswith("C1:WF?") for w in conn.writes)
+        scope.disconnect()
+
+
+def build_wavedesc(codes: bytes, gain: float = 0.04, offset: float = 0.0, hinterval: float = 1e-3, hoffset: float = -2e-3, comm_type: int = 0) -> bytes:
+    desc = bytearray(346)
+    desc[0:8] = b"WAVEDESC"
+    struct.pack_into("<h", desc, 32, comm_type)          # COMM_TYPE: 0=byte, 1=word
+    struct.pack_into("<i", desc, 36, 346)                # WAVE_DESCRIPTOR length
+    struct.pack_into("<i", desc, 40, 0)                  # USER_TEXT length
+    struct.pack_into("<i", desc, 116, len(codes))        # WAVE_ARRAY_COUNT
+    struct.pack_into("<f", desc, 156, gain)              # VERTICAL_GAIN
+    struct.pack_into("<f", desc, 160, offset)            # VERTICAL_OFFSET
+    struct.pack_into("<f", desc, 176, hinterval)         # HORIZ_INTERVAL
+    struct.pack_into("<d", desc, 180, hoffset)           # HORIZ_OFFSET
+    return bytes(desc) + codes
+
+
+class TestWavedescGoldenBlob:
+    def test_parse_wavedesc_fields(self):
+        payload = build_wavedesc(bytes([0, 25, 231, 75]))  # 231 == -25 signed
+        meta = parse_wavedesc(payload)
+        assert meta["wave_array_count"] == 4
+        assert meta["vertical_gain"] == pytest.approx(0.04)
+        assert meta["horiz_interval"] == pytest.approx(1e-3)
+        assert meta["data_offset"] == 346
+
+    def test_missing_wavedesc_raises(self):
+        with pytest.raises(exceptions.CommandError):
+            parse_wavedesc(b"\x00" * 400)
+
+
+class TestLeCroyAcquire:
+    def test_acquire_scales_via_wavedesc(self):
+        conn = MockConnection(
+            "mock",
+            idn=LECROY_IDN,
+            channel_states={1: True},
+            voltage_scales={1: 1.0},
+            waveform_payloads={1: bytes([0, 25, 50, 75])},
+            sample_rate=1_000.0,
+            timebase=1e-3,
+        )
+        scope = Oscilloscope("mock", connection=conn)
+        scope.connect()
+        wf = scope.get_waveform(1)
+        # mock gain = vdiv/25 = 0.04, offset 0: codes [0,25,50,75] -> [0,1,2,3] V
+        assert wf.voltage == pytest.approx([0.0, 1.0, 2.0, 3.0])
+        assert wf.time[1] - wf.time[0] == pytest.approx(1e-3)
+        assert "CFMT DEF9,BYTE,BIN" in conn.writes
+        assert "CORD LO" in conn.writes
+        assert "C1:WF? ALL" in conn.writes
         scope.disconnect()

--- a/tests/test_waveform_transfer.py
+++ b/tests/test_waveform_transfer.py
@@ -1,0 +1,77 @@
+"""Waveform transfer strategies: golden-blob parses and wire dispatch."""
+
+import numpy as np
+import pytest
+
+from scpi_control import Oscilloscope, exceptions
+from scpi_control.connection.mock import MockConnection
+from scpi_control.waveform_transfer import parse_ieee_block
+
+TEK_IDN = "TEKTRONIX,MSO24,MOCK0100,CF:91.1CT FV:1.28"
+LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+
+
+def _block(payload: bytes) -> bytes:
+    length = str(len(payload)).encode()
+    return b"#" + str(len(length)).encode() + length + payload
+
+
+class TestParseIeeeBlock:
+    def test_parses_int8_block(self):
+        data = parse_ieee_block(_block(bytes([0, 25, 231, 75])), np.int8)
+        assert data.tolist() == [0, 25, -25, 75]
+
+    def test_rejects_missing_hash(self):
+        with pytest.raises(exceptions.CommandError):
+            parse_ieee_block(b"garbage", np.int8)
+
+
+class TestTektronixGoldenBlob:
+    """Hand-built CURVe response with known WFMOutpre scaling.
+
+    ymult=0.04, yoff=0, yzero=0 -> code 25 == 1.0 V exactly.
+    xincr=1e-3 -> 1 kSa/s.
+    """
+
+    def _scope(self):
+        conn = MockConnection(
+            "mock",
+            idn=TEK_IDN,
+            channel_states={1: True, 2: True},
+            voltage_scales={1: 1.0},
+            waveform_payloads={1: bytes([0, 25, 50, 75])},
+            sample_rate=1_000.0,
+            timebase=1e-3,
+        )
+        scope = Oscilloscope("mock", connection=conn)
+        scope.connect()
+        return scope, conn
+
+    def test_acquire_scales_via_preamble(self):
+        scope, conn = self._scope()
+        wf = scope.get_waveform(1)
+        # mock YMUlt = vdiv/25 = 0.04; codes [0,25,50,75] -> [0,1,2,3] V
+        assert wf.voltage == pytest.approx([0.0, 1.0, 2.0, 3.0])
+        assert wf.sample_rate == pytest.approx(1_000.0)
+        assert len(wf.time) == 4
+        assert wf.time[1] - wf.time[0] == pytest.approx(1e-3)
+        assert "CURVe?" in conn.writes
+        assert "DATa:SOUrce CH1" in conn.writes
+        scope.disconnect()
+
+    def test_word_format_not_supported_yet(self):
+        scope, conn = self._scope()
+        with pytest.raises(exceptions.FeatureNotSupportedError):
+            scope.waveform.acquire(1, format="WORD")
+        scope.disconnect()
+
+
+class TestSiglentPathUnchanged:
+    def test_legacy_acquire_still_works(self):
+        conn = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, sample_rate=1_000.0, timebase=1e-3)
+        scope = Oscilloscope("mock", connection=conn)
+        scope.connect()
+        wf = scope.get_waveform(1)
+        assert len(wf.voltage) > 0
+        assert any(w.startswith("C1:WF?") for w in conn.writes)
+        scope.disconnect()

--- a/tests/test_waveform_transfer.py
+++ b/tests/test_waveform_transfer.py
@@ -80,18 +80,31 @@ class TestSiglentPathUnchanged:
         scope.disconnect()
 
 
-def build_wavedesc(codes: bytes, gain: float = 0.04, offset: float = 0.0, hinterval: float = 1e-3, hoffset: float = -2e-3, comm_type: int = 0) -> bytes:
+def build_wavedesc(
+    codes: bytes,
+    gain: float = 0.04,
+    offset: float = 0.0,
+    hinterval: float = 1e-3,
+    hoffset: float = -2e-3,
+    comm_type: int = 0,
+    trigtime_len: int = 0,
+    ristime_len: int = 0,
+) -> bytes:
     desc = bytearray(346)
     desc[0:8] = b"WAVEDESC"
     struct.pack_into("<h", desc, 32, comm_type)          # COMM_TYPE: 0=byte, 1=word
     struct.pack_into("<i", desc, 36, 346)                # WAVE_DESCRIPTOR length
     struct.pack_into("<i", desc, 40, 0)                  # USER_TEXT length
+    struct.pack_into("<i", desc, 48, trigtime_len)       # TRIGTIME_ARRAY length
+    struct.pack_into("<i", desc, 52, ristime_len)        # RIS_TIME_ARRAY length
     struct.pack_into("<i", desc, 116, len(codes))        # WAVE_ARRAY_COUNT
     struct.pack_into("<f", desc, 156, gain)              # VERTICAL_GAIN
     struct.pack_into("<f", desc, 160, offset)            # VERTICAL_OFFSET
     struct.pack_into("<f", desc, 176, hinterval)         # HORIZ_INTERVAL
     struct.pack_into("<d", desc, 180, hoffset)           # HORIZ_OFFSET
-    return bytes(desc) + codes
+    # DATA_ARRAY_1 follows the two optional time arrays; pad them with the
+    # declared number of filler bytes so data_offset has something to skip.
+    return bytes(desc) + b"\x00" * (trigtime_len + ristime_len) + codes
 
 
 class TestWavedescGoldenBlob:
@@ -106,6 +119,20 @@ class TestWavedescGoldenBlob:
     def test_missing_wavedesc_raises(self):
         with pytest.raises(exceptions.CommandError):
             parse_wavedesc(b"\x00" * 400)
+
+    def test_parse_wavedesc_skips_trigtime_array(self):
+        # A non-zero TRIGTIME_ARRAY sits between USER_TEXT and the sample data;
+        # data_offset must skip WAVEDESC + USER_TEXT + TRIGTIME_ARRAY +
+        # RIS_TIME_ARRAY so the codes still decode to the correct volts.
+        trigtime = 24
+        payload = build_wavedesc(bytes([0, 25, 50, 75]), trigtime_len=trigtime)
+        meta = parse_wavedesc(payload)
+        assert meta["trigtime_len"] == trigtime
+        assert meta["ristime_len"] == 0
+        assert meta["data_offset"] == 346 + trigtime
+        codes = np.frombuffer(payload, dtype=np.int8, count=meta["wave_array_count"], offset=meta["data_offset"])
+        voltage = meta["vertical_gain"] * codes.astype(np.float64) - meta["vertical_offset"]
+        assert voltage == pytest.approx([0.0, 1.0, 2.0, 3.0])
 
 
 class TestLeCroyAcquire:


### PR DESCRIPTION
Adds Tektronix and LeCroy oscilloscope support by generalizing the Siglent legacy/modern dialect system into a vendor-aware wire-language axis. Core control + measurements: connect/auto-detect, channel control, timebase, edge trigger, waveform acquisition, and basic measurements.

## What's in here

**Vendor axis (behavior-preserving refactors first):**
- `detect_model_from_idn()` now reads the `*IDN?` manufacturer field: `TEKTRONIX` and `LECROY`/`TELEDYNE LECROY` route to their vendors; everything else takes the historic Siglent path byte-for-byte. New registry models: TBS1102C, MSO24, WaveSurfer 3024z, WaveRunner 8104 (+ conservative generic fallbacks per vendor).
- `SCPICommandSet` is now a dialect→table mapping over a shared IEEE-488.2 base, with dialect-scoped family overrides (`tek_tbs`/`tek_mso`/`lecroy_maui`) and per-dialect connect setup (`CHDR OFF` / `HEADer OFF`).
- Converters (mode/slope/coupling/status/measurement/probe) are per-dialect lookup tables with a uniform error contract: invalid public token raises `ValueError`; a valid token the dialect can't express raises `FeatureNotSupportedError` — never a silent timeout or KeyError.
- `measurement.py`, trigger holdoff, and channel unit no longer bypass the command table.
- The mock is now a package with one personality per vendor; wrong-dialect commands still time out like real hardware.

**Tektronix (TBS1000C + MSO 2-Series):** full trigger/channel/timebase control (single-shot as `ACQuire:STOPAfter SEQuence`), `CURVe?`/`WFMOutpre` waveform transfer (8-bit; 16-bit is a follow-up), `MEASUrement:IMMed` measurements on TBS (the MSO 2-Series lacks the subsystem and gates cleanly — badge-based `MEAS<x>` is a follow-up), probe gain↔ratio inversion, external trigger `EX`→`AUX`.

**LeCroy (MAUI):** the legacy dialect's ancestor — table corrected from the MAUI manual (`INR?` bit-0 acquisition status, native `C<n>:PAVA?` measurements, `WF? ALL` + WAVEDESC descriptor scaling with TRIGTIME/RIS array handling, `CFMT`/`CORD` setup, `BWL` with public `ON`→`20MHZ`).

## Verification (no hardware — by design)

- Every new wire string carries a page citation against the TBS1000C Programmer Manual (077-1691-01), 2 Series MSO Programmer Manual (077-1776-07), and the MAUI Remote Control and Automation Manual; reviewers independently spot-verified the high-consequence claims against the PDFs (including "LINE absent from MSO2 edge sources" and "no GND coupling on either Tek family").
- Golden-blob parser tests: hand-packed `WFMOutpre`+`CURVe` and WAVEDESC byte fixtures with independently computed expected volts/time.
- The dialect test matrix runs the same public-API scenarios across all four dialects end-to-end against the mocks.
- Suite: 641 → 747 passed (19 skipped throughout); docs build stays at its 70-warning baseline.

## Behavior changes for existing users (see CHANGELOG "Changed")

- On the Siglent modern dialect, holdoff/statistics/cursors/unit now raise `FeatureNotSupportedError` immediately instead of timing out.
- Probe-ratio wire format serializes floats compactly (`10.0` → `10`); `add_measurement` validates/normalizes its measurement type.

## Known gaps (documented in the dialects guide, queued as follow-ups)

Gateway discovery/sessions for the new vendors; GUI; screen capture; Tek 16-bit transfer; MSO2 badge measurements; LeCroy `TRIG_SELECT HT/HV` holdoff; the LeCroy VBS sample-rate cvar is flagged unverified in code (transfer path doesn't depend on it); mock personalities are vendor-level, not family-level.
