### PR TITLE
refactor: one canonical waveform model, and stop inventing instrument metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- **The report generator's `WaveformData` fields are renamed, and `channel`
+  moved from the first constructor argument to the third.** `channel_name`,
+  `time_data`, and `voltage_data` are now `channel`, `time`, and `voltage`,
+  matching the base class's field order (`time`, `voltage`, `channel`, ...).
+  Because the position changed along with the name, positional construction
+  such as `WaveformData("CH1", t, v, ...)` does **not** fail with a
+  recognizable rename error — it silently assigns `"CH1"` to `time` and
+  blows up later with `AttributeError: 'str' object has no attribute
+  'shape'`. Construct with keywords (`channel=`, `time=`, `voltage=`) to
+  migrate safely. This is a documented public API — see
+  [`docs/report-generator/api-reference.md`](docs/report-generator/api-reference.md).
+- **`WaveformData.source` and `WaveformData.description` are removed**, on
+  both the library and report waveform types. `WaveformData(..., source="x")`
+  now raises `TypeError` instead of silently accepting the keyword.
+- **`WaveformData.timebase` and `WaveformData.voltage_scale` are `None`
+  unless an instrument actually reported them**, instead of being derived by
+  assuming a 14-division horizontal grid and an 8-division vertical one —
+  Siglent's geometry, previously applied to Tektronix and LeCroy captures too
+  — with a flat trace given a bare 1.0 V/div. Real acquisitions are
+  unaffected: all three vendor backends pass genuine scope values. Code that
+  does arithmetic on `timebase`/`voltage_scale` from a *synthetic* waveform
+  (a math channel, or hand-built test data) — e.g. `wf.timebase * 1e6` — now
+  raises `TypeError` on `None` instead of silently using an invented number.
+  Guard with a `None` check, or supply real values.
+
 ### Added
 
 - Tektronix and LeCroy oscilloscope support (core control, waveform
@@ -39,22 +66,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of a fixed 1-4 range. Scopes with fewer than four channels now raise
   `InvalidParameterError` for a channel they do not have, where they
   previously queried it.
-- `WaveformData.timebase` and `WaveformData.voltage_scale` are now `None` unless an
-  instrument actually reported them. They were previously derived by assuming a
-  14-division horizontal grid and an 8-division vertical one — Siglent's geometry,
-  applied to Tektronix and LeCroy captures too — and a flat trace was given a bare
-  1.0 V/div. All three vendor backends pass real values, so only synthetic
-  waveforms (math channels, hand-built test data) are affected.
 - The report generator's `WaveformData` is now a subclass of
-  `scpi_control.waveform.WaveformData`, and its `channel_name`, `time_data` and
-  `voltage_data` fields are renamed to `channel`, `time` and `voltage` to match.
-  Report waveforms now inherit the library's array-shape validation, and `channel`
-  is coerced to `str` by the type rather than at each loader call site.
-
-### Removed
-
-- `WaveformData.source` and `WaveformData.description`. Both were write-only —
-  set by a manual test script and read by nothing.
+  `scpi_control.waveform.WaveformData` (see Breaking Changes above for the
+  field rename and reorder this involved). Report waveforms now inherit the
+  library's array-shape validation, and `channel` is now guaranteed to be a
+  `str` by the type itself. The loader's explicit `str()` calls at each
+  construction site are unchanged and now redundant, not removed — they stay
+  as a defensive measure against `np.str_`/`bytes` values handed back at the
+  MAT/HDF5 boundary.
 
 ## [2.0.0] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of a fixed 1-4 range. Scopes with fewer than four channels now raise
   `InvalidParameterError` for a channel they do not have, where they
   previously queried it.
+- `WaveformData.timebase` and `WaveformData.voltage_scale` are now `None` unless an
+  instrument actually reported them. They were previously derived by assuming a
+  14-division horizontal grid and an 8-division vertical one — Siglent's geometry,
+  applied to Tektronix and LeCroy captures too — and a flat trace was given a bare
+  1.0 V/div. All three vendor backends pass real values, so only synthetic
+  waveforms (math channels, hand-built test data) are affected.
+- The report generator's `WaveformData` is now a subclass of
+  `scpi_control.waveform.WaveformData`, and its `channel_name`, `time_data` and
+  `voltage_data` fields are renamed to `channel`, `time` and `voltage` to match.
+  Report waveforms now inherit the library's array-shape validation, and `channel`
+  is coerced to `str` by the type rather than at each loader call site.
+
+### Removed
+
+- `WaveformData.source` and `WaveformData.description`. Both were write-only —
+  set by a manual test script and read by nothing.
 
 ## [2.0.0] - 2026-07-15
 

--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -388,7 +388,7 @@ trimmer capacitor requires adjustment.
     # Generate test waveform (flat plateaus, minimal slope)
     t1, v1 = generate_test_square_wave(slope=0, noise=0.005)
 
-    waveform1 = WaveformData(channel_name="CH1", time_data=t1, voltage_data=v1, sample_rate=100000, record_length=len(t1), label="Properly Compensated Probe", probe_ratio=10)
+    waveform1 = WaveformData(channel="CH1", time=t1, voltage=v1, sample_rate=100000, record_length=len(t1), label="Properly Compensated Probe", probe_ratio=10)
 
     # Analyze the waveform (detects signal type)
     print("   - Analyzing waveform...")
@@ -424,7 +424,7 @@ trimmer capacitor requires adjustment.
     # Generate test waveform (positive slope = undercompensated)
     t2, v2 = generate_test_square_wave(slope=15000, noise=0.008)
 
-    waveform2 = WaveformData(channel_name="CH2", time_data=t2, voltage_data=v2, sample_rate=100000, record_length=len(t2), label="Undercompensated Probe", probe_ratio=10)
+    waveform2 = WaveformData(channel="CH2", time=t2, voltage=v2, sample_rate=100000, record_length=len(t2), label="Undercompensated Probe", probe_ratio=10)
 
     waveform2.analyze()
     WaveformAnalyzer.detect_regions(waveform2, auto_detect_plateaus=True, auto_detect_edges=False)
@@ -448,7 +448,7 @@ trimmer capacitor requires adjustment.
     # Generate test waveform (negative slope = overcompensated)
     t3, v3 = generate_test_square_wave(slope=-18000, noise=0.006)
 
-    waveform3 = WaveformData(channel_name="CH3", time_data=t3, voltage_data=v3, sample_rate=100000, record_length=len(t3), label="Overcompensated Probe", probe_ratio=10)
+    waveform3 = WaveformData(channel="CH3", time=t3, voltage=v3, sample_rate=100000, record_length=len(t3), label="Overcompensated Probe", probe_ratio=10)
 
     waveform3.analyze()
     WaveformAnalyzer.detect_regions(waveform3, auto_detect_plateaus=True, auto_detect_edges=False)
@@ -472,7 +472,7 @@ trimmer capacitor requires adjustment.
     # Generate another test waveform
     t4, v4 = generate_test_square_wave(slope=5000, noise=0.01)
 
-    waveform4 = WaveformData(channel_name="CH4", time_data=t4, voltage_data=v4, sample_rate=100000, record_length=len(t4), label="Manual Region Example")
+    waveform4 = WaveformData(channel="CH4", time=t4, voltage=v4, sample_rate=100000, record_length=len(t4), label="Manual Region Example")
 
     waveform4.analyze()
 
@@ -840,9 +840,9 @@ def create_sample_waveform() -> WaveformData:
     voltage_data += 0.1 * np.random.randn(num_samples)  # Add noise
 
     return WaveformData(
-        channel_name="CH1",
-        time_data=time_data,
-        voltage_data=voltage_data,
+        channel="CH1",
+        time=time_data,
+        voltage=voltage_data,
         sample_rate=sample_rate,
         record_length=num_samples,
         timebase=100e-6,  # 100 μs/div

--- a/docs/report-generator/api-reference.md
+++ b/docs/report-generator/api-reference.md
@@ -72,9 +72,9 @@ ReportMetadata(
 
 ```python
 WaveformData(
-    channel_name: str,         # e.g., "CH1"
-    time_data: np.ndarray,     # Time values
-    voltage_data: np.ndarray,  # Voltage values
+    channel: str,               # e.g., "CH1"
+    time: np.ndarray,           # Time values
+    voltage: np.ndarray,        # Voltage values
     sample_rate: float,        # Samples per second
     record_length: int,        # Number of samples
     timebase: Optional[float],  # s/div
@@ -404,14 +404,14 @@ def generate_automated_report(waveform_files, output_path):
     # 5. Add measurements (calculate from waveforms)
     for wf in waveforms:
         # Calculate measurements
-        vpp = np.ptp(wf.voltage_data)
-        mean = np.mean(wf.voltage_data)
-        rms = np.sqrt(np.mean(wf.voltage_data**2))
+        vpp = np.ptp(wf.voltage)
+        mean = np.mean(wf.voltage)
+        rms = np.sqrt(np.mean(wf.voltage**2))
 
         section.measurements.extend([
-            MeasurementResult(name="Vpp", value=vpp, unit="V", channel=wf.channel_name),
-            MeasurementResult(name="Mean", value=mean, unit="V", channel=wf.channel_name),
-            MeasurementResult(name="RMS", value=rms, unit="V", channel=wf.channel_name),
+            MeasurementResult(name="Vpp", value=vpp, unit="V", channel=wf.channel),
+            MeasurementResult(name="Mean", value=mean, unit="V", channel=wf.channel),
+            MeasurementResult(name="RMS", value=rms, unit="V", channel=wf.channel),
         ])
 
     report.add_section(section)
@@ -525,11 +525,11 @@ with ThreadPoolExecutor(max_workers=4) as executor:
 ```python
 def validate_waveform(wf: WaveformData) -> bool:
     """Validate waveform data before adding to report."""
-    if len(wf.time_data) != len(wf.voltage_data):
+    if len(wf.time) != len(wf.voltage):
         return False
     if wf.sample_rate <= 0:
         return False
-    if wf.record_length != len(wf.voltage_data):
+    if wf.record_length != len(wf.voltage):
         return False
     return True
 

--- a/docs/report-generator/api-reference.md
+++ b/docs/report-generator/api-reference.md
@@ -72,9 +72,9 @@ ReportMetadata(
 
 ```python
 WaveformData(
-    channel: str,               # e.g., "CH1"
     time: np.ndarray,           # Time values
     voltage: np.ndarray,        # Voltage values
+    channel: str,               # e.g., "CH1"
     sample_rate: float,        # Samples per second
     record_length: int,        # Number of samples
     timebase: Optional[float],  # s/div

--- a/examples/probe_calibration_analysis.py
+++ b/examples/probe_calibration_analysis.py
@@ -39,7 +39,7 @@ def generate_test_square_wave(slope: float = 0, noise: float = 0.01):
         noise: Noise level to add (RMS voltage)
 
     Returns:
-        Tuple of (time_data, voltage_data)
+        Tuple of (time, voltage)
     """
     # 1kHz square wave, 10ms duration, 100kS/s
     sample_rate = 100000
@@ -116,7 +116,7 @@ trimmer capacitor requires adjustment.
     # Generate test waveform (flat plateaus, minimal slope)
     t1, v1 = generate_test_square_wave(slope=0, noise=0.005)
 
-    waveform1 = WaveformData(channel_name="CH1", time_data=t1, voltage_data=v1, sample_rate=100000, record_length=len(t1), label="Properly Compensated Probe", probe_ratio=10)
+    waveform1 = WaveformData(channel="CH1", time=t1, voltage=v1, sample_rate=100000, record_length=len(t1), label="Properly Compensated Probe", probe_ratio=10)
 
     # Analyze the waveform (detects signal type)
     print("   - Analyzing waveform...")
@@ -152,7 +152,7 @@ trimmer capacitor requires adjustment.
     # Generate test waveform (positive slope = undercompensated)
     t2, v2 = generate_test_square_wave(slope=15000, noise=0.008)
 
-    waveform2 = WaveformData(channel_name="CH2", time_data=t2, voltage_data=v2, sample_rate=100000, record_length=len(t2), label="Undercompensated Probe", probe_ratio=10)
+    waveform2 = WaveformData(channel="CH2", time=t2, voltage=v2, sample_rate=100000, record_length=len(t2), label="Undercompensated Probe", probe_ratio=10)
 
     waveform2.analyze()
     WaveformAnalyzer.detect_regions(waveform2, auto_detect_plateaus=True, auto_detect_edges=False)
@@ -176,7 +176,7 @@ trimmer capacitor requires adjustment.
     # Generate test waveform (negative slope = overcompensated)
     t3, v3 = generate_test_square_wave(slope=-18000, noise=0.006)
 
-    waveform3 = WaveformData(channel_name="CH3", time_data=t3, voltage_data=v3, sample_rate=100000, record_length=len(t3), label="Overcompensated Probe", probe_ratio=10)
+    waveform3 = WaveformData(channel="CH3", time=t3, voltage=v3, sample_rate=100000, record_length=len(t3), label="Overcompensated Probe", probe_ratio=10)
 
     waveform3.analyze()
     WaveformAnalyzer.detect_regions(waveform3, auto_detect_plateaus=True, auto_detect_edges=False)
@@ -200,7 +200,7 @@ trimmer capacitor requires adjustment.
     # Generate another test waveform
     t4, v4 = generate_test_square_wave(slope=5000, noise=0.01)
 
-    waveform4 = WaveformData(channel_name="CH4", time_data=t4, voltage_data=v4, sample_rate=100000, record_length=len(t4), label="Manual Region Example")
+    waveform4 = WaveformData(channel="CH4", time=t4, voltage=v4, sample_rate=100000, record_length=len(t4), label="Manual Region Example")
 
     waveform4.analyze()
 

--- a/examples/report_generation_example.py
+++ b/examples/report_generation_example.py
@@ -51,9 +51,9 @@ def create_sample_waveform() -> WaveformData:
     voltage_data += 0.1 * np.random.randn(num_samples)  # Add noise
 
     return WaveformData(
-        channel_name="CH1",
-        time_data=time_data,
-        voltage_data=voltage_data,
+        channel="CH1",
+        time=time_data,
+        voltage=voltage_data,
         sample_rate=sample_rate,
         record_length=num_samples,
         timebase=100e-6,  # 100 μs/div

--- a/scpi_control/math_channel.py
+++ b/scpi_control/math_channel.py
@@ -24,27 +24,18 @@ class MathOperations:
         Returns:
             New WaveformData with calculated voltage and source metadata
         """
-        # Safely propagate optional metadata and estimate missing values
-        sample_rate = getattr(source_waveform, "sample_rate", None)
-        if sample_rate is None and len(source_waveform.time) > 1:
-            dt = float(np.mean(np.diff(source_waveform.time)))
-            if dt > 0:
-                sample_rate = 1.0 / dt
-
+        # Propagate what the source actually carries. Nothing is invented here:
+        # sample_rate is left to WaveformData.__post_init__, which derives it from
+        # the same time axis; timebase and voltage_scale stay None unless the
+        # source has real ones, because a math result cannot know the scope's grid.
         voltage_scale = getattr(source_waveform, "voltage_scale", None)
-        if voltage_scale is None:
-            span = float(np.max(voltage) - np.min(voltage)) if len(voltage) > 0 else 0.0
-            voltage_scale = span / 8.0 if span > 0 else 1.0
-
         timebase = getattr(source_waveform, "timebase", None)
-        if timebase is None and sample_rate:
-            timebase = len(voltage) / sample_rate / 14.0
 
         return type(source_waveform)(
             time=source_waveform.time,
             voltage=voltage,
             channel=channel,
-            sample_rate=sample_rate,
+            sample_rate=getattr(source_waveform, "sample_rate", None),
             record_length=len(voltage),
             timebase=timebase,
             voltage_scale=voltage_scale,

--- a/scpi_control/report_generator/generators/markdown_generator.py
+++ b/scpi_control/report_generator/generators/markdown_generator.py
@@ -287,8 +287,8 @@ class MarkdownReportGenerator(BaseReportGenerator):
 
         else:
             # Fallback to basic statistics if not analyzed
-            v_min = np.min(waveform.voltage_data)
-            v_max = np.max(waveform.voltage_data)
+            v_min = np.min(waveform.voltage)
+            v_max = np.max(waveform.voltage)
             v_pp = v_max - v_min
             lines.append(f"| Peak-to-Peak | {v_pp:.4f} V |")
             lines.append(f"| Min | {v_min:.4f} V |")
@@ -501,7 +501,7 @@ class MarkdownReportGenerator(BaseReportGenerator):
         fig, ax = plt.subplots(figsize=(10, 4))
 
         # Use plot style colors and settings
-        ax.plot(waveform.time_data * 1e6, waveform.voltage_data, color=waveform.color or self.plot_style.waveform_color, linewidth=self.plot_style.waveform_linewidth)
+        ax.plot(waveform.time * 1e6, waveform.voltage, color=waveform.color or self.plot_style.waveform_color, linewidth=self.plot_style.waveform_linewidth)
 
         # Apply style to axes
         self.plot_style.apply_to_axes(ax)

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -638,8 +638,8 @@ class PDFReportGenerator(BaseReportGenerator):
             story.append(KeepTogether(keep_together_elements))
 
         # Info table (can be on next page if needed)
-        v_min = np.min(waveform.voltage_data)
-        v_max = np.max(waveform.voltage_data)
+        v_min = np.min(waveform.voltage)
+        v_max = np.max(waveform.voltage)
         v_pp = v_max - v_min
 
         data = [
@@ -1113,7 +1113,7 @@ class PDFReportGenerator(BaseReportGenerator):
             fig, ax = plt.subplots(figsize=(self.plot_width / inch, self.plot_height / inch))
 
             # Use plot style colors and settings
-            ax.plot(waveform.time_data * 1e6, waveform.voltage_data, color=waveform.color or self.plot_style.waveform_color, linewidth=self.plot_style.waveform_linewidth)
+            ax.plot(waveform.time * 1e6, waveform.voltage, color=waveform.color or self.plot_style.waveform_color, linewidth=self.plot_style.waveform_linewidth)
 
             # Apply style to axes
             self.plot_style.apply_to_axes(ax)

--- a/scpi_control/report_generator/llm/context_builder.py
+++ b/scpi_control/report_generator/llm/context_builder.py
@@ -30,7 +30,7 @@ class ContextBuilder:
         Returns:
             Formatted context string
         """
-        lines = [f"Waveform: {waveform.label or waveform.channel_name}"]
+        lines = [f"Waveform: {waveform.label or waveform.channel}"]
 
         # Basic stats
         lines.append(f"  Sample Rate: {waveform.sample_rate / 1e6:.2f} MS/s")
@@ -40,10 +40,10 @@ class ContextBuilder:
             lines.append(f"  Timebase: {waveform.timebase * 1e6:.2f} µs/div")
 
         # Voltage statistics
-        v_min = np.min(waveform.voltage_data)
-        v_max = np.max(waveform.voltage_data)
-        v_mean = np.mean(waveform.voltage_data)
-        v_std = np.std(waveform.voltage_data)
+        v_min = np.min(waveform.voltage)
+        v_max = np.max(waveform.voltage)
+        v_mean = np.mean(waveform.voltage)
+        v_std = np.std(waveform.voltage)
         v_pp = v_max - v_min
 
         lines.append(f"  Voltage Range: {v_min:.4f} V to {v_max:.4f} V")
@@ -52,7 +52,7 @@ class ContextBuilder:
         lines.append(f"  Std Dev: {v_std:.4f} V")
 
         # Time statistics
-        time_span = waveform.time_data[-1] - waveform.time_data[0]
+        time_span = waveform.time[-1] - waveform.time[0]
         lines.append(f"  Time Span: {time_span * 1e6:.2f} µs")
 
         return "\n".join(lines)

--- a/scpi_control/report_generator/models/report_data.py
+++ b/scpi_control/report_generator/models/report_data.py
@@ -185,9 +185,9 @@ class WaveformRegion:
 class WaveformData:
     """Waveform data for inclusion in reports."""
 
-    channel_name: str
-    time_data: np.ndarray
-    voltage_data: np.ndarray
+    channel: str
+    time: np.ndarray
+    voltage: np.ndarray
     sample_rate: float
     record_length: int
 
@@ -217,7 +217,7 @@ class WaveformData:
     def __post_init__(self):
         """Set default label if not provided."""
         if self.label is None:
-            self.label = self.channel_name
+            self.label = self.channel
 
     def analyze(self) -> None:
         """
@@ -291,11 +291,11 @@ class WaveformData:
             region: WaveformRegion to extract
 
         Returns:
-            Tuple of (time_data, voltage_data) for the region
+            Tuple of (time, voltage) for the region
         """
         # Find indices for this time range
-        mask = (self.time_data >= region.start_time) & (self.time_data <= region.end_time)
-        return self.time_data[mask], self.voltage_data[mask]
+        mask = (self.time >= region.start_time) & (self.time <= region.end_time)
+        return self.time[mask], self.voltage[mask]
 
     def remove_region(self, region: WaveformRegion) -> bool:
         """
@@ -332,7 +332,7 @@ class WaveformData:
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary (excludes numpy arrays for JSON serialization)."""
         data = {
-            "channel_name": self.channel_name,
+            "channel_name": self.channel,
             "sample_rate": self.sample_rate,
             "record_length": self.record_length,
             "color": self.color,

--- a/scpi_control/report_generator/models/report_data.py
+++ b/scpi_control/report_generator/models/report_data.py
@@ -195,8 +195,10 @@ class WaveformData(CaptureWaveform):
     # `field()` with no default is REQUIRED, and is the only spelling that works.
     # A bare `sample_rate: float` does NOT re-require the field: @dataclass keeps
     # defaults as class attributes, so the annotation inherits the base's None and
-    # the field silently stays optional. The report pipeline divides by sample_rate
-    # and record_length, so both must be present.
+    # the field silently stays optional. Losing that would not raise at runtime --
+    # the base's __post_init__ derives both sample_rate and record_length from the
+    # arrays anyway -- so what field() actually protects is the explicit contract:
+    # callers must state these rather than let them be silently inferred.
     sample_rate: float = field()
     record_length: int = field()
 

--- a/scpi_control/report_generator/models/report_data.py
+++ b/scpi_control/report_generator/models/report_data.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
+from scpi_control.waveform import WaveformData as CaptureWaveform
+
 
 @dataclass
 class ReportMetadata:
@@ -182,19 +184,23 @@ class WaveformRegion:
 
 
 @dataclass
-class WaveformData:
-    """Waveform data for inclusion in reports."""
+class WaveformData(CaptureWaveform):
+    """A captured waveform plus everything a report needs to present it.
 
-    channel: str
-    time: np.ndarray
-    voltage: np.ndarray
-    sample_rate: float
-    record_length: int
+    Subclasses the library's WaveformData so the physics -- time, voltage, channel,
+    sample_rate, record_length and the instrument's timebase/voltage_scale -- is
+    defined once, in scpi_control.waveform. Only report concerns live here.
+    """
 
-    # Optional metadata
-    timebase: Optional[float] = None
-    voltage_scale: Optional[float] = None
-    voltage_offset: Optional[float] = None
+    # `field()` with no default is REQUIRED, and is the only spelling that works.
+    # A bare `sample_rate: float` does NOT re-require the field: @dataclass keeps
+    # defaults as class attributes, so the annotation inherits the base's None and
+    # the field silently stays optional. The report pipeline divides by sample_rate
+    # and record_length, so both must be present.
+    sample_rate: float = field()
+    record_length: int = field()
+
+    # Instrument metadata the library does not carry
     probe_ratio: Optional[float] = None
     coupling: Optional[str] = None
 
@@ -215,7 +221,9 @@ class WaveformData:
     regions: List[WaveformRegion] = field(default_factory=list)
 
     def __post_init__(self):
-        """Set default label if not provided."""
+        """Validate via the library's rules, then apply report defaults."""
+        super().__post_init__()
+        self.channel = str(self.channel)
         if self.label is None:
             self.label = self.channel
 

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -81,7 +81,7 @@ class WaveformAnalyzer:
     @staticmethod
     def calculate_amplitude_stats(waveform: WaveformData) -> Dict[str, float]:
         """Calculate amplitude-related statistics."""
-        v = waveform.voltage_data
+        v = waveform.voltage
 
         vmax = np.max(v)
         vmin = np.min(v)
@@ -104,7 +104,7 @@ class WaveformAnalyzer:
     def calculate_frequency_stats(waveform: WaveformData) -> Dict[str, Optional[float]]:
         """Calculate frequency and period using FFT."""
         try:
-            v = waveform.voltage_data
+            v = waveform.voltage
             sample_rate = waveform.sample_rate
 
             # Compute FFT
@@ -145,8 +145,8 @@ class WaveformAnalyzer:
     def calculate_timing_stats(waveform: WaveformData) -> Dict[str, Optional[float]]:
         """Calculate timing measurements (rise time, fall time, pulse width, duty cycle)."""
         try:
-            v = waveform.voltage_data
-            t = waveform.time_data
+            v = waveform.voltage
+            t = waveform.time
             dt = np.mean(np.diff(t))  # Average time step
 
             vmax = np.max(v)
@@ -227,7 +227,7 @@ class WaveformAnalyzer:
     def calculate_quality_stats(waveform: WaveformData) -> Dict[str, Optional[float]]:
         """Calculate signal quality metrics (SNR, noise, overshoot, undershoot, jitter)."""
         try:
-            v = waveform.voltage_data
+            v = waveform.voltage
 
             # Estimate noise level (high-frequency component)
             # Use standard deviation of detrended signal
@@ -259,7 +259,7 @@ class WaveformAnalyzer:
             if len(rising_edges) > 2:
                 # Calculate period jitter
                 periods = np.diff(rising_edges)
-                jitter = np.std(periods) * np.mean(np.diff(waveform.time_data))
+                jitter = np.std(periods) * np.mean(np.diff(waveform.time))
 
             return {
                 "noise_level": noise_level,
@@ -361,7 +361,7 @@ class WaveformAnalyzer:
             Tuple of (signal_type, confidence) where confidence is 0-100%
         """
         try:
-            v = waveform.voltage_data
+            v = waveform.voltage
 
             # Check for DC signal first
             if WaveformAnalyzer._is_dc_signal(v):
@@ -449,7 +449,7 @@ class WaveformAnalyzer:
         Values are normalized so fundamental = 1.0 for periodic signals.
         """
         try:
-            v = waveform.voltage_data
+            v = waveform.voltage
             sample_rate = waveform.sample_rate
 
             # Compute FFT
@@ -643,8 +643,8 @@ class WaveformAnalyzer:
             Dictionary with plateau stability metrics
         """
         try:
-            v = waveform.voltage_data
-            t = waveform.time_data
+            v = waveform.voltage
+            t = waveform.time
 
             vmax = np.max(v)
             vmin = np.min(v)
@@ -795,8 +795,8 @@ class WaveformAnalyzer:
         """
         from scpi_control.report_generator.models.report_data import WaveformRegion
 
-        t = waveform.time_data
-        v = waveform.voltage_data
+        t = waveform.time
+        v = waveform.voltage
 
         if len(v) < 10:
             return []
@@ -882,8 +882,8 @@ class WaveformAnalyzer:
         """
         from scpi_control.report_generator.models.report_data import WaveformRegion
 
-        t = waveform.time_data
-        v = waveform.voltage_data
+        t = waveform.time
+        v = waveform.voltage
 
         if len(v) < 10:
             return []
@@ -959,8 +959,8 @@ class WaveformAnalyzer:
         """
         from scpi_control.report_generator.models.report_data import WaveformRegion
 
-        t = waveform.time_data
-        v = waveform.voltage_data
+        t = waveform.time
+        v = waveform.voltage
 
         if len(v) < 20:
             return []

--- a/scpi_control/report_generator/utils/waveform_loader.py
+++ b/scpi_control/report_generator/utils/waveform_loader.py
@@ -94,9 +94,9 @@ class WaveformLoader:
         """Read an NPZ written by scpi_control.waveform's _save_npy."""
         voltage = np.asarray(data[ws.VOLTAGE])
         return WaveformData(
-            channel_name=str(data[ws.CHANNEL]),
-            time_data=np.asarray(data[ws.TIME]),
-            voltage_data=voltage,
+            channel=str(data[ws.CHANNEL]),
+            time=np.asarray(data[ws.TIME]),
+            voltage=voltage,
             sample_rate=float(data[ws.SAMPLE_RATE]),
             record_length=len(voltage),
             source_file=filepath,
@@ -117,9 +117,9 @@ class WaveformLoader:
             voltage = np.asarray(data[voltage_key])
             waveforms.append(
                 WaveformData(
-                    channel_name=voltage_key,
-                    time_data=time_data,
-                    voltage_data=voltage,
+                    channel=voltage_key,
+                    time=time_data,
+                    voltage=voltage,
                     sample_rate=WaveformLoader._rate_from_time(time_data),
                     record_length=len(voltage),
                     source_file=filepath,
@@ -187,9 +187,9 @@ class WaveformLoader:
                 channel_name = f"CH{i}"
             waveforms.append(
                 WaveformData(
-                    channel_name=channel_name,
-                    time_data=time_data,
-                    voltage_data=voltage,
+                    channel=channel_name,
+                    time=time_data,
+                    voltage=voltage,
                     sample_rate=WaveformLoader._rate_from_header(header, derived_rate),
                     record_length=len(voltage),
                     source_file=filepath,
@@ -266,9 +266,9 @@ class WaveformLoader:
             # loadmat returns even scalars as 2-D arrays; .item() unwraps them.
             return [
                 WaveformData(
-                    channel_name=str(np.asarray(data[ws.CHANNEL]).item()),
-                    time_data=np.asarray(data[ws.TIME]).flatten(),
-                    voltage_data=voltage,
+                    channel=str(np.asarray(data[ws.CHANNEL]).item()),
+                    time=np.asarray(data[ws.TIME]).flatten(),
+                    voltage=voltage,
                     sample_rate=float(np.asarray(data[ws.SAMPLE_RATE]).item()),
                     record_length=len(voltage),
                     source_file=filepath,
@@ -286,9 +286,9 @@ class WaveformLoader:
             voltage = np.asarray(data[voltage_key]).flatten()
             waveforms.append(
                 WaveformData(
-                    channel_name=voltage_key,
-                    time_data=time_data,
-                    voltage_data=voltage,
+                    channel=voltage_key,
+                    time=time_data,
+                    voltage=voltage,
                     sample_rate=WaveformLoader._rate_from_time(time_data),
                     record_length=len(voltage),
                     source_file=filepath,
@@ -321,9 +321,9 @@ class WaveformLoader:
                     channel = channel.decode()
                 return [
                     WaveformData(
-                        channel_name=str(channel),
-                        time_data=time_data,
-                        voltage_data=voltage,
+                        channel=str(channel),
+                        time=time_data,
+                        voltage=voltage,
                         # Foreign files can name datasets 'time'/'voltage' without
                         # carrying our sample_rate attr; derive it from the
                         # numeric time axis instead of silently reporting 0.0,
@@ -347,9 +347,9 @@ class WaveformLoader:
                 attrs = dict(f[key].attrs)
                 waveforms.append(
                     WaveformData(
-                        channel_name=key,
-                        time_data=time_data,
-                        voltage_data=voltage,
+                        channel=key,
+                        time=time_data,
+                        voltage=voltage,
                         sample_rate=float(attrs.get(ws.SAMPLE_RATE, WaveformLoader._rate_from_time(time_data))),
                         record_length=len(voltage),
                         source_file=filepath,

--- a/scpi_control/waveform.py
+++ b/scpi_control/waveform.py
@@ -55,7 +55,13 @@ class WaveformData:
         return len(self.voltage)
 
     def __post_init__(self) -> None:
-        """Validate and populate optional metadata."""
+        """Validate the arrays and derive what they determine.
+
+        Only values the samples actually determine are derived here: record_length
+        is the array's length, and sample_rate is 1/dt off the time axis. Timebase
+        and voltage_scale are NOT derived -- they depend on the scope's display
+        grid, which the samples do not carry. A real acquisition supplies both.
+        """
         if self.time.shape != self.voltage.shape:
             raise ValueError("Time and voltage arrays must have the same shape")
 
@@ -68,21 +74,6 @@ class WaveformData:
             dt = float(np.mean(np.diff(self.time)))
             if dt > 0:
                 self.sample_rate = 1.0 / dt
-
-        # generic fallback; real acquisitions carry explicit timebase --
-        # per-model grids live in ModelCapability
-        if self.timebase is None and self.sample_rate:
-            total_time = self.record_length / self.sample_rate
-            self.timebase = total_time / 14.0
-
-        # Infer a reasonable voltage scale when none is supplied
-        if self.voltage_scale is None:
-            if len(self.voltage) > 0:
-                span = float(np.max(self.voltage) - np.min(self.voltage))
-                # Standard 8 vertical divisions on most scopes
-                self.voltage_scale = span / 8.0 if span > 0 else 1.0
-            else:
-                self.voltage_scale = 1.0
 
 
 class Waveform:

--- a/scpi_control/waveform.py
+++ b/scpi_control/waveform.py
@@ -47,8 +47,6 @@ class WaveformData:
     timebase: Optional[float] = None
     voltage_scale: Optional[float] = None
     voltage_offset: float = 0.0
-    source: Optional[str] = None
-    description: Optional[str] = None
 
     def __len__(self) -> int:
         """Get number of samples."""

--- a/scripts/manual_test_waveform_display.py
+++ b/scripts/manual_test_waveform_display.py
@@ -63,7 +63,7 @@ class TestWindow(QMainWindow):
         v = np.sin(2 * np.pi * 1000 * t)  # 1kHz sine wave
 
         # Create waveform data
-        waveform = WaveformData(time=t, voltage=v, channel=1, source="Test", description="1kHz Sine Wave")
+        waveform = WaveformData(time=t, voltage=v, channel=1)
 
         # Plot it
         self.display.plot_waveform(waveform, clear_others=True)
@@ -78,7 +78,7 @@ class TestWindow(QMainWindow):
         v = np.sign(np.sin(2 * np.pi * 1000 * t))  # 1kHz square wave
 
         # Create waveform data
-        waveform = WaveformData(time=t, voltage=v, channel=2, source="Test", description="1kHz Square Wave")
+        waveform = WaveformData(time=t, voltage=v, channel=2)
 
         # Plot it
         self.display.plot_waveform(waveform, clear_others=True)
@@ -95,8 +95,6 @@ class TestWindow(QMainWindow):
             time=t,
             voltage=np.sin(2 * np.pi * 1000 * t),
             channel=1,
-            source="Test",
-            description="CH1: 1kHz Sine",
         )
 
         # Square wave on CH2
@@ -104,8 +102,6 @@ class TestWindow(QMainWindow):
             time=t,
             voltage=0.5 * np.sign(np.sin(2 * np.pi * 500 * t)),
             channel=2,
-            source="Test",
-            description="CH2: 500Hz Square",
         )
 
         # Sawtooth on CH3
@@ -113,8 +109,6 @@ class TestWindow(QMainWindow):
             time=t,
             voltage=0.8 * (2 * (t * 2000 % 1) - 1),
             channel=3,
-            source="Test",
-            description="CH3: 2kHz Sawtooth",
         )
 
         # Plot all

--- a/scripts/test_pdf_progress.py
+++ b/scripts/test_pdf_progress.py
@@ -56,9 +56,9 @@ def create_test_report():
     for i in range(3):
         t, v = generate_test_waveform(freq=1000 * (i + 1))
         waveform = WaveformData(
-            channel_name=f"CH{i+1}",
-            time_data=t,
-            voltage_data=v,
+            channel=f"CH{i+1}",
+            time=t,
+            voltage=v,
             sample_rate=100000,
             record_length=len(t),
             label=f"Sine Wave {i+1}"
@@ -79,9 +79,9 @@ def create_test_report():
     # Clean square wave
     t, v = generate_square_wave(freq=1000, amplitude=2.0, noise_level=0.0)
     waveform = WaveformData(
-        channel_name="CH4",
-        time_data=t,
-        voltage_data=v,
+        channel="CH4",
+        time=t,
+        voltage=v,
         sample_rate=100000,
         record_length=len(t),
         label="Clean Square Wave"
@@ -92,9 +92,9 @@ def create_test_report():
     # Noisy square wave (low noise)
     t, v = generate_square_wave(freq=1000, amplitude=2.0, noise_level=0.05)
     waveform = WaveformData(
-        channel_name="CH5",
-        time_data=t,
-        voltage_data=v,
+        channel="CH5",
+        time=t,
+        voltage=v,
         sample_rate=100000,
         record_length=len(t),
         label="Square Wave (Low Noise)"
@@ -105,9 +105,9 @@ def create_test_report():
     # Noisy square wave (high noise)
     t, v = generate_square_wave(freq=1000, amplitude=2.0, noise_level=0.1)
     waveform = WaveformData(
-        channel_name="CH6",
-        time_data=t,
-        voltage_data=v,
+        channel="CH6",
+        time=t,
+        voltage=v,
         sample_rate=100000,
         record_length=len(t),
         label="Square Wave (High Noise)"

--- a/scripts/test_signal_detection.py
+++ b/scripts/test_signal_detection.py
@@ -72,9 +72,9 @@ def test_waveform(name, time_data, voltage_data, sample_rate, expected_type=None
 
     # Create waveform data
     waveform = WaveformData(
-        channel_name="CH1",
-        time_data=time_data,
-        voltage_data=voltage_data,
+        channel="CH1",
+        time=time_data,
+        voltage=voltage_data,
         sample_rate=sample_rate,
         record_length=len(time_data)
     )

--- a/scripts/test_unicode_rendering.py
+++ b/scripts/test_unicode_rendering.py
@@ -97,9 +97,9 @@ Note: These results are within \u00b15% of theoretical predictions.
     # Add a test waveform
     t, v = generate_test_waveform()
     waveform = WaveformData(
-        channel_name="CH1",
-        time_data=t,
-        voltage_data=v,
+        channel="CH1",
+        time=t,
+        voltage=v,
         sample_rate=100000,
         record_length=len(t),
         label="Test Sine Wave"

--- a/tests/test_dialect_matrix.py
+++ b/tests/test_dialect_matrix.py
@@ -115,6 +115,11 @@ def test_get_waveform_wire_and_value(rig):
     scope.channel1.voltage_scale = 0.5
     waveform = scope.get_waveform(1)
     assert waveform.voltage_scale == pytest.approx(0.5)
+    # The instrument's own timebase, not a derived one: every vendor backend must
+    # read it from the scope now that __post_init__ no longer invents a fallback.
+    # Asserting the exact mock value is what distinguishes "the backend reported
+    # it" from "something computed it" -- a fabricated value would not be 1e-3.
+    assert waveform.timebase == pytest.approx(1e-3)
     assert len(waveform.voltage) > 0
 
 

--- a/tests/test_report_generators.py
+++ b/tests/test_report_generators.py
@@ -21,9 +21,9 @@ def make_report():
     """A minimal but complete TestReport, including one waveform."""
     t = np.arange(100) / 1e6
     waveform = WaveformData(
-        channel_name="C1",
-        time_data=t,
-        voltage_data=np.sin(2 * np.pi * 10_000 * t),
+        channel="C1",
+        time=t,
+        voltage=np.sin(2 * np.pi * 10_000 * t),
         sample_rate=1e6,
         record_length=100,
     )

--- a/tests/test_report_waveform_loader.py
+++ b/tests/test_report_waveform_loader.py
@@ -37,10 +37,10 @@ def test_npz_round_trip_preserves_everything(tmp_path):
 
     assert len(loaded) == 1
     got = loaded[0]
-    assert got.channel_name == "C1"  # was 'voltage'
+    assert got.channel == "C1"  # was 'voltage'
     assert got.sample_rate == pytest.approx(SAMPLE_RATE)  # was a fabricated 1e9
-    np.testing.assert_allclose(got.time_data, wf.time)  # was a 0-dim timestamp STRING
-    np.testing.assert_allclose(got.voltage_data, wf.voltage)
+    np.testing.assert_allclose(got.time, wf.time)  # was a 0-dim timestamp STRING
+    np.testing.assert_allclose(got.voltage, wf.voltage)
     assert got.record_length == 100
 
 
@@ -52,9 +52,9 @@ def test_npz_timestamp_never_shadows_time(tmp_path):
 
     got = WaveformLoader.load(p)[0]
 
-    assert got.time_data.ndim == 1
-    assert len(got.time_data) == 100
-    assert not isinstance(got.time_data.dtype.type(), np.str_)
+    assert got.time.ndim == 1
+    assert len(got.time) == 100
+    assert not isinstance(got.time.dtype.type(), np.str_)
 
 
 def test_npz_meta_keys_do_not_disturb_the_schema_path(tmp_path):
@@ -65,8 +65,8 @@ def test_npz_meta_keys_do_not_disturb_the_schema_path(tmp_path):
     saver()._save_npy(wf, str(p), metadata={"dut": "board7"})
 
     got = WaveformLoader.load(p)[0]
-    assert got.channel_name == "C1"
-    np.testing.assert_allclose(got.time_data, wf.time)
+    assert got.channel == "C1"
+    np.testing.assert_allclose(got.time, wf.time)
 
 
 def test_mat_round_trip_preserves_everything(tmp_path):
@@ -79,10 +79,10 @@ def test_mat_round_trip_preserves_everything(tmp_path):
 
     assert len(loaded) == 1, "the channel name must not become a phantom waveform"
     got = loaded[0]
-    assert got.channel_name == "C1"
+    assert got.channel == "C1"
     assert got.sample_rate == pytest.approx(SAMPLE_RATE)
-    np.testing.assert_allclose(got.time_data, wf.time)
-    np.testing.assert_allclose(got.voltage_data, wf.voltage)
+    np.testing.assert_allclose(got.time, wf.time)
+    np.testing.assert_allclose(got.voltage, wf.voltage)
 
 
 def test_mat_does_not_invent_a_channel_waveform(tmp_path):
@@ -92,7 +92,7 @@ def test_mat_does_not_invent_a_channel_waveform(tmp_path):
     saver()._save_mat(make_waveform(), str(p))
 
     for got in WaveformLoader.load(p):
-        assert np.issubdtype(got.voltage_data.dtype, np.number)
+        assert np.issubdtype(got.voltage.dtype, np.number)
 
 
 def test_foreign_npz_still_loads_heuristically(tmp_path):
@@ -103,7 +103,7 @@ def test_foreign_npz_still_loads_heuristically(tmp_path):
     loaded = WaveformLoader.load(p)
 
     assert len(loaded) == 1
-    assert len(loaded[0].time_data) == 10
+    assert len(loaded[0].time) == 10
 
 
 def test_foreign_npz_with_both_time_and_timestamp(tmp_path):
@@ -113,8 +113,8 @@ def test_foreign_npz_with_both_time_and_timestamp(tmp_path):
 
     got = WaveformLoader.load(p)[0]
 
-    assert got.time_data.ndim == 1
-    assert len(got.time_data) == 10
+    assert got.time.ndim == 1
+    assert len(got.time) == 10
 
 
 def test_foreign_npz_with_our_names_but_no_sample_rate_falls_back(tmp_path):
@@ -126,7 +126,7 @@ def test_foreign_npz_with_our_names_but_no_sample_rate_falls_back(tmp_path):
     loaded = WaveformLoader.load(p)
 
     assert len(loaded) == 1
-    assert len(loaded[0].time_data) == 10
+    assert len(loaded[0].time) == 10
 
 
 def test_foreign_npz_with_a_string_first_key_is_rejected_cleanly(tmp_path):
@@ -175,10 +175,10 @@ def test_plain_csv_round_trip(tmp_path):
 
     assert len(loaded) == 1
     got = loaded[0]
-    assert got.channel_name == "CH1"  # synthesized: the format cannot carry 'C1'
+    assert got.channel == "CH1"  # synthesized: the format cannot carry 'C1'
     assert got.sample_rate == pytest.approx(SAMPLE_RATE, rel=1e-6)  # derived from the time axis
-    np.testing.assert_allclose(got.time_data, wf.time)
-    np.testing.assert_allclose(got.voltage_data, wf.voltage)
+    np.testing.assert_allclose(got.time, wf.time)
+    np.testing.assert_allclose(got.voltage, wf.voltage)
 
 
 def test_csv_enhanced_loads_at_all(tmp_path):
@@ -191,8 +191,8 @@ def test_csv_enhanced_loads_at_all(tmp_path):
     loaded = WaveformLoader.load(p)
 
     assert len(loaded) == 1
-    np.testing.assert_allclose(loaded[0].time_data, wf.time)
-    np.testing.assert_allclose(loaded[0].voltage_data, wf.voltage)
+    np.testing.assert_allclose(loaded[0].time, wf.time)
+    np.testing.assert_allclose(loaded[0].voltage, wf.voltage)
 
 
 def test_csv_enhanced_reads_channel_and_rate_from_its_header(tmp_path):
@@ -203,7 +203,7 @@ def test_csv_enhanced_reads_channel_and_rate_from_its_header(tmp_path):
 
     got = WaveformLoader.load(p)[0]
 
-    assert got.channel_name == "C3"
+    assert got.channel == "C3"
     assert got.sample_rate == pytest.approx(SAMPLE_RATE)
 
 
@@ -226,9 +226,9 @@ def test_csv_with_legacy_siglent_header_still_loads(tmp_path):
 
     got = WaveformLoader.load(p)[0]
 
-    assert got.channel_name == "C2"
+    assert got.channel == "C2"
     assert got.sample_rate == pytest.approx(1e6)
-    assert len(got.time_data) == 3
+    assert len(got.time) == 3
 
 
 def test_single_column_csv_raises_rather_than_returning_nothing(tmp_path):
@@ -247,7 +247,7 @@ def test_csv_header_with_an_empty_channel_value_falls_back(tmp_path):
 
     got = WaveformLoader.load(p)[0]
 
-    assert got.channel_name == "CH1"
+    assert got.channel == "CH1"
     assert got.sample_rate == pytest.approx(1e6)
 
 
@@ -269,7 +269,7 @@ def test_csv_user_metadata_key_named_channel_cannot_override_the_real_one(tmp_pa
 
     got = WaveformLoader.load(p)[0]
 
-    assert got.channel_name == "C2"
+    assert got.channel == "C2"
     assert got.sample_rate == pytest.approx(1e6)
 
 
@@ -283,10 +283,10 @@ def test_hdf5_round_trip_preserves_everything(tmp_path):
 
     assert len(loaded) == 1
     got = loaded[0]
-    assert got.channel_name == "C1"  # was 'voltage'
+    assert got.channel == "C1"  # was 'voltage'
     assert got.sample_rate == pytest.approx(SAMPLE_RATE)  # was 1e9: read from the wrong attrs
-    np.testing.assert_allclose(got.time_data, wf.time)
-    np.testing.assert_allclose(got.voltage_data, wf.voltage)
+    np.testing.assert_allclose(got.time, wf.time)
+    np.testing.assert_allclose(got.voltage, wf.voltage)
 
 
 def test_hdf5_with_user_metadata_loads(tmp_path):
@@ -300,8 +300,8 @@ def test_hdf5_with_user_metadata_loads(tmp_path):
     loaded = WaveformLoader.load(p)
 
     assert len(loaded) == 1
-    assert loaded[0].channel_name == "C1"
-    np.testing.assert_allclose(loaded[0].voltage_data, wf.voltage)
+    assert loaded[0].channel == "C1"
+    np.testing.assert_allclose(loaded[0].voltage, wf.voltage)
 
 
 def test_foreign_hdf5_still_loads_heuristically(tmp_path):
@@ -316,7 +316,7 @@ def test_foreign_hdf5_still_loads_heuristically(tmp_path):
     loaded = WaveformLoader.load(p)
 
     assert len(loaded) == 1
-    assert len(loaded[0].time_data) == 10
+    assert len(loaded[0].time) == 10
 
 
 def test_foreign_hdf5_with_a_string_time_dataset_is_rejected_cleanly(tmp_path):
@@ -368,4 +368,4 @@ def test_load_multiple_happy_path(tmp_path):
 
     loaded = WaveformLoader.load_multiple([a, b])
 
-    assert [w.channel_name for w in loaded] == ["C1", "C2"]
+    assert [w.channel for w in loaded] == ["C1", "C2"]

--- a/tests/test_report_waveform_model.py
+++ b/tests/test_report_waveform_model.py
@@ -1,7 +1,8 @@
 """The report waveform is the library waveform plus report concerns.
 
 One model owns the physics. This pins the properties that make the subclass real:
-substitutability, the required-field contract, the inherited validation, and the
+substitutability (including through `type(source_waveform)(...)` reconstruction in
+MathOperations), the required-field contract, the inherited validation, and the
 str-coercion the loader used to do by hand.
 """
 
@@ -30,12 +31,17 @@ def test_a_report_waveform_is_a_capture_waveform():
 
 
 def test_sample_rate_and_record_length_are_genuinely_required():
-    """The bare-annotation trap: `sample_rate: float` would silently inherit the
-    base's None default and this contract would weaken with nothing to catch it.
-    Every other test passes sample_rate, so this is the only test that would fail."""
+    """The bare-annotation trap: `sample_rate: float` (or `record_length: int`)
+    would silently inherit the base's None default and that field's contract
+    would weaken with nothing to catch it. Each field is checked with its own
+    construction, omitting exactly that field -- omitting both at once would
+    leave a hole: reverting `record_length` alone stays undetected, because the
+    missing `sample_rate` alone already satisfies `pytest.raises(TypeError)`."""
     t = np.arange(10) / 1e6
     with pytest.raises(TypeError):
-        ReportWaveform(time=t, voltage=np.ones(10), channel="C1")
+        ReportWaveform(time=t, voltage=np.ones(10), channel="C1", record_length=10)
+    with pytest.raises(TypeError):
+        ReportWaveform(time=t, voltage=np.ones(10), channel="C1", sample_rate=1e6)
 
 
 def test_channel_is_coerced_to_str():
@@ -107,3 +113,19 @@ def test_a_report_waveform_can_be_saved_by_the_library(tmp_path):
     p = tmp_path / "cap.npz"
     object.__new__(Waveform)._save_npy(make_report_waveform(), str(p))
     assert p.exists()
+
+
+def test_math_add_preserves_the_report_waveform_type():
+    """MathOperations._create_result_waveform builds the result via
+    `type(source_waveform)(...)`, silently depending on the report subclass's
+    constructor accepting exactly those kwargs. Pre-branch this raised
+    AttributeError on a report waveform -- the old report type had no time/
+    voltage/channel kwargs at all. It works now; pin it so a future required
+    field on ReportWaveform breaks this test instead of breaking silently."""
+    from scpi_control.math_channel import MathOperations
+
+    wf = make_report_waveform()
+    result = MathOperations.add(wf, wf)
+
+    assert isinstance(result, ReportWaveform)
+    np.testing.assert_allclose(result.voltage, wf.voltage * 2)

--- a/tests/test_report_waveform_model.py
+++ b/tests/test_report_waveform_model.py
@@ -1,0 +1,109 @@
+"""The report waveform is the library waveform plus report concerns.
+
+One model owns the physics. This pins the properties that make the subclass real:
+substitutability, the required-field contract, the inherited validation, and the
+str-coercion the loader used to do by hand.
+"""
+
+from dataclasses import fields
+
+import numpy as np
+import pytest
+
+from scpi_control.report_generator.models.report_data import WaveformData as ReportWaveform
+from scpi_control.waveform import WaveformData as CaptureWaveform
+
+
+def make_report_waveform(channel="C1", n=100, rate=1e6):
+    t = np.arange(n) / rate
+    return ReportWaveform(
+        time=t,
+        voltage=np.sin(2 * np.pi * 10_000 * t),
+        channel=channel,
+        sample_rate=rate,
+        record_length=n,
+    )
+
+
+def test_a_report_waveform_is_a_capture_waveform():
+    assert isinstance(make_report_waveform(), CaptureWaveform)
+
+
+def test_sample_rate_and_record_length_are_genuinely_required():
+    """The bare-annotation trap: `sample_rate: float` would silently inherit the
+    base's None default and this contract would weaken with nothing to catch it.
+    Every other test passes sample_rate, so this is the only test that would fail."""
+    t = np.arange(10) / 1e6
+    with pytest.raises(TypeError):
+        ReportWaveform(time=t, voltage=np.ones(10), channel="C1")
+
+
+def test_channel_is_coerced_to_str():
+    """The loader used to do this by hand at each construction site; it is now a
+    property of the type. An int 1 and a str '1' are not equal, so the coercion
+    point matters."""
+    wf = make_report_waveform(channel=1)
+    assert wf.channel == "1"
+    assert wf.label == "1"
+
+
+def test_shape_validation_is_inherited():
+    """The report type never validated shapes. It does now -- a malformed file
+    fails loudly instead of producing a quietly broken report."""
+    with pytest.raises(ValueError):
+        ReportWaveform(time=np.arange(10), voltage=np.ones(9), channel="C1", sample_rate=1e6, record_length=9)
+
+
+def test_report_fields_still_work():
+    wf = make_report_waveform()
+    assert wf.color == "#1f77b4"
+    assert wf.regions == []
+    wf.regions.append("x")
+    assert make_report_waveform().regions == [], "regions must not be a shared mutable default"
+
+
+def test_explicit_label_wins_over_the_channel_default():
+    t = np.arange(10) / 1e6
+    wf = ReportWaveform(time=t, voltage=np.ones(10), channel="C1", sample_rate=1e6, record_length=10, label="Probe A")
+    assert wf.label == "Probe A"
+
+
+def test_no_invented_timebase_on_a_report_waveform():
+    """The whole reason the fabrication had to die first: this object now runs the
+    library's __post_init__, and a report renders whatever timebase it finds."""
+    wf = make_report_waveform()
+    assert wf.timebase is None
+    assert wf.voltage_scale is None
+
+
+def test_field_order_is_the_library_core_then_report_concerns():
+    assert [f.name for f in fields(ReportWaveform)] == [
+        "time",
+        "voltage",
+        "channel",
+        "sample_rate",
+        "record_length",
+        "timebase",
+        "voltage_scale",
+        "voltage_offset",
+        "probe_ratio",
+        "coupling",
+        "source_file",
+        "capture_timestamp",
+        "color",
+        "label",
+        "signal_type",
+        "signal_type_confidence",
+        "statistics",
+        "regions",
+    ]
+
+
+def test_a_report_waveform_can_be_saved_by_the_library(tmp_path):
+    """A consequence of the is-a relationship, not a goal of it -- but worth pinning,
+    because it is the property a future direct-capture path would rely on."""
+    from scpi_control.waveform import Waveform
+
+    p = tmp_path / "cap.npz"
+    object.__new__(Waveform)._save_npy(make_report_waveform(), str(p))
+    assert p.exists()

--- a/tests/test_waveform_comprehensive.py
+++ b/tests/test_waveform_comprehensive.py
@@ -313,17 +313,6 @@ class TestWaveformUtilities:
             descriptor = waveform_handler._get_waveform_descriptor(1)
             assert isinstance(descriptor, dict)
 
-    def test_calculate_timebase(self):
-        """Test calculating timebase from sample rate."""
-        sample_rate = 1e6  # 1 MSa/s
-        record_length = 1000
-
-        duration = record_length / sample_rate
-        time = np.linspace(0, duration, record_length, endpoint=False)
-
-        assert len(time) == record_length
-        assert time[-1] < duration
-
 
 class TestWaveformComparison:
     """Test waveform comparison functions."""

--- a/tests/test_waveform_comprehensive.py
+++ b/tests/test_waveform_comprehensive.py
@@ -18,13 +18,12 @@ class TestWaveformData:
         time = np.linspace(0, 1e-3, 1000)
         voltage = np.sin(2 * np.pi * 1000 * time)
 
-        waveform = WaveformData(time=time, voltage=voltage, channel=1, sample_rate=1e6, record_length=1000, source="Test", description="Test waveform")
+        waveform = WaveformData(time=time, voltage=voltage, channel=1, sample_rate=1e6, record_length=1000)
 
         assert len(waveform.time) == 1000
         assert len(waveform.voltage) == 1000
         assert waveform.channel == 1
         assert waveform.sample_rate == 1e6
-        assert waveform.source == "Test"
 
     def test_waveform_data_minimal(self):
         """Test creating WaveformData with minimal parameters."""

--- a/tests/test_waveform_metadata_honesty.py
+++ b/tests/test_waveform_metadata_honesty.py
@@ -1,0 +1,84 @@
+"""The waveform model must never invent instrument metadata.
+
+`__post_init__` may compute what the arrays determine (record_length from the
+array's length, sample_rate from the time axis). It must not invent what depends
+on the scope's display geometry: timebase needs a horizontal division count and
+voltage_scale a vertical one, and neither is present in the samples. The old code
+assumed 14 and 8 -- Siglent's grid -- inside a library that also drives Tektronix
+and LeCroy, which use 10.
+"""
+
+import numpy as np
+import pytest
+
+from scpi_control.math_channel import MathOperations
+from scpi_control.waveform import WaveformData
+
+
+def make(n=100, rate=1e6):
+    t = np.arange(n) / rate
+    return t, np.sin(2 * np.pi * 10_000 * t)
+
+
+def test_timebase_is_none_when_no_instrument_reported_one():
+    t, v = make()
+    assert WaveformData(time=t, voltage=v, channel=1).timebase is None
+
+
+def test_voltage_scale_is_none_when_no_instrument_reported_one():
+    t, v = make()
+    assert WaveformData(time=t, voltage=v, channel=1).voltage_scale is None
+
+
+def test_flat_trace_gets_no_invented_voltage_scale():
+    """The old code handed a flat trace a bare 1.0 V/div -- invention, not measurement."""
+    t = np.arange(10) / 1e6
+    assert WaveformData(time=t, voltage=np.zeros(10), channel=1).voltage_scale is None
+
+
+def test_explicit_instrument_values_survive():
+    """What the scope reports must pass through untouched."""
+    t, v = make()
+    wf = WaveformData(time=t, voltage=v, channel=1, timebase=1e-3, voltage_scale=0.5)
+    assert wf.timebase == pytest.approx(1e-3)
+    assert wf.voltage_scale == pytest.approx(0.5)
+
+
+def test_record_length_is_still_derived():
+    """The data IS its length -- a measurement, so it stays."""
+    t, v = make(n=64)
+    assert WaveformData(time=t, voltage=v, channel=1).record_length == 64
+
+
+def test_sample_rate_is_still_derived_from_the_time_axis():
+    """dt is IN the data -- a measurement, so it stays."""
+    t, v = make(n=100, rate=1e6)
+    assert WaveformData(time=t, voltage=v, channel=1).sample_rate == pytest.approx(1e6)
+
+
+def test_shape_mismatch_still_raises():
+    with pytest.raises(ValueError):
+        WaveformData(time=np.arange(10), voltage=np.ones(9), channel=1)
+
+
+def test_math_channel_propagates_real_instrument_values():
+    t, v = make()
+    src = WaveformData(time=t, voltage=v, channel=1, timebase=1e-3, voltage_scale=0.5)
+    result = MathOperations._create_result_waveform(src, v * 2)
+    assert result.timebase == pytest.approx(1e-3)
+    assert result.voltage_scale == pytest.approx(0.5)
+
+
+def test_math_channel_invents_nothing_when_the_source_has_nothing():
+    t, v = make()
+    src = WaveformData(time=t, voltage=v, channel=1)
+    result = MathOperations._create_result_waveform(src, v * 2)
+    assert result.timebase is None
+    assert result.voltage_scale is None
+
+
+def test_math_channel_still_derives_sample_rate():
+    t, v = make(rate=1e6)
+    src = WaveformData(time=t, voltage=v, channel=1)
+    result = MathOperations._create_result_waveform(src, v * 2)
+    assert result.sample_rate == pytest.approx(1e6)

--- a/tests/test_waveform_metadata_honesty.py
+++ b/tests/test_waveform_metadata_honesty.py
@@ -82,3 +82,29 @@ def test_math_channel_still_derives_sample_rate():
     src = WaveformData(time=t, voltage=v, channel=1)
     result = MathOperations._create_result_waveform(src, v * 2)
     assert result.sample_rate == pytest.approx(1e6)
+
+
+def test_dead_metadata_fields_are_gone():
+    """`source` and `description` were write-only: set by a manual script and a few
+    tests, read by nothing. Removing them leaves the library type as exactly the
+    core the report type shares, which is what lets the report type subclass it."""
+    t, v = make()
+    with pytest.raises(TypeError):
+        WaveformData(time=t, voltage=v, channel=1, source="Test")
+    with pytest.raises(TypeError):
+        WaveformData(time=t, voltage=v, channel=1, description="1kHz Sine")
+
+
+def test_the_canonical_field_set_is_exactly_the_shared_core():
+    from dataclasses import fields
+
+    assert [f.name for f in fields(WaveformData)] == [
+        "time",
+        "voltage",
+        "channel",
+        "sample_rate",
+        "record_length",
+        "timebase",
+        "voltage_scale",
+        "voltage_offset",
+    ]


### PR DESCRIPTION
Makes `scpi_control.waveform.WaveformData` the single canonical waveform model, and makes the report generator's `WaveformData` a subclass of it. Sub-project 2 of four.

**This ships no new user-facing capability.** It is deliberately structural — see "What was deferred, and why" below.

## The duplication was smaller, and stranger, than "duplicate model" suggests

The report generator defined its own `WaveformData`. Of its 18 fields, **8 were the library's concepts verbatim** — three of them renamed for no reason anyone recorded (`time`→`time_data`, `voltage`→`voltage_data`, `channel`→`channel_name`). The other 10 were genuinely report-only: plot colour, label, regions, statistics, disk provenance.

And the library's two non-shared fields — `source` and `description` — turned out to be **write-only**. Set by a manual test script, read by nothing in production.

Which means: **delete the two dead fields and the library type _is_ exactly the shared core.** No base class to extract, no `WaveformCore` ceremony. The field census produced that result; it wasn't engineered.

So the report type now subclasses the library type and adds only report concerns. The physics is defined once.

There's a second payoff that only showed up during the census: `waveform_schema.py` already spelled the on-disk keys `TIME = "time"`, `CHANNEL = "channel"`. Renaming to the library's names makes **the in-memory field name and the on-disk key the same string**, so the loader's translation layer collapses to identity:

```python
channel_name=str(data[ws.CHANNEL])   ->   channel=str(data[ws.CHANNEL])
```

Hand-mapping is where three of the previous sub-project's seven bugs lived. That category is now gone.

## The fabrication: a bug this PR would have *created*

`__post_init__` didn't validate — it invented. Absent a real value it derived `timebase` by **assuming 14 horizontal divisions** and `voltage_scale` by **assuming 8 vertical ones**. A flat trace got a bare `1.0` V/div. That 14 is Siglent's grid, sitting in a library that now also drives Tektronix and LeCroy, which use 10.

Today that's nearly harmless, because almost nothing reads those fields — and the one renderer that does, the report generator, used a *different class*, so an invented value could never reach it.

**Unifying the models is exactly what would have made it dangerous.** The moment the report type subclasses the library type, `__post_init__` runs on every loaded waveform and the generators' truthiness gates — which have *never fired* — start printing invented numbers as measured ones. So this isn't adjacent scope creep; it's a defect this change would have introduced, and it had to die first. That ordering is load-bearing: the reviewer confirmed that reversing it would have made `context_builder.py` emit a Timebase row that never existed.

The line drawn: **`__post_init__` may compute what the arrays determine; it may not invent what depends on the instrument's display geometry.** `record_length` (the data *is* its length) and `sample_rate` (Δt is *in* the data) stay. Division counts aren't in the samples, so they go.

`math_channel.py` turned out to duplicate all three fabrications verbatim — same `/14.0`, same `span / 8.0 if span > 0 else 1.0` — re-implementing logic `__post_init__` would have run anyway. It now propagates what the source carries and invents nothing.

Net: a waveform's `timebase` is non-`None` **iff an instrument actually reported one**.

## The one subtle mechanic

Re-requiring an inherited field has a trap, and the obvious spelling is the wrong one:

```python
sample_rate: float            # WRONG - silently inherits the base's None; field stays optional
sample_rate: float = field()  # RIGHT - genuinely required
```

`@dataclass` keeps defaults as *class attributes*, so a bare annotation finds the base's inherited `sample_rate = None`. The contract weakens with nothing to show for it. It's documented at the site, and pinned by a test that omits each field independently — because every *other* test supplies `sample_rate`, so all of them would pass either way.

## Verification

Suite **820 → 841** (19 skipped throughout). Beyond that, two checks worth naming:

- **Reports render byte-for-byte identically.** The reviewer extracted `c243cfe` via `git archive` and ran a 7-file corpus (schema NPZ/MAT/HDF5, plain CSV, enhanced CSV, foreign-heuristic NPZ, flat trace) through load → construct → analyze → render on both trees. Identical markdown, identical LLM context strings.
- **The 3.9 floor was settled empirically, not by reasoning.** The `field()` mechanic and re-declared-field ordering were verified on real 3.9, 3.10, 3.12 and 3.14 interpreters. Identical on all four; the only difference is TypeError message text, which no test matches on.

## An accidental fix

`MathOperations` builds results via `type(source_waveform)(...)`. Pre-branch, a math operation on a *report* waveform raised `AttributeError` — the old report type had no `time`/`voltage`/`channel` kwargs. It now works. Nobody planned this; the review found it. There's now a test pinning it, since that duck-typed call silently depends on the subclass's constructor signature.

## Breaking changes

Documented under `### ⚠️ Breaking Changes` in the CHANGELOG. The one to actually watch:

**The positional order changed** — `channel` moved from position 1 to 3. So `WaveformData("CH1", t, v, ...)` doesn't fail with a recognizable rename error; it fails with `AttributeError: 'str' object has no attribute 'shape'`. Every construction site in this repo uses kwargs (verified — there are zero positional sites), which is why the in-repo rename was fail-loud, but external positional callers get a confusing failure. Use keywords.

Also: `WaveformData(..., source=...)` now raises `TypeError`; and `wf.timebase * 1e6` on a *synthetic* waveform now raises `TypeError` because the value is honestly `None` rather than invented. Real acquisitions are unaffected.

## What was deferred, and why

The original charter for this sub-project said "direct capture → report: in-process `WaveformData` handoff". Exploration showed that framing conflated two independent decisions — and that **"in-process" isn't a refactor here, because there is no shared process.** `siglent-gui` and `siglent-report-generator` are separate console scripts, each building its own `QApplication`; the report generator calls itself standalone. Disk is the handoff *by design*.

Merging the types doesn't move a waveform across a process boundary, and moving one across doesn't require merging them. So this PR does the model; the workflow stays an open architecture decision.

No `from_capture()` either — an adapter with no caller is speculative. The subclass relationship *is* the enabling change; promotion is a few lines whenever a successor wants it.

## Known gaps

- **The loader's three `str()` calls are now redundant** (`waveform_loader.py:97,269,324`) — the type coerces `channel` itself. Left in place deliberately: they're defensive at MAT/HDF5 boundaries that hand back `np.str_`/`bytes`, so removing them is a separate judgement.
- **`to_dict()` now emits `voltage_offset: 0.0`** where the key was previously absent, via inheritance. Verified dead — `TestReport.to_dict()` has no caller anywhere.
- **Qt widgets remain untested**, unchanged by this work.
- Roughly half the 21 new tests pass against pre-fix code. That's deliberate: for a refactor whose central risk *is* silent behaviour change, invariant-pinning is the right instrument, and each names the invariant it protects.
