### PR TITLE
feat: LLM tool calling over a loaded report (local Ollama)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,web]" httpx ollama  # httpx: fastapi.testclient; ollama: LLM tool-calling schema tests
+          pip install -e ".[dev,web]" httpx "ollama>=0.6.0"  # httpx: fastapi.testclient; ollama: LLM tool-calling schema tests
           pip install pytest pytest-cov pytest-xdist
 
       - name: Run tests with coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,web]" httpx  # httpx: required by fastapi.testclient
+          pip install -e ".[dev,web]" httpx ollama  # httpx: fastapi.testclient; ollama: LLM tool-calling schema tests
           pip install pytest pytest-cov pytest-xdist
 
       - name: Run tests with coverage

--- a/scpi_control/report_generator/llm/analyzer.py
+++ b/scpi_control/report_generator/llm/analyzer.py
@@ -4,12 +4,16 @@ High-level analyzer that uses LLM to generate insights and summaries.
 Provides convenient methods for common analysis tasks.
 """
 
+import logging
 from typing import List, Optional
 
 from scpi_control.report_generator.llm.client import LLMClient
 from scpi_control.report_generator.llm.context_builder import ContextBuilder
 from scpi_control.report_generator.llm.prompts import get_system_prompt
+from scpi_control.report_generator.llm.tools import ReportTools
 from scpi_control.report_generator.models.report_data import MeasurementResult, TestReport
+
+logger = logging.getLogger(__name__)
 
 
 class ReportAnalyzer:
@@ -91,6 +95,10 @@ class ReportAnalyzer:
         """
         Answer a user question about the test report.
 
+        Uses tool calling when the model supports it, so the model can reach the
+        real analyses. Otherwise falls back to the summarized context, which is
+        eight scalars per waveform.
+
         Args:
             report: Test report context
             question: User's question
@@ -98,16 +106,20 @@ class ReportAnalyzer:
         Returns:
             Answer text, or None if generation failed
         """
-        system_prompt = get_system_prompt("chat")
-        user_prompt = ContextBuilder.build_chat_context(report, question)
+        if self.client.supports_tools():
+            logger.info("Answering with tool calling")
+            messages = [
+                {"role": "system", "content": get_system_prompt("chat_tools")},
+                {"role": "user", "content": question},
+            ]
+            return self.client.chat_with_tools(messages, ReportTools(report).functions())
 
-        answer = self.client.complete(
-            prompt=user_prompt,
-            system_prompt=system_prompt,
+        logger.info("Model cannot call tools; answering from the summarized context")
+        return self.client.complete(
+            prompt=ContextBuilder.build_chat_context(report, question),
+            system_prompt=get_system_prompt("chat"),
             temperature=0.7,
         )
-
-        return answer
 
     def explain_measurement(
         self,

--- a/scpi_control/report_generator/llm/client.py
+++ b/scpi_control/report_generator/llm/client.py
@@ -149,9 +149,9 @@ class LLMClient:
     def supports_tools(self) -> bool:
         """Whether the configured model can call tools.
 
-        False on any doubt -- no SDK client, an unreachable server, an unknown
-        model. Never guesses, never raises. Call it from a worker thread, never
-        the GUI thread.
+        False whenever tool support isn't positively confirmed -- no SDK client,
+        an unreachable server, an unknown model. Never guesses, never raises.
+        Call it from a worker thread, never the GUI thread.
 
         Caches a *decided* answer (tools present or absent, or no SDK client at
         all) after one network round trip, so the healthy path probes once. But
@@ -211,7 +211,7 @@ class LLMClient:
 
         for round_number in range(1, max_rounds + 1):
             try:
-                response = self._ollama_client.chat(model=self.config.model, messages=conversation, tools=tools)
+                response = self._ollama_client.chat(model=self.config.model, messages=conversation, tools=tools, options={"temperature": self.config.temperature})
             except Exception:
                 logger.exception("Tool-calling chat failed")
                 return None

--- a/scpi_control/report_generator/llm/client.py
+++ b/scpi_control/report_generator/llm/client.py
@@ -9,7 +9,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import requests
 
@@ -183,6 +183,73 @@ class LLMClient:
         supported = "tools" in capabilities
         logger.info(f"Model {self.config.model!r} tool support: {supported}")
         return supported
+
+    def chat_with_tools(self, messages: List[Dict[str, str]], tools: List[Callable], max_rounds: int = 5) -> Optional[str]:
+        """Run a tool-calling conversation until the model answers.
+
+        Takes plain callables: ollama builds each schema from the signature and
+        docstring, and this method dispatches by __name__. It therefore needs no
+        protocol and knows nothing about what the tools do.
+
+        Only works on the Ollama SDK path -- returns None otherwise. Gate calls
+        with supports_tools().
+
+        Args:
+            messages: Conversation so far, e.g. a system and a user message.
+            tools: Bound callables the model may invoke.
+            max_rounds: Maximum model turns before giving up.
+
+        Returns:
+            The model's answer, or None if it failed or never produced one.
+        """
+        if self._ollama_client is None:
+            logger.warning("chat_with_tools called with no Ollama SDK client; cannot send tools")
+            return None
+
+        by_name = {fn.__name__: fn for fn in tools}
+        conversation = list(messages)
+
+        for round_number in range(1, max_rounds + 1):
+            try:
+                response = self._ollama_client.chat(model=self.config.model, messages=conversation, tools=tools)
+            except Exception:
+                logger.exception("Tool-calling chat failed")
+                return None
+
+            message = response.message
+            if not message.tool_calls:
+                return message.content
+
+            logger.debug(f"Round {round_number}: model called {len(message.tool_calls)} tool(s)")
+            conversation.append(message)
+            for call in message.tool_calls:
+                conversation.append(
+                    {
+                        "role": "tool",
+                        "content": self._run_tool(by_name, call.function.name, call.function.arguments),
+                        "tool_name": call.function.name,
+                    }
+                )
+
+        logger.warning(f"Tool loop hit max_rounds={max_rounds} without an answer; giving up")
+        return None
+
+    @staticmethod
+    def _run_tool(by_name: Dict[str, Callable], name: str, arguments: Dict[str, Any]) -> str:
+        """Run one tool call, converting failure into a result the model can read.
+
+        Errors are data, not exceptions: told "no waveform for 'C9'. Available:
+        C1, C2", the model retries by itself. Raising here would waste the turn.
+        """
+        function = by_name.get(name)
+        if function is None:
+            logger.warning(f"Model called unknown tool {name!r}")
+            return f"Error: no tool named {name!r}. Available tools: {', '.join(sorted(by_name))}"
+        try:
+            return function(**arguments)
+        except Exception as exc:
+            logger.info(f"Tool {name!r} failed: {exc}")
+            return f"Error from {name}: {exc}"
 
     def test_connection(self) -> bool:
         """

--- a/scpi_control/report_generator/llm/client.py
+++ b/scpi_control/report_generator/llm/client.py
@@ -124,11 +124,14 @@ class LLMClient:
 
         # Initialize Ollama Python client if available and using Ollama
         self._ollama_client = None
+        self._supports_tools: Optional[bool] = None
         if self._is_ollama_native and OLLAMA_CLIENT_AVAILABLE:
             try:
                 # Extract host from endpoint (e.g., "http://192.168.1.4:11434/api" -> "http://192.168.1.4:11434")
                 host = config.endpoint.rsplit("/api", 1)[0] if "/api" in config.endpoint else config.endpoint
-                self._ollama_client = ollama.Client(host=host)
+                # config.timeout was dead on this path until now: ollama.Client
+                # forwards kwargs to httpx.Client, so a stalled server hung forever.
+                self._ollama_client = ollama.Client(host=host, timeout=config.timeout)
                 logger.debug(f"Using Ollama Python SDK (host: {host})")
 
                 # Verify connection by listing models
@@ -142,6 +145,31 @@ class LLMClient:
                 logger.exception(f"Failed to initialize Ollama client: {e}")
                 logger.warning("Falling back to HTTP requests")
                 self._ollama_client = None
+
+    def supports_tools(self) -> bool:
+        """Whether the configured model can call tools.
+
+        False on any doubt -- no SDK client, an unreachable server, an unknown
+        model. Never guesses, never raises. Performs one network round trip on
+        first call and caches, so call it from a worker thread, never the GUI
+        thread.
+        """
+        if self._supports_tools is None:
+            self._supports_tools = self._probe_tool_support()
+        return self._supports_tools
+
+    def _probe_tool_support(self) -> bool:
+        if self._ollama_client is None:
+            logger.debug("Tool calling unavailable: no Ollama SDK client for this endpoint")
+            return False
+        try:
+            capabilities = self._ollama_client.show(self.config.model).capabilities or []
+        except Exception:
+            logger.warning(f"Could not read capabilities for model {self.config.model!r}; assuming no tool support", exc_info=True)
+            return False
+        supported = "tools" in capabilities
+        logger.info(f"Model {self.config.model!r} tool support: {supported}")
+        return supported
 
     def test_connection(self) -> bool:
         """

--- a/scpi_control/report_generator/llm/client.py
+++ b/scpi_control/report_generator/llm/client.py
@@ -150,23 +150,36 @@ class LLMClient:
         """Whether the configured model can call tools.
 
         False on any doubt -- no SDK client, an unreachable server, an unknown
-        model. Never guesses, never raises. Performs one network round trip on
-        first call and caches, so call it from a worker thread, never the GUI
-        thread.
+        model. Never guesses, never raises. Call it from a worker thread, never
+        the GUI thread.
+
+        Caches a *decided* answer (tools present or absent, or no SDK client at
+        all) after one network round trip, so the healthy path probes once. But
+        a probe that could not decide -- the server was briefly unreachable, or
+        the model was not pulled yet -- is deliberately not cached: this client
+        is long-lived (main_window keeps it until the settings dialog rebuilds
+        it), so a transient outage must not silently disable tools for the whole
+        session. The retry cost falls only on the already-broken path.
         """
         if self._supports_tools is None:
             self._supports_tools = self._probe_tool_support()
-        return self._supports_tools
+        return self._supports_tools is True
 
-    def _probe_tool_support(self) -> bool:
+    def _probe_tool_support(self) -> Optional[bool]:
+        """Decided True/False, or None when the probe could not decide.
+
+        None means "unknown, retry on the next call" and is not cached. A
+        missing SDK client is a decided False -- a /v1 endpoint or a missing SDK
+        never changes for this client instance, so there is nothing to retry.
+        """
         if self._ollama_client is None:
             logger.debug("Tool calling unavailable: no Ollama SDK client for this endpoint")
             return False
         try:
             capabilities = self._ollama_client.show(self.config.model).capabilities or []
         except Exception:
-            logger.warning(f"Could not read capabilities for model {self.config.model!r}; assuming no tool support", exc_info=True)
-            return False
+            logger.warning(f"Could not read capabilities for model {self.config.model!r}; leaving tool support undecided, will retry", exc_info=True)
+            return None
         supported = "tools" in capabilities
         logger.info(f"Model {self.config.model!r} tool support: {supported}")
         return supported

--- a/scpi_control/report_generator/llm/prompts.py
+++ b/scpi_control/report_generator/llm/prompts.py
@@ -86,13 +86,25 @@ You have access to the complete test report data including:
 
 Be helpful, accurate, and professional. Your goal is to help users understand their measurements and make informed decisions about their tests."""
 
+CHAT_WITH_TOOLS_SYSTEM_PROMPT = """You are an expert test engineer answering questions about an oscilloscope test report.
+
+You cannot see the report. Use the tools to inspect it:
+- list_waveforms: which channels the report contains. Call this first.
+- analyze_waveform: a channel's measured characteristics (signal type, amplitude, frequency, timing, quality, THD).
+- detect_transients: sudden anomalies (glitches, spikes) in a channel.
+- list_measurements: recorded measurements and their pass/fail status.
+
+Base every claim on tool results. Never invent a value you have not measured. If a tool
+returns an error, read it and try again with valid arguments. If the tools cannot answer the
+question, say so plainly."""
+
 
 def get_system_prompt(prompt_type: str = "expert") -> str:
     """
     Get a system prompt by type.
 
     Args:
-        prompt_type: One of 'expert', 'summary', 'analysis', 'interpretation', 'chat'
+        prompt_type: One of 'expert', 'summary', 'analysis', 'interpretation', 'chat', 'chat_tools'
 
     Returns:
         System prompt string
@@ -103,6 +115,7 @@ def get_system_prompt(prompt_type: str = "expert") -> str:
         "analysis": WAVEFORM_ANALYSIS_SYSTEM_PROMPT,
         "interpretation": PASS_FAIL_INTERPRETATION_SYSTEM_PROMPT,
         "chat": CHAT_ASSISTANT_SYSTEM_PROMPT,
+        "chat_tools": CHAT_WITH_TOOLS_SYSTEM_PROMPT,
     }
 
     return prompts.get(prompt_type, OSCILLOSCOPE_EXPERT_SYSTEM_PROMPT)

--- a/scpi_control/report_generator/llm/tools.py
+++ b/scpi_control/report_generator/llm/tools.py
@@ -66,7 +66,7 @@ class ReportTools:
         for waveform, section_title in self._waveforms():
             if waveform.channel == channel or waveform.label == channel:
                 return waveform, section_title
-        available = ", ".join(wf.channel for wf, _ in self._waveforms()) or "none"
+        available = ", ".join(f"{wf.channel} [{title}]" for wf, title in self._waveforms()) or "none"
         raise ValueError(f"no waveform for channel {channel!r}. Available: {available}")
 
     # -- tools --
@@ -89,7 +89,7 @@ class ReportTools:
         signals.
 
         If two sections captured the same channel, this analyzes the first and
-        names the section it used, so check that section is the one you meant.
+        names the section it used; report that section alongside your answer.
 
         Args:
             channel: Channel to analyze, e.g. "C1". Must be one listed by list_waveforms.
@@ -107,7 +107,7 @@ class ReportTools:
         starts and ends, in microseconds.
 
         If two sections captured the same channel, this inspects the first and
-        names the section it used, so check that section is the one you meant.
+        names the section it used; report that section alongside your answer.
 
         Args:
             channel: Channel to inspect, e.g. "C1". Must be one listed by list_waveforms.

--- a/scpi_control/report_generator/llm/tools.py
+++ b/scpi_control/report_generator/llm/tools.py
@@ -1,0 +1,139 @@
+"""Callable tools the local model invokes to inspect a loaded report.
+
+Every public method of ReportTools is a tool. `ollama` builds each tool's JSON
+schema from its SIGNATURE and its Google-style DOCSTRING, so both are wire
+contract rather than documentation:
+
+  * Type-hint every parameter. An unhinted parameter is silently typed "string".
+  * Spell every optional `Optional[X] = None`. A plain default (`x: float = 3.0`)
+    is marked REQUIRED in the schema despite having a default.
+  * Keep the `Args:` block accurate -- it is the model's only description of each
+    parameter.
+
+Numeric bounds do NOT survive into the schema: ollama's Tool model keeps only
+type/items/description/enum and drops minimum, maximum, default and
+additionalProperties. State bounds in the docstring and enforce them here.
+
+Everything in this module is pure CPU over in-memory arrays: no I/O, no
+instrument, and no knowledge of the LLM.
+"""
+
+import logging
+from typing import Callable, List, Optional
+
+from scpi_control.report_generator.models.report_data import TestReport, WaveformData
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+logger = logging.getLogger(__name__)
+
+# WaveformAnalyzer.detect_transients already truncates its own return to 10
+# (waveform_analyzer.py:1003), but that is an internal implementation detail,
+# not part of its documented contract -- unlike detect_edges(max_edges=4), which
+# advertises its bound in its signature. MAX_TRANSIENTS makes the bound part of
+# this tool's own explicit contract rather than an accident of the collaborator.
+MAX_TRANSIENTS = 10
+
+_SENSITIVITY_DEFAULT = 3.0
+_SENSITIVITY_MIN = 1.0
+_SENSITIVITY_MAX = 10.0
+
+
+class ReportTools:
+    """Read-only tools over one loaded report."""
+
+    def __init__(self, report: TestReport):
+        self.report = report
+
+    def functions(self) -> List[Callable]:
+        """The bound tool methods, for LLMClient.chat_with_tools."""
+        return [
+            self.list_waveforms,
+            self.analyze_waveform,
+            self.detect_transients,
+            self.list_measurements,
+        ]
+
+    # -- internals (not tools) --
+
+    def _waveforms(self) -> List[WaveformData]:
+        return [wf for section in self.report.sections for wf in section.waveforms]
+
+    def _find(self, channel: str) -> WaveformData:
+        for waveform in self._waveforms():
+            if waveform.channel == channel or waveform.label == channel:
+                return waveform
+        available = ", ".join(wf.channel for wf in self._waveforms()) or "none"
+        raise ValueError(f"no waveform for channel {channel!r}. Available: {available}")
+
+    # -- tools --
+
+    def list_waveforms(self) -> str:
+        """List the captured waveforms available in this report.
+
+        Call this first to discover which channels exist before asking about one.
+        """
+        waveforms = self._waveforms()
+        if not waveforms:
+            return "This report contains no waveforms."
+        return "\n".join(f"{wf.channel}: label={wf.label!r}, {wf.record_length} samples at {wf.sample_rate / 1e6:.2f} MSa/s" for wf in waveforms)
+
+    def analyze_waveform(self, channel: str) -> str:
+        """Analyze one captured waveform and report its measured characteristics.
+
+        Reports the detected signal type and confidence, amplitude, frequency,
+        timing and quality statistics, and total harmonic distortion for periodic
+        signals.
+
+        Args:
+            channel: Channel to analyze, e.g. "C1". Must be one listed by list_waveforms.
+        """
+        waveform = self._find(channel)
+        stats = WaveformAnalyzer.analyze(waveform)
+        lines = [f"analyze_waveform(channel={channel}):"]
+        lines.extend(f"  {name}: {WaveformAnalyzer.format_stat_value(name, value)}" for name, value in stats.items())
+        return "\n".join(lines)
+
+    def detect_transients(self, channel: str, sensitivity: Optional[float] = None) -> str:
+        """Find sudden anomalies (glitches, spikes) in one captured waveform.
+
+        Use this to judge whether a signal is clean. Reports where each transient
+        starts and ends, in microseconds.
+
+        Args:
+            channel: Channel to inspect, e.g. "C1". Must be one listed by list_waveforms.
+            sensitivity: Detection threshold in standard deviations; lower finds more.
+                Must be between 1.0 and 10.0. Defaults to 3.0.
+        """
+        if sensitivity is None:
+            sensitivity = _SENSITIVITY_DEFAULT
+        if not _SENSITIVITY_MIN <= sensitivity <= _SENSITIVITY_MAX:
+            raise ValueError(f"sensitivity must be between {_SENSITIVITY_MIN} and {_SENSITIVITY_MAX}, got {sensitivity}")
+
+        waveform = self._find(channel)
+        regions = WaveformAnalyzer.detect_transients(waveform, sensitivity=sensitivity)
+        head = f"detect_transients(channel={channel}, sensitivity={sensitivity}):"
+        if not regions:
+            return f"{head} none found."
+
+        shown = regions[:MAX_TRANSIENTS]
+        summary = f"{head} {len(regions)} found"
+        if len(regions) > len(shown):
+            summary += f", showing first {len(shown)}"
+        lines = [summary]
+        lines.extend(f"  {r.label}: {r.start_time * 1e6:.2f} to {r.end_time * 1e6:.2f} µs" for r in shown)
+        return "\n".join(lines)
+
+    def list_measurements(self) -> str:
+        """List the measurements recorded in this report, with pass/fail status.
+
+        Use this to judge whether the test passed.
+        """
+        rows = [(m, section.title) for section in self.report.sections for m in section.measurements]
+        if not rows:
+            return "This report contains no measurements."
+        lines = []
+        for measurement, section_title in rows:
+            status = "" if measurement.passed is None else ("  PASS" if measurement.passed else "  FAIL")
+            channel = f" on {measurement.channel}" if measurement.channel else ""
+            lines.append(f"{measurement.name}{channel}: {measurement.value:.4g} {measurement.unit}{status}  [{section_title}]")
+        return "\n".join(lines)

--- a/scpi_control/report_generator/llm/tools.py
+++ b/scpi_control/report_generator/llm/tools.py
@@ -26,11 +26,12 @@ from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyz
 
 logger = logging.getLogger(__name__)
 
-# WaveformAnalyzer.detect_transients already truncates its own return to 10
-# (waveform_analyzer.py:1003), but that is an internal implementation detail,
-# not part of its documented contract -- unlike detect_edges(max_edges=4), which
-# advertises its bound in its signature. MAX_TRANSIENTS makes the bound part of
-# this tool's own explicit contract rather than an accident of the collaborator.
+# detect_transients is unbounded by default in WaveformAnalyzer, so a noisy
+# capture really can yield hundreds and blow the context. This is the real
+# backstop: the analyzer is called with no limit so the TRUE total is known, and
+# the truncation to MAX_TRANSIENTS is reported rather than hidden -- "400 found,
+# showing first 10" instead of a bare "10 found", which would teach the model the
+# signal is cleaner than it is.
 MAX_TRANSIENTS = 10
 
 _SENSITIVITY_DEFAULT = 3.0

--- a/scpi_control/report_generator/llm/tools.py
+++ b/scpi_control/report_generator/llm/tools.py
@@ -18,13 +18,10 @@ Everything in this module is pure CPU over in-memory arrays: no I/O, no
 instrument, and no knowledge of the LLM.
 """
 
-import logging
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Tuple
 
 from scpi_control.report_generator.models.report_data import TestReport, WaveformData
 from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
-
-logger = logging.getLogger(__name__)
 
 # detect_transients is unbounded by default in WaveformAnalyzer, so a noisy
 # capture really can yield hundreds and blow the context. This is the real
@@ -56,14 +53,20 @@ class ReportTools:
 
     # -- internals (not tools) --
 
-    def _waveforms(self) -> List[WaveformData]:
-        return [wf for section in self.report.sections for wf in section.waveforms]
+    def _waveforms(self) -> List[Tuple[WaveformData, str]]:
+        """Every waveform paired with the section title it was captured under.
 
-    def _find(self, channel: str) -> WaveformData:
-        for waveform in self._waveforms():
+        The title travels with the waveform because a channel is only unique
+        within a section: two sections can each capture C1, and a caller that
+        drops the title cannot say which one it got.
+        """
+        return [(wf, section.title) for section in self.report.sections for wf in section.waveforms]
+
+    def _find(self, channel: str) -> Tuple[WaveformData, str]:
+        for waveform, section_title in self._waveforms():
             if waveform.channel == channel or waveform.label == channel:
-                return waveform
-        available = ", ".join(wf.channel for wf in self._waveforms()) or "none"
+                return waveform, section_title
+        available = ", ".join(wf.channel for wf, _ in self._waveforms()) or "none"
         raise ValueError(f"no waveform for channel {channel!r}. Available: {available}")
 
     # -- tools --
@@ -76,7 +79,7 @@ class ReportTools:
         waveforms = self._waveforms()
         if not waveforms:
             return "This report contains no waveforms."
-        return "\n".join(f"{wf.channel}: label={wf.label!r}, {wf.record_length} samples at {wf.sample_rate / 1e6:.2f} MSa/s" for wf in waveforms)
+        return "\n".join(f"{wf.channel}: label={wf.label!r}, {wf.record_length} samples at {wf.sample_rate / 1e6:.2f} MSa/s  [{section_title}]" for wf, section_title in waveforms)
 
     def analyze_waveform(self, channel: str) -> str:
         """Analyze one captured waveform and report its measured characteristics.
@@ -85,12 +88,15 @@ class ReportTools:
         timing and quality statistics, and total harmonic distortion for periodic
         signals.
 
+        If two sections captured the same channel, this analyzes the first and
+        names the section it used, so check that section is the one you meant.
+
         Args:
             channel: Channel to analyze, e.g. "C1". Must be one listed by list_waveforms.
         """
-        waveform = self._find(channel)
+        waveform, section_title = self._find(channel)
         stats = WaveformAnalyzer.analyze(waveform)
-        lines = [f"analyze_waveform(channel={channel}):"]
+        lines = [f"analyze_waveform(channel={channel}) [{section_title}]:"]
         lines.extend(f"  {name}: {WaveformAnalyzer.format_stat_value(name, value)}" for name, value in stats.items())
         return "\n".join(lines)
 
@@ -99,6 +105,9 @@ class ReportTools:
 
         Use this to judge whether a signal is clean. Reports where each transient
         starts and ends, in microseconds.
+
+        If two sections captured the same channel, this inspects the first and
+        names the section it used, so check that section is the one you meant.
 
         Args:
             channel: Channel to inspect, e.g. "C1". Must be one listed by list_waveforms.
@@ -110,9 +119,9 @@ class ReportTools:
         if not _SENSITIVITY_MIN <= sensitivity <= _SENSITIVITY_MAX:
             raise ValueError(f"sensitivity must be between {_SENSITIVITY_MIN} and {_SENSITIVITY_MAX}, got {sensitivity}")
 
-        waveform = self._find(channel)
+        waveform, section_title = self._find(channel)
         regions = WaveformAnalyzer.detect_transients(waveform, sensitivity=sensitivity)
-        head = f"detect_transients(channel={channel}, sensitivity={sensitivity}):"
+        head = f"detect_transients(channel={channel}, sensitivity={sensitivity}) [{section_title}]:"
         if not regions:
             return f"{head} none found."
 

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -774,7 +774,10 @@ class WaveformAnalyzer:
 
         # Detect transients if requested
         if auto_detect_transients:
-            transients = WaveformAnalyzer.detect_transients(waveform)
+            # limit=10 preserves this path's long-standing behavior: detect_transients
+            # used to truncate to 10 internally, and region lists feed plots and PDFs
+            # where an unbounded append would change what gets rendered.
+            transients = WaveformAnalyzer.detect_transients(waveform, limit=10)
             for transient in transients:
                 waveform.regions.append(transient)
 
@@ -943,7 +946,7 @@ class WaveformAnalyzer:
         return edges
 
     @staticmethod
-    def detect_transients(waveform: "WaveformData", sensitivity: float = 3.0) -> list:
+    def detect_transients(waveform: "WaveformData", sensitivity: float = 3.0, limit: Optional[int] = None) -> list:
         """
         Detect transient responses in a waveform.
 
@@ -953,6 +956,11 @@ class WaveformAnalyzer:
         Args:
             waveform: WaveformData object
             sensitivity: Detection sensitivity (sigma multiplier)
+            limit: Maximum number of transients to return. None (the default)
+                means no limit: every detected transient is returned. Callers
+                that truncate must report the true total, so the count is the
+                caller's to keep -- returning a silently shortened list would
+                make a noisy capture look clean.
 
         Returns:
             List of WaveformRegion objects for detected transients
@@ -1000,7 +1008,7 @@ class WaveformAnalyzer:
                     )
                     transients.append(transient)
 
-        return transients[:10]  # Limit to 10 transients
+        return transients if limit is None else transients[:limit]
 
     @staticmethod
     def analyze_region(waveform: "WaveformData", region: "WaveformRegion", calculate_calibration: bool = True) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,33 @@
 """Fixtures shared across the test suite."""
 
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
 import numpy as np
 import pytest
 
 from scpi_control.report_generator.models.report_data import WaveformData
+
+
+@contextmanager
+def ollama_sdk(capabilities=("completion", "tools")):
+    """Patch the ollama SDK class so nothing reaches the network.
+
+    LLMClient.__init__ calls .list() against a real server (client.py:136), and a
+    live Ollama runs on this machine. The existing dodges in
+    test_report_llm_client.py -- patching OLLAMA_CLIENT_AVAILABLE=False, or using
+    a /v1 endpoint -- both work by AVOIDING the SDK path, which is exactly where
+    tool calling lives. So tool tests must patch the class itself.
+
+    Get this wrong and the test does not fail: it does a real round-trip and
+    passes for the wrong reason, and .list()'s failure is caught and merely
+    warned (client.py:138-140), so a half-mock stays silent.
+    """
+    fake = MagicMock()
+    fake.list.return_value = MagicMock(models=[])
+    fake.show.return_value = MagicMock(capabilities=list(capabilities))
+    with patch("scpi_control.report_generator.llm.client.ollama.Client", return_value=fake) as cls:
+        yield fake, cls
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Fixtures shared across the test suite."""
+
+import numpy as np
+import pytest
+
+from scpi_control.report_generator.models.report_data import WaveformData
+
+
+@pytest.fixture
+def bursty_waveform():
+    """A sine carrying 20 multi-sample spikes -- more real transients than the
+    tools will show, so truncation paths are reachable.
+
+    The spikes are several samples wide because detect_transients discards any
+    region shorter than 0.1% of the capture; single-sample spikes never clear
+    that, however many you add. Function-scoped: detect_regions mutates
+    waveform.regions, so each test needs its own.
+    """
+    n, rate = 4000, 1e6
+    t = np.arange(n) / rate
+    v = np.sin(2 * np.pi * 10_000 * t)
+    for start in np.linspace(50, n - 100, 20).astype(int):
+        v[start : start + 6] += 8.0
+    return WaveformData(channel="C1", time=t, voltage=v, sample_rate=rate, record_length=n)

--- a/tests/test_llm_tool_loop.py
+++ b/tests/test_llm_tool_loop.py
@@ -1,0 +1,145 @@
+"""The tool-calling loop: dispatch, feedback, recovery, termination.
+
+The fixture patches the ollama SDK class -- see tests/conftest.py's ollama_sdk
+docstring for why nothing else works for the SDK path.
+"""
+
+from unittest.mock import MagicMock
+
+from scpi_control.report_generator.llm.client import LLMClient, LLMConfig
+
+from tests.conftest import ollama_sdk
+
+
+def reply(content=None, tool_calls=None):
+    """A fake ChatResponse: .message.content and .message.tool_calls."""
+    message = MagicMock()
+    message.content = content
+    message.tool_calls = tool_calls or []
+    return MagicMock(message=message)
+
+
+def tool_call(tool_name, **arguments):
+    """Build a fake ToolCall.
+
+    The parameter is `tool_name`, not `name`, because several tools under
+    test (greet, explode) themselves take a `name` argument -- `tool_call(
+    "greet", name="robin")` would otherwise collide: the positional tool name
+    and the keyword argument would both bind to a parameter called `name`,
+    raising "got multiple values for argument 'name'". All call sites below
+    pass the tool name positionally, so this rename is invisible to them.
+    """
+    call = MagicMock()
+    call.function.name = tool_name
+    call.function.arguments = arguments
+    return call
+
+
+def client():
+    return LLMClient(LLMConfig(endpoint="http://localhost:11434/api", model="llama3.2"))
+
+
+def greet(name: str) -> str:
+    """Greet someone.
+
+    Args:
+        name: Who to greet.
+    """
+    return f"hello {name}"
+
+
+def explode(name: str) -> str:
+    """Always fails.
+
+    Args:
+        name: Ignored.
+    """
+    raise ValueError("no such channel 'C9'")
+
+
+def test_returns_the_answer_when_the_model_calls_no_tools():
+    with ollama_sdk() as (fake, _):
+        fake.chat.side_effect = [reply(content="42")]
+        assert client().chat_with_tools([{"role": "user", "content": "hi"}], [greet]) == "42"
+
+
+def test_dispatches_a_tool_call_and_feeds_the_result_back():
+    with ollama_sdk() as (fake, _):
+        fake.chat.side_effect = [reply(tool_calls=[tool_call("greet", name="robin")]), reply(content="done")]
+        answer = client().chat_with_tools([{"role": "user", "content": "hi"}], [greet])
+
+    assert answer == "done"
+    sent = fake.chat.call_args_list[1].kwargs["messages"]
+    result = sent[-1]
+    assert result["role"] == "tool"
+    assert result["tool_name"] == "greet"
+    assert result["content"] == "hello robin"
+
+
+def test_tools_are_passed_to_the_sdk():
+    with ollama_sdk() as (fake, _):
+        fake.chat.side_effect = [reply(content="ok")]
+        client().chat_with_tools([{"role": "user", "content": "hi"}], [greet])
+    assert fake.chat.call_args.kwargs["tools"] == [greet]
+
+
+def test_a_failing_tool_becomes_a_tool_result_not_an_exception():
+    """A tool error is data for the model, not an exception for the user: given
+    the message it can retry with a valid argument. That recovery is the loop
+    earning its keep."""
+    with ollama_sdk() as (fake, _):
+        fake.chat.side_effect = [reply(tool_calls=[tool_call("explode", name="C9")]), reply(content="recovered")]
+        answer = client().chat_with_tools([{"role": "user", "content": "hi"}], [explode])
+
+    assert answer == "recovered"
+    result = fake.chat.call_args_list[1].kwargs["messages"][-1]
+    assert result["role"] == "tool"
+    assert "no such channel 'C9'" in result["content"]
+
+
+def test_an_unexpected_keyword_argument_becomes_a_tool_result_not_an_exception():
+    """Task 1's tool docstrings can nudge the model into inventing a keyword
+    argument no tool accepts (e.g. section=). That raises TypeError inside
+    function(**arguments); _run_tool's `except Exception` must catch it exactly
+    like any other tool failure -- a readable tool-result message, not a crash
+    that propagates out of the loop."""
+    with ollama_sdk() as (fake, _):
+        fake.chat.side_effect = [
+            reply(tool_calls=[tool_call("greet", name="robin", section="intro")]),
+            reply(content="recovered"),
+        ]
+        answer = client().chat_with_tools([{"role": "user", "content": "hi"}], [greet])
+
+    assert answer == "recovered"
+    result = fake.chat.call_args_list[1].kwargs["messages"][-1]
+    assert result["role"] == "tool"
+    assert "unexpected keyword argument" in result["content"]
+    assert "section" in result["content"]
+
+
+def test_an_unknown_tool_name_becomes_a_tool_result():
+    """The model can hallucinate a tool. Tell it what actually exists."""
+    with ollama_sdk() as (fake, _):
+        fake.chat.side_effect = [reply(tool_calls=[tool_call("teleport")]), reply(content="ok")]
+        client().chat_with_tools([{"role": "user", "content": "hi"}], [greet])
+
+    result = fake.chat.call_args_list[1].kwargs["messages"][-1]
+    assert "teleport" in result["content"]
+    assert "greet" in result["content"]
+
+
+def test_max_rounds_terminates_a_model_that_never_stops_calling_tools():
+    """Without this bound the loop is an infinite hang. Nothing else in the
+    suite would catch it."""
+    with ollama_sdk() as (fake, _):
+        fake.chat.side_effect = [reply(tool_calls=[tool_call("greet", name="x")]) for _ in range(20)]
+        answer = client().chat_with_tools([{"role": "user", "content": "hi"}], [greet], max_rounds=3)
+
+    assert answer is None, "an exhausted loop must fail honestly, not return a half-answer"
+    assert fake.chat.call_count == 3
+
+
+def test_without_an_sdk_client_it_returns_none():
+    c = LLMClient(LLMConfig(endpoint="http://localhost:11434/v1", model="llama3.2"))
+    assert c._ollama_client is None
+    assert c.chat_with_tools([{"role": "user", "content": "hi"}], [greet]) is None

--- a/tests/test_llm_tool_loop.py
+++ b/tests/test_llm_tool_loop.py
@@ -143,3 +143,26 @@ def test_without_an_sdk_client_it_returns_none():
     c = LLMClient(LLMConfig(endpoint="http://localhost:11434/v1", model="llama3.2"))
     assert c._ollama_client is None
     assert c.chat_with_tools([{"role": "user", "content": "hi"}], [greet]) is None
+
+
+def test_a_transport_exception_from_the_sdk_returns_none():
+    """.chat() itself can raise -- a dropped connection, a server restart mid-
+    request -- and that must not propagate out of the loop, the same as any
+    other failure mode here."""
+    with ollama_sdk() as (fake, _):
+        fake.chat.side_effect = RuntimeError("boom")
+        answer = client().chat_with_tools([{"role": "user", "content": "hi"}], [greet])
+
+    assert answer is None
+
+
+def test_the_tool_loop_uses_the_configured_temperature():
+    """The tool path must run at the configured temperature, not Ollama's
+    model-default (~0.8), matching the summarized-context path (analyzer.py's
+    complete(..., temperature=0.7))."""
+    with ollama_sdk() as (fake, _):
+        fake.chat.side_effect = [reply(content="ok")]
+        c = client()
+        c.chat_with_tools([{"role": "user", "content": "hi"}], [greet])
+
+    assert fake.chat.call_args.kwargs["options"]["temperature"] == c.config.temperature

--- a/tests/test_llm_tool_support.py
+++ b/tests/test_llm_tool_support.py
@@ -1,0 +1,58 @@
+"""Model tool-capability gating, and the SDK client's timeout.
+
+READ THE FIXTURE'S DOCSTRING (tests/conftest.py:ollama_sdk). LLMClient.__init__
+probes a live Ollama server, and there is one running on the dev machine.
+"""
+
+from scpi_control.report_generator.llm.client import LLMClient, LLMConfig
+
+from tests.conftest import ollama_sdk
+
+
+def ollama_config(model="llama3.2", timeout=60):
+    """A config that routes to the SDK path: /api, no /v1."""
+    return LLMConfig(endpoint="http://localhost:11434/api", model=model, timeout=timeout)
+
+
+def test_supports_tools_reads_the_model_capabilities():
+    with ollama_sdk(capabilities=("completion", "tools")) as (fake, _):
+        client = LLMClient(ollama_config())
+        assert client.supports_tools() is True
+    fake.show.assert_called_with("llama3.2")
+
+
+def test_supports_tools_is_false_when_the_model_lacks_them():
+    """deepseek-coder-v2 is a real example: ['completion', 'insert'], no tools.
+    Passing tools to it would advertise a capability we cannot deliver."""
+    with ollama_sdk(capabilities=("completion", "insert")):
+        assert LLMClient(ollama_config(model="deepseek-coder-v2")).supports_tools() is False
+
+
+def test_supports_tools_is_false_when_the_probe_raises():
+    with ollama_sdk() as (fake, _):
+        fake.show.side_effect = RuntimeError("server gone")
+        assert LLMClient(ollama_config()).supports_tools() is False
+
+
+def test_supports_tools_is_false_without_an_sdk_client():
+    """A /v1 endpoint never constructs the SDK client, so tools cannot be sent."""
+    client = LLMClient(LLMConfig(endpoint="http://localhost:11434/v1", model="llama3.2"))
+    assert client._ollama_client is None
+    assert client.supports_tools() is False
+
+
+def test_supports_tools_is_cached():
+    with ollama_sdk() as (fake, _):
+        client = LLMClient(ollama_config())
+        assert client.supports_tools() is True
+        assert client.supports_tools() is True
+    assert fake.show.call_count == 1
+
+
+def test_the_sdk_client_receives_the_configured_timeout():
+    """config.timeout was silently dead on this path: ollama.Client(host=host)
+    took no timeout, so a stalled server hung the worker forever -- while the
+    OpenAI path honoured it. A tool loop is multi-turn, so this bites harder."""
+    with ollama_sdk() as (_, cls):
+        LLMClient(ollama_config(timeout=17))
+    assert cls.call_args.kwargs["timeout"] == 17

--- a/tests/test_llm_tool_support.py
+++ b/tests/test_llm_tool_support.py
@@ -24,14 +24,32 @@ def test_supports_tools_reads_the_model_capabilities():
 def test_supports_tools_is_false_when_the_model_lacks_them():
     """deepseek-coder-v2 is a real example: ['completion', 'insert'], no tools.
     Passing tools to it would advertise a capability we cannot deliver."""
-    with ollama_sdk(capabilities=("completion", "insert")):
+    with ollama_sdk(capabilities=("completion", "insert")) as (fake, _):
         assert LLMClient(ollama_config(model="deepseek-coder-v2")).supports_tools() is False
+        # Prove the capability parse ran, not a no-SDK-client short-circuit.
+        assert fake.show.called
 
 
 def test_supports_tools_is_false_when_the_probe_raises():
     with ollama_sdk() as (fake, _):
         fake.show.side_effect = RuntimeError("server gone")
         assert LLMClient(ollama_config()).supports_tools() is False
+        # Prove the exception path ran, not a no-SDK-client short-circuit.
+        assert fake.show.called
+
+
+def test_supports_tools_retries_after_a_probe_that_raised():
+    """A raised probe is undecided, not a decided False -- the client is
+    long-lived, so a transient outage must not disable tools for the whole
+    session. The failure is not cached: a later call retries and can succeed."""
+    with ollama_sdk() as (fake, _):
+        fake.show.side_effect = RuntimeError("server briefly gone")
+        client = LLMClient(ollama_config())
+        assert client.supports_tools() is False  # could not decide
+        assert client._supports_tools is None  # deliberately not cached
+        fake.show.side_effect = None  # server recovers, falls back to return_value
+        assert client.supports_tools() is True  # retried, now decided
+    assert fake.show.call_count == 2
 
 
 def test_supports_tools_is_false_without_an_sdk_client():
@@ -39,6 +57,14 @@ def test_supports_tools_is_false_without_an_sdk_client():
     client = LLMClient(LLMConfig(endpoint="http://localhost:11434/v1", model="llama3.2"))
     assert client._ollama_client is None
     assert client.supports_tools() is False
+
+
+def test_supports_tools_caches_the_no_sdk_client_false():
+    """No SDK client is a DECIDED False -- a /v1 endpoint never grows one, so
+    there is nothing to retry. It must be cached, not re-evaluated every call."""
+    client = LLMClient(LLMConfig(endpoint="http://localhost:11434/v1", model="llama3.2"))
+    assert client.supports_tools() is False
+    assert client._supports_tools is False  # decided and cached, not left None
 
 
 def test_supports_tools_is_cached():

--- a/tests/test_report_analyzer_tools.py
+++ b/tests/test_report_analyzer_tools.py
@@ -1,0 +1,71 @@
+"""answer_question picks the tool path when the model supports it, and falls
+back to the summarized-context path when it does not."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from scpi_control.report_generator.llm.analyzer import ReportAnalyzer
+from scpi_control.report_generator.llm.prompts import get_system_prompt
+from scpi_control.report_generator.models.report_data import (
+    ReportMetadata,
+    TestReport,
+    TestSection,
+    WaveformData,
+)
+
+
+def make_report():
+    t = np.arange(100) / 1e6
+    waveform = WaveformData(channel="C1", time=t, voltage=np.sin(2 * np.pi * 10_000 * t), sample_rate=1e6, record_length=100)
+    return TestReport(
+        metadata=ReportMetadata(title="Bench", technician="robin", test_date=datetime(2026, 7, 16)),
+        sections=[TestSection(title="Captures", waveforms=[waveform])],
+    )
+
+
+def test_answer_question_uses_tools_when_the_model_supports_them():
+    client = MagicMock()
+    client.supports_tools.return_value = True
+    client.chat_with_tools.return_value = "C1 is a sine."
+
+    answer = ReportAnalyzer(client).answer_question(make_report(), "What is on C1?")
+
+    assert answer == "C1 is a sine."
+    client.complete.assert_not_called()
+    tools = client.chat_with_tools.call_args.args[1]
+    assert [fn.__name__ for fn in tools] == ["list_waveforms", "analyze_waveform", "detect_transients", "list_measurements"]
+
+
+def test_the_tool_path_sends_the_question_and_a_tool_aware_system_prompt():
+    client = MagicMock()
+    client.supports_tools.return_value = True
+    client.chat_with_tools.return_value = "ok"
+
+    ReportAnalyzer(client).answer_question(make_report(), "What is on C1?")
+
+    messages = client.chat_with_tools.call_args.args[0]
+    assert messages[0]["role"] == "system"
+    assert "list_waveforms" in messages[0]["content"], "the model is told nothing about the report; it must be told to discover it"
+    assert messages[1] == {"role": "user", "content": "What is on C1?"}
+
+
+def test_answer_question_falls_back_when_the_model_cannot_call_tools():
+    """A model without tool support must still work exactly as it does today --
+    no error, and no capability advertised that cannot be delivered."""
+    client = MagicMock()
+    client.supports_tools.return_value = False
+    client.complete.return_value = "From the summary."
+
+    answer = ReportAnalyzer(client).answer_question(make_report(), "What is on C1?")
+
+    assert answer == "From the summary."
+    client.chat_with_tools.assert_not_called()
+    assert "C1" in client.complete.call_args.kwargs["prompt"], "the fallback must still send the summarized context"
+
+
+def test_the_tool_aware_prompt_is_registered():
+    prompt = get_system_prompt("chat_tools")
+    assert "list_waveforms" in prompt
+    assert prompt != get_system_prompt("chat")

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -1,0 +1,166 @@
+"""The tools the local model calls to inspect a loaded report.
+
+These need no LLM, no mock and no network: ReportTools is pure CPU over
+in-memory arrays. The schema tests at the bottom are the ones that keep the
+signature discipline honest -- see their docstrings.
+"""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from scpi_control.report_generator.llm.tools import MAX_TRANSIENTS, ReportTools
+from scpi_control.report_generator.models.report_data import (
+    MeasurementResult,
+    ReportMetadata,
+    TestReport,
+    TestSection,
+    WaveformData,
+    WaveformRegion,
+)
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+
+def make_waveform(channel="C1", n=2000, rate=1e6, freq=10_000, label=None):
+    t = np.arange(n) / rate
+    return WaveformData(
+        channel=channel,
+        time=t,
+        voltage=np.sin(2 * np.pi * freq * t),
+        sample_rate=rate,
+        record_length=n,
+        label=label,
+    )
+
+
+def make_report(waveforms=None, measurements=None):
+    section = TestSection(
+        title="Captures",
+        content="Bench run.",
+        waveforms=[make_waveform()] if waveforms is None else list(waveforms),
+        measurements=[] if measurements is None else list(measurements),
+    )
+    return TestReport(
+        metadata=ReportMetadata(title="Bench Check", technician="robin", test_date=datetime(2026, 7, 16)),
+        sections=[section],
+    )
+
+
+def test_functions_returns_exactly_the_four_tools():
+    names = [fn.__name__ for fn in ReportTools(make_report()).functions()]
+    assert names == ["list_waveforms", "analyze_waveform", "detect_transients", "list_measurements"]
+
+
+def test_list_waveforms_names_every_channel():
+    tools = ReportTools(make_report(waveforms=[make_waveform("C1"), make_waveform("C2")]))
+    out = tools.list_waveforms()
+    assert "C1" in out and "C2" in out
+
+
+def test_list_waveforms_on_a_report_with_none():
+    assert "no waveforms" in ReportTools(make_report(waveforms=[])).list_waveforms().lower()
+
+
+def test_analyze_waveform_identifies_a_sine():
+    """The payload: the model can reach signal-type detection, which the
+    eight-scalar context could never express."""
+    out = ReportTools(make_report()).analyze_waveform("C1")
+    assert "signal_type" in out
+    assert "sine" in out.lower()
+
+
+def test_analyze_waveform_formats_values_with_units():
+    """Tool results reuse the report's own unit-aware formatter, so the model
+    reads the same units a human does."""
+    out = ReportTools(make_report()).analyze_waveform("C1")
+    assert "kHz" in out or "Hz" in out
+
+
+def test_analyze_waveform_unknown_channel_lists_the_valid_ones():
+    """The error is data for the model: it must be able to recover by itself."""
+    with pytest.raises(ValueError) as exc:
+        ReportTools(make_report()).analyze_waveform("C9")
+    assert "C9" in str(exc.value) and "C1" in str(exc.value)
+
+
+def test_tool_results_echo_their_arguments():
+    """Ollama tags tool results by tool_name only -- there is no tool_call_id --
+    so two parallel calls to one tool are indistinguishable at the protocol
+    level. Echoing the arguments is what lets the model tell them apart."""
+    out = ReportTools(make_report()).analyze_waveform("C1")
+    assert "channel=C1" in out
+
+
+def test_detect_transients_reports_none_on_a_clean_sine():
+    out = ReportTools(make_report()).detect_transients("C1")
+    assert "none" in out.lower()
+
+
+def test_detect_transients_caps_its_output_and_says_so(monkeypatch):
+    """A noisy capture can produce hundreds of transients and blow the context.
+    Truncation must be stated: silently returning 10 of 400 teaches the model the
+    signal is cleaner than it is.
+
+    WaveformAnalyzer.detect_transients hard-truncates its own return to 10
+    (waveform_analyzer.py:1003) as an internal implementation detail, so no real
+    capture -- however noisy -- can ever hand ReportTools more than that. The
+    collaborator is stubbed here so this test exercises ReportTools' OWN
+    truncation and "showing first" message in isolation, which is the behaviour
+    this tool layer is actually responsible for."""
+    fake_regions = [WaveformRegion(start_time=i * 1e-6, end_time=(i + 1) * 1e-6, label=f"Transient {i}") for i in range(15)]
+    monkeypatch.setattr(WaveformAnalyzer, "detect_transients", lambda waveform, sensitivity=3.0: fake_regions)
+
+    out = ReportTools(make_report()).detect_transients("C1")
+
+    assert "showing first" in out
+    assert out.count("µs") <= MAX_TRANSIENTS
+
+
+def test_detect_transients_rejects_an_out_of_range_sensitivity():
+    """ollama strips minimum/maximum from tool schemas, so out-of-range values
+    arrive no matter what we declare. The dispatcher is the only real bound."""
+    with pytest.raises(ValueError):
+        ReportTools(make_report()).detect_transients("C1", sensitivity=99.0)
+
+
+def test_list_measurements_reports_pass_and_fail():
+    measurements = [
+        MeasurementResult(name="Rise Time", value=1.2e-9, unit="s", channel="C1", passed=True),
+        MeasurementResult(name="Overshoot", value=12.0, unit="%", channel="C1", passed=False),
+    ]
+    out = ReportTools(make_report(measurements=measurements)).list_measurements()
+    assert "PASS" in out and "FAIL" in out
+    assert "Rise Time" in out and "Overshoot" in out
+
+
+def test_list_measurements_on_a_report_with_none():
+    assert "no measurements" in ReportTools(make_report()).list_measurements().lower()
+
+
+def test_every_tool_has_a_description_and_described_parameters():
+    """ollama builds each schema from the signature and the Google-style
+    docstring, so both are wire contract. A missing Args: entry means the model
+    gets a parameter with no description."""
+    convert_function_to_tool = pytest.importorskip("ollama._utils").convert_function_to_tool
+    for fn in ReportTools(make_report()).functions():
+        tool = convert_function_to_tool(fn)
+        assert tool.function.description, f"{fn.__name__} has no description"
+        for pname, prop in (tool.function.parameters.properties or {}).items():
+            assert prop.description, f"{fn.__name__}.{pname} has no description"
+
+
+def test_optional_parameters_are_not_marked_required():
+    """THE discipline test. ollama marks `x: float = 3.0` REQUIRED despite the
+    default; only `Optional[X] = None` escapes, and an unhinted parameter is
+    silently typed "string". Every other test here passes either way, so this is
+    the only thing standing between the tools and a schema that lies to the model.
+    """
+    convert_function_to_tool = pytest.importorskip("ollama._utils").convert_function_to_tool
+    tool = convert_function_to_tool(ReportTools(make_report()).detect_transients)
+    params = tool.function.parameters
+
+    assert set(params.properties) == {"channel", "sensitivity"}
+    assert params.required == ["channel"], "sensitivity has a default and must not be required"
+    assert params.properties["channel"].type == "string"
+    assert params.properties["sensitivity"].type == "number"

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -32,16 +32,6 @@ def make_waveform(channel="C1", n=2000, rate=1e6, freq=10_000, label=None):
     )
 
 
-def make_bursty_waveform(channel="C1", n=4000, rate=1e6, freq=10_000, bursts=20, width=6):
-    """A sine carrying `bursts` multi-sample spikes -- enough real transients to
-    exceed MAX_TRANSIENTS."""
-    t = np.arange(n) / rate
-    v = np.sin(2 * np.pi * freq * t)
-    for start in np.linspace(50, n - 100, bursts).astype(int):
-        v[start : start + width] += 8.0
-    return WaveformData(channel=channel, time=t, voltage=v, sample_rate=rate, record_length=n)
-
-
 def make_report(waveforms=None, measurements=None):
     section = TestSection(
         title="Captures",
@@ -68,6 +58,42 @@ def test_list_waveforms_names_every_channel():
 
 def test_list_waveforms_on_a_report_with_none():
     assert "no waveforms" in ReportTools(make_report(waveforms=[])).list_waveforms().lower()
+
+
+def make_two_section_report():
+    """The normal shape of a real report: several sections each capturing C1."""
+    return TestReport(
+        metadata=ReportMetadata(title="Bench Check", technician="robin", test_date=datetime(2026, 7, 16)),
+        sections=[
+            TestSection(title="Rise Time Test", waveforms=[make_waveform("C1")]),
+            TestSection(title="Overshoot Test", waveforms=[make_waveform("C1")]),
+        ],
+    )
+
+
+def test_list_waveforms_distinguishes_the_same_channel_in_two_sections():
+    """Two bare "C1:" rows would read as a duplicate or a bug. The section is
+    what tells them apart."""
+    out = ReportTools(make_two_section_report()).list_waveforms()
+
+    assert "Rise Time Test" in out and "Overshoot Test" in out
+
+
+def test_analyze_waveform_names_the_section_it_actually_used():
+    """Only the first C1 is reachable, so the result must say which capture it
+    is. Silently analyzing Rise Time while the model believes it asked about
+    Overshoot is the failure this prevents."""
+    out = ReportTools(make_two_section_report()).analyze_waveform("C1")
+
+    assert "Rise Time Test" in out
+    assert "Overshoot Test" not in out
+
+
+def test_detect_transients_names_the_section_it_actually_used():
+    out = ReportTools(make_two_section_report()).detect_transients("C1")
+
+    assert "Rise Time Test" in out
+    assert "Overshoot Test" not in out
 
 
 def test_analyze_waveform_identifies_a_sine():
@@ -105,18 +131,20 @@ def test_detect_transients_reports_none_on_a_clean_sine():
     assert "none" in out.lower()
 
 
-def test_detect_transients_caps_its_output_and_says_so():
+def test_detect_transients_caps_its_output_and_says_so(bursty_waveform):
     """A noisy capture can produce hundreds of transients and blow the context.
     Truncation must be stated: silently returning 10 of 400 teaches the model the
     signal is cleaner than it is.
 
-    Drives the real analyzer: the spikes are multi-sample bursts because the
-    analyzer discards any region shorter than 0.1% of the capture, which single
-    -sample spikes never clear."""
-    out = ReportTools(make_report(waveforms=[make_bursty_waveform()])).detect_transients("C1")
+    The TOTAL is the load-bearing half. Reporting "10 found, showing first 10"
+    on a 20-transient capture would announce truncation while still lying about
+    the size of what was dropped, so the count is pinned exactly, not just its
+    presence. Deterministic: the fixture's spikes are placed by linspace, not RNG.
+    """
+    out = ReportTools(make_report(waveforms=[bursty_waveform])).detect_transients("C1")
 
-    assert "showing first" in out
-    assert out.count("µs") <= MAX_TRANSIENTS
+    assert "20 found, showing first 10" in out
+    assert out.count("µs") == MAX_TRANSIENTS
 
 
 def test_detect_transients_rejects_an_out_of_range_sensitivity():

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -17,9 +17,7 @@ from scpi_control.report_generator.models.report_data import (
     TestReport,
     TestSection,
     WaveformData,
-    WaveformRegion,
 )
-from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
 
 
 def make_waveform(channel="C1", n=2000, rate=1e6, freq=10_000, label=None):
@@ -32,6 +30,16 @@ def make_waveform(channel="C1", n=2000, rate=1e6, freq=10_000, label=None):
         record_length=n,
         label=label,
     )
+
+
+def make_bursty_waveform(channel="C1", n=4000, rate=1e6, freq=10_000, bursts=20, width=6):
+    """A sine carrying `bursts` multi-sample spikes -- enough real transients to
+    exceed MAX_TRANSIENTS."""
+    t = np.arange(n) / rate
+    v = np.sin(2 * np.pi * freq * t)
+    for start in np.linspace(50, n - 100, bursts).astype(int):
+        v[start : start + width] += 8.0
+    return WaveformData(channel=channel, time=t, voltage=v, sample_rate=rate, record_length=n)
 
 
 def make_report(waveforms=None, measurements=None):
@@ -97,21 +105,15 @@ def test_detect_transients_reports_none_on_a_clean_sine():
     assert "none" in out.lower()
 
 
-def test_detect_transients_caps_its_output_and_says_so(monkeypatch):
+def test_detect_transients_caps_its_output_and_says_so():
     """A noisy capture can produce hundreds of transients and blow the context.
     Truncation must be stated: silently returning 10 of 400 teaches the model the
     signal is cleaner than it is.
 
-    WaveformAnalyzer.detect_transients hard-truncates its own return to 10
-    (waveform_analyzer.py:1003) as an internal implementation detail, so no real
-    capture -- however noisy -- can ever hand ReportTools more than that. The
-    collaborator is stubbed here so this test exercises ReportTools' OWN
-    truncation and "showing first" message in isolation, which is the behaviour
-    this tool layer is actually responsible for."""
-    fake_regions = [WaveformRegion(start_time=i * 1e-6, end_time=(i + 1) * 1e-6, label=f"Transient {i}") for i in range(15)]
-    monkeypatch.setattr(WaveformAnalyzer, "detect_transients", lambda waveform, sensitivity=3.0: fake_regions)
-
-    out = ReportTools(make_report()).detect_transients("C1")
+    Drives the real analyzer: the spikes are multi-sample bursts because the
+    analyzer discards any region shorter than 0.1% of the capture, which single
+    -sample spikes never clear."""
+    out = ReportTools(make_report(waveforms=[make_bursty_waveform()])).detect_transients("C1")
 
     assert "showing first" in out
     assert out.count("µs") <= MAX_TRANSIENTS

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -118,6 +118,18 @@ def test_analyze_waveform_unknown_channel_lists_the_valid_ones():
     assert "C9" in str(exc.value) and "C1" in str(exc.value)
 
 
+def test_analyze_waveform_unknown_channel_tags_each_option_with_its_section():
+    """A two-section report answering an unknown channel with a bare "C1, C1"
+    would invite the exact "two separately addressable C1s" misconception the
+    section-naming fix exists to prevent. Each available channel must be tagged
+    with the section it came from."""
+    with pytest.raises(ValueError) as exc:
+        ReportTools(make_two_section_report()).analyze_waveform("C9")
+    message = str(exc.value)
+    assert "Rise Time Test" in message
+    assert "Overshoot Test" in message
+
+
 def test_tool_results_echo_their_arguments():
     """Ollama tags tool results by tool_name only -- there is no tool_call_id --
     so two parallel calls to one tool are indistinguishable at the protocol

--- a/tests/test_waveform_analyzer_transients.py
+++ b/tests/test_waveform_analyzer_transients.py
@@ -1,0 +1,54 @@
+"""The transient-detection contract WaveformAnalyzer owes its callers.
+
+detect_transients used to slice its own return to 10 and throw the count away,
+so a capture with 400 transients was indistinguishable from one with 10. Any
+caller that truncates has to be able to say what it dropped, which means the
+analyzer must hand over the true list and let the caller decide. These pin that:
+unbounded by default, bounded only on request.
+
+Pure CPU over in-memory arrays -- no instrument, no network.
+"""
+
+import numpy as np
+
+from scpi_control.report_generator.models.report_data import WaveformData
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+
+def make_bursty_waveform(channel="C1", n=4000, rate=1e6, freq=10_000, bursts=20, width=6):
+    """A sine carrying `bursts` multi-sample spikes.
+
+    The spikes are several samples wide because detect_transients discards any
+    region shorter than 0.1% of the capture; single-sample spikes never clear it.
+    """
+    t = np.arange(n) / rate
+    v = np.sin(2 * np.pi * freq * t)
+    for start in np.linspace(50, n - 100, bursts).astype(int):
+        v[start : start + width] += 8.0
+    return WaveformData(channel=channel, time=t, voltage=v, sample_rate=rate, record_length=n)
+
+
+def test_detect_transients_is_unbounded_by_default():
+    """THE regression test. A silent internal cap here is invisible at this
+    call site -- it just quietly reports a noisy signal as a clean one -- so the
+    default must return every transient found, however many that is."""
+    transients = WaveformAnalyzer.detect_transients(make_bursty_waveform())
+
+    assert len(transients) > 10, "the default must not truncate"
+
+
+def test_detect_transients_truncates_to_an_explicit_limit():
+    transients = WaveformAnalyzer.detect_transients(make_bursty_waveform(), limit=4)
+
+    assert len(transients) == 4
+
+
+def test_detect_regions_still_appends_at_most_ten_transients():
+    """detect_regions fed plots and PDFs with a 10-region cap long before the
+    limit parameter existed; making the analyzer unbounded must not change what
+    it renders."""
+    waveform = make_bursty_waveform()
+
+    WaveformAnalyzer.detect_regions(waveform, auto_detect_edges=False, auto_detect_transients=True)
+
+    assert len(waveform.regions) == 10

--- a/tests/test_waveform_analyzer_transients.py
+++ b/tests/test_waveform_analyzer_transients.py
@@ -9,46 +9,33 @@ unbounded by default, bounded only on request.
 Pure CPU over in-memory arrays -- no instrument, no network.
 """
 
-import numpy as np
-
-from scpi_control.report_generator.models.report_data import WaveformData
 from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
 
 
-def make_bursty_waveform(channel="C1", n=4000, rate=1e6, freq=10_000, bursts=20, width=6):
-    """A sine carrying `bursts` multi-sample spikes.
-
-    The spikes are several samples wide because detect_transients discards any
-    region shorter than 0.1% of the capture; single-sample spikes never clear it.
-    """
-    t = np.arange(n) / rate
-    v = np.sin(2 * np.pi * freq * t)
-    for start in np.linspace(50, n - 100, bursts).astype(int):
-        v[start : start + width] += 8.0
-    return WaveformData(channel=channel, time=t, voltage=v, sample_rate=rate, record_length=n)
-
-
-def test_detect_transients_is_unbounded_by_default():
+def test_detect_transients_is_unbounded_by_default(bursty_waveform):
     """THE regression test. A silent internal cap here is invisible at this
     call site -- it just quietly reports a noisy signal as a clean one -- so the
     default must return every transient found, however many that is."""
-    transients = WaveformAnalyzer.detect_transients(make_bursty_waveform())
+    transients = WaveformAnalyzer.detect_transients(bursty_waveform)
 
     assert len(transients) > 10, "the default must not truncate"
 
 
-def test_detect_transients_truncates_to_an_explicit_limit():
-    transients = WaveformAnalyzer.detect_transients(make_bursty_waveform(), limit=4)
+def test_detect_transients_truncates_to_an_explicit_limit(bursty_waveform):
+    transients = WaveformAnalyzer.detect_transients(bursty_waveform, limit=4)
 
     assert len(transients) == 4
 
 
-def test_detect_regions_still_appends_at_most_ten_transients():
+def test_detect_regions_still_appends_at_most_ten_transients(bursty_waveform):
     """detect_regions fed plots and PDFs with a 10-region cap long before the
     limit parameter existed; making the analyzer unbounded must not change what
-    it renders."""
-    waveform = make_bursty_waveform()
+    it renders.
 
-    WaveformAnalyzer.detect_regions(waveform, auto_detect_edges=False, auto_detect_transients=True)
+    Counts transients specifically rather than every region: the fixture is a
+    sine, so the default plateau pass contributes nothing today, and a total
+    would pin that coincidence instead of the cap.
+    """
+    WaveformAnalyzer.detect_regions(bursty_waveform, auto_detect_edges=False, auto_detect_transients=True)
 
-    assert len(waveform.regions) == 10
+    assert len([r for r in bursty_waveform.regions if r.region_type == "transient"]) == 10


### PR DESCRIPTION
## What this does

Gives the local Ollama model **callable tools** over a loaded `TestReport`, so it can reach the analyses the app already computes instead of reasoning from the eight scalars per waveform that the summarized-context builder produces (a 1k-point and a 1M-point capture produce byte-identical context today, while ~1100 lines of signal-type detection, frequency, timing, quality and THD sit unused by the LLM path).

Four read-only tools over a report — `list_waveforms`, `analyze_waveform`, `detect_transients`, `list_measurements` — are offered to the model only when it can actually call tools; a model without tool support keeps exactly today's summarized-context behaviour.

**Local LLM only.** No cloud providers, no API keys, no provider abstraction — that scope was deliberately cut earlier and is not reintroduced here.

## How it fits together

- **`ReportTools`** (`llm/tools.py`) — four pure-CPU tools over one loaded report. `ollama` builds each tool's JSON schema from its signature and Google-style docstring, so both are wire contract.
- **`LLMClient.supports_tools()`** — a cached capability gate. Asks the model (`show(model).capabilities`) rather than assuming; returns `False` on any doubt and never raises.
- **`LLMClient.chat_with_tools()`** — the multi-turn loop. Takes plain callables, dispatches by `__name__`, feeds tool results back, and terminates on `max_rounds` returning `None` rather than a half-answer.
- **`ReportAnalyzer.answer_question()`** — picks the tool path when `supports_tools()`, else falls back to today's summarized-context path.

## Test coverage

Baseline `main` (`e330a32`): 841 passed / 19 skipped. This branch: **884 passed / 19 skipped** (+43). `black --check` clean, `flake8 E9,F63,F7,F82` = 0, across Python 3.9–3.14.

`ollama` is added to the CI test install (it lives only in the `report-generator`/`all` extras, and the test job installs `.[dev,web]`); the two schema-pinning tests `importorskip` it so the file still runs for anyone without the extra.

**No test touches the network**, which matters because a live Ollama runs on the dev machine and `LLMClient.__init__` probes a real server — a mis-mocked test would pass on a real round-trip rather than fail. The SDK path is exercised only through a shared `ollama_sdk` fixture (`tests/conftest.py`) that patches `ollama.Client` itself; the final review verified containment empirically by blocking `socket.connect` and running the whole LLM suite with the live server up (with a negative control confirming the block fires).

## A latent bug fixed along the way

`WaveformAnalyzer.detect_transients` silently truncated its result to 10 **and discarded the true count**, so a tool reporting "10 found" on a 400-transient capture would have told the model a noisy signal was clean. It now takes an opt-in `limit` (unbounded by default); `detect_regions` passes `limit=10` so its rendering behaviour is byte-for-byte unchanged, and the tool reports the honest total ("400 found, showing first 10"). This shared analyzer had **zero** test coverage before this branch; it now has a pin that would catch a re-introduced silent cap.

## Behavioural notes worth knowing

- **The SDK-path timeout now bites generations, not just stalls.** `config.timeout` (default 60s) was previously dead on the Ollama SDK path — a stalled server hung the worker forever. It is now honoured, which also makes it a **whole-generation budget** on the non-streaming `.chat()` call: a slow local model emitting the default `max_tokens=2000` can newly time out where it previously succeeded-slowly. Kept at 60s deliberately — it matches the budget the other two chat paths already impose, and it's configurable via `LLMConfig.timeout`.
- **`supports_tools()` distinguishes decided from unknown.** A read capability (tools present/absent, or no SDK client) is cached; a probe that *raised* (server briefly unreachable, model not yet pulled) is not cached, so a long-lived client retries next call instead of disabling tools for the whole session.
- **The tool path runs at the configured temperature** (`config.temperature`, default 0.7), matching the summarized-context path rather than the model default.

## Not automated — manual verification needed

Success criterion 1 from the design ("a tool-capable local model answers a report question by calling tools, citing an analysis the eight-scalar context could not have produced") **cannot be proven by any test here** — it needs a real model and a live server, and no test in this branch may touch the network. This wants a manual check against the dev-machine Ollama with a real scope capture before it's trusted end-to-end.

## Deferred follow-ups

- **Channel addressability within a section.** Section-tagging disambiguates a channel captured in *different* sections, but two captures of the same channel in *one* section are still indistinguishable and only the first is reachable. Belongs to the report-content sub-project.
- **Schema-pin robustness.** The two schema tests `importorskip("ollama._utils")` (a private module); if a future ollama moves it, they skip rather than fail. Left as-is deliberately (a hard import would break the pure-CPU tests for anyone without the extra), but worth a CI-side "assert not skipped" guard later.
- Minor doc line-reference drift; a fuller schema pin for `analyze_waveform`; and a `pytest-socket`-style guard to make the no-network property self-enforcing rather than convention-enforced.
