### PR TITLE
feat: waveform analysis tools for the local model (plateaus, edges, spectrum)

### DIFF
--- a/scpi_control/report_generator/llm/prompts.py
+++ b/scpi_control/report_generator/llm/prompts.py
@@ -91,6 +91,9 @@ CHAT_WITH_TOOLS_SYSTEM_PROMPT = """You are an expert test engineer answering que
 You cannot see the report. Use the tools to inspect it:
 - list_waveforms: which channels the report contains. Call this first.
 - analyze_waveform: a channel's measured characteristics (signal type, amplitude, frequency, timing, quality, THD).
+- analyze_plateaus: per-plateau level, slope, flatness, drift and noise (for probe-compensation and settling questions).
+- list_edges: where the rising and falling edges are and how many.
+- analyze_spectrum: the dominant frequency peaks and per-harmonic content.
 - detect_transients: sudden anomalies (glitches, spikes) in a channel.
 - list_measurements: recorded measurements and their pass/fail status.
 

--- a/scpi_control/report_generator/llm/tools.py
+++ b/scpi_control/report_generator/llm/tools.py
@@ -37,6 +37,9 @@ _SENSITIVITY_MAX = 10.0
 
 MAX_PLATEAUS = 8
 
+_EDGES_DEFAULT = 4
+_EDGES_MAX = 20
+
 
 def _format_volts(value: Optional[float]) -> str:
     return "n/a" if value is None else f"{value:.4g} V"
@@ -142,6 +145,36 @@ class ReportTools:
                 f"flatness={_format_volts(region.flatness)}, drift={_format_volts(region.drift)}, "
                 f"noise={_format_volts(region.noise_level)}"
             )
+        return "\n".join(lines)
+
+    def list_edges(self, channel: str, max_edges: Optional[int] = None) -> str:
+        """List the rising and falling edges in a captured waveform, with their times.
+
+        Reports where each edge occurs and how many there are. This is edge
+        LOCATION, not transition speed: for a channel's representative rise/fall
+        time use analyze_waveform instead.
+
+        Args:
+            channel: Channel to inspect, e.g. "C1". Must be one listed by list_waveforms.
+            max_edges: Maximum edges to report, between 2 and 20. Defaults to 4. If
+                the result reports exactly this many, there may be more -- raise it.
+        """
+        if max_edges is None:
+            max_edges = _EDGES_DEFAULT
+        if not 2 <= max_edges <= _EDGES_MAX:
+            raise ValueError(f"max_edges must be between 2 and {_EDGES_MAX}, got {max_edges}")
+
+        waveform, section_title = self._find(channel)
+        edges = WaveformAnalyzer.detect_edges(waveform, max_edges=max_edges)
+        head = f"list_edges(channel={channel}) [{section_title}]:"
+        if not edges:
+            return f"{head} no edges found."
+
+        lines = [f"{head} {len(edges)} found (max_edges={max_edges})"]
+        for edge in edges:
+            kind = "rising" if edge.region_type == "edge_rising" else "falling"
+            midpoint = (edge.start_time + edge.end_time) / 2
+            lines.append(f"  {kind} edge @ {midpoint * 1e6:.2f} µs")
         return "\n".join(lines)
 
     def detect_transients(self, channel: str, sensitivity: Optional[float] = None) -> str:

--- a/scpi_control/report_generator/llm/tools.py
+++ b/scpi_control/report_generator/llm/tools.py
@@ -75,6 +75,9 @@ class ReportTools:
         return [
             self.list_waveforms,
             self.analyze_waveform,
+            self.analyze_plateaus,
+            self.list_edges,
+            self.analyze_spectrum,
             self.detect_transients,
             self.list_measurements,
         ]

--- a/scpi_control/report_generator/llm/tools.py
+++ b/scpi_control/report_generator/llm/tools.py
@@ -18,6 +18,7 @@ Everything in this module is pure CPU over in-memory arrays: no I/O, no
 instrument, and no knowledge of the LLM.
 """
 
+import math
 from typing import Callable, List, Optional, Tuple
 
 from scpi_control.report_generator.models.report_data import TestReport, WaveformData
@@ -47,6 +48,20 @@ def _format_volts(value: Optional[float]) -> str:
 
 def _format_slope(value: Optional[float]) -> str:
     return "n/a" if value is None else f"{value:.4g} V/s"
+
+
+def _format_hz(freq: float) -> str:
+    if freq >= 1e6:
+        return f"{freq / 1e6:.3f} MHz"
+    if freq >= 1e3:
+        return f"{freq / 1e3:.3f} kHz"
+    return f"{freq:.1f} Hz"
+
+
+def _format_db(ratio: float) -> str:
+    if ratio <= 0:
+        return "-inf dB"
+    return f"{20 * math.log10(ratio):.1f} dB"
 
 
 class ReportTools:
@@ -175,6 +190,36 @@ class ReportTools:
             kind = "rising" if edge.region_type == "edge_rising" else "falling"
             midpoint = (edge.start_time + edge.end_time) / 2
             lines.append(f"  {kind} edge @ {midpoint * 1e6:.2f} µs")
+        return "\n".join(lines)
+
+    def analyze_spectrum(self, channel: str) -> str:
+        """Report the dominant frequency components of a captured waveform.
+
+        Lists the strongest frequency peaks and, for a periodic signal, the
+        per-harmonic content -- more detail than analyze_waveform's single THD
+        value.
+
+        Args:
+            channel: Channel to inspect, e.g. "C1". Must be one listed by list_waveforms.
+        """
+        waveform, section_title = self._find(channel)
+        spectrum = WaveformAnalyzer.calculate_spectrum(waveform)
+        head = f"analyze_spectrum(channel={channel}) [{section_title}]:"
+
+        peaks = spectrum["dominant_peaks"]
+        if not peaks:
+            return f"{head} no significant frequency content."
+
+        lines = [head, "  dominant peaks:"]
+        for freq, rel in peaks:
+            lines.append(f"    {_format_hz(freq)}: {_format_db(rel)}")
+
+        ratios = spectrum["harmonic_ratios"]
+        if ratios:
+            lines.append("  harmonic content (relative to fundamental):")
+            for index, ratio in enumerate(ratios, start=1):
+                label = "fundamental" if index == 1 else f"harmonic {index}"
+                lines.append(f"    {label}: {_format_db(ratio)}")
         return "\n".join(lines)
 
     def detect_transients(self, channel: str, sensitivity: Optional[float] = None) -> str:

--- a/scpi_control/report_generator/llm/tools.py
+++ b/scpi_control/report_generator/llm/tools.py
@@ -35,6 +35,16 @@ _SENSITIVITY_DEFAULT = 3.0
 _SENSITIVITY_MIN = 1.0
 _SENSITIVITY_MAX = 10.0
 
+MAX_PLATEAUS = 8
+
+
+def _format_volts(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"{value:.4g} V"
+
+
+def _format_slope(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"{value:.4g} V/s"
+
 
 class ReportTools:
     """Read-only tools over one loaded report."""
@@ -98,6 +108,40 @@ class ReportTools:
         stats = WaveformAnalyzer.analyze(waveform)
         lines = [f"analyze_waveform(channel={channel}) [{section_title}]:"]
         lines.extend(f"  {name}: {WaveformAnalyzer.format_stat_value(name, value)}" for name, value in stats.items())
+        return "\n".join(lines)
+
+    def analyze_plateaus(self, channel: str) -> str:
+        """Measure the flat plateau regions of a captured waveform.
+
+        Reports each plateau's level, slope, flatness, drift and noise -- the raw
+        facts for judging probe compensation and settling. A plateau that slopes
+        instead of staying flat suggests probe miscompensation; interpret the
+        slope yourself rather than expecting a verdict.
+
+        Args:
+            channel: Channel to inspect, e.g. "C1". Must be one listed by list_waveforms.
+        """
+        waveform, section_title = self._find(channel)
+        regions = WaveformAnalyzer.detect_plateaus(waveform)
+        head = f"analyze_plateaus(channel={channel}) [{section_title}]:"
+        if not regions:
+            return f"{head} no flat plateaus found."
+
+        for region in regions:
+            WaveformAnalyzer.analyze_region(waveform, region, calculate_calibration=False)
+
+        shown = regions[:MAX_PLATEAUS]
+        summary = f"{head} {len(regions)} found"
+        if len(regions) > len(shown):
+            summary += f", showing first {len(shown)}"
+        lines = [summary]
+        for region in shown:
+            lines.append(
+                f"  {region.region_type} {region.start_time * 1e6:.2f}-{region.end_time * 1e6:.2f} µs: "
+                f"level={_format_volts(region.ideal_value)}, slope={_format_slope(region.slope)}, "
+                f"flatness={_format_volts(region.flatness)}, drift={_format_volts(region.drift)}, "
+                f"noise={_format_volts(region.noise_level)}"
+            )
         return "\n".join(lines)
 
     def detect_transients(self, channel: str, sensitivity: Optional[float] = None) -> str:

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -142,6 +142,63 @@ class WaveformAnalyzer:
             }
 
     @staticmethod
+    def calculate_spectrum(waveform: "WaveformData", num_peaks: int = 5) -> dict:
+        """
+        Find the dominant frequency components of a waveform.
+
+        Returns the strongest spectral peaks and, when a clear fundamental
+        exists, the per-harmonic amplitude ratios. Pure CPU; never raises on
+        degenerate input.
+
+        Args:
+            waveform: WaveformData object
+            num_peaks: Maximum number of dominant peaks to return
+
+        Returns:
+            Dict with:
+              - 'dominant_peaks': list of (frequency_hz, relative_magnitude)
+                tuples, strongest first; relative_magnitude is vs the strongest
+                peak (so the first is always 1.0). Empty if none found.
+              - 'fundamental_hz': frequency of the strongest peak, or None.
+              - 'harmonic_ratios': list of harmonic amplitudes relative to the
+                fundamental (index 0 = fundamental = 1.0), or None.
+        """
+        empty = {"dominant_peaks": [], "fundamental_hz": None, "harmonic_ratios": None}
+
+        v = waveform.voltage
+        sample_rate = waveform.sample_rate
+        n = len(v)
+        if n < 4 or sample_rate <= 0:
+            return empty
+
+        yf = np.abs(fft(v - np.mean(v)))  # remove DC
+        xf = fftfreq(n, 1 / sample_rate)
+        pos = xf > 0
+        xf_pos = xf[pos]
+        yf_pos = yf[pos]
+        if len(yf_pos) < 2 or np.max(yf_pos) == 0:
+            return empty
+
+        peak_indices, _ = scipy_signal.find_peaks(yf_pos)
+        if len(peak_indices) == 0:
+            peak_indices = np.array([int(np.argmax(yf_pos))])
+
+        # Strongest first, keep the top num_peaks
+        order = np.argsort(yf_pos[peak_indices])[::-1][:num_peaks]
+        peak_indices = peak_indices[order]
+        strongest = yf_pos[peak_indices[0]]
+        dominant_peaks = [(float(xf_pos[i]), float(yf_pos[i] / strongest)) for i in peak_indices]
+
+        ratios = WaveformAnalyzer._get_harmonic_ratios(waveform)
+        harmonic_ratios = None if ratios is None else [float(x) for x in ratios]
+
+        return {
+            "dominant_peaks": dominant_peaks,
+            "fundamental_hz": float(xf_pos[peak_indices[0]]),
+            "harmonic_ratios": harmonic_ratios,
+        }
+
+    @staticmethod
     def calculate_timing_stats(waveform: WaveformData) -> Dict[str, Optional[float]]:
         """Calculate timing measurements (rise time, fall time, pulse width, duty cycle)."""
         try:

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -165,6 +165,9 @@ class WaveformAnalyzer:
         """
         empty = {"dominant_peaks": [], "fundamental_hz": None, "harmonic_ratios": None}
 
+        if num_peaks < 1:
+            return empty
+
         v = waveform.voltage
         sample_rate = waveform.sample_rate
         n = len(v)

--- a/tests/test_report_analyzer_tools.py
+++ b/tests/test_report_analyzer_tools.py
@@ -35,7 +35,15 @@ def test_answer_question_uses_tools_when_the_model_supports_them():
     assert answer == "C1 is a sine."
     client.complete.assert_not_called()
     tools = client.chat_with_tools.call_args.args[1]
-    assert [fn.__name__ for fn in tools] == ["list_waveforms", "analyze_waveform", "detect_transients", "list_measurements"]
+    assert [fn.__name__ for fn in tools] == [
+        "list_waveforms",
+        "analyze_waveform",
+        "analyze_plateaus",
+        "list_edges",
+        "analyze_spectrum",
+        "detect_transients",
+        "list_measurements",
+    ]
 
 
 def test_the_tool_path_sends_the_question_and_a_tool_aware_system_prompt():
@@ -68,4 +76,7 @@ def test_answer_question_falls_back_when_the_model_cannot_call_tools():
 def test_the_tool_aware_prompt_is_registered():
     prompt = get_system_prompt("chat_tools")
     assert "list_waveforms" in prompt
+    assert "analyze_plateaus" in prompt
+    assert "list_edges" in prompt
+    assert "analyze_spectrum" in prompt
     assert prompt != get_system_prompt("chat")

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -10,7 +10,7 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-from scpi_control.report_generator.llm.tools import MAX_TRANSIENTS, ReportTools
+from scpi_control.report_generator.llm.tools import MAX_PLATEAUS, MAX_TRANSIENTS, ReportTools
 from scpi_control.report_generator.models.report_data import (
     MeasurementResult,
     ReportMetadata,
@@ -190,6 +190,74 @@ def test_every_tool_has_a_description_and_described_parameters():
         assert tool.function.description, f"{fn.__name__} has no description"
         for pname, prop in (tool.function.parameters.properties or {}).items():
             assert prop.description, f"{fn.__name__}.{pname} has no description"
+
+
+def make_square(channel="C1", n=4000, rate=1e6, freq=500.1):
+    """A clean square wave, ~2 cycles over 4000 samples -> a few long plateaus
+    (well under MAX_PLATEAUS, so nothing truncates and both plateau_high and
+    plateau_low show). Raise freq to force many plateaus.
+
+    Note: detect_plateaus thresholds at median(v) +/- 0.3*std(v). A perfect +-1
+    square wave is bimodal, so that threshold only splits both polarities apart
+    when the high/low sample counts are exactly equal (median lands on 0);
+    otherwise the median snaps entirely to whichever side has one more sample
+    and the other polarity is never detected. At an exact divisor like 500 Hz
+    every zero-crossing lands on an integer sample index and ties into the high
+    side (`>= 0`), which is why 500.1 Hz -- not 500 Hz -- is the default: it
+    avoids that exact tie so both plateau_high and plateau_low actually appear.
+
+    Also note: detect_plateaus requires each plateau to last >= 1% of the record,
+    so a high-frequency square whose half-periods fall below that yields NO
+    plateaus -- keep freq low enough that half_period_samples =
+    rate/(2*freq) >> n*0.01."""
+    t = np.arange(n) / rate
+    v = np.where(np.sin(2 * np.pi * freq * t) >= 0, 1.0, -1.0)
+    return WaveformData(channel=channel, time=t, voltage=v, sample_rate=rate, record_length=n)
+
+
+def make_flatless(channel="C1", n=2000, rate=1e6, freq=50_000):
+    """A fast sine: its arcs above threshold are too brief to register as plateaus
+    (detect_plateaus -> none), and a pure sine's slope never crosses detect_edges'
+    2-sigma derivative threshold (detect_edges -> none). One deterministic 'empty'
+    fixture for both the no-plateaus and no-edges cases."""
+    t = np.arange(n) / rate
+    return WaveformData(channel=channel, time=t, voltage=np.sin(2 * np.pi * freq * t), sample_rate=rate, record_length=n)
+
+
+def report_of(waveform):
+    return make_report(waveforms=[waveform])
+
+
+def test_analyze_plateaus_reports_slope_per_plateau():
+    out = ReportTools(report_of(make_square())).analyze_plateaus("C1")
+    assert "plateau_high" in out and "plateau_low" in out
+    assert "slope=" in out and "V/s" in out
+    assert "channel=C1" in out and "[Captures]" in out
+
+
+def test_analyze_plateaus_on_a_signal_with_no_plateaus():
+    out = ReportTools(report_of(make_flatless())).analyze_plateaus("C1")
+    assert "no flat plateaus" in out.lower()
+
+
+def test_analyze_plateaus_caps_its_output_and_states_the_true_total():
+    """A many-cycle square wave yields far more than MAX_PLATEAUS regions. The
+    reported total must be true and the truncation stated -- the detect_transients
+    lesson: a silent slice teaches the model the signal is simpler than it is."""
+    many = make_square(freq=5_000)  # 20 cycles over 4000 samples -> 19 plateaus, well over MAX_PLATEAUS
+    out = ReportTools(report_of(many)).analyze_plateaus("C1")
+    assert "showing first" in out
+    # one plateau line per shown region; count the leading "  plateau_" bullets
+    assert out.count("  plateau_") == MAX_PLATEAUS
+
+
+def test_analyze_plateaus_does_not_mutate_the_report():
+    """Read-only: the tool must never append to waveform.regions."""
+    report = report_of(make_square())
+    waveform = report.sections[0].waveforms[0]
+    before = len(waveform.regions)
+    ReportTools(report).analyze_plateaus("C1")
+    assert len(waveform.regions) == before
 
 
 def test_optional_parameters_are_not_marked_required():

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -246,6 +246,10 @@ def test_analyze_plateaus_caps_its_output_and_states_the_true_total():
     lesson: a silent slice teaches the model the signal is simpler than it is."""
     many = make_square(freq=5_000)  # 20 cycles over 4000 samples -> 19 plateaus, well over MAX_PLATEAUS
     out = ReportTools(report_of(many)).analyze_plateaus("C1")
+    # Pin the TRUE total, not just the truncation marker: printing "8 found,
+    # showing first 8" would still satisfy "showing first" and the bullet count
+    # (that is the exact silent-slice regression), so assert the real number.
+    assert "19 found, showing first 8" in out
     assert "showing first" in out
     # one plateau line per shown region; count the leading "  plateau_" bullets
     assert out.count("  plateau_") == MAX_PLATEAUS

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -330,6 +330,7 @@ def test_analyze_spectrum_names_the_dominant_frequency():
 def test_analyze_spectrum_shows_harmonic_content_for_a_periodic_signal():
     out = ReportTools(report_of(make_square())).analyze_spectrum("C1")
     assert "harmonic" in out.lower()
+    assert "fundamental" in out
 
 
 def test_analyze_spectrum_on_a_degenerate_signal():

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -224,6 +224,12 @@ def make_flatless(channel="C1", n=2000, rate=1e6, freq=50_000):
     return WaveformData(channel=channel, time=t, voltage=np.sin(2 * np.pi * freq * t), sample_rate=rate, record_length=n)
 
 
+def make_two_tone(channel="C1", n=2000, rate=1e6):
+    t = np.arange(n) / rate
+    v = 1.0 * np.sin(2 * np.pi * 10_000 * t) + 0.5 * np.sin(2 * np.pi * 30_000 * t)
+    return WaveformData(channel=channel, time=t, voltage=v, sample_rate=rate, record_length=n)
+
+
 def report_of(waveform):
     return make_report(waveforms=[waveform])
 
@@ -304,3 +310,21 @@ def test_optional_parameters_are_not_marked_required():
     assert params.required == ["channel"], "sensitivity has a default and must not be required"
     assert params.properties["channel"].type == "string"
     assert params.properties["sensitivity"].type == "number"
+
+
+def test_analyze_spectrum_names_the_dominant_frequency():
+    out = ReportTools(report_of(make_two_tone())).analyze_spectrum("C1")
+    assert "kHz" in out
+    assert "10.0" in out  # the 10 kHz fundamental appears
+    assert "channel=C1" in out and "[Captures]" in out
+
+
+def test_analyze_spectrum_shows_harmonic_content_for_a_periodic_signal():
+    out = ReportTools(report_of(make_square())).analyze_spectrum("C1")
+    assert "harmonic" in out.lower()
+
+
+def test_analyze_spectrum_on_a_degenerate_signal():
+    flat = WaveformData(channel="C1", time=np.arange(3) / 1e6, voltage=np.zeros(3), sample_rate=1e6, record_length=3)
+    out = ReportTools(report_of(flat)).analyze_spectrum("C1")
+    assert "no significant frequency content" in out.lower()

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -45,9 +45,17 @@ def make_report(waveforms=None, measurements=None):
     )
 
 
-def test_functions_returns_exactly_the_four_tools():
+def test_functions_returns_the_seven_tools_in_order():
     names = [fn.__name__ for fn in ReportTools(make_report()).functions()]
-    assert names == ["list_waveforms", "analyze_waveform", "detect_transients", "list_measurements"]
+    assert names == [
+        "list_waveforms",
+        "analyze_waveform",
+        "analyze_plateaus",
+        "list_edges",
+        "analyze_spectrum",
+        "detect_transients",
+        "list_measurements",
+    ]
 
 
 def test_list_waveforms_names_every_channel():

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -264,6 +264,32 @@ def test_analyze_plateaus_does_not_mutate_the_report():
     assert len(waveform.regions) == before
 
 
+def test_list_edges_reports_rising_and_falling_edges():
+    out = ReportTools(report_of(make_square())).list_edges("C1")
+    assert "rising" in out and "falling" in out
+    assert "µs" in out
+    assert "channel=C1" in out and "[Captures]" in out
+
+
+def test_list_edges_names_the_cap_so_the_model_can_raise_it():
+    """detect_edges gives no true total, so the honest signal is the cap itself:
+    if the model sees as many edges as it asked for, it can ask for more."""
+    out = ReportTools(report_of(make_square())).list_edges("C1", max_edges=2)
+    assert "max_edges=2" in out
+
+
+def test_list_edges_on_a_flat_signal():
+    out = ReportTools(report_of(make_flatless())).list_edges("C1")
+    assert "no edges" in out.lower()
+
+
+def test_list_edges_rejects_an_out_of_range_max_edges():
+    """ollama strips numeric bounds from the schema, so the dispatcher is the only
+    real guard."""
+    with pytest.raises(ValueError):
+        ReportTools(report_of(make_square())).list_edges("C1", max_edges=99)
+
+
 def test_optional_parameters_are_not_marked_required():
     """THE discipline test. ollama marks `x: float = 3.0` REQUIRED despite the
     default; only `Optional[X] = None` escapes, and an unhinted parameter is

--- a/tests/test_waveform_analyzer_spectrum.py
+++ b/tests/test_waveform_analyzer_spectrum.py
@@ -55,3 +55,13 @@ def test_degenerate_signal_returns_empty_rather_than_raising():
     assert spec["dominant_peaks"] == []
     assert spec["fundamental_hz"] is None
     assert spec["harmonic_ratios"] is None
+
+
+def test_non_positive_num_peaks_returns_empty_rather_than_raising():
+    """num_peaks<=0 slices the peak list to empty; without a guard the [0] index
+    raises. The docstring promises never to raise on degenerate input."""
+    v = np.sin(2 * np.pi * 1000 * np.arange(2000) / 1e6)
+    for bad in (0, -1):
+        spec = WaveformAnalyzer.calculate_spectrum(make_waveform(v), num_peaks=bad)
+        assert spec["dominant_peaks"] == []
+        assert spec["fundamental_hz"] is None

--- a/tests/test_waveform_analyzer_spectrum.py
+++ b/tests/test_waveform_analyzer_spectrum.py
@@ -1,0 +1,57 @@
+"""WaveformAnalyzer.calculate_spectrum -- dominant peaks and harmonic content.
+
+Pure CPU over synthesized signals with known frequency content. No LLM, no mock,
+no network.
+"""
+
+import numpy as np
+
+from scpi_control.report_generator.models.report_data import WaveformData
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+
+def make_waveform(voltage, rate=1e6):
+    n = len(voltage)
+    return WaveformData(channel="C1", time=np.arange(n) / rate, voltage=voltage, sample_rate=rate, record_length=n)
+
+
+def test_dominant_peak_is_the_strongest_tone():
+    """A 10 kHz tone at twice the amplitude of a 30 kHz tone must come back as the
+    strongest peak, and the 30 kHz tone must appear among the peaks."""
+    t = np.arange(2000) / 1e6  # 1 MHz sample rate -> 500 Hz FFT bins
+    v = 1.0 * np.sin(2 * np.pi * 10_000 * t) + 0.5 * np.sin(2 * np.pi * 30_000 * t)
+    spec = WaveformAnalyzer.calculate_spectrum(make_waveform(v))
+
+    assert abs(spec["fundamental_hz"] - 10_000) < 500  # within one bin
+    freqs = [f for f, _ in spec["dominant_peaks"]]
+    assert any(abs(f - 30_000) < 500 for f in freqs)
+
+
+def test_peaks_are_ordered_strongest_first_and_relative_to_the_strongest():
+    t = np.arange(2000) / 1e6
+    v = 1.0 * np.sin(2 * np.pi * 10_000 * t) + 0.5 * np.sin(2 * np.pi * 30_000 * t)
+    spec = WaveformAnalyzer.calculate_spectrum(make_waveform(v))
+
+    mags = [m for _, m in spec["dominant_peaks"]]
+    assert mags == sorted(mags, reverse=True)
+    assert mags[0] == 1.0  # strongest peak is the reference
+
+
+def test_square_wave_has_odd_harmonic_content():
+    """A square wave's 3rd harmonic is stronger than its 2nd (odd-harmonic rich).
+    This proves harmonic_ratios is populated and correctly ordered."""
+    t = np.arange(2000) / 1e6
+    v = np.where(np.sin(2 * np.pi * 5_000 * t) >= 0, 1.0, -1.0)
+    spec = WaveformAnalyzer.calculate_spectrum(make_waveform(v))
+
+    ratios = spec["harmonic_ratios"]
+    assert ratios is not None
+    assert ratios[0] == 1.0  # normalized to the fundamental
+    assert ratios[2] > ratios[1]  # 3rd harmonic > 2nd
+
+
+def test_degenerate_signal_returns_empty_rather_than_raising():
+    spec = WaveformAnalyzer.calculate_spectrum(make_waveform(np.array([0.0, 0.0, 0.0])))
+    assert spec["dominant_peaks"] == []
+    assert spec["fundamental_hz"] is None
+    assert spec["harmonic_ratios"] is None


### PR DESCRIPTION
## What this does

Adds three read-only analysis tools to the local Ollama model's report toolbox (following #64), so it can reach analyses the existing `analyze_waveform` umbrella doesn't cover:

- **`analyze_plateaus`** — per-plateau level, slope, flatness, drift and noise, for judging probe compensation and settling. Raw measured facts, no canned verdict — the model reasons from the slope.
- **`list_edges`** — where the rising/falling edges are and how many, complementing `analyze_waveform`'s single representative rise/fall time.
- **`analyze_spectrum`** — the dominant frequency peaks (in dB relative to the strongest) plus, for a periodic signal, the per-harmonic breakdown — richer than the single THD scalar.

Plus one supporting analyzer method, `WaveformAnalyzer.calculate_spectrum`, built from the FFT machinery already in `calculate_frequency_stats`.

Cross-channel comparison (delay/phase/gain between two channels) was scoped out to its own later sub-project — it's net-new analysis, not a wrapper.

**Local LLM only.** No cloud providers, keys, or provider surface added.

## The read-only guarantee (the load-bearing property)

Every tool is read-only over the report. `analyze_plateaus` is the one that touches the region-analysis machinery, which has a mutation trap: `WaveformAnalyzer.detect_regions` *appends* to `waveform.regions`. The tool deliberately uses `detect_plateaus` (which returns a **fresh list** and never touches `waveform.regions`) and then `analyze_region(..., calculate_calibration=False)` on each **throwaway** region — so nothing on the shared report is mutated, and no canned calibration verdict is attached. This is enforced three ways: the code path, a grep confirming `detect_regions`/`generate_calibration_guidance`/`.regions` appear nowhere under `report_generator/llm/`, and a regression test (`test_analyze_plateaus_does_not_mutate_the_report`).

## Honest, bounded output

`analyze_plateaus` caps its output at `MAX_PLATEAUS` and reports the **true total** ("19 found, showing first 8"), never a silent slice — the same lesson #64 learned when `detect_transients` silently discarded its count, and a dedicated test pins the true number rather than merely the truncation marker.

`list_edges` is the deliberate exception: `detect_edges` exposes no true total, so instead of fabricating one, the tool names the cap in its output (`max_edges=M`) so the model knows to raise it when the result is capped. That's the honest story for a bounded-input tool, not a silent truncation.

## Test coverage

Baseline `main` (`7371f89`): 884 passed / 19 skipped. This branch: **900 passed / 19 skipped** (+16). `black --check` clean, `flake8 E9,F63,F7,F82` = 0, across Python 3.9–3.14.

All tests are pure CPU over synthesized signals — no test constructs an `LLMClient`, so the live-Ollama network hazard from #64 is structurally absent from this work. `calculate_spectrum` gets its own dedicated pin against a signal with known frequency content.

## Not automated — manual verification owed

Success criterion 8 — a real tool-capable local model actually calling these tools and answering well — **cannot be proven by any test here** (it needs a live model and server, and no test may touch the network). This wants a manual check against the dev-machine Ollama with a real scope capture. **First thing to eyeball:** `analyze_spectrum` on a clean signal currently lists up to 5 spectral peaks, so a two-tone shows the 2 real tones plus ~3 near-Nyquist float-noise peaks at ~-295 dB. The data is honest and dB-labelled (the noise reads as unambiguously negligible), but a small model might parrot them — if it does, the fix is a relative-magnitude floor (drop peaks below ~1e-6 of the strongest). Deferred to this manual check per the design.

## Deferred follow-ups

- **Cross-channel comparison** — its own later sub-project.
- **`analyze_spectrum` noise-floor peaks** — the relative-floor tweak above, pending the manual check.
- **`list_edges` odd-`max_edges` cap signal** — the analyzer floors `max_edges // 2` per direction, so for odd values the "raise the cap" hint can't fire (data is never wrong; the default 4 and typical values are even). Analyzer-side fix.
- **Pre-existing `detect_edges` boundary `IndexError`** — a latent bug already on `main` (`t[end_idx]` out of bounds when a derivative peak sits in the last ~2% of samples). This branch makes it reachable from the model via `list_edges`, but the tool loop's `_run_tool` degrades any tool exception to an error string the model can recover from, so it can't crash the chat. Worth fixing in the analyzer (`min(len(t) - 1, idx + window)`).
- Minor docstring nuance on when `harmonic_ratios` is `None` (rarely, since `_get_harmonic_ratios` does no periodicity check).
