### PR TITLE
feat: PDF page framework - running header/footer + page numbers, no stranded headings

### DIFF
--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -7,6 +7,7 @@ company branding, and AI-generated insights.
 
 from __future__ import annotations
 
+import functools
 import io
 import logging
 import re
@@ -20,6 +21,7 @@ try:
     from reportlab.lib.pagesizes import A4, letter
     from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
     from reportlab.lib.units import inch
+    from reportlab.pdfgen import canvas
     from reportlab.platypus import Image as RLImage
     from reportlab.platypus import KeepTogether, PageBreak, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
     from reportlab.graphics.shapes import Drawing
@@ -57,6 +59,46 @@ def _svg_to_drawing(buf, max_width, max_height):
     drawing.width *= scale
     drawing.height *= scale
     return drawing
+
+
+class _NumberedCanvas(canvas.Canvas):
+    """Draws running page furniture (header on pages 2+, footer + 'Page X of Y'
+    on every page). Two-pass: it records each page's state on showPage, then draws
+    the furniture with the true total page count on save."""
+
+    def __init__(self, *args, furniture=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._furniture = furniture or {}
+        self._saved_states = []
+
+    def showPage(self):
+        self._saved_states.append(dict(self.__dict__))
+        self._startPage()
+
+    def save(self):
+        total = len(self._saved_states)
+        for index, state in enumerate(self._saved_states, start=1):
+            self.__dict__.update(state)
+            self._draw_furniture(index, total)
+            super().showPage()
+        super().save()
+
+    def _draw_furniture(self, page, total):
+        width, height = self._pagesize
+        self.setFont("Helvetica", 8)
+        self.setFillColor(colors.grey)
+        # Footer on every page: footer_text (left) + "Page X of Y" (right)
+        if self._furniture.get("footer_text"):
+            self.drawString(0.75 * inch, 0.5 * inch, self._furniture["footer_text"])
+        self.drawRightString(width - 0.75 * inch, 0.5 * inch, f"Page {page} of {total}")
+        # Running header on pages 2+ (page 1 already has the big title/logo block)
+        if page > 1:
+            if self._furniture.get("title"):
+                self.drawString(0.75 * inch, height - 0.6 * inch, self._furniture["title"])
+            if self._furniture.get("header_text"):
+                self.drawRightString(width - 0.75 * inch, height - 0.6 * inch, self._furniture["header_text"])
+            self.setStrokeColor(colors.lightgrey)
+            self.line(0.75 * inch, height - 0.7 * inch, width - 0.75 * inch, height - 0.7 * inch)
 
 
 class PDFReportGenerator(BaseReportGenerator):
@@ -392,7 +434,12 @@ class PDFReportGenerator(BaseReportGenerator):
             self._report_progress(88, "Building PDF document")
 
             # Build PDF
-            doc.build(story)
+            furniture = {
+                "title": report.metadata.title,
+                "header_text": report.metadata.header_text,
+                "footer_text": report.metadata.footer_text,
+            }
+            doc.build(story, canvasmaker=functools.partial(_NumberedCanvas, furniture=furniture))
 
             self._report_progress(100, "PDF generation complete")
 

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -61,44 +61,46 @@ def _svg_to_drawing(buf, max_width, max_height):
     return drawing
 
 
-class _NumberedCanvas(canvas.Canvas):
-    """Draws running page furniture (header on pages 2+, footer + 'Page X of Y'
-    on every page). Two-pass: it records each page's state on showPage, then draws
-    the furniture with the true total page count on save."""
+if REPORTLAB_AVAILABLE:
 
-    def __init__(self, *args, furniture=None, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._furniture = furniture or {}
-        self._saved_states = []
+    class _NumberedCanvas(canvas.Canvas):
+        """Draws running page furniture (header on pages 2+, footer + 'Page X of Y'
+        on every page). Two-pass: it records each page's state on showPage, then draws
+        the furniture with the true total page count on save."""
 
-    def showPage(self):
-        self._saved_states.append(dict(self.__dict__))
-        self._startPage()
+        def __init__(self, *args, furniture=None, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._furniture = furniture or {}
+            self._saved_states = []
 
-    def save(self):
-        total = len(self._saved_states)
-        for index, state in enumerate(self._saved_states, start=1):
-            self.__dict__.update(state)
-            self._draw_furniture(index, total)
-            super().showPage()
-        super().save()
+        def showPage(self):
+            self._saved_states.append(dict(self.__dict__))
+            self._startPage()
 
-    def _draw_furniture(self, page, total):
-        width, height = self._pagesize
-        self.setFont("Helvetica", 8)
-        self.setFillColor(colors.grey)
-        # Footer on every page: footer_text (left) + "Page X of Y" (right)
-        if self._furniture.get("footer_text"):
-            self.drawString(0.75 * inch, 0.5 * inch, self._furniture["footer_text"])
-        self.drawRightString(width - 0.75 * inch, 0.5 * inch, f"Page {page} of {total}")
-        # Running header on pages 2+ (page 1 already has the big title/logo block)
-        if page > 1:
-            if self._furniture.get("title"):
-                self.drawString(0.75 * inch, height - 0.6 * inch, self._furniture["title"])
-            if self._furniture.get("header_text"):
-                self.drawRightString(width - 0.75 * inch, height - 0.6 * inch, self._furniture["header_text"])
-            self.setStrokeColor(colors.lightgrey)
-            self.line(0.75 * inch, height - 0.7 * inch, width - 0.75 * inch, height - 0.7 * inch)
+        def save(self):
+            total = len(self._saved_states)
+            for index, state in enumerate(self._saved_states, start=1):
+                self.__dict__.update(state)
+                self._draw_furniture(index, total)
+                super().showPage()
+            super().save()
+
+        def _draw_furniture(self, page, total):
+            width, height = self._pagesize
+            self.setFont("Helvetica", 8)
+            self.setFillColor(colors.grey)
+            # Footer on every page: footer_text (left) + "Page X of Y" (right)
+            if self._furniture.get("footer_text"):
+                self.drawString(0.75 * inch, 0.5 * inch, self._furniture["footer_text"])
+            self.drawRightString(width - 0.75 * inch, 0.5 * inch, f"Page {page} of {total}")
+            # Running header on pages 2+ (page 1 already has the big title/logo block)
+            if page > 1:
+                if self._furniture.get("title"):
+                    self.drawString(0.75 * inch, height - 0.6 * inch, self._furniture["title"])
+                if self._furniture.get("header_text"):
+                    self.drawRightString(width - 0.75 * inch, height - 0.6 * inch, self._furniture["header_text"])
+                self.setStrokeColor(colors.lightgrey)
+                self.line(0.75 * inch, height - 0.7 * inch, width - 0.75 * inch, height - 0.7 * inch)
 
 
 class PDFReportGenerator(BaseReportGenerator):
@@ -408,8 +410,8 @@ class PDFReportGenerator(BaseReportGenerator):
                     section_percent = 20 + int((i / num_sections) * section_progress_range)
                     self._report_progress(section_percent, f"Processing section {i+1}/{num_sections}")
 
-                    # Pass waveform progress tracking
                     story.append(CondPageBreak(1.5 * inch))
+                    # Pass waveform progress tracking
                     story.extend(
                         self._generate_section(
                             section,

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -23,7 +23,7 @@ try:
     from reportlab.lib.units import inch
     from reportlab.pdfgen import canvas
     from reportlab.platypus import Image as RLImage
-    from reportlab.platypus import KeepTogether, PageBreak, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+    from reportlab.platypus import CondPageBreak, KeepTogether, PageBreak, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
     from reportlab.graphics.shapes import Drawing
     from svglib.svglib import svg2rlg
 
@@ -409,6 +409,7 @@ class PDFReportGenerator(BaseReportGenerator):
                     self._report_progress(section_percent, f"Processing section {i+1}/{num_sections}")
 
                     # Pass waveform progress tracking
+                    story.append(CondPageBreak(1.5 * inch))
                     story.extend(
                         self._generate_section(
                             section,

--- a/tests/test_generators_import_without_reportlab.py
+++ b/tests/test_generators_import_without_reportlab.py
@@ -1,0 +1,22 @@
+"""The report_generator.generators package must import even when reportlab is
+absent -- this is the CI condition. A module-level use of a reportlab name (e.g.
+subclassing canvas.Canvas) would raise NameError at import and crash unrelated
+CI tests. Run in a subprocess so blocking reportlab can't pollute this process."""
+
+import subprocess
+import sys
+
+
+def test_generators_package_imports_without_reportlab():
+    code = (
+        "import sys\n"
+        "class _Block:\n"
+        "    def find_spec(self, name, path=None, target=None):\n"
+        "        if name == 'reportlab' or name.startswith('reportlab.'):\n"
+        "            raise ImportError('reportlab blocked for this test')\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _Block())\n"
+        "import scpi_control.report_generator.generators  # must not raise\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, f"generators import crashed without reportlab:\n{result.stderr}"

--- a/tests/test_pdf_page_framework.py
+++ b/tests/test_pdf_page_framework.py
@@ -1,0 +1,75 @@
+"""Every PDF page gets a footer with a page number; pages 2+ get a running header.
+
+Needs reportlab + svglib + fitz (the report-generator extra) -- runs locally,
+skips in CI, like tests/test_report_generators.py.
+"""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+pytest.importorskip("reportlab")
+pytest.importorskip("svglib")
+fitz = pytest.importorskip("fitz")
+
+from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator  # noqa: E402
+from scpi_control.report_generator.models.report_data import (  # noqa: E402
+    ReportMetadata,
+    TestReport,
+    TestSection,
+    WaveformData,
+)
+
+RUN_HDR = "RUNNINGHEADERXYZ"
+FOOT = "CONFIDENTIALFOOTERXYZ"
+
+
+def make_waveforms(n):
+    t = np.arange(200) / 1e6
+    return [WaveformData(channel=f"C{i}", time=t, voltage=np.sin(2 * np.pi * 10_000 * t), sample_rate=1e6, record_length=200, label=f"Capture {i}") for i in range(n)]
+
+
+def make_report(n_waveforms=10, header_text=RUN_HDR, footer_text=FOOT):
+    md = ReportMetadata(title="Bench Check", technician="robin", test_date=datetime(2026, 7, 17), header_text=header_text, footer_text=footer_text)
+    return TestReport(metadata=md, sections=[TestSection(title="Captures", waveforms=make_waveforms(n_waveforms))])
+
+
+def test_every_page_has_a_page_number_and_footer_text(tmp_path):
+    out = tmp_path / "r.pdf"
+    assert PDFReportGenerator().generate(make_report(), str(out)) is True
+    doc = fitz.open(out)
+    try:
+        assert doc.page_count >= 2  # enough waveforms to span pages
+        total = doc.page_count
+        for i in range(total):
+            text = doc[i].get_text()
+            assert f"Page {i + 1} of {total}" in text  # footer page number on every page
+            assert FOOT in text  # footer_text on every page
+    finally:
+        doc.close()
+
+
+def test_running_header_is_on_pages_two_plus_only(tmp_path):
+    """header_text is drawn ONLY in the running header, so it is the clean
+    discriminator: absent on page 1 (which has the big title block instead),
+    present on pages 2+."""
+    out = tmp_path / "r.pdf"
+    assert PDFReportGenerator().generate(make_report(), str(out)) is True
+    doc = fitz.open(out)
+    try:
+        assert RUN_HDR not in doc[0].get_text()
+        assert RUN_HDR in doc[1].get_text()
+    finally:
+        doc.close()
+
+
+def test_report_without_header_footer_text_still_builds_with_page_numbers(tmp_path):
+    out = tmp_path / "r.pdf"
+    report = make_report(n_waveforms=1, header_text=None, footer_text=None)
+    assert PDFReportGenerator().generate(report, str(out)) is True
+    doc = fitz.open(out)
+    try:
+        assert "Page 1 of" in doc[0].get_text()  # page number always renders
+    finally:
+        doc.close()

--- a/tests/test_pdf_page_framework.py
+++ b/tests/test_pdf_page_framework.py
@@ -73,3 +73,26 @@ def test_report_without_header_footer_text_still_builds_with_page_numbers(tmp_pa
         assert "Page 1 of" in doc[0].get_text()  # page number always renders
     finally:
         doc.close()
+
+
+def test_a_multi_section_report_builds_to_a_valid_multipage_pdf(tmp_path):
+    """Integration: sections with CondPageBreaks between them still compile to a
+    valid multi-page PDF. (The anti-stranding EFFECT is layout-dependent and is
+    verified manually; this pins that the CondPageBreaks don't break the build.)"""
+    t = np.arange(200) / 1e6
+    sections = [
+        TestSection(title=f"Section {i}", content=f"Body {i}.", waveforms=[WaveformData(channel="C1", time=t, voltage=np.sin(2 * np.pi * 10_000 * t), sample_rate=1e6, record_length=200, label="C1")])
+        for i in range(6)
+    ]
+    report = TestReport(metadata=ReportMetadata(title="Bench", technician="robin", test_date=datetime(2026, 7, 17)), sections=sections)
+    out = tmp_path / "multi.pdf"
+    assert PDFReportGenerator().generate(report, str(out)) is True
+    doc = fitz.open(out)
+    try:
+        assert doc.page_count >= 2
+        # each section heading appears in the rendered text
+        text = "".join(doc[i].get_text() for i in range(doc.page_count))
+        for i in range(6):
+            assert f"Section {i}" in text
+    finally:
+        doc.close()


### PR DESCRIPTION
## What this does

Gives multi-page PDF reports a proper page framework: a running header and footer with **page numbers ("Page X of Y") on every page**, renders the `header_text`/`footer_text` metadata that was captured but never shown, and stops section headings from stranding at the bottom of a page.

This is the first of three **placement** pieces (page framework → image placement → item ordering); it is the page-framework + flow-control piece.

## Before / after

Today the PDF is a single flowing column: the header renders once at the top and the footer once at the very end, so on a multi-page report **pages 2+ are naked** — no branding, no page numbers. And `header_text`/`footer_text` are captured in the UI and saved but **never rendered anywhere** in the output.

After: every page has a footer with "Page X of Y", pages 2+ carry a compact running header (report title + `header_text`), and `footer_text` appears on every page. Page 1 keeps its full title/logo block; the existing end-of-document "generated on …" note is preserved.

## The change

- **`_NumberedCanvas`** — the standard reportlab two-pass `canvas.Canvas` subclass — draws the running header (pages 2+), the footer, and "Page X of Y" (which needs the total page count, hence the two-pass). It's wired via `doc.build(story, canvasmaker=functools.partial(_NumberedCanvas, furniture=...))`. `SimpleDocTemplate` and the flowable story are otherwise **unchanged** — the furniture is drawn in the page margins.
- **`header_text`/`footer_text` now render** (previously dead metadata).
- **Flow control:** a `CondPageBreak(1.5in)` before each section moves it to the next page when little space remains, so a heading no longer dangles at a page bottom. It's conditional, so short sections never waste a page.

Scope was kept tight: an explicit "new page per section" toggle, configurable margins, image placement, item ordering, and templates are all deliberately out of scope (later pieces).

## Verification

Baseline `main` (`68b67eb`): 919 passed / 19 skipped. This branch: **924 passed / 19 skipped** locally. `black --check` clean, `flake8 E9,F63,F7,F82` = 0.

The furniture-placement tests use PyMuPDF (`fitz`) to extract per-page text and assert the page numbers, running header (pages-2+-only, with `header_text` as the clean discriminator), and footer text land on the right pages. These guard with `pytest.importorskip`, so they run locally and skip in CI (existing PDF-test convention).

Layout was confirmed end-to-end: a generated **11-page** report (8 sections, header/footer text set) shows "Page X of 11" and the footer on every page, the running header absent on page 1 and present on later pages, and all 8 section headings intact. The anti-stranding *visual* is still worth a manual eyeball.

## A caught-in-review Critical worth calling out

The `_NumberedCanvas` class subclasses `canvas.Canvas`, which is imported inside the reportlab `try/except`. A module-level class base is evaluated at **import time**, so in an environment without reportlab (like CI's `.[dev,web]` test job) the class statement raised `NameError` — crashing the whole generators package import and taking down two unrelated CI tests. Everything passed locally because reportlab is installed here.

Fixed by wrapping the class in the existing `if REPORTLAB_AVAILABLE:` guard (it's only referenced inside `generate()`, which is already gated). And added a **regression test that runs in CI** (`test_generators_import_without_reportlab.py`): it imports the generators package in a subprocess with reportlab blocked and asserts it doesn't crash — closing this whole class of "module-level use of a gated dependency" bug for good.

## Follow-ups (cosmetic, non-blocking)

- A very long `header_text`/`footer_text` can overrun the page number horizontally (no crash) — needs measured truncation.
- The furniture fits the current hardcoded margins with clearance; re-check if margins ever become configurable.
