### PR TITLE
Template branding + built-in starter template

### DIFF
--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -42,6 +42,7 @@ from scpi_control.report_generator.generators.base import BaseReportGenerator
 from scpi_control.report_generator.models.plot_style import PlotStyle
 from scpi_control.report_generator.models.report_data import MeasurementResult, TestReport, TestSection, WaveformData, WaveformRegion
 from scpi_control.report_generator.models.report_options import ReportOptions
+from scpi_control.report_generator.models.template import BrandingTemplate
 from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
 
 logger = logging.getLogger(__name__)
@@ -115,6 +116,7 @@ class PDFReportGenerator(BaseReportGenerator):
         plot_style: PlotStyle = None,
         report_options: ReportOptions = None,
         progress_callback: Optional[Callable[[int, str], None]] = None,
+        branding=None,
     ):
         """
         Initialize PDF generator.
@@ -127,6 +129,8 @@ class PDFReportGenerator(BaseReportGenerator):
             plot_style: Plot style configuration for matplotlib plots
             report_options: Report options for statistics and other settings
             progress_callback: Optional callback function(progress_percent, status_message)
+            branding: Optional BrandingTemplate providing brand colors for the
+                report styles. Defaults to BrandingTemplate() (today's colors).
         """
         if not REPORTLAB_AVAILABLE:
             raise ImportError("reportlab is required for PDF generation. " "Install with: pip install reportlab")
@@ -142,6 +146,7 @@ class PDFReportGenerator(BaseReportGenerator):
         self.plot_style = plot_style or PlotStyle()
         self.report_options = report_options or ReportOptions()
         self.progress_callback = progress_callback
+        self.branding = branding or BrandingTemplate()
 
         # Set up styles
         self.styles = getSampleStyleSheet()
@@ -155,7 +160,7 @@ class PDFReportGenerator(BaseReportGenerator):
                 name="ReportTitle",
                 parent=self.styles["Heading1"],
                 fontSize=24,
-                textColor=colors.HexColor("#1f77b4"),
+                textColor=colors.HexColor(self.branding.primary_color),
                 spaceAfter=30,
                 alignment=TA_CENTER,
             )
@@ -167,7 +172,7 @@ class PDFReportGenerator(BaseReportGenerator):
                 name="SectionHeading",
                 parent=self.styles["Heading2"],
                 fontSize=16,
-                textColor=colors.HexColor("#1f77b4"),
+                textColor=colors.HexColor(self.branding.primary_color),
                 spaceAfter=12,
                 spaceBefore=20,
             )
@@ -179,7 +184,7 @@ class PDFReportGenerator(BaseReportGenerator):
                 name="SubsectionHeading",
                 parent=self.styles["Heading3"],
                 fontSize=14,
-                textColor=colors.HexColor("#2ca02c"),
+                textColor=colors.HexColor(self.branding.success_color),
                 spaceAfter=10,
                 spaceBefore=15,
             )
@@ -193,7 +198,7 @@ class PDFReportGenerator(BaseReportGenerator):
                     name="Heading4",
                     parent=self.styles["Heading3"],
                     fontSize=12,
-                    textColor=colors.HexColor("#ff7f0e"),
+                    textColor=colors.HexColor(self.branding.secondary_color),
                     spaceAfter=6,
                     spaceBefore=10,
                 )
@@ -205,7 +210,7 @@ class PDFReportGenerator(BaseReportGenerator):
                 name="ResultPass",
                 parent=self.styles["Normal"],
                 fontSize=18,
-                textColor=colors.HexColor("#2ca02c"),
+                textColor=colors.HexColor(self.branding.success_color),
                 alignment=TA_CENTER,
                 spaceAfter=20,
             )
@@ -217,7 +222,7 @@ class PDFReportGenerator(BaseReportGenerator):
                 name="ResultFail",
                 parent=self.styles["Normal"],
                 fontSize=18,
-                textColor=colors.HexColor("#d62728"),
+                textColor=colors.HexColor(self.branding.failure_color),
                 alignment=TA_CENTER,
                 spaceAfter=20,
             )

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -190,19 +190,10 @@ class PDFReportGenerator(BaseReportGenerator):
             )
         )
 
-        # Waveform heading (for individual waveforms)
-        # Only add if it doesn't exist
-        if "Heading4" not in self.styles:
-            self.styles.add(
-                ParagraphStyle(
-                    name="Heading4",
-                    parent=self.styles["Heading3"],
-                    fontSize=12,
-                    textColor=colors.HexColor(self.branding.secondary_color),
-                    spaceAfter=6,
-                    spaceBefore=10,
-                )
-            )
+        # Waveform heading (for individual waveforms). reportlab's sample stylesheet
+        # already ships a "Heading4", so recolor it with the brand's secondary color
+        # rather than adding a duplicate that the stylesheet would ignore.
+        self.styles["Heading4"].textColor = colors.HexColor(self.branding.secondary_color)
 
         # Result PASS style
         self.styles.add(

--- a/scpi_control/report_generator/main_window.py
+++ b/scpi_control/report_generator/main_window.py
@@ -41,7 +41,7 @@ from scpi_control.report_generator.models.app_settings import AppSettings
 from scpi_control.report_generator.models.plot_style import PlotStyle
 from scpi_control.report_generator.models.report_data import SUMMARY_SOURCE_AI, TestReport, TestSection, WaveformData
 from scpi_control.report_generator.models.report_options import ReportOptions
-from scpi_control.report_generator.models.template import ReportTemplate
+from scpi_control.report_generator.models.template import BrandingTemplate, ReportTemplate
 from scpi_control.report_generator.utils.waveform_loader import WaveformLoader
 
 try:
@@ -406,6 +406,8 @@ class MainWindow(QMainWindow):
                         progress.setLabelText(f"Generating PDF... {percent}%")
                     QApplication.processEvents()  # Keep UI responsive
 
+                branding = BrandingTemplate(**self.metadata_panel.get_branding_colors())
+
                 generator = PDFReportGenerator(
                     page_size=page_size,
                     include_plots=self.current_options.include_waveform_plots,
@@ -414,6 +416,7 @@ class MainWindow(QMainWindow):
                     plot_style=plot_style,
                     report_options=self.current_options,
                     progress_callback=update_progress,
+                    branding=branding,
                 )
 
                 success = generator.generate(report, temp_pdf_path)
@@ -745,6 +748,19 @@ class MainWindow(QMainWindow):
         self.current_options.plot_height_inches = template.plot_height_inches
         self.current_options.plot_dpi = template.plot_dpi
 
+        # Apply the template's branding (logo/company/header/footer + colors)
+        metadata = self.metadata_panel.get_metadata()
+        template.branding.apply_to_metadata(metadata)
+        self.metadata_panel.set_metadata(metadata)
+        self.metadata_panel.set_branding_colors(
+            {
+                "primary_color": template.branding.primary_color,
+                "secondary_color": template.branding.secondary_color,
+                "success_color": template.branding.success_color,
+                "failure_color": template.branding.failure_color,
+            }
+        )
+
         self.statusBar().showMessage(f"Loaded template: {template.name}")
 
     def _save_template(self):
@@ -798,6 +814,7 @@ class MainWindow(QMainWindow):
                 default_temperature=metadata.temperature,
                 default_humidity=metadata.humidity,
                 default_location=metadata.location,
+                branding=BrandingTemplate.from_metadata(metadata, colors=self.metadata_panel.get_branding_colors()),
             )
 
             if self.llm_config:

--- a/scpi_control/report_generator/models/template.py
+++ b/scpi_control/report_generator/models/template.py
@@ -90,6 +90,32 @@ class BrandingTemplate:
             data["company_logo_path"] = Path(data["company_logo_path"])
         return cls(**data)
 
+    def apply_to_metadata(self, metadata) -> None:
+        """Copy this branding's logo/company/header/footer into a ReportMetadata,
+        only where set -- an empty branding field never overwrites the metadata."""
+        if self.company_name:
+            metadata.company_name = self.company_name
+        if self.company_logo_path:
+            metadata.company_logo_path = self.company_logo_path
+        if self.header_text:
+            metadata.header_text = self.header_text
+        if self.footer_text:
+            metadata.footer_text = self.footer_text
+
+    @classmethod
+    def from_metadata(cls, metadata, colors=None) -> "BrandingTemplate":
+        """Capture a report's logo/company/header/footer (and optional color
+        overrides) into a new BrandingTemplate. `colors` is a dict of any of
+        primary_color/secondary_color/success_color/failure_color; unspecified
+        colors keep the class defaults."""
+        return cls(
+            company_name=metadata.company_name,
+            company_logo_path=metadata.company_logo_path,
+            header_text=metadata.header_text,
+            footer_text=metadata.footer_text,
+            **(colors or {}),
+        )
+
 
 @dataclass
 class ReportTemplate:

--- a/scpi_control/report_generator/widgets/metadata_panel.py
+++ b/scpi_control/report_generator/widgets/metadata_panel.py
@@ -9,10 +9,27 @@ from datetime import datetime
 from pathlib import Path
 
 from PyQt6.QtCore import QDateTime, Qt, pyqtSignal
-from PyQt6.QtWidgets import QComboBox, QDateTimeEdit, QFileDialog, QFormLayout, QGroupBox, QLineEdit, QPushButton, QTextEdit, QVBoxLayout, QWidget
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import QColorDialog, QComboBox, QDateTimeEdit, QFileDialog, QFormLayout, QGroupBox, QLineEdit, QPushButton, QTextEdit, QVBoxLayout, QWidget
 
 from scpi_control.report_generator.models.report_data import ReportMetadata
 from scpi_control.report_generator.models.test_types import get_test_type_names
+
+#: Default brand colors, matching `BrandingTemplate`'s field defaults.
+DEFAULT_BRAND_COLORS = {
+    "primary_color": "#1f77b4",
+    "secondary_color": "#ff7f0e",
+    "success_color": "#2ca02c",
+    "failure_color": "#d62728",
+}
+
+#: Human-readable labels for each brand color key, used for button/dialog titles.
+BRAND_COLOR_LABELS = {
+    "primary_color": "Title",
+    "secondary_color": "Heading",
+    "success_color": "Pass",
+    "failure_color": "Fail",
+}
 
 
 class MetadataPanel(QWidget):
@@ -30,6 +47,7 @@ class MetadataPanel(QWidget):
         super().__init__(parent)
 
         self.company_logo_path = None
+        self._brand_colors = dict(DEFAULT_BRAND_COLORS)
 
         self._setup_ui()
 
@@ -147,6 +165,30 @@ class MetadataPanel(QWidget):
 
         branding_layout.addRow("Logo:", logo_layout)
 
+        self.title_color_btn = QPushButton()
+        self.title_color_btn.clicked.connect(lambda: self._pick_color("primary_color"))
+        branding_layout.addRow("Title Color:", self.title_color_btn)
+
+        self.heading_color_btn = QPushButton()
+        self.heading_color_btn.clicked.connect(lambda: self._pick_color("secondary_color"))
+        branding_layout.addRow("Heading Color:", self.heading_color_btn)
+
+        self.pass_color_btn = QPushButton()
+        self.pass_color_btn.clicked.connect(lambda: self._pick_color("success_color"))
+        branding_layout.addRow("Pass Color:", self.pass_color_btn)
+
+        self.fail_color_btn = QPushButton()
+        self.fail_color_btn.clicked.connect(lambda: self._pick_color("failure_color"))
+        branding_layout.addRow("Fail Color:", self.fail_color_btn)
+
+        self._color_buttons = {
+            "primary_color": self.title_color_btn,
+            "secondary_color": self.heading_color_btn,
+            "success_color": self.pass_color_btn,
+            "failure_color": self.fail_color_btn,
+        }
+        self._refresh_color_swatches()
+
         self.header_edit = QLineEdit()
         self.header_edit.setPlaceholderText("e.g., CONFIDENTIAL")
         self.header_edit.textChanged.connect(self.metadata_changed.emit)
@@ -190,6 +232,48 @@ class MetadataPanel(QWidget):
             self.company_logo_path = Path(file_path)
             self.logo_path_label.setText(str(self.company_logo_path))
             self.metadata_changed.emit()
+
+    def _pick_color(self, key: str):
+        """
+        Open a color picker dialog for one brand color.
+
+        Args:
+            key: One of "primary_color", "secondary_color", "success_color", "failure_color".
+        """
+        label = BRAND_COLOR_LABELS.get(key, key)
+        current_color = QColor(self._brand_colors[key])
+        color = QColorDialog.getColor(current_color, self, f"Select {label} Color")
+
+        if color.isValid():
+            self._brand_colors[key] = color.name()
+            self._refresh_color_swatches()
+            self.metadata_changed.emit()
+
+    def _refresh_color_swatches(self):
+        """Re-paint the four brand color buttons to match `self._brand_colors`."""
+        for key, button in self._color_buttons.items():
+            button.setStyleSheet(f"background-color: {self._brand_colors[key]}")
+
+    def get_branding_colors(self) -> dict:
+        """
+        Get the current brand colors.
+
+        Returns:
+            Dict with keys "primary_color", "secondary_color", "success_color", "failure_color".
+        """
+        return dict(self._brand_colors)
+
+    def set_branding_colors(self, colors: dict) -> None:
+        """
+        Load brand colors into the form, updating only the keys present in `colors`.
+
+        Args:
+            colors: Dict of brand color hex strings, keyed as in get_branding_colors().
+        """
+        for key in self._brand_colors:
+            if colors.get(key):
+                self._brand_colors[key] = colors[key]
+        self._refresh_color_swatches()
 
     def get_metadata(self) -> ReportMetadata:
         """
@@ -295,5 +379,7 @@ class MetadataPanel(QWidget):
         self.company_name_edit.clear()
         self.company_logo_path = None
         self.logo_path_label.clear()
+        self._brand_colors = dict(DEFAULT_BRAND_COLORS)
+        self._refresh_color_swatches()
         self.header_edit.clear()
         self.footer_edit.clear()

--- a/scpi_control/report_generator/widgets/template_manager_dialog.py
+++ b/scpi_control/report_generator/widgets/template_manager_dialog.py
@@ -62,6 +62,13 @@ class TemplateManagerDialog(QDialog):
         export_btn.clicked.connect(self._export_template)
         action_layout.addWidget(export_btn)
 
+        create_default_btn = QPushButton("Create Default Template")
+        create_default_btn.setToolTip(
+            "Adds a starter template with standard defaults, report options, and branding colors. " "Its sections are carried for future use but are not yet applied when the template is loaded."
+        )
+        create_default_btn.clicked.connect(self._create_default_template)
+        action_layout.addWidget(create_default_btn)
+
         left_layout.addLayout(action_layout)
 
         layout.addLayout(left_layout, 60)
@@ -352,6 +359,28 @@ class TemplateManagerDialog(QDialog):
                 self,
                 "Error Importing Template",
                 f"Failed to import template:\n{str(e)}",
+            )
+
+    def _create_default_template(self):
+        """Create and save the built-in default template to the library."""
+        try:
+            template = ReportTemplate.create_default_template()
+
+            template.save_to_library()
+
+            QMessageBox.information(
+                self,
+                "Default Template Created",
+                f"Template '{template.name}' created successfully.\n" "Its sections are not yet applied when the template is loaded.",
+            )
+
+            self._refresh_template_list()
+
+        except Exception as e:
+            QMessageBox.critical(
+                self,
+                "Error Creating Default Template",
+                f"Failed to create default template:\n{str(e)}",
             )
 
     def _export_template(self):

--- a/tests/test_branding_template.py
+++ b/tests/test_branding_template.py
@@ -1,0 +1,51 @@
+"""BrandingTemplate applies to / captures from a ReportMetadata. Pure model, no Qt, no reportlab."""
+
+from datetime import datetime
+
+from scpi_control.report_generator.models.report_data import ReportMetadata
+from scpi_control.report_generator.models.template import BrandingTemplate
+
+
+def bare_metadata():
+    return ReportMetadata(title="Bench", technician="robin", test_date=datetime(2026, 7, 17))
+
+
+def test_apply_to_metadata_sets_all_branding_fields():
+    branding = BrandingTemplate(company_name="ACME", header_text="H", footer_text="F")
+    md = bare_metadata()
+    branding.apply_to_metadata(md)
+    assert md.company_name == "ACME"
+    assert md.header_text == "H"
+    assert md.footer_text == "F"
+
+
+def test_apply_to_metadata_does_not_overwrite_with_empty_branding():
+    """A branding with no company_name must not wipe an existing one."""
+    md = bare_metadata()
+    md.company_name = "Existing Co"
+    BrandingTemplate(company_name=None, header_text="H").apply_to_metadata(md)
+    assert md.company_name == "Existing Co"  # preserved
+    assert md.header_text == "H"  # applied
+
+
+def test_from_metadata_captures_text_and_colors():
+    md = bare_metadata()
+    md.company_name = "ACME"
+    md.header_text = "H"
+    branding = BrandingTemplate.from_metadata(md, colors={"primary_color": "#ff0000", "failure_color": "#00ff00"})
+    assert branding.company_name == "ACME"
+    assert branding.header_text == "H"
+    assert branding.primary_color == "#ff0000"
+    assert branding.failure_color == "#00ff00"
+    # unspecified colors keep the defaults
+    assert branding.secondary_color == "#ff7f0e"
+
+
+def test_apply_capture_round_trips():
+    original = BrandingTemplate(company_name="ACME", footer_text="F", primary_color="#123456")
+    md = bare_metadata()
+    original.apply_to_metadata(md)
+    recaptured = BrandingTemplate.from_metadata(md, colors={"primary_color": original.primary_color})
+    assert recaptured.company_name == original.company_name
+    assert recaptured.footer_text == original.footer_text
+    assert recaptured.primary_color == original.primary_color

--- a/tests/test_default_template.py
+++ b/tests/test_default_template.py
@@ -1,0 +1,19 @@
+"""ReportTemplate.create_default_template ships a valid, round-trippable starter
+template with branding and 6 sections. Pure model, no Qt, no reportlab."""
+
+from scpi_control.report_generator.models.template import BrandingTemplate, ReportTemplate
+
+
+def test_default_template_has_branding_and_six_sections():
+    t = ReportTemplate.create_default_template()
+    assert isinstance(t.branding, BrandingTemplate)
+    assert len(t.sections) == 6
+    assert t.name  # named
+
+
+def test_default_template_round_trips():
+    t = ReportTemplate.create_default_template()
+    restored = ReportTemplate.from_dict(t.to_dict())
+    assert restored.name == t.name
+    assert len(restored.sections) == 6
+    assert restored.branding.primary_color == t.branding.primary_color

--- a/tests/test_pdf_branding_colors.py
+++ b/tests/test_pdf_branding_colors.py
@@ -1,0 +1,27 @@
+"""PDFReportGenerator threads a template's brand colors into its styles; a
+no-branding generator keeps today's defaults. Needs reportlab (skips in CI)."""
+
+import pytest
+
+pytest.importorskip("reportlab")
+
+from reportlab.lib import colors  # noqa: E402
+
+from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator  # noqa: E402
+from scpi_control.report_generator.models.template import BrandingTemplate  # noqa: E402
+
+
+def test_branding_colors_reach_the_styles():
+    branding = BrandingTemplate(primary_color="#010203", secondary_color="#040506", success_color="#070809", failure_color="#0a0b0c")
+    gen = PDFReportGenerator(branding=branding)
+    assert gen.styles["ReportTitle"].textColor == colors.HexColor("#010203")  # primary
+    assert gen.styles["SectionHeading"].textColor == colors.HexColor("#010203")  # primary
+    assert gen.styles["SubsectionHeading"].textColor == colors.HexColor("#070809")  # success
+    assert gen.styles["ResultPass"].textColor == colors.HexColor("#070809")  # success
+    assert gen.styles["ResultFail"].textColor == colors.HexColor("#0a0b0c")  # failure
+
+
+def test_no_branding_keeps_todays_default_colors():
+    gen = PDFReportGenerator()  # no branding
+    assert gen.styles["ReportTitle"].textColor == colors.HexColor("#1f77b4")
+    assert gen.styles["ResultFail"].textColor == colors.HexColor("#d62728")

--- a/tests/test_pdf_branding_colors.py
+++ b/tests/test_pdf_branding_colors.py
@@ -17,6 +17,7 @@ def test_branding_colors_reach_the_styles():
     assert gen.styles["ReportTitle"].textColor == colors.HexColor("#010203")  # primary
     assert gen.styles["SectionHeading"].textColor == colors.HexColor("#010203")  # primary
     assert gen.styles["SubsectionHeading"].textColor == colors.HexColor("#070809")  # success
+    assert gen.styles["Heading4"].textColor == colors.HexColor("#040506")  # secondary
     assert gen.styles["ResultPass"].textColor == colors.HexColor("#070809")  # success
     assert gen.styles["ResultFail"].textColor == colors.HexColor("#0a0b0c")  # failure
 
@@ -24,4 +25,5 @@ def test_branding_colors_reach_the_styles():
 def test_no_branding_keeps_todays_default_colors():
     gen = PDFReportGenerator()  # no branding
     assert gen.styles["ReportTitle"].textColor == colors.HexColor("#1f77b4")
+    assert gen.styles["Heading4"].textColor == colors.HexColor("#ff7f0e")  # secondary default, now live
     assert gen.styles["ResultFail"].textColor == colors.HexColor("#d62728")


### PR DESCRIPTION
## Template branding + built-in starter template

Report **templates now carry branding** — a template's logo, company name, header/footer text, and four brand colours actually apply to the generated PDF — and a fresh user can seed a **built-in starter template** instead of facing an empty library. This is the first templates piece; section composition and pass/fail criteria remain deferred.

### What changed

- **`BrandingTemplate.apply_to_metadata` / `from_metadata`** (`models/template.py`) — the mechanism that copies a template's logo/company/header/footer into a `ReportMetadata`, only where set (an empty branding field never wipes an existing value).
- **`PDFReportGenerator(branding=...)`** (`generators/pdf_generator.py`) — threads the four brand colours into the report's title / section / subsection / heading / pass / fail styles. With no branding it falls back to `BrandingTemplate()`, whose defaults equal the former hardcoded literals.
- **Metadata-panel colour pickers** (`widgets/metadata_panel.py`) — four `QColorDialog` swatch buttons (Title/primary, Heading/secondary, Pass/success, Fail/failure) with `get_branding_colors()` / `set_branding_colors()`.
- **main_window wiring** (`main_window.py`) — loading a template applies its branding (text/logo → panel, colours → pickers); **Save as Template** captures the current branding; PDF generation threads the panel's colours into the generator.
- **Built-in default template** (`widgets/template_manager_dialog.py`) — a "Create Default Template" action seeds `ReportTemplate.create_default_template()` (6 sections + branding) into the library.

### Notable fix (whole-branch review)

The **heading colour was a dead control**: the branded `Heading4` style was added under `if "Heading4" not in self.styles:`, but reportlab's sample stylesheet already ships `Heading4`, so the block never ran and the picker did nothing — waveform sub-headings had *always* rendered black, on `main` too (not a regression). The existing Heading4 is now recoloured directly. **Consequence, intended:** a no-template report's waveform sub-headings change from black to the palette's orange (`#ff7f0e`), completing the four-colour scheme (blue title / orange heading / green pass / red fail). All other no-branding output is byte-identical to before.

### Honest scope

The starter template carries 6 sections, but **section composition is not yet applied on load** — loading a template still produces the single hardcoded "Waveform Captures" section. The Template Manager action's tooltip and success message say so. Pass/fail criteria remain blocked on a missing measurements producer.

### Tests

Full suite **932 passed / 19 skipped** (+8 over the `main` baseline). New: `apply_to_metadata`/`from_metadata` round-trips, the generator colour mappings (incl. the byte-identical default and the now-live heading colour), and the default-template validity/round-trip. reportlab-dependent tests use `pytest.importorskip` (run locally, skip in CI); the no-reportlab import-safety guard still passes.

### Follow-ups (tracked, out of scope here)

Section composition on load; pass/fail criteria; remaining hardcoded table/box colour literals; the Options/Template field-duplication refactor; hex validation on `set_branding_colors`; a few missing type annotations.
