### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-07-17
+
 ### ⚠️ Breaking Changes
 
 - **The report generator's `WaveformData` fields are renamed, and `channel`
@@ -49,6 +51,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   MSO58LP, MSO64), including 6- and 8-channel models.
 - Badge-based measurements for the modern Tektronix MSO families, which also
   enables `measure()` on the MSO 2-Series.
+- **Report generator — local-LLM analysis and richer PDFs**
+  (`pip install "SCPI-Instrument-Control[report-generator]"`). Everything here
+  is local-only — no cloud providers, no API keys.
+  - Local-LLM (Ollama) tool calling: the model can call read-only report tools
+    to ground its answers, behind a capability gate that no-ops when the local
+    model cannot do tool calls.
+  - Waveform analysis tools for the model — `analyze_plateaus`, `list_edges`,
+    and `analyze_spectrum` — plus `WaveformAnalyzer.calculate_spectrum`.
+  - Deterministic no-LLM analysis: a `ComputedAnalyzer` populates per-waveform
+    statistics and regions on every report, and composes a summary, findings,
+    and recommendations when no LLM wrote them. Reports now attribute their
+    summary by source (manual / AI / computed) rather than a bare AI flag.
+  - Vector PDF plots: waveform, FFT, and region plots render as scalable vector
+    graphics instead of rasterized images.
+  - Page framework: a running header/footer and page numbers on every page,
+    with section headings kept from stranding at the bottom of a page.
+  - Template branding: a template's logo, company name, header/footer text, and
+    four brand colours apply to the generated PDF, and a built-in starter
+    template can be seeded from the Template Manager.
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "2.0.0"
+version = "3.0.0"
 description = "Universal Python library for controlling SCPI-compatible test equipment via Ethernet/LAN. Supports oscilloscopes (Siglent SDS series, generic SCPI scopes), function generators/AWGs (Siglent SDG series, generic SCPI AWGs), and power supplies (Siglent SPD series, generic SCPI PSUs). Features include waveform capture, measurements, FFT analysis, PyQt6 GUI, automated report generation with AI analysis, and comprehensive SCPI command abstraction."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "2.0.0"
+__version__ = "3.0.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
## Release 3.0.0

The first release since v2.0.0 (2026-07-15). A **major** bump: the accumulated `[Unreleased]` changelog documents breaking API changes.

### Version
- `2.0.0 → 3.0.0` in `pyproject.toml` and `scpi_control/__init__.py` (kept consistent).

### Changelog
- Converted the accumulated `[Unreleased]` section into `## [3.0.0] - 2026-07-17` and started a fresh empty `[Unreleased]`.
- **Recorded the report-generator feature series (#64–#69)**, which hadn't been in the changelog: local-LLM tool calling, waveform analysis tools, deterministic no-LLM analysis, vector PDF plots, the PDF page framework (running header/footer + page numbers), and template branding + starter template.
- The breaking changes driving the major bump (WaveformData field rename/reorder, removed `source`/`description`, `timebase`/`voltage_scale` now `None`, trigger features raising instead of timing out) were already recorded under `[Unreleased]`.

### What happens after merge
Merging this is the release trigger. Next steps (automated): tag `v3.0.0`, create the GitHub Release → `publish.yml` builds the webapp frontend and the package and publishes to PyPI via trusted publishing (OIDC). A `workflow_dispatch` fallback covers the known case where the `release: published` event doesn't dispatch the workflow.

### Verification
- Full suite: **932 passed / 19 skipped**.
- Version files consistent; changelog validated (exactly one `[Unreleased]`, one `[3.0.0]`); no test pins the version string.
