### PR TITLE
Polish report-generator LLM prompts: shared grounding rule + tolerant list parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Report generator AI: every oscilloscope system prompt now carries one shared grounding rule (claim only what the report data or a tool actually returned; say so plainly when a value is missing rather than inventing it).
+- Report generator AI: key-findings and recommendations are parsed more tolerantly — multi-digit numbering, markdown-bold list markers, and a leading preamble line no longer corrupt the extracted list.
+
 ## [3.0.0] - 2026-07-17
 
 ### ⚠️ Breaking Changes

--- a/scpi_control/report_generator/llm/analyzer.py
+++ b/scpi_control/report_generator/llm/analyzer.py
@@ -23,6 +23,21 @@ logger = logging.getLogger(__name__)
 _LIST_ITEM = re.compile(r"^\s*\*{0,2}\s*(?:\d+[.)]|[-*•])\*{0,2}\s+")
 
 
+def _unwrap_bold(text: str) -> str:
+    """Remove a markdown emphasis wrapper only when it surrounds the WHOLE item.
+
+    ``**foo**`` -> ``foo`` and ``*foo*`` -> ``foo``, but a partially-bolded item
+    like ``**foo** bar`` or a leading glob like ``*.tmp`` is left untouched --
+    stripping those would strand an interior marker or eat real content.
+    """
+    for marker in ("**", "*"):
+        if len(text) > 2 * len(marker) and text.startswith(marker) and text.endswith(marker):
+            inner = text[len(marker) : -len(marker)].strip()
+            if inner:
+                return inner
+    return text
+
+
 def _parse_numbered_list(text: Optional[str], max_items: int) -> Optional[List[str]]:
     """Parse a model's numbered/bulleted list into clean items.
 
@@ -37,7 +52,7 @@ def _parse_numbered_list(text: Optional[str], max_items: int) -> Optional[List[s
     if not text:
         return None
     lines = [line.strip() for line in text.strip().splitlines() if line.strip()]
-    items = [line[m.end() :].strip().strip("*").strip() for line in lines if (m := _LIST_ITEM.match(line))]
+    items = [_unwrap_bold(line[m.end() :].strip()) for line in lines if (m := _LIST_ITEM.match(line))]
     if not items:
         items = [line for line in lines if not line.endswith(":")]
     items = [item for item in items if item]

--- a/scpi_control/report_generator/llm/analyzer.py
+++ b/scpi_control/report_generator/llm/analyzer.py
@@ -5,6 +5,7 @@ Provides convenient methods for common analysis tasks.
 """
 
 import logging
+import re
 from typing import List, Optional
 
 from scpi_control.report_generator.llm.client import LLMClient
@@ -14,6 +15,33 @@ from scpi_control.report_generator.llm.tools import ReportTools
 from scpi_control.report_generator.models.report_data import MeasurementResult, TestReport
 
 logger = logging.getLogger(__name__)
+
+# The local model is asked for a numbered list but does not always oblige: it
+# may bold the numbers, count past 9, or open with a "Here are the findings:"
+# line. Match list markers tolerantly; if the reply has no markers at all,
+# salvage its non-preamble lines rather than returning nothing.
+_LIST_ITEM = re.compile(r"^\s*\*{0,2}\s*(?:\d+[.)]|[-*•])\*{0,2}\s+")
+
+
+def _parse_numbered_list(text: Optional[str], max_items: int) -> Optional[List[str]]:
+    """Parse a model's numbered/bulleted list into clean items.
+
+    Handles multi-digit prefixes, markdown-bold numbering (``**1.**``), and a
+    leading preamble line. Falls back to plain non-preamble lines when the model
+    emits no list markers at all. Returns None for empty/whitespace/None input.
+
+    Args:
+        text: The raw model reply.
+        max_items: Cap on the number of items returned.
+    """
+    if not text:
+        return None
+    lines = [line.strip() for line in text.strip().splitlines() if line.strip()]
+    items = [line[m.end() :].strip().strip("*").strip() for line in lines if (m := _LIST_ITEM.match(line))]
+    if not items:
+        items = [line for line in lines if not line.endswith(":")]
+    items = [item for item in items if item]
+    return items[:max_items] if items else None
 
 
 class ReportAnalyzer:
@@ -215,7 +243,8 @@ class ReportAnalyzer:
 
         prompt = (
             f"Please identify the {max_findings} most important findings from this test report. "
-            "Return them as a numbered list, with each finding on its own line. "
+            "Return ONLY a numbered list, one finding per line, starting at '1.'. "
+            "No heading, no preamble, no text before the first item or after the last. "
             "Focus on the most significant results, issues, or noteworthy observations.\n\n"
             "=== TEST REPORT ===\n\n"
         )
@@ -227,26 +256,7 @@ class ReportAnalyzer:
             temperature=0.7,
         )
 
-        if not response:
-            return None
-
-        # Parse numbered list into individual findings
-        findings = []
-        for line in response.strip().split("\n"):
-            line = line.strip()
-            if not line:
-                continue
-
-            # Remove list numbering (e.g., "1.", "1)", "- ", etc.)
-            for prefix in ["1.", "2.", "3.", "4.", "5.", "6.", "7.", "8.", "9.", "1)", "2)", "3)", "4)", "5)", "6)", "7)", "8)", "9)", "- ", "* ", "• "]:
-                if line.startswith(prefix):
-                    line = line[len(prefix) :].strip()
-                    break
-
-            if line:
-                findings.append(line)
-
-        return findings[:max_findings] if findings else None
+        return _parse_numbered_list(response, max_findings)
 
     def generate_recommendations(self, report: TestReport, max_recommendations: int = 5) -> Optional[List[str]]:
         """
@@ -265,7 +275,8 @@ class ReportAnalyzer:
         prompt = (
             f"Based on this test report, provide {max_recommendations} specific, actionable recommendations. "
             "These should be practical next steps or suggestions for the technician. "
-            "Return them as a numbered list, with each recommendation on its own line. "
+            "Return ONLY a numbered list, one recommendation per line, starting at '1.'. "
+            "No heading, no preamble, no text before the first item or after the last. "
             "Focus on what actions should be taken based on the results.\n\n"
             "=== TEST REPORT ===\n\n"
         )
@@ -277,23 +288,4 @@ class ReportAnalyzer:
             temperature=0.7,
         )
 
-        if not response:
-            return None
-
-        # Parse numbered list into individual recommendations
-        recommendations = []
-        for line in response.strip().split("\n"):
-            line = line.strip()
-            if not line:
-                continue
-
-            # Remove list numbering (e.g., "1.", "1)", "- ", etc.)
-            for prefix in ["1.", "2.", "3.", "4.", "5.", "6.", "7.", "8.", "9.", "1)", "2)", "3)", "4)", "5)", "6)", "7)", "8)", "9)", "- ", "* ", "• "]:
-                if line.startswith(prefix):
-                    line = line[len(prefix) :].strip()
-                    break
-
-            if line:
-                recommendations.append(line)
-
-        return recommendations[:max_recommendations] if recommendations else None
+        return _parse_numbered_list(response, max_recommendations)

--- a/scpi_control/report_generator/llm/prompts.py
+++ b/scpi_control/report_generator/llm/prompts.py
@@ -5,7 +5,20 @@ Contains expert knowledge about oscilloscopes, signal analysis,
 and test procedures to guide LLM responses.
 """
 
-OSCILLOSCOPE_EXPERT_SYSTEM_PROMPT = """You are an expert oscilloscope technician and test engineer with deep knowledge of:
+# One grounding rule, interpolated into every system prompt below so it cannot
+# drift across six hand-edited copies. Worded to cover both data sources: the
+# static report context (five prompts) and tool results (chat_tools).
+# NOTE: the prompts that embed this are f-strings — keep literal braces out of
+# their bodies, or double them ({{ }}).
+_GROUNDING = (
+    "Ground every statement in the data available to you — the values in the "
+    "report context you were given, or the results a tool returned. Cite specific "
+    "values rather than describing them vaguely. Never invent or estimate a value: "
+    "if a specific number or detail isn't in the data you have, say so plainly "
+    "instead of guessing."
+)
+
+OSCILLOSCOPE_EXPERT_SYSTEM_PROMPT = f"""You are an expert oscilloscope technician and test engineer with deep knowledge of:
 
 - Digital oscilloscope operation and measurement techniques
 - Signal analysis (time domain and frequency domain)
@@ -22,9 +35,11 @@ When analyzing test reports:
 - Consider both time-domain and frequency-domain characteristics
 - Relate measurements to real-world circuit behavior
 
-Your responses should be professional, accurate, and helpful for both experienced engineers and technicians learning the craft."""
+Your responses should be professional, accurate, and helpful for both experienced engineers and technicians learning the craft.
 
-REPORT_SUMMARY_SYSTEM_PROMPT = """You are writing an executive summary for an oscilloscope test report.
+{_GROUNDING}"""
+
+REPORT_SUMMARY_SYSTEM_PROMPT = f"""You are writing an executive summary for an oscilloscope test report.
 
 Your summary should:
 - Start with the overall test result (PASS/FAIL)
@@ -34,9 +49,13 @@ Your summary should:
 - Use clear, professional language suitable for technical stakeholders
 - Avoid unnecessary jargon, but be technically accurate
 
-Focus on what matters most: overall test outcome, significant deviations from expected values, and any actions needed."""
+Focus on what matters most: overall test outcome, significant deviations from expected values, and any actions needed.
 
-WAVEFORM_ANALYSIS_SYSTEM_PROMPT = """You are analyzing oscilloscope waveform data to assess signal quality and integrity.
+Write only the summary itself — no 'Here is the summary' preamble and no closing remarks.
+
+{_GROUNDING}"""
+
+WAVEFORM_ANALYSIS_SYSTEM_PROMPT = f"""You are analyzing oscilloscope waveform data to assess signal quality and integrity.
 
 Consider these key aspects:
 - Signal-to-noise ratio (SNR) - is the signal clean?
@@ -52,9 +71,11 @@ Your analysis should:
 - Suggest potential root causes for problems
 - Recommend improvements or further investigation if needed
 
-Be specific and reference actual measurement values."""
+Be specific and reference actual measurement values.
 
-PASS_FAIL_INTERPRETATION_SYSTEM_PROMPT = """You are interpreting pass/fail measurement results from an oscilloscope test.
+{_GROUNDING}"""
+
+PASS_FAIL_INTERPRETATION_SYSTEM_PROMPT = f"""You are interpreting pass/fail measurement results from an oscilloscope test.
 
 For each failed measurement:
 - Explain what the parameter measures and why it matters
@@ -67,9 +88,11 @@ For measurements that passed but are near limits:
 - Assess whether this indicates a marginal condition
 - Suggest monitoring or retesting if appropriate
 
-Be practical and actionable in your recommendations."""
+Be practical and actionable in your recommendations.
 
-CHAT_ASSISTANT_SYSTEM_PROMPT = """You are an expert oscilloscope technician assistant helping users understand their test data.
+{_GROUNDING}"""
+
+CHAT_ASSISTANT_SYSTEM_PROMPT = f"""You are an expert oscilloscope technician assistant helping users understand their test data.
 
 When answering questions:
 - Reference specific measurements and values from the test report
@@ -84,9 +107,11 @@ You have access to the complete test report data including:
 - Test metadata and conditions
 - Multiple test sections and captures
 
-Be helpful, accurate, and professional. Your goal is to help users understand their measurements and make informed decisions about their tests."""
+Be helpful, accurate, and professional. Your goal is to help users understand their measurements and make informed decisions about their tests.
 
-CHAT_WITH_TOOLS_SYSTEM_PROMPT = """You are an expert test engineer answering questions about an oscilloscope test report.
+{_GROUNDING}"""
+
+CHAT_WITH_TOOLS_SYSTEM_PROMPT = f"""You are an expert test engineer answering questions about an oscilloscope test report.
 
 You cannot see the report. Use the tools to inspect it:
 - list_waveforms: which channels the report contains. Call this first.
@@ -97,9 +122,9 @@ You cannot see the report. Use the tools to inspect it:
 - detect_transients: sudden anomalies (glitches, spikes) in a channel.
 - list_measurements: recorded measurements and their pass/fail status.
 
-Base every claim on tool results. Never invent a value you have not measured. If a tool
-returns an error, read it and try again with valid arguments. If the tools cannot answer the
-question, say so plainly."""
+{_GROUNDING}
+
+If a tool returns an error, read it and try again with valid arguments."""
 
 
 def get_system_prompt(prompt_type: str = "expert") -> str:

--- a/tests/test_report_analyzer_parsing.py
+++ b/tests/test_report_analyzer_parsing.py
@@ -46,6 +46,21 @@ def test_bold_wrapped_item_is_unwrapped():
     assert _parse_numbered_list("1. **Rise time slow**", 5) == ["Rise time slow"]
 
 
+def test_italic_wrapped_item_is_unwrapped():
+    assert _parse_numbered_list("1. *emphasis*", 5) == ["emphasis"]
+
+
+def test_partial_bold_leaves_valid_markdown():
+    # Only the leading keyword is bolded: the item is NOT symmetrically wrapped,
+    # so it must be left intact rather than losing its leading ** and stranding
+    # the interior one (which produced "Clipping** detected on CH1" before).
+    assert _parse_numbered_list("1. **Clipping** detected on CH1", 5) == ["**Clipping** detected on CH1"]
+
+
+def test_leading_glob_star_is_preserved():
+    assert _parse_numbered_list("1. *.tmp files should be deleted", 5) == ["*.tmp files should be deleted"]
+
+
 def test_preamble_line_is_dropped_when_markers_exist():
     assert _parse_numbered_list("Here are the findings:\n1. First\n2. Second", 5) == ["First", "Second"]
 

--- a/tests/test_report_analyzer_parsing.py
+++ b/tests/test_report_analyzer_parsing.py
@@ -1,0 +1,83 @@
+"""_parse_numbered_list tolerates the list shapes a small local model actually
+emits, and the two parsed analyzer methods run it end-to-end."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from scpi_control.report_generator.llm.analyzer import ReportAnalyzer, _parse_numbered_list
+from scpi_control.report_generator.models.report_data import (
+    ReportMetadata,
+    TestReport,
+    TestSection,
+    WaveformData,
+)
+
+
+def make_report():
+    t = np.arange(100) / 1e6
+    waveform = WaveformData(channel="C1", time=t, voltage=np.sin(2 * np.pi * 10_000 * t), sample_rate=1e6, record_length=100)
+    return TestReport(
+        metadata=ReportMetadata(title="Bench", technician="robin", test_date=datetime(2026, 7, 18)),
+        sections=[TestSection(title="Captures", waveforms=[waveform])],
+    )
+
+
+def test_plain_numbered_list():
+    assert _parse_numbered_list("1. First\n2. Second\n3. Third", 5) == ["First", "Second", "Third"]
+
+
+def test_multi_digit_prefixes_survive():
+    text = "\n".join(f"{i}. item{i}" for i in range(1, 13))
+    assert _parse_numbered_list(text, 20)[9:] == ["item10", "item11", "item12"]
+
+
+def test_paren_delimiter_and_bullets():
+    assert _parse_numbered_list("1) a\n2) b", 5) == ["a", "b"]
+    assert _parse_numbered_list("- a\n* b\n• c", 5) == ["a", "b", "c"]
+
+
+def test_markdown_bold_numbering():
+    assert _parse_numbered_list("**1.** First\n**2.** Second", 5) == ["First", "Second"]
+
+
+def test_bold_wrapped_item_is_unwrapped():
+    assert _parse_numbered_list("1. **Rise time slow**", 5) == ["Rise time slow"]
+
+
+def test_preamble_line_is_dropped_when_markers_exist():
+    assert _parse_numbered_list("Here are the findings:\n1. First\n2. Second", 5) == ["First", "Second"]
+
+
+def test_no_marker_salvage_returns_plain_lines():
+    assert _parse_numbered_list("First finding\nSecond finding", 5) == ["First finding", "Second finding"]
+
+
+def test_no_marker_salvage_drops_trailing_colon_preamble():
+    assert _parse_numbered_list("Findings:\nFirst\nSecond", 5) == ["First", "Second"]
+
+
+def test_max_items_truncates():
+    assert _parse_numbered_list("1. a\n2. b\n3. c", 2) == ["a", "b"]
+
+
+def test_empty_input_returns_none():
+    assert _parse_numbered_list("", 5) is None
+    assert _parse_numbered_list("   \n  ", 5) is None
+    assert _parse_numbered_list(None, 5) is None
+
+
+def test_generate_key_findings_parses_a_messy_model_reply():
+    client = MagicMock()
+    client.complete.return_value = "Here are the findings:\n1. Clipping on C1\n2. **Noise high**"
+    assert ReportAnalyzer(client).generate_key_findings(make_report(), max_findings=5) == ["Clipping on C1", "Noise high"]
+
+
+def test_generate_recommendations_parses_a_messy_model_reply():
+    client = MagicMock()
+    client.complete.return_value = "1. Re-run with 50 ohm termination\n2. Check probe compensation"
+    assert ReportAnalyzer(client).generate_recommendations(make_report(), max_recommendations=5) == [
+        "Re-run with 50 ohm termination",
+        "Check probe compensation",
+    ]

--- a/tests/test_report_llm_prompts.py
+++ b/tests/test_report_llm_prompts.py
@@ -1,0 +1,25 @@
+"""The six oscilloscope system prompts carry the shared grounding rule, and
+chat_tools keeps its tool-loop specifics on top of it."""
+
+import pytest
+
+from scpi_control.report_generator.llm.prompts import _GROUNDING, get_system_prompt
+
+ALL_PROMPTS = ["expert", "summary", "analysis", "interpretation", "chat", "chat_tools"]
+
+
+@pytest.mark.parametrize("prompt_type", ALL_PROMPTS)
+def test_every_prompt_carries_the_shared_grounding_rule(prompt_type):
+    assert _GROUNDING, "the grounding constant must be non-empty"
+    assert _GROUNDING in get_system_prompt(prompt_type)
+
+
+def test_chat_tools_keeps_its_tool_loop_specifics():
+    prompt = get_system_prompt("chat_tools")
+    assert "list_waveforms" in prompt
+    assert prompt.index("list_waveforms") < prompt.index("analyze_waveform"), "discover-first ordering must survive"
+    assert "returns an error" in prompt, "the retry guidance unique to the tool loop must survive"
+
+
+def test_summary_forbids_preamble_and_closing_remarks():
+    assert "Write only the summary itself" in get_system_prompt("summary")


### PR DESCRIPTION
## Summary

A focused polish pass on the report generator's six oscilloscope LLM system prompts (`scpi_control/report_generator/llm/`). Prompt text and parser robustness only — no behaviour-breaking changes.

## Changes

- **Shared grounding rule.** New `_GROUNDING` constant in `prompts.py`, interpolated into all six prompts as a single source of truth. Previously only `chat_tools` told the model to claim only what the data actually contains; now all six do — closing the fabrication gap on the summarized-context paths (`summary` / `analysis` / `interpretation`), which see only ~8 scalars per waveform yet were asked to "reference actual measurement values". `chat_tools` keeps its tool list, its `list_waveforms`-first ordering, and its tool-error-retry line.
- **Tolerant list parsing.** `generate_key_findings` and `generate_recommendations` are machine-parsed as numbered lists. Replaced two duplicated, fragile inline splitters (which stripped only single-digit `1.`–`9.` prefixes) with one shared `_parse_numbered_list` helper that also handles multi-digit prefixes, markdown-bold numbering (`**1.**`), and a leading "Here are the findings:" preamble line; and tightened both user prompts to request "ONLY a numbered list".
- **Changelog.** Entry under `## [Unreleased]` → `### Changed`.

## Testing

- 22 new tests (8 grounding-presence / `chat_tools`-invariant, 14 parser + end-to-end method).
- Full suite: **952 passed, 19 skipped**.

## Scope

Limited to `prompts.py`, `analyzer.py`, `CHANGELOG.md`, and two new test files. No changes to `tools.py`, `client.py`, `daq_prompts.py`, or the context builders. Non-breaking: `get_system_prompt` and both analyzer methods keep their signatures and return types.
