### PR TITLE
Examples refresh: fix stale/broken examples, add four new ones, guard with a smoke-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Examples: four new runnable, no-hardware examples — `report_ai_qa.py` (local-LLM tool-calling Q&A over a report), `network_discovery.py` (scan the network for SCPI instruments), `report_branding.py` (apply company branding/colours to a report), and `report_computed_analysis.py` (deterministic, LLM-free report analysis).
+- Examples: a `tests/test_examples_smoke.py` guard that executes the no-hardware examples, compile-checks the rest, and blocks known-stale tokens from reappearing.
+
 ### Changed
 
 - Report generator AI: every oscilloscope system prompt now carries one shared grounding rule (claim only what the report data or a tool actually returned; say so plainly when a value is missing rather than inventing it).
 - Report generator AI: key-findings and recommendations are parsed more tolerantly — multi-digit numbering, markdown-bold list markers, and a leading preamble line no longer corrupt the extracted list.
+
+### Fixed
+
+- Examples: repaired broken examples — `simple_capture.py` and `advanced_analysis.py` referenced a non-existent `waveform.time_interval` (now the sample period `1.0 / sample_rate`), and the interactive tutorial saved with an invalid `format="NPZ"` (now `"NPY"`). The report-generation and branding examples now degrade cleanly when reportlab is absent instead of crashing.
+- Examples: updated the stale `Siglent-Oscilloscope` package name (and dead repo links) to `SCPI-Instrument-Control`, and corrected the README's hardware/no-hardware annotations.
 
 ## [3.0.0] - 2026-07-17
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,6 +63,7 @@ pip install "SCPI-Instrument-Control"
 | File | What it shows | Requirements |
 | --- | --- | --- |
 | `report_generation_example.py` | Generating professional PDF/Markdown test reports: loading waveform data, adding measurements with pass/fail criteria, optional AI analysis, and rendering the report. | `SCPI-Instrument-Control[report-generator]` |
+| `report_computed_analysis.py` | Deterministic, LLM-free report analysis: `ComputedAnalyzer` fills the executive summary, key findings, and recommendations from the waveform data with no model or network. | `SCPI-Instrument-Control[report-generator]` (no hardware) |
 
 ## Interactive Tutorial
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,7 +82,8 @@ LAN address: **Utility → I/O → LAN** on the instrument's front panel.
 
 The scripts marked "no hardware" above (`dialect_override_example.py`,
 `trend_logging_walkthrough.py`, `psu_gui_test.py`, `probe_calibration_analysis.py`,
-`psu_advanced_features.py`) use mock connections and run as-is.
+`psu_advanced_features.py`, `network_discovery.py`, `report_computed_analysis.py`,
+`report_branding.py`, `report_ai_qa.py`) use mock connections and run as-is.
 
 ## Running an example
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,7 @@ pip install "SCPI-Instrument-Control"
 | --- | --- | --- |
 | `gateway_rest_client.py` | Driving the web gateway's REST API from Python: creating a mock session, configuring a channel, fetching waveform JSON, downloading a screenshot, and sending a raw SCPI command — the same API the browser UI uses. | `SCPI-Instrument-Control[web]` + a running `scpi-web` gateway |
 | `trend_logging_walkthrough.py` | Recording measurement trends in-process via the gateway's session layer (no server or browser): polling measurements, recording them, and exporting to CSV. | Core install only (no hardware, no server) |
+| `network_discovery.py` | Scanning the network for SCPI instruments via `discovery.discover()`: probes a CIDR range for `*IDN?` responses and lists what it finds. | `SCPI-Instrument-Control` (core install, no hardware) |
 
 ## Function Generator / AWG
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -64,6 +64,7 @@ pip install "SCPI-Instrument-Control"
 | --- | --- | --- |
 | `report_generation_example.py` | Generating professional PDF/Markdown test reports: loading waveform data, adding measurements with pass/fail criteria, optional AI analysis, and rendering the report. | `SCPI-Instrument-Control[report-generator]` |
 | `report_computed_analysis.py` | Deterministic, LLM-free report analysis: `ComputedAnalyzer` fills the executive summary, key findings, and recommendations from the waveform data with no model or network. | `SCPI-Instrument-Control[report-generator]` (no hardware) |
+| `report_branding.py` | Applying a `BrandingTemplate` to a report: company name, header/footer text, and a brand colour scheme, rendered to a branded Markdown report and a colour-branded PDF. | `SCPI-Instrument-Control[report-generator]` (no hardware) |
 
 ## Interactive Tutorial
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -66,6 +66,7 @@ pip install "SCPI-Instrument-Control"
 | `report_generation_example.py` | Generating professional PDF/Markdown test reports: loading waveform data, adding measurements with pass/fail criteria, optional AI analysis, and rendering the report. | `SCPI-Instrument-Control[report-generator]` |
 | `report_computed_analysis.py` | Deterministic, LLM-free report analysis: `ComputedAnalyzer` fills the executive summary, key findings, and recommendations from the waveform data with no model or network. | `SCPI-Instrument-Control[report-generator]` (no hardware) |
 | `report_branding.py` | Applying a `BrandingTemplate` to a report: company name, header/footer text, and a brand colour scheme, rendered to a branded Markdown report and a colour-branded PDF. | `SCPI-Instrument-Control[report-generator]` (no hardware) |
+| `report_ai_qa.py` | Interactive Q&A over a report with a local LLM using tool-calling: the model calls the report's analysis tools to answer, and the example degrades cleanly when no tool-capable Ollama model is running. | `SCPI-Instrument-Control[report-generator]`; optional local Ollama (no hardware) |
 
 ## Interactive Tutorial
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,7 @@ pip install "SCPI-Instrument-Control"
 | `continuous_capture.py` | Collecting waveforms continuously over a period of time, for monitoring, statistics, or time-varying phenomena. | Oscilloscope on the network |
 | `trigger_based_capture.py` | Waiting for specific trigger conditions and capturing waveforms when they occur, for sporadic events. | Oscilloscope on the network |
 | `advanced_analysis.py` | Advanced waveform analysis and visualization: FFT analysis, statistical analysis, and matplotlib plots. | Oscilloscope on the network, matplotlib |
-| `probe_calibration_analysis.py` | Waveform region extraction for probe compensation analysis: plateau detection, slope analysis, calibration guidance, and zoomed PDF report plots. | Oscilloscope on the network, `SCPI-Instrument-Control[report-generator]` |
+| `probe_calibration_analysis.py` | Waveform region extraction for probe compensation analysis: plateau detection, slope analysis, calibration guidance, and zoomed PDF report plots. | `SCPI-Instrument-Control[report-generator]` (no hardware — fully synthetic) |
 | `dialect_override_example.py` | SCPI dialect auto-detection from `*IDN?` and the `dialect=` override for forcing a command set; runs entirely on mock connections. | Core install only (no hardware) |
 
 ## Web Gateway
@@ -48,7 +48,7 @@ pip install "SCPI-Instrument-Control"
 | File | What it shows | Requirements |
 | --- | --- | --- |
 | `psu_basic_control.py` | Controlling a SCPI power supply (Siglent SPD series or generic SCPI-99) over Ethernet/LAN. | Power supply on the network |
-| `psu_advanced_features.py` | Advanced PSU features: CSV data logging, tracking modes (series/parallel), timer functionality, waveform generation, and OVP/OCP protection. | Power supply on the network |
+| `psu_advanced_features.py` | Advanced PSU features: CSV data logging, tracking modes (series/parallel), timer functionality, waveform generation, and OVP/OCP protection. | Core install only (no hardware — uses a mock connection) |
 | `psu_usb_connection.py` | Connecting to a power supply via USB/GPIB/Serial/TCP-IP using `VISAConnection`. | `SCPI-Instrument-Control[usb]`, PSU reachable via USB-TMC/GPIB/Serial/VXI-11 |
 | `psu_gui_test.py` | Testing the PSU control GUI against a mock connection, with no physical hardware required. | `SCPI-Instrument-Control[gui]` |
 
@@ -77,8 +77,8 @@ the file — update it to match your instrument. To find an oscilloscope's
 LAN address: **Utility → I/O → LAN** on the instrument's front panel.
 
 The scripts marked "no hardware" above (`dialect_override_example.py`,
-`trend_logging_walkthrough.py`, `psu_gui_test.py`) use mock connections and
-run as-is.
+`trend_logging_walkthrough.py`, `psu_gui_test.py`, `probe_calibration_analysis.py`,
+`psu_advanced_features.py`) use mock connections and run as-is.
 
 ## Running an example
 

--- a/examples/advanced_analysis.py
+++ b/examples/advanced_analysis.py
@@ -16,7 +16,7 @@ SCOPE_IP = "192.168.1.100"
 
 def plot_waveform(waveform, channel_num, title="Waveform"):
     """Plot time-domain waveform."""
-    time = np.arange(len(waveform.voltage)) * waveform.time_interval
+    time = np.arange(len(waveform.voltage)) * (1.0 / waveform.sample_rate)
     time_ms = time * 1000  # Convert to milliseconds
 
     plt.figure(figsize=(12, 4))
@@ -32,7 +32,7 @@ def plot_fft(waveform, channel_num):
     """Plot frequency spectrum using FFT."""
     # Perform FFT
     fft_result = np.fft.fft(waveform.voltage)
-    fft_freq = np.fft.fftfreq(len(waveform.voltage), waveform.time_interval)
+    fft_freq = np.fft.fftfreq(len(waveform.voltage), 1.0 / waveform.sample_rate)
 
     # Take only positive frequencies
     positive_freq_idx = fft_freq > 0

--- a/examples/interactive_tutorial.ipynb
+++ b/examples/interactive_tutorial.ipynb
@@ -6,13 +6,13 @@
    "source": [
     "# Siglent Oscilloscope Control - Interactive Tutorial\n",
     "\n",
-    "This notebook demonstrates how to use the Siglent-Oscilloscope package to control your oscilloscope, capture waveforms, and perform measurements.\n",
+    "This notebook demonstrates how to use the SCPI-Instrument-Control package to control your oscilloscope, capture waveforms, and perform measurements.\n",
     "\n",
     "## Prerequisites\n",
     "\n",
-    "- Siglent-Oscilloscope package installed: `pip install Siglent-Oscilloscope`\n",
+    "- SCPI-Instrument-Control package installed: `pip install SCPI-Instrument-Control`\n",
     "- Oscilloscope connected to your network\n",
-    "- Oscilloscope IP address (check in Utility \u2192 I/O \u2192 LAN settings)"
+    "- Oscilloscope IP address (check in Utility → I/O → LAN settings)"
    ]
   },
   {
@@ -204,7 +204,7 @@
     "\n",
     "print(\"Automated Measurements:\")\n",
     "print(f\"  Frequency: {freq/1e3:.3f} kHz\")\n",
-    "print(f\"  Period: {period*1e6:.2f} \u03bcs\")\n",
+    "print(f\"  Period: {period*1e6:.2f} μs\")\n",
     "print(f\"  Vpp: {vpp:.3f} V\")\n",
     "print(f\"  Vrms: {vrms:.3f} V\")\n",
     "print(f\"  Duty Cycle: {duty:.1f}%\")"
@@ -318,18 +318,18 @@
    "source": [
     "# Save to different formats\n",
     "scope.waveform.save_waveform(wf1, \"waveform_ch1.csv\", format=\"CSV\")\n",
-    "scope.waveform.save_waveform(wf1, \"waveform_ch1.npz\", format=\"NPZ\")\n",
+    "scope.waveform.save_waveform(wf1, \"waveform_ch1.npy\", format=\"NPY\")\n",
     "\n",
     "print(\"Waveform saved to:\")\n",
     "print(\"  waveform_ch1.csv\")\n",
-    "print(\"  waveform_ch1.npz\")\n",
+    "print(\"  waveform_ch1.npy\")\n",
     "\n",
     "# Optional: Save to HDF5 (requires h5py)\n",
     "try:\n",
     "    scope.waveform.save_waveform(wf1, \"waveform_ch1.h5\", format=\"HDF5\")\n",
     "    print(\"  waveform_ch1.h5\")\n",
     "except ImportError:\n",
-    "    print(\"  (HDF5 format requires: pip install 'Siglent-Oscilloscope[hdf5]')\")"
+    "    print(\"  (HDF5 format requires: pip install 'SCPI-Instrument-Control[hdf5]')\")"
    ]
   },
   {
@@ -358,17 +358,17 @@
    "source": [
     "## Next Steps\n",
     "\n",
-    "- Explore the [examples](https://github.com/little-did-I-know/Siglent-Oscilloscope/tree/main/examples) directory for more advanced use cases\n",
-    "- Check out the [automation API](https://github.com/little-did-I-know/Siglent-Oscilloscope#programmatic-data-collection--automation) for batch processing\n",
+    "- Explore the [examples](https://github.com/little-did-I-know/SCPI-Instrument-Control/tree/main/examples) directory for more advanced use cases\n",
+    "- Check out the [automation API](https://github.com/little-did-I-know/SCPI-Instrument-Control#programmatic-data-collection--automation) for batch processing\n",
     "- Try the GUI application: `siglent-gui`\n",
-    "- Read the full [documentation](https://github.com/little-did-I-know/Siglent-Oscilloscope#readme)\n",
+    "- Read the full [documentation](https://github.com/little-did-I-know/SCPI-Instrument-Control#readme)\n",
     "\n",
     "## Useful Resources\n",
     "\n",
-    "- [GitHub Repository](https://github.com/little-did-I-know/Siglent-Oscilloscope)\n",
-    "- [PyPI Package](https://pypi.org/project/Siglent-Oscilloscope/)\n",
-    "- [Report Issues](https://github.com/little-did-I-know/Siglent-Oscilloscope/issues)\n",
-    "- [Contributing Guide](https://github.com/little-did-I-know/Siglent-Oscilloscope/blob/main/CONTRIBUTING.md)"
+    "- [GitHub Repository](https://github.com/little-did-I-know/SCPI-Instrument-Control)\n",
+    "- [PyPI Package](https://pypi.org/project/SCPI-Instrument-Control/)\n",
+    "- [Report Issues](https://github.com/little-did-I-know/SCPI-Instrument-Control/issues)\n",
+    "- [Contributing Guide](https://github.com/little-did-I-know/SCPI-Instrument-Control/blob/main/CONTRIBUTING.md)"
    ]
   }
  ],

--- a/examples/network_discovery.py
+++ b/examples/network_discovery.py
@@ -1,0 +1,39 @@
+"""Discover SCPI instruments on the local network.
+
+Scans a range of addresses, probes each for a SCPI *IDN? response, and prints
+what it finds. This example scans a documentation-only TEST-NET range so it
+returns quickly with no results in most environments; change `cidr` (or pass
+cidr=None to auto-scan your local /24) to find real instruments.
+
+Requirements: SCPI-Instrument-Control (core install, no hardware)
+"""
+
+from scpi_control.server.discovery import discover
+
+
+def main():
+    print("=" * 60)
+    print("Network instrument discovery")
+    print("=" * 60)
+
+    # A small TEST-NET-1 range (RFC 5737): fast and hostless, for a safe demo.
+    # For real use: discover(cidr=None) auto-scans your local subnet, or pass a
+    # CIDR like discover(cidr="192.168.1.0/24").
+    cidr = "192.0.2.0/30"
+    print(f"Scanning {cidr} ...")
+    found = discover(cidr=cidr, connect_timeout=0.3, probe_timeout=0.5)
+
+    if not found:
+        print("No instruments found in this range.")
+    else:
+        print(f"Found {len(found)} instrument(s):")
+        for entry in found:
+            print(f"  {entry}")
+
+    print("=" * 60)
+    print("Done.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/psu_basic_control.py
+++ b/examples/psu_basic_control.py
@@ -8,7 +8,7 @@ Connection Methods:
     - USB: See psu_usb_connection.py
 
 For USB support:
-    pip install "Siglent-Oscilloscope[usb]"
+    pip install "SCPI-Instrument-Control[usb]"
 """
 
 from scpi_control import PowerSupply

--- a/examples/psu_usb_connection.py
+++ b/examples/psu_usb_connection.py
@@ -4,7 +4,7 @@ This example demonstrates how to connect to a Siglent power supply via USB
 using the VISAConnection class.
 
 Requirements:
-    pip install "Siglent-Oscilloscope[usb]"
+    pip install "SCPI-Instrument-Control[usb]"
 
 Supports:
     - USB (USB-TMC protocol)
@@ -39,7 +39,7 @@ def discover_devices():
     except ImportError as e:
         print(f"  Error: {e}")
         print("\nInstall USB support with:")
-        print("  pip install 'Siglent-Oscilloscope[usb]'")
+        print("  pip install 'SCPI-Instrument-Control[usb]'")
         return None
 
     # Find Siglent devices specifically
@@ -226,7 +226,7 @@ def main():
         print("\nMake sure:")
         print("  1. Device is connected via USB")
         print("  2. USB drivers are installed")
-        print("  3. PyVISA is installed: pip install 'Siglent-Oscilloscope[usb]'")
+        print("  3. PyVISA is installed: pip install 'SCPI-Instrument-Control[usb]'")
         print("\nFor testing without hardware:")
         print("  - See examples below (commented out)")
         return
@@ -260,7 +260,7 @@ if __name__ == "__main__":
         print("=" * 60)
         print("\nUSB support requires PyVISA.")
         print("\nInstall with:")
-        print("  pip install 'Siglent-Oscilloscope[usb]'")
+        print("  pip install 'SCPI-Instrument-Control[usb]'")
         print("\nThis includes:")
         print("  - pyvisa: VISA library interface")
         print("  - pyvisa-py: Pure Python backend (no NI-VISA needed)")

--- a/examples/report_ai_qa.py
+++ b/examples/report_ai_qa.py
@@ -1,0 +1,72 @@
+"""Ask a local LLM questions about a report, using tool-calling.
+
+Builds a synthetic report and asks a local Ollama model questions about it. When
+the model supports tools, it answers by CALLING the report's analysis tools
+(list_waveforms, analyze_waveform, ...) rather than guessing from a summary.
+
+This needs a local Ollama running with a tool-capable model (e.g. `ollama run
+llama3.2`). With none available it prints that and exits cleanly -- so the
+example is safe to run anywhere.
+
+Requirements: SCPI-Instrument-Control[report-generator]; optional local Ollama
+for the live Q&A. No hardware.
+"""
+
+from datetime import datetime
+
+import numpy as np
+
+from scpi_control.report_generator.llm.analyzer import ReportAnalyzer
+from scpi_control.report_generator.llm.client import LLMClient, LLMConfig
+from scpi_control.report_generator.models.report_data import ReportMetadata, TestReport, TestSection, WaveformData
+
+
+def build_report() -> TestReport:
+    sample_rate = 1e6
+    t = np.arange(2000) / sample_rate
+    v = 3.3 * np.sin(2 * np.pi * 1000 * t) + 0.02 * np.random.randn(t.size)
+    waveform = WaveformData(channel="C1", time=t, voltage=v, sample_rate=sample_rate, record_length=t.size, label="1 kHz reference")
+    return TestReport(
+        metadata=ReportMetadata(title="AI Q&A Demo", technician="Lab Tech", test_date=datetime.now()),
+        sections=[TestSection(title="Captures", waveforms=[waveform], order=1)],
+    )
+
+
+def main():
+    print("=" * 60)
+    print("Local-LLM tool-calling Q&A over a report")
+    print("=" * 60)
+
+    report = build_report()
+
+    client = LLMClient(LLMConfig.create_ollama_config(model="llama3.2"))
+
+    if not client.supports_tools():
+        print("No tool-capable local model available.")
+        print("Start Ollama with a tool-capable model (e.g. `ollama run llama3.2`) to try the live Q&A.")
+        print("=" * 60)
+        print("Done (skipped live Q&A).")
+        print("=" * 60)
+        return
+
+    analyzer = ReportAnalyzer(client)
+    questions = [
+        "What channels are in this report?",
+        "What kind of signal is on C1, and what is its frequency?",
+    ]
+    for question in questions:
+        print(f"\nQ: {question}")
+        try:
+            answer = analyzer.answer_question(report, question)
+        except Exception as exc:  # never let a model hiccup crash the example
+            print(f"A: (the model call failed: {exc})")
+            continue
+        print(f"A: {answer}")
+
+    print("\n" + "=" * 60)
+    print("Done.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/report_ai_qa.py
+++ b/examples/report_ai_qa.py
@@ -24,6 +24,7 @@ from scpi_control.report_generator.models.report_data import ReportMetadata, Tes
 def build_report() -> TestReport:
     sample_rate = 1e6
     t = np.arange(2000) / sample_rate
+    np.random.seed(0)
     v = 3.3 * np.sin(2 * np.pi * 1000 * t) + 0.02 * np.random.randn(t.size)
     waveform = WaveformData(channel="C1", time=t, voltage=v, sample_rate=sample_rate, record_length=t.size, label="1 kHz reference")
     return TestReport(
@@ -61,7 +62,7 @@ def main():
         except Exception as exc:  # never let a model hiccup crash the example
             print(f"A: (the model call failed: {exc})")
             continue
-        print(f"A: {answer}")
+        print(f"A: {answer if answer is not None else '(no answer)'}")
 
     print("\n" + "=" * 60)
     print("Done.")

--- a/examples/report_branding.py
+++ b/examples/report_branding.py
@@ -68,12 +68,12 @@ def main():
     if MarkdownReportGenerator(include_plots=False).generate(report, md_path):
         print(f"  [OK] {md_path}")
 
-    if PDF_AVAILABLE:
-        print("Rendering colour-branded PDF...")
+    print("Rendering colour-branded PDF...")
+    try:
         pdf_path = output_dir / "branded_report.pdf"
         if PDFReportGenerator(branding=branding, include_plots=False).generate(report, pdf_path):
             print(f"  [OK] {pdf_path}")
-    else:
+    except ImportError:
         print("  PDF skipped (reportlab not installed).")
 
     print("=" * 60)

--- a/examples/report_branding.py
+++ b/examples/report_branding.py
@@ -1,0 +1,85 @@
+"""Apply company branding to a generated report.
+
+Builds a synthetic report, applies a BrandingTemplate (company name, header and
+footer text, and a brand colour scheme), then renders a branded Markdown report
+plus a colour-branded PDF. Text (company/header/footer) rides on the report
+metadata; the brand colours reach the PDF via PDFReportGenerator(branding=...).
+
+Requirements: SCPI-Instrument-Control[report-generator] (no hardware). The PDF
+step is skipped with a message if reportlab is not installed.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+
+from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
+from scpi_control.report_generator.models.report_data import MeasurementResult, ReportMetadata, TestReport, TestSection, WaveformData
+from scpi_control.report_generator.models.template import BrandingTemplate
+
+try:
+    from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator
+
+    PDF_AVAILABLE = True
+except ImportError:
+    PDF_AVAILABLE = False
+
+
+def build_report() -> TestReport:
+    sample_rate = 1e6
+    t = np.arange(2000) / sample_rate
+    v = 3.3 * np.sin(2 * np.pi * 1000 * t)
+    waveform = WaveformData(channel="C1", time=t, voltage=v, sample_rate=sample_rate, record_length=t.size, label="Output")
+    measurement = MeasurementResult(name="Peak-to-Peak", value=6.6, unit="V", channel="C1", passed=True, criteria_min=6.0, criteria_max=7.0)
+    report = TestReport(
+        metadata=ReportMetadata(title="Branded Report Demo", technician="Lab Tech", test_date=datetime.now()),
+        sections=[TestSection(title="Captures", waveforms=[waveform], measurements=[measurement], order=1)],
+    )
+    report.overall_result = report.calculate_overall_result()
+    return report
+
+
+def main():
+    print("=" * 60)
+    print("Report branding demo")
+    print("=" * 60)
+
+    report = build_report()
+
+    # Text (company/header/footer) goes onto the metadata; colours go to the PDF.
+    branding = BrandingTemplate(
+        company_name="Acme Test Labs",
+        header_text="Acme Test Labs - Confidential",
+        footer_text="(c) 2026 Acme Test Labs",
+        primary_color="#0b5394",
+        secondary_color="#674ea7",
+        success_color="#38761d",
+        failure_color="#cc0000",
+    )
+    # To add a logo, set company_logo_path=Path("logo.png") on the branding above.
+    branding.apply_to_metadata(report.metadata)
+
+    output_dir = Path("branded_reports")
+    output_dir.mkdir(exist_ok=True)
+
+    print("Rendering branded Markdown...")
+    md_path = output_dir / "branded_report.md"
+    if MarkdownReportGenerator(include_plots=False).generate(report, md_path):
+        print(f"  [OK] {md_path}")
+
+    if PDF_AVAILABLE:
+        print("Rendering colour-branded PDF...")
+        pdf_path = output_dir / "branded_report.pdf"
+        if PDFReportGenerator(branding=branding, include_plots=False).generate(report, pdf_path):
+            print(f"  [OK] {pdf_path}")
+    else:
+        print("  PDF skipped (reportlab not installed).")
+
+    print("=" * 60)
+    print("Done.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/report_computed_analysis.py
+++ b/examples/report_computed_analysis.py
@@ -27,6 +27,7 @@ def build_report() -> TestReport:
     """A one-channel synthetic report: a 1 kHz sine with light noise."""
     sample_rate = 1e6
     t = np.arange(2000) / sample_rate
+    np.random.seed(0)
     v = 3.3 * np.sin(2 * np.pi * 1000 * t) + 0.02 * np.random.randn(t.size)
     waveform = WaveformData(
         channel="C1",

--- a/examples/report_computed_analysis.py
+++ b/examples/report_computed_analysis.py
@@ -1,0 +1,77 @@
+"""Deterministic (LLM-free) report analysis.
+
+Builds a synthetic test report and runs ComputedAnalyzer over it. Unlike the AI
+path, this needs no local model and no network: it fills the executive summary,
+key findings, and recommendations straight from the waveform analysis and sets
+summary_source to "computed".
+
+Requirements: SCPI-Instrument-Control[report-generator] (no hardware, no network)
+"""
+
+from datetime import datetime
+
+import numpy as np
+
+from scpi_control.report_generator.analysis.computed_analyzer import ComputedAnalyzer
+from scpi_control.report_generator.models.report_data import (
+    SUMMARY_SOURCE_COMPUTED,
+    MeasurementResult,
+    ReportMetadata,
+    TestReport,
+    TestSection,
+    WaveformData,
+)
+
+
+def build_report() -> TestReport:
+    """A one-channel synthetic report: a 1 kHz sine with light noise."""
+    sample_rate = 1e6
+    t = np.arange(2000) / sample_rate
+    v = 3.3 * np.sin(2 * np.pi * 1000 * t) + 0.02 * np.random.randn(t.size)
+    waveform = WaveformData(
+        channel="C1",
+        time=t,
+        voltage=v,
+        sample_rate=sample_rate,
+        record_length=t.size,
+        label="1 kHz reference",
+    )
+    measurements = [
+        MeasurementResult(name="Frequency", value=1000.0, unit="Hz", channel="C1", passed=True, criteria_min=990, criteria_max=1010),
+        MeasurementResult(name="Peak-to-Peak", value=6.6, unit="V", channel="C1", passed=True, criteria_min=6.0, criteria_max=7.0),
+    ]
+    report = TestReport(
+        metadata=ReportMetadata(title="Computed Analysis Demo", technician="Lab Tech", test_date=datetime.now()),
+        sections=[TestSection(title="Captures", waveforms=[waveform], measurements=measurements, order=1)],
+    )
+    report.overall_result = report.calculate_overall_result()
+    return report
+
+
+def main():
+    print("=" * 60)
+    print("Deterministic (LLM-free) report analysis")
+    print("=" * 60)
+
+    report = build_report()
+
+    print("Running ComputedAnalyzer (no model, no network)...")
+    ComputedAnalyzer().analyze_report(report)
+
+    print(f"\nsummary_source: {report.summary_source!r}  (expected {SUMMARY_SOURCE_COMPUTED!r})")
+    print("\nExecutive summary:")
+    print(f"  {report.executive_summary}")
+    print("\nKey findings:")
+    for finding in report.key_findings:
+        print(f"  - {finding}")
+    print("\nRecommendations:")
+    for recommendation in report.recommendations:
+        print(f"  - {recommendation}")
+
+    print("\n" + "=" * 60)
+    print("Done.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/report_generation_example.py
+++ b/examples/report_generation_example.py
@@ -39,7 +39,7 @@ from scpi_control.report_generator.llm.client import LLMClient, LLMConfig
 def create_sample_waveform() -> WaveformData:
     """Create a sample waveform for demonstration."""
     # Generate a simple sine wave with some noise
-    sample_rate = 1e9  # 1 GS/s
+    sample_rate = 1e6  # 1 MS/s
     duration = 1e-3  # 1 ms
     frequency = 1e3  # 1 kHz
 

--- a/examples/report_generation_example.py
+++ b/examples/report_generation_example.py
@@ -315,8 +315,8 @@ def main():
         print(f"    [FAILED] Failed to generate Markdown report")
 
     # Generate PDF report (if available)
-    if PDF_AVAILABLE:
-        print("  - Generating PDF report...")
+    print("  - Generating PDF report...")
+    try:
         pdf_path = output_dir / "example_report.pdf"
         pdf_generator = PDFReportGenerator()
 
@@ -324,7 +324,7 @@ def main():
             print(f"    [OK] PDF report saved: {pdf_path}")
         else:
             print(f"    [FAILED] Failed to generate PDF report")
-    else:
+    except ImportError:
         print("  - PDF generation skipped (reportlab not installed)")
 
     # Done!

--- a/examples/simple_capture.py
+++ b/examples/simple_capture.py
@@ -25,7 +25,7 @@ def main():
             print(f"\nChannel {ch}:")
             print(f"  Samples: {len(waveform.voltage)}")
             print(f"  Sample rate: {waveform.sample_rate / 1e6:.2f} MSa/s")
-            print(f"  Time interval: {waveform.time_interval * 1e9:.2f} ns")
+            print(f"  Time interval: {(1.0 / waveform.sample_rate) * 1e9:.2f} ns")
             print(f"  Voltage range: {waveform.voltage.min():.3f}V to {waveform.voltage.max():.3f}V")
 
         # Analyze waveforms

--- a/examples/vector_graphics_xy_mode.py
+++ b/examples/vector_graphics_xy_mode.py
@@ -4,7 +4,7 @@ This example demonstrates how to use the oscilloscope as a vector display
 by generating waveforms for XY mode.
 
 REQUIREMENTS:
-    - Install fun extras: pip install "Siglent-Oscilloscope[fun]"
+    - Install fun extras: pip install "SCPI-Instrument-Control[fun]"
     - External AWG/DAC to feed signals into scope channels
       OR use scope's built-in AWG if available
     - Oscilloscope channels connected to AWG outputs
@@ -221,7 +221,7 @@ if __name__ == "__main__":
             print("Vector graphics features require additional packages.")
             print()
             print("Install with:")
-            print('  pip install "Siglent-Oscilloscope[fun]"')
+            print('  pip install "SCPI-Instrument-Control[fun]"')
             print()
             print("This will install:")
             print("  - shapely (geometric operations)")

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -36,6 +36,7 @@ EXECUTE = [
     ("psu_advanced_features.py", None),
     ("probe_calibration_analysis.py", "reportlab"),
     ("report_generation_example.py", "matplotlib"),
+    ("report_computed_analysis.py", None),
 ]
 
 _TIMEOUTS = {"report_ai_qa.py": 240}

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -39,6 +39,7 @@ EXECUTE = [
     ("report_computed_analysis.py", None),
     ("report_branding.py", None),
     ("network_discovery.py", None),
+    ("report_ai_qa.py", None),
 ]
 
 _TIMEOUTS = {"report_ai_qa.py": 240}

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -38,6 +38,7 @@ EXECUTE = [
     ("report_generation_example.py", "matplotlib"),
     ("report_computed_analysis.py", None),
     ("report_branding.py", None),
+    ("network_discovery.py", None),
 ]
 
 _TIMEOUTS = {"report_ai_qa.py": 240}

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -1,0 +1,57 @@
+"""Smoke-tests for the examples/ tree.
+
+Guards three things: (1) no known-stale tokens survive (verifies the fixes and
+blocks their reintroduction), (2) every .py example at least compiles, (3) the
+notebook is valid JSON. Task 2 adds a fourth guard: executing the no-hardware
+examples as subprocesses.
+
+Limitation: hardware-bound examples (e.g. simple_capture.py, advanced_analysis.py)
+cannot be executed headless, so their fixes are covered by the token scan and the
+compile check, not by running them.
+"""
+
+import json
+import py_compile
+from pathlib import Path
+
+import pytest
+
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
+
+# Strings that must never appear under examples/ again.
+FORBIDDEN = ["Siglent-Oscilloscope", ".time_interval", 'format="NPZ"']
+
+
+def _example_text(path):
+    """Scannable text for an example. For a notebook, return the concatenated
+    cell SOURCE (unescaped Python), not the raw JSON -- otherwise a token like
+    format="NPZ" is stored escaped (format=\\"NPZ\\") and a raw scan misses it."""
+    if path.suffix == ".ipynb":
+        nb = json.loads(path.read_text(encoding="utf-8"))
+        parts = []
+        for cell in nb.get("cells", []):
+            src = cell.get("source", [])
+            parts.append(src if isinstance(src, str) else "".join(src))
+        return "\n".join(parts)
+    return path.read_text(encoding="utf-8")
+
+
+def test_no_stale_tokens():
+    hits = []
+    for path in sorted(EXAMPLES_DIR.rglob("*")):
+        if path.is_file() and path.suffix in {".py", ".ipynb"}:
+            text = _example_text(path)
+            for token in FORBIDDEN:
+                if token in text:
+                    hits.append(f"{path.name}: {token!r}")
+    assert not hits, "stale tokens found:\n" + "\n".join(hits)
+
+
+@pytest.mark.parametrize("path", sorted(EXAMPLES_DIR.glob("*.py")), ids=lambda p: p.name)
+def test_example_compiles(path):
+    py_compile.compile(str(path), doraise=True)
+
+
+def test_notebook_is_valid_json():
+    nb = EXAMPLES_DIR / "interactive_tutorial.ipynb"
+    json.loads(nb.read_text(encoding="utf-8"))

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -7,8 +7,7 @@ examples as subprocesses.
 
 Limitation: hardware-bound examples (e.g. simple_capture.py, advanced_analysis.py)
 cannot be executed headless, so their fixes are covered by the token scan and the
-compile check, not by running them. report_generation_example.py is excluded from
-EXECUTE for a different reason -- see the comment above EXECUTE.
+compile check, not by running them.
 """
 
 import importlib.util
@@ -27,20 +26,10 @@ EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
 FORBIDDEN = ["Siglent-Oscilloscope", ".time_interval", 'format="NPZ"']
 
 # (filename, module-that-must-import-or-skip). Only examples that run to
-# completion headless with no instrument belong here.
-#
-# report_generation_example.py is deliberately NOT included: it builds a
-# synthetic 1,000,000-sample waveform (1 GS/s over 1 ms), and generating its
-# PDF report runs WaveformAnalyzer.analyze() -> detect_signal_type() ->
-# _is_noise(), which computes a full autocorrelation via
-# np.correlate(v, v, mode="full") -- a direct (non-FFT) O(n^2)-ish
-# convolution. Benchmarked standalone: ~8s at n=50k, ~23s at n=100k, ~50s at
-# n=200k; at the example's n=1,000,000 this did not finish within several
-# minutes. That's a pre-existing performance bug in
-# scpi_control/report_generator/utils/waveform_analyzer.py, not a hardware
-# or interactivity limitation, and fixing it is out of scope for this
-# test-only task. The example is still covered by test_no_stale_tokens and
-# test_example_compiles.
+# completion headless with no instrument belong here. report_generation_example.py's
+# synthetic waveform was reduced to ~1000 samples so analysis runs in ~1.8s. Note:
+# a pre-existing O(n^2) autocorrelation in scpi_control/report_generator/utils/
+# waveform_analyzer.py makes very large captures slow; this library issue is out of scope.
 EXECUTE = [
     ("dialect_override_example.py", None),
     ("trend_logging_walkthrough.py", None),

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -35,11 +35,11 @@ EXECUTE = [
     ("trend_logging_walkthrough.py", None),
     ("psu_advanced_features.py", None),
     ("probe_calibration_analysis.py", "reportlab"),
-    ("report_generation_example.py", "matplotlib"),
+    ("report_generation_example.py", "requests"),
     ("report_computed_analysis.py", None),
     ("report_branding.py", None),
     ("network_discovery.py", None),
-    ("report_ai_qa.py", None),
+    ("report_ai_qa.py", "requests"),
 ]
 
 _TIMEOUTS = {"report_ai_qa.py": 240}

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -46,6 +46,7 @@ EXECUTE = [
     ("trend_logging_walkthrough.py", None),
     ("psu_advanced_features.py", None),
     ("probe_calibration_analysis.py", "reportlab"),
+    ("report_generation_example.py", "matplotlib"),
 ]
 
 _TIMEOUTS = {"report_ai_qa.py": 240}

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -7,11 +7,16 @@ examples as subprocesses.
 
 Limitation: hardware-bound examples (e.g. simple_capture.py, advanced_analysis.py)
 cannot be executed headless, so their fixes are covered by the token scan and the
-compile check, not by running them.
+compile check, not by running them. report_generation_example.py is excluded from
+EXECUTE for a different reason -- see the comment above EXECUTE.
 """
 
+import importlib.util
 import json
+import os
 import py_compile
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -20,6 +25,35 @@ EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
 
 # Strings that must never appear under examples/ again.
 FORBIDDEN = ["Siglent-Oscilloscope", ".time_interval", 'format="NPZ"']
+
+# (filename, module-that-must-import-or-skip). Only examples that run to
+# completion headless with no instrument belong here.
+#
+# report_generation_example.py is deliberately NOT included: it builds a
+# synthetic 1,000,000-sample waveform (1 GS/s over 1 ms), and generating its
+# PDF report runs WaveformAnalyzer.analyze() -> detect_signal_type() ->
+# _is_noise(), which computes a full autocorrelation via
+# np.correlate(v, v, mode="full") -- a direct (non-FFT) O(n^2)-ish
+# convolution. Benchmarked standalone: ~8s at n=50k, ~23s at n=100k, ~50s at
+# n=200k; at the example's n=1,000,000 this did not finish within several
+# minutes. That's a pre-existing performance bug in
+# scpi_control/report_generator/utils/waveform_analyzer.py, not a hardware
+# or interactivity limitation, and fixing it is out of scope for this
+# test-only task. The example is still covered by test_no_stale_tokens and
+# test_example_compiles.
+EXECUTE = [
+    ("dialect_override_example.py", None),
+    ("trend_logging_walkthrough.py", None),
+    ("psu_advanced_features.py", None),
+    ("probe_calibration_analysis.py", "reportlab"),
+]
+
+_TIMEOUTS = {"report_ai_qa.py": 240}
+_DEFAULT_TIMEOUT = 90
+
+
+def _available(module):
+    return module is None or importlib.util.find_spec(module) is not None
 
 
 def _example_text(path):
@@ -55,3 +89,33 @@ def test_example_compiles(path):
 def test_notebook_is_valid_json():
     nb = EXAMPLES_DIR / "interactive_tutorial.ipynb"
     json.loads(nb.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("filename, module", EXECUTE, ids=[f for f, _ in EXECUTE])
+def test_no_hardware_example_runs(filename, module, tmp_path):
+    if not _available(module):
+        pytest.skip(f"optional dependency {module!r} not installed")
+    path = EXAMPLES_DIR / filename
+    assert path.exists(), f"missing example: {filename}"
+    # PYTHONIOENCODING: some examples print unicode (checkmarks, etc.) and
+    # Windows defaults a captured child's stdout/stderr to the cp1252
+    # console codepage, which raises UnicodeEncodeError. utf-8 matches what
+    # a real terminal on any platform would accept.
+    env = {**os.environ, "MPLBACKEND": "Agg", "PYTHONIOENCODING": "utf-8"}
+    result = subprocess.run(
+        [sys.executable, str(path)],
+        cwd=tmp_path,
+        env=env,
+        # input="" (rather than stdin=subprocess.DEVNULL) closes stdin after
+        # writing nothing. On Windows, stdin=DEVNULL wires stdin to the NUL
+        # device, and sys.stdin.isatty() reports True for NUL -- so an
+        # example's "am I interactive?" check is fooled into calling input()
+        # and hanging until the timeout. An empty piped stdin reports
+        # isatty() False (as DEVNULL correctly does on POSIX) while still
+        # never blocking: any input() call gets an immediate EOFError.
+        input="",
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUTS.get(filename, _DEFAULT_TIMEOUT),
+    )
+    assert result.returncode == 0, f"{filename} exited {result.returncode}\n--- stderr ---\n{result.stderr[-3000:]}"

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -37,6 +37,7 @@ EXECUTE = [
     ("probe_calibration_analysis.py", "reportlab"),
     ("report_generation_example.py", "matplotlib"),
     ("report_computed_analysis.py", None),
+    ("report_branding.py", None),
 ]
 
 _TIMEOUTS = {"report_ai_qa.py": 240}


### PR DESCRIPTION
## Summary

Refreshes the `examples/` tree: fixes broken/stale examples, adds four new no-hardware examples, and adds a smoke-test that keeps them from rotting. Scope is limited to `examples/`, `tests/test_examples_smoke.py`, and `CHANGELOG.md` — no `scpi_control/` library changes.

## Fixed

- **Runtime bugs.** `simple_capture.py` / `advanced_analysis.py` used a non-existent `waveform.time_interval` (now the sample period `1.0 / sample_rate`); the interactive tutorial saved with an invalid `format="NPZ"` (now `"NPY"`).
- **Graceful degradation.** `report_generation_example.py` and `report_branding.py` now skip PDF cleanly when reportlab is absent instead of crashing — the old `PDF_AVAILABLE` guard never fired, because `pdf_generator` swallows its own reportlab `ImportError` and only raises later, inside the constructor.
- **Usability.** `report_generation_example.py`'s synthetic waveform reduced 1,000,000 → 1,000 samples so it completes quickly (it previously hung — see Note).
- **Branding drift.** `Siglent-Oscilloscope` → `SCPI-Instrument-Control` across three scripts and the notebook (including dead GitHub links).
- **README** hardware / no-hardware annotations corrected.

## Added

- Four runnable, no-hardware examples:
  - `report_ai_qa.py` — local-LLM tool-calling Q&A over a report (degrades cleanly when no Ollama model is available)
  - `network_discovery.py` — scan the network for SCPI instruments
  - `report_branding.py` — apply company branding / colours to a report
  - `report_computed_analysis.py` — deterministic, LLM-free report analysis
- `tests/test_examples_smoke.py` — executes the no-hardware examples (asserts exit 0, isolated CWD, `MPLBACKEND=Agg`, skip-if-extra-missing), compile-checks the rest, and blocks known-stale tokens (`Siglent-Oscilloscope`, `.time_interval`, `format="NPZ"`) from reappearing.

## Testing

Full suite **991 passed, 19 skipped**; smoke tests **36 passed**. Every commit reviewed (per-task + a whole-branch pass); the `report_*` degradation paths were verified by running with reportlab import-blocked.

## Note — follow-up, not in this PR

`WaveformAnalyzer._is_noise()` (`scpi_control/report_generator/utils/waveform_analyzer.py:492`) computes a full **O(n²)** autocorrelation via `np.correlate(v, v, mode="full")`, which effectively hangs on ~1,000,000-sample captures (and hung `report_generation_example.py` before this PR). This PR works around it by shrinking one example's waveform; the real fix (an FFT-based, O(n log n) autocorrelation) is a separate library change.
