### PR TITLE
perf: make WaveformAnalyzer._is_noise O(n) instead of O(n^2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report generator AI: every oscilloscope system prompt now carries one shared grounding rule (claim only what the report data or a tool actually returned; say so plainly when a value is missing rather than inventing it).
 - Report generator AI: key-findings and recommendations are parsed more tolerantly — multi-digit numbering, markdown-bold list markers, and a leading preamble line no longer corrupt the extracted list.
 
+### Fixed
+
+- Report generator analysis: `WaveformAnalyzer`'s noise check no longer computes an O(n²) full autocorrelation — it now reads only the two autocorrelation lags it uses, so analysing large captures (e.g. 1,000,000-sample records) completes in milliseconds instead of hanging. Also removes a divide-by-zero `RuntimeWarning` on constant signals.
+
 ## [3.0.0] - 2026-07-17
 
 ### ⚠️ Breaking Changes

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -486,19 +486,22 @@ class WaveformAnalyzer:
 
     @staticmethod
     def _is_noise(v: np.ndarray) -> bool:
-        """Check if signal is primarily noise."""
-        # Calculate autocorrelation
-        v_normalized = v - np.mean(v)
-        autocorr = np.correlate(v_normalized, v_normalized, mode="full")
-        autocorr = autocorr[len(autocorr) // 2 :]
-        autocorr = autocorr / autocorr[0]
+        """Check whether the signal is primarily noise.
 
-        # For noise, autocorrelation drops quickly
-        # Check if autocorrelation at lag=10% of signal is < 0.3
-        lag = max(1, len(autocorr) // 10)
-        if lag < len(autocorr):
-            return autocorr[lag] < 0.3
-        return False
+        Noise decorrelates quickly, so its autocorrelation at a lag of 10% of the
+        record is small relative to lag 0. Only those two autocorrelation values
+        are needed, so compute them directly as O(n) dot products rather than
+        forming the full O(n^2) autocorrelation.
+        """
+        x = v - np.mean(v)
+        r0 = float(np.dot(x, x))  # autocorrelation at lag 0
+        if r0 == 0.0:
+            return False  # constant/flat signal: not noise (and avoids divide-by-zero)
+        lag = max(1, len(x) // 10)
+        if lag >= len(x):
+            return False
+        rk = float(np.dot(x[:-lag], x[lag:]))  # autocorrelation at `lag`
+        return bool((rk / r0) < 0.3)
 
     @staticmethod
     def _get_harmonic_ratios(waveform: WaveformData, num_harmonics: int = 5) -> Optional[np.ndarray]:

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -423,6 +423,11 @@ class WaveformAnalyzer:
         try:
             v = waveform.voltage
 
+            # No samples: nothing to classify. (Guards the analysis below, which
+            # would otherwise divide/transform an empty array.)
+            if v.size == 0:
+                return SignalType.UNKNOWN, 0.0
+
             # Check for DC signal first
             if WaveformAnalyzer._is_dc_signal(v):
                 return SignalType.DC, 95.0

--- a/tests/test_waveform_analyzer_is_noise.py
+++ b/tests/test_waveform_analyzer_is_noise.py
@@ -1,12 +1,13 @@
 """_is_noise is O(n) and behaviorally identical to the old O(n^2) autocorrelation."""
 
 import time
+import types
 import warnings
 
 import numpy as np
 import pytest
 
-from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+from scpi_control.report_generator.utils.waveform_analyzer import SignalType, WaveformAnalyzer
 
 
 def _reference_is_noise(v: np.ndarray) -> bool:
@@ -64,6 +65,24 @@ def test_constant_is_not_noise_and_raises_no_warning():
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # any RuntimeWarning becomes a test failure
         assert WaveformAnalyzer._is_noise(np.full(4000, 2.5)) is False
+
+
+def test_empty_is_not_noise():
+    # Old code RAISED ValueError here (np.correlate on an empty array); the new
+    # code returns False without raising. (detect_signal_type guards empty before
+    # ever calling this, so numpy's benign "mean of empty" warning is unreachable
+    # in practice -- ignore it here.) See test_detect_signal_type_empty for the
+    # preserved caller-level behavior.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert WaveformAnalyzer._is_noise(np.array([])) is False
+
+
+def test_detect_signal_type_empty_is_unknown():
+    # Behavior-preserving: an empty capture still classifies as (UNKNOWN, 0.0),
+    # as it did when the old _is_noise raised and detect_signal_type swallowed it.
+    waveform = types.SimpleNamespace(voltage=np.array([]))
+    assert WaveformAnalyzer.detect_signal_type(waveform) == (SignalType.UNKNOWN, 0.0)
 
 
 def test_large_input_is_fast():

--- a/tests/test_waveform_analyzer_is_noise.py
+++ b/tests/test_waveform_analyzer_is_noise.py
@@ -1,0 +1,75 @@
+"""_is_noise is O(n) and behaviorally identical to the old O(n^2) autocorrelation."""
+
+import time
+import warnings
+
+import numpy as np
+import pytest
+
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+
+def _reference_is_noise(v: np.ndarray) -> bool:
+    """The ORIGINAL O(n^2) implementation, kept as the behavioral oracle.
+
+    The optimized _is_noise must return the same boolean as this for every input.
+    """
+    v_normalized = v - np.mean(v)
+    autocorr = np.correlate(v_normalized, v_normalized, mode="full")
+    autocorr = autocorr[len(autocorr) // 2 :]
+    with np.errstate(invalid="ignore", divide="ignore"):
+        autocorr = autocorr / autocorr[0]
+    lag = max(1, len(autocorr) // 10)
+    if lag < len(autocorr):
+        return bool(autocorr[lag] < 0.3)
+    return False
+
+
+def _fixtures():
+    rng = np.random.default_rng(0)
+    t = np.linspace(0, 1e-3, 5000, endpoint=False)
+    return {
+        "sine": np.sin(2 * np.pi * 1000 * t),
+        "square": np.sign(np.sin(2 * np.pi * 1000 * t)),
+        "ramp": np.linspace(-1.0, 1.0, 5000),
+        "white_noise": rng.standard_normal(5000),
+        "dc": np.full(5000, 2.5),
+        "tiny1": np.array([3.0]),
+        "tiny2": np.array([1.0, -1.0]),
+        "tiny15": rng.standard_normal(15),
+    }
+
+
+@pytest.mark.parametrize("name", list(_fixtures().keys()))
+def test_matches_reference(name):
+    v = _fixtures()[name]
+    # Silence the reference's divide warning on the constant fixture; we only
+    # care that the OPTIMIZED function agrees on the boolean.
+    with np.errstate(invalid="ignore", divide="ignore"):
+        expected = _reference_is_noise(v)
+    assert WaveformAnalyzer._is_noise(v) == expected
+
+
+def test_sine_is_not_noise():
+    t = np.linspace(0, 1e-3, 5000, endpoint=False)
+    assert WaveformAnalyzer._is_noise(np.sin(2 * np.pi * 1000 * t)) is False
+
+
+def test_white_noise_is_noise():
+    rng = np.random.default_rng(1)
+    assert WaveformAnalyzer._is_noise(rng.standard_normal(5000)) is True
+
+
+def test_constant_is_not_noise_and_raises_no_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any RuntimeWarning becomes a test failure
+        assert WaveformAnalyzer._is_noise(np.full(4000, 2.5)) is False
+
+
+def test_large_input_is_fast():
+    rng = np.random.default_rng(2)
+    v = rng.standard_normal(1_000_000)
+    start = time.perf_counter()
+    WaveformAnalyzer._is_noise(v)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 5.0, f"_is_noise took {elapsed:.2f}s on 1M samples (O(n^2) regression?)"


### PR DESCRIPTION
## Summary

`WaveformAnalyzer._is_noise` computed a full **O(n²)** autocorrelation via `np.correlate(v, v, mode="full")` but read only two of the resulting values — lag 0 (the normalizer) and lag `n//10` (the actual `< 0.3` test). On large captures this hung: measured ≈8.8s at 50k samples, ≈50s at 200k, and it never finished at 1,000,000. This is the follow-up flagged in the examples-refresh PR (#72), where it forced `report_generation_example.py`'s waveform to be shrunk as a workaround.

## The fix

Compute exactly the two autocorrelation lags that are used, each as a single **O(n)** dot product:

```python
x  = v - np.mean(v)
r0 = float(np.dot(x, x))                 # lag 0   (was autocorr[0])
lag = max(1, len(x) // 10)
rk = float(np.dot(x[:-lag], x[lag:]))    # lag k   (was autocorr[lag])
return bool((rk / r0) < 0.3)
```

This is **mathematically identical** to what the old code read out — same two sums, same threshold — just O(n) instead of O(n²). Chosen over an FFT-based autocorrelation because we never use the whole curve (YAGNI), and two dot products are exact (no inverse-FFT rounding).

Two incidental robustness improvements, both **behavior-preserving** at the caller level:
- Constant signals no longer raise a divide-by-zero `RuntimeWarning` (the old code divided by `autocorr[0] == 0`); an explicit `r0 == 0` guard returns `False` as before.
- Empty captures previously raised `ValueError` inside `_is_noise` (swallowed by `detect_signal_type` → `(UNKNOWN, 0.0)`). `detect_signal_type` now guards an empty capture explicitly and returns the same `(UNKNOWN, 0.0)`.

## Testing

New `tests/test_waveform_analyzer_is_noise.py` (14 tests):
- **Parity** — a kept copy of the original O(n²) algorithm as an oracle; the optimized function must return the same boolean across sine / square / ramp / white-noise / DC / and small arrays (n = 1, 2, 15).
- **Behavior** — sine → not noise, white noise → noise, constant → not noise with no warning, empty capture → `(UNKNOWN, 0.0)`.
- **Perf guard** — `_is_noise` on 1,000,000 samples completes in well under 5 s (it now runs in milliseconds; an O(n²) regression would take minutes).

Full suite **969 passed, 19 skipped** — existing signal-type tests unchanged, confirming classification is preserved. Reviewed adversarially; the equivalence was independently verified bit-for-bit for n ≥ 1.

## Scope

`scpi_control/report_generator/utils/waveform_analyzer.py` (`_is_noise` + an empty-capture guard in `detect_signal_type`), the new test file, and a CHANGELOG entry. No public-API or signature changes; non-breaking.
