### PR TITLE
fix: classify periodic signals correctly instead of calling them noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples: repaired broken examples — `simple_capture.py` and `advanced_analysis.py` referenced a non-existent `waveform.time_interval` (now the sample period `1.0 / sample_rate`), and the interactive tutorial saved with an invalid `format="NPZ"` (now `"NPY"`). The report-generation and branding examples now degrade cleanly when reportlab is absent instead of crashing.
 - Examples: updated the stale `Siglent-Oscilloscope` package name (and dead repo links) to `SCPI-Instrument-Control`, and corrected the README's hardware/no-hardware annotations.
 - Screen capture on modern-dialect scopes (SDS800X HD): `ScreenCapture` now selects the correct SCDP command per dialect and reads the raw BMP sized by its own header, instead of over-reading a fixed 10&nbsp;MB — which timed out and dropped the connection. `scope.screen_capture.get_screenshot_pil()` now works on the modern scopes.
+- Report generator analysis: `WaveformAnalyzer.detect_signal_type` no longer misclassifies clean periodic signals (e.g. a square wave captured over many periods) as noise. The noise check now measures spectral concentration — whether one frequency bin dominates — instead of testing autocorrelation at an arbitrary fixed lag.
 
 ## [3.0.0] - 2026-07-17
 

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -10,11 +10,17 @@ from typing import Dict, Optional, Tuple
 
 import numpy as np
 from scipy import signal as scipy_signal
-from scipy.fft import fft, fftfreq
+from scipy.fft import fft, fftfreq, rfft
 
 from scpi_control.report_generator.models.report_data import WaveformData, WaveformRegion
 
 logger = logging.getLogger(__name__)
+
+# A periodic signal concentrates its spectral energy in a dominant peak; noise
+# spreads it out. _is_noise flags a signal as noise when its strongest FFT bin
+# is less than this multiple of the median bin. Empirically, real periodic
+# signals sit >=~280x while white noise sits ~4x, so this is not sensitive.
+_NOISE_PEAK_TO_MEDIAN = 15.0
 
 
 class SignalType:
@@ -491,22 +497,24 @@ class WaveformAnalyzer:
 
     @staticmethod
     def _is_noise(v: np.ndarray) -> bool:
-        """Check whether the signal is primarily noise.
+        """Return True if the signal is primarily noise.
 
-        Noise decorrelates quickly, so its autocorrelation at a lag of 10% of the
-        record is small relative to lag 0. Only those two autocorrelation values
-        are needed, so compute them directly as O(n) dot products rather than
-        forming the full O(n^2) autocorrelation.
+        Noise spreads its energy across the spectrum, so no frequency bin stands
+        out; a periodic signal concentrates energy in a dominant peak (and its
+        harmonics). Compare the strongest magnitude bin to the median bin: a small
+        ratio means nothing dominates -> noise.
         """
-        x = v - np.mean(v)
-        r0 = float(np.dot(x, x))  # autocorrelation at lag 0
-        if r0 == 0.0:
-            return False  # constant/flat signal: not noise (and avoids divide-by-zero)
-        lag = max(1, len(x) // 10)
-        if lag >= len(x):
+        n = v.size
+        if n < 4:
             return False
-        rk = float(np.dot(x[:-lag], x[lag:]))  # autocorrelation at `lag`
-        return bool((rk / r0) < 0.3)
+        x = v - np.mean(v)
+        mag = np.abs(rfft(x))[1:]  # positive-frequency magnitudes, DC bin dropped
+        if mag.size == 0:
+            return False
+        median = float(np.median(mag))
+        if median == 0.0:
+            return False  # isolated tones on a zero floor: not noise
+        return bool((float(np.max(mag)) / median) < _NOISE_PEAK_TO_MEDIAN)
 
     @staticmethod
     def _get_harmonic_ratios(waveform: WaveformData, num_harmonics: int = 5) -> Optional[np.ndarray]:

--- a/tests/test_real_capture_fixture.py
+++ b/tests/test_real_capture_fixture.py
@@ -4,12 +4,6 @@
 square wave captured over LAN from a Siglent SDS824X HD (decimated to 20k points
 to keep the fixture small). Real hardware data complements the synthetic/mock
 signals used elsewhere.
-
-Note: `WaveformAnalyzer.detect_signal_type` currently labels this clean square as
-"noise" -- `_is_noise` tests the autocorrelation at a lag of 10% of the record,
-which for a multi-period capture is near a half-period, where a square is
-strongly anti-correlated. That is a pre-existing heuristic limitation this real
-capture exposes; the frequency/amplitude analysis below is unaffected.
 """
 
 from pathlib import Path
@@ -17,7 +11,7 @@ from pathlib import Path
 import numpy as np
 
 from scpi_control.report_generator.models.report_data import WaveformData
-from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+from scpi_control.report_generator.utils.waveform_analyzer import SignalType, WaveformAnalyzer
 
 FIXTURE = Path(__file__).parent / "fixtures" / "cal_square_sds824x.npz"
 
@@ -49,3 +43,13 @@ def test_real_capture_amplitude():
     wf = _load()
     vpp = float(wf.voltage.max() - wf.voltage.min())
     assert 3.4 < vpp < 3.8  # measured ~3.62 Vpp
+
+
+def test_real_square_is_not_noise():
+    wf = _load()
+    assert WaveformAnalyzer._is_noise(wf.voltage) is False
+
+
+def test_real_square_classifies_as_square():
+    signal_type, _ = WaveformAnalyzer.detect_signal_type(_load())
+    assert signal_type == SignalType.SQUARE

--- a/tests/test_waveform_analyzer_is_noise.py
+++ b/tests/test_waveform_analyzer_is_noise.py
@@ -1,86 +1,68 @@
-"""_is_noise is O(n) and behaviorally identical to the old O(n^2) autocorrelation."""
+"""_is_noise classifies noise vs periodic signals by spectral concentration.
+
+A periodic signal (sine, square, ramp) concentrates energy in a dominant
+spectral peak; noise spreads it. _is_noise is True only for the latter.
+"""
 
 import time
 import types
 import warnings
 
 import numpy as np
-import pytest
 
 from scpi_control.report_generator.utils.waveform_analyzer import SignalType, WaveformAnalyzer
 
-
-def _reference_is_noise(v: np.ndarray) -> bool:
-    """The ORIGINAL O(n^2) implementation, kept as the behavioral oracle.
-
-    The optimized _is_noise must return the same boolean as this for every input.
-    """
-    v_normalized = v - np.mean(v)
-    autocorr = np.correlate(v_normalized, v_normalized, mode="full")
-    autocorr = autocorr[len(autocorr) // 2 :]
-    with np.errstate(invalid="ignore", divide="ignore"):
-        autocorr = autocorr / autocorr[0]
-    lag = max(1, len(autocorr) // 10)
-    if lag < len(autocorr):
-        return bool(autocorr[lag] < 0.3)
-    return False
-
-
-def _fixtures():
-    rng = np.random.default_rng(0)
-    t = np.linspace(0, 1e-3, 5000, endpoint=False)
-    return {
-        "sine": np.sin(2 * np.pi * 1000 * t),
-        "square": np.sign(np.sin(2 * np.pi * 1000 * t)),
-        "ramp": np.linspace(-1.0, 1.0, 5000),
-        "white_noise": rng.standard_normal(5000),
-        "dc": np.full(5000, 2.5),
-        "tiny1": np.array([3.0]),
-        "tiny2": np.array([1.0, -1.0]),
-        "tiny15": rng.standard_normal(15),
-    }
-
-
-@pytest.mark.parametrize("name", list(_fixtures().keys()))
-def test_matches_reference(name):
-    v = _fixtures()[name]
-    # Silence the reference's divide warning on the constant fixture; we only
-    # care that the OPTIMIZED function agrees on the boolean.
-    with np.errstate(invalid="ignore", divide="ignore"):
-        expected = _reference_is_noise(v)
-    assert WaveformAnalyzer._is_noise(v) == expected
-
-
-def test_sine_is_not_noise():
-    t = np.linspace(0, 1e-3, 5000, endpoint=False)
-    assert WaveformAnalyzer._is_noise(np.sin(2 * np.pi * 1000 * t)) is False
+SR = 1_000_000
+T = np.arange(20_000) / SR
 
 
 def test_white_noise_is_noise():
+    rng = np.random.default_rng(0)
+    assert WaveformAnalyzer._is_noise(rng.standard_normal(20_000)) is True
+
+
+def test_sine_is_not_noise():
+    assert WaveformAnalyzer._is_noise(np.sin(2 * np.pi * 1000 * T)) is False
+
+
+def test_single_period_square_is_not_noise():
+    t = np.arange(1000) / SR  # exactly one 1 kHz period
+    assert WaveformAnalyzer._is_noise(np.sign(np.sin(2 * np.pi * 1000 * t))) is False
+
+
+def test_multi_period_square_is_not_noise():
+    # 5 periods in the record puts the old 10%-of-record lag near a half-period,
+    # where a square is anti-correlated -- the exact case the old heuristic called
+    # "noise" (this is the shape of the real SDS824X HD capture).
+    square = np.sign(np.sin(2 * np.pi * 5 * np.linspace(0.0, 1.0, 20_000, endpoint=False)))
+    assert WaveformAnalyzer._is_noise(square) is False
+
+
+def test_sawtooth_is_not_noise():
+    saw = (np.mod(np.arange(20_000), 200) / 200.0).astype(float)
+    assert WaveformAnalyzer._is_noise(saw) is False
+
+
+def test_sine_in_moderate_noise_is_not_noise():
     rng = np.random.default_rng(1)
-    assert WaveformAnalyzer._is_noise(rng.standard_normal(5000)) is True
+    v = np.sin(2 * np.pi * 1000 * T) + 0.3 * rng.standard_normal(T.size)
+    assert WaveformAnalyzer._is_noise(v) is False
 
 
 def test_constant_is_not_noise_and_raises_no_warning():
     with warnings.catch_warnings():
-        warnings.simplefilter("error")  # any RuntimeWarning becomes a test failure
+        warnings.simplefilter("error")  # any RuntimeWarning fails the test
         assert WaveformAnalyzer._is_noise(np.full(4000, 2.5)) is False
 
 
-def test_empty_is_not_noise():
-    # Old code RAISED ValueError here (np.correlate on an empty array); the new
-    # code returns False without raising. (detect_signal_type guards empty before
-    # ever calling this, so numpy's benign "mean of empty" warning is unreachable
-    # in practice -- ignore it here.) See test_detect_signal_type_empty for the
-    # preserved caller-level behavior.
+def test_empty_and_short_are_not_noise():
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+        warnings.simplefilter("error")
         assert WaveformAnalyzer._is_noise(np.array([])) is False
+        assert WaveformAnalyzer._is_noise(np.array([1.0, -1.0, 1.0])) is False  # n < 4
 
 
 def test_detect_signal_type_empty_is_unknown():
-    # Behavior-preserving: an empty capture still classifies as (UNKNOWN, 0.0),
-    # as it did when the old _is_noise raised and detect_signal_type swallowed it.
     waveform = types.SimpleNamespace(voltage=np.array([]))
     assert WaveformAnalyzer.detect_signal_type(waveform) == (SignalType.UNKNOWN, 0.0)
 
@@ -91,4 +73,4 @@ def test_large_input_is_fast():
     start = time.perf_counter()
     WaveformAnalyzer._is_noise(v)
     elapsed = time.perf_counter() - start
-    assert elapsed < 5.0, f"_is_noise took {elapsed:.2f}s on 1M samples (O(n^2) regression?)"
+    assert elapsed < 5.0, f"_is_noise took {elapsed:.2f}s on 1M samples"


### PR DESCRIPTION
## Summary

Fixes `WaveformAnalyzer.detect_signal_type` misclassifying clean **periodic** signals — most visibly a square wave — as **noise**. Surfaced by analysing a real 1 kHz calibration square wave captured from a Siglent SDS824X HD (`tests/fixtures/cal_square_sds824x.npz`): `detect_signal_type` returned `("noise", 85.0)` even though the frequency analysis correctly found 1 kHz.

## Root cause

`_is_noise` tested the autocorrelation at a lag fixed at **10% of the record length** — unrelated to the signal's period. On a capture with ~5 periods, that lag lands near a *half*-period, where a square wave is strongly *anti*-correlated, so the test declared "noise". (It was not a regression: PR #73 preserved the old value exactly; the heuristic was always wrong for multi-period periodics. Synthetic single-period test signals never hit it; real multi-period hardware data did.)

## The fix — spectral concentration

Noise spreads its energy across the spectrum (no bin dominates); a periodic signal concentrates it in a dominant peak. `_is_noise` now returns True only when the strongest FFT bin is a small multiple of the median bin:

```python
mag = np.abs(rfft(x))[1:]                 # positive-freq magnitudes, DC dropped
return max(mag) / median(mag) < 15.0      # _NOISE_PEAK_TO_MEDIAN
```

O(n log n), reuses the `scipy.fft` the analyzer already imports, and needs no `sample_rate`, so the `_is_noise(v)` signature is unchanged.

**Measured peak/median (n=20000):** real square 11444, synthetic square 3839, sine ~1e16, sine + heavy noise 281, **white noise 3.8**. The threshold (15) sits in a ~74× gap — not sensitive to the exact value.

## Testing

- `tests/test_waveform_analyzer_is_noise.py` rewritten: the PR-#73 parity-with-the-old-algorithm tests are removed (the point is that the new result differs from the old one on squares), replaced with correctness tests — white noise → noise; sine, single- and multi-period square, sawtooth, and sine+noise → not noise; constant/short/empty → not noise with no warnings; and the 1M-sample perf guard is retained (rfft stays fast).
- `tests/test_real_capture_fixture.py`: the real square now classifies as `SignalType.SQUARE` (asserted), and the "known issue" note is gone.
- Full suite: **1013 passed, 19 skipped**. The RED→GREEN was independently verified against the reconstructed old algorithm during review (5-period square: old `True`, new `False`).

## Scope

`_is_noise` + a `_NOISE_PEAK_TO_MEDIAN` constant + the `rfft` import in `waveform_analyzer.py`, plus the two test files and CHANGELOG. `detect_signal_type` and the scoring helpers are untouched. Non-breaking; signature unchanged.
