### PR TITLE
fix: classify pulse/PWM signals as pulse instead of sawtooth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples: updated the stale `Siglent-Oscilloscope` package name (and dead repo links) to `SCPI-Instrument-Control`, and corrected the README's hardware/no-hardware annotations.
 - Screen capture on modern-dialect scopes (SDS800X HD): `ScreenCapture` now selects the correct SCDP command per dialect and reads the raw BMP sized by its own header, instead of over-reading a fixed 10&nbsp;MB — which timed out and dropped the connection. `scope.screen_capture.get_screenshot_pil()` now works on the modern scopes.
 - Report generator analysis: `WaveformAnalyzer.detect_signal_type` no longer misclassifies clean periodic signals (e.g. a square wave captured over many periods) as noise. The noise check now measures spectral concentration — whether one frequency bin dominates — instead of testing autocorrelation at an arbitrary fixed lag.
+- Report generator analysis: `WaveformAnalyzer.detect_signal_type` now classifies pulse/PWM signals (non-50%-duty square waves) as pulse instead of sawtooth. Two-level (flat-topped) signals are separated from ramps before the harmonic scorers run.
 
 ## [3.0.0] - 2026-07-17
 

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -442,6 +442,15 @@ class WaveformAnalyzer:
             if WaveformAnalyzer._is_noise(v):
                 return SignalType.NOISE, 85.0
 
+            # A two-level signal is a square (symmetric) or a pulse (asymmetric
+            # duty), never a ramp -- decide by duty cycle here, before the
+            # triangle/sawtooth scorers below can mislabel a pulse as sawtooth.
+            if WaveformAnalyzer._is_two_level(v):
+                duty_cycle = WaveformAnalyzer._estimate_duty_cycle(v)
+                if duty_cycle is not None and not (40 <= duty_cycle <= 60):
+                    return SignalType.PULSE, 85.0
+                return SignalType.SQUARE, 90.0
+
             # Analyze frequency content
             harmonics = WaveformAnalyzer._get_harmonic_ratios(waveform)
 
@@ -494,6 +503,24 @@ class WaveformAnalyzer:
         if mean == 0:
             return std < threshold
         return (std / mean) < threshold
+
+    @staticmethod
+    def _is_two_level(v: np.ndarray, band: float = 0.15, min_fraction: float = 0.8) -> bool:
+        """Return True if the signal sits at two discrete levels (square/pulse).
+
+        A flat-topped signal clusters near its min and max; a ramp (triangle,
+        sawtooth) or a sine spreads across the range. Measures the fraction of
+        samples within `band` of either extreme.
+        """
+        v = np.asarray(v, dtype=float)
+        lo = float(np.min(v))
+        hi = float(np.max(v))
+        span = hi - lo
+        if span == 0.0:
+            return False  # constant: handled upstream by _is_dc_signal
+        edge = band * span
+        near_extremes = (v <= lo + edge) | (v >= hi - edge)
+        return bool(np.mean(near_extremes) >= min_fraction)
 
     @staticmethod
     def _is_noise(v: np.ndarray) -> bool:

--- a/tests/test_signal_type_classification.py
+++ b/tests/test_signal_type_classification.py
@@ -1,0 +1,47 @@
+"""detect_signal_type classifies the standard waveform battery correctly.
+
+One table-driven test (kept deliberately to a single test: the suite is already
+large): build each signal, classify it, and assert there are no mismatches. This
+doubles as the regression guard against classifier drift -- how the noise and
+pulse bugs slipped in. The real cal-square is covered by test_real_capture_fixture.py
+and not repeated here.
+
+Known limitation (documented, not asserted): a SINGLE-period sine misclassifies
+as triangle (one cycle gives poor FFT resolution); multi-period sine is correct.
+"""
+
+import numpy as np
+from scipy import signal as sp
+
+from scpi_control.report_generator.models.report_data import WaveformData
+from scpi_control.report_generator.utils.waveform_analyzer import SignalType, WaveformAnalyzer
+
+_SR = 1_000_000
+_N = 20_000
+_T = np.linspace(0.0, 1.0, _N, endpoint=False)
+
+
+def _wf(v):
+    v = np.asarray(v, dtype=float)
+    return WaveformData(channel="C1", time=np.arange(v.size) / _SR, voltage=v, sample_rate=_SR, record_length=v.size)
+
+
+def test_signal_type_classification_battery():
+    rng = np.random.default_rng(0)
+    battery = {
+        "sine": (np.sin(2 * np.pi * 5 * _T), SignalType.SINE),
+        "square_50pct": (np.sign(np.sin(2 * np.pi * 5 * _T)), SignalType.SQUARE),
+        "triangle": (sp.sawtooth(2 * np.pi * 5 * _T, 0.5), SignalType.TRIANGLE),
+        "sawtooth": (sp.sawtooth(2 * np.pi * 5 * _T), SignalType.SAWTOOTH),
+        "pulse_20pct": (sp.square(2 * np.pi * 5 * _T, 0.2), SignalType.PULSE),
+        "pulse_80pct": (sp.square(2 * np.pi * 5 * _T, 0.8), SignalType.PULSE),
+        "white_noise": (rng.standard_normal(_N), SignalType.NOISE),
+        "dc": (np.full(_N, 2.5), SignalType.DC),
+        "sine_plus_noise": (np.sin(2 * np.pi * 5 * _T) + 0.2 * rng.standard_normal(_N), SignalType.SINE),
+    }
+    mismatches = []
+    for name, (v, expected) in battery.items():
+        got, _ = WaveformAnalyzer.detect_signal_type(_wf(v))
+        if got != expected:
+            mismatches.append(f"{name}: expected {expected!r}, got {got!r}")
+    assert not mismatches, "signal-type misclassifications:\n" + "\n".join(mismatches)


### PR DESCRIPTION
## Summary

Fixes `WaveformAnalyzer.detect_signal_type` classifying **pulse/PWM** signals (non-50%-duty square waves) as **sawtooth**, and adds a lean regression guard for the whole classifier. Found by auditing the classifier across a signal battery after the noise-heuristic fix (PR #75) — the noise bug wasn't the only misclassification.

## Root cause

After ruling out sine, `detect_signal_type` scored the harmonic pattern against square/triangle/**sawtooth** and returned the best match (>0.6) *before* it ever reached the duty-cycle/PULSE check. `_score_sawtooth_wave` correlates the harmonic envelope against `[1, ½, ⅓, …]`, and a pulse's harmonics fit that well enough to win. The scorers only see harmonic amplitudes — they can't tell that square/pulse are **two-level** (flat-topped) while triangle/sawtooth are **ramps**.

## The fix

A new `_is_two_level(v)` (fraction of samples within 15% of either extreme; threshold 0.8). In `detect_signal_type`, right after the noise check and *before* the harmonic scorers:

```python
if _is_two_level(v):                 # square or pulse, never a ramp
    duty = _estimate_duty_cycle(v)
    return (PULSE, 85.0) if duty is not None and not (40 <= duty <= 60) else (SQUARE, 90.0)
```

The existing triangle/sawtooth scorers are **byte-for-byte unchanged** — they now run only for ramp-family signals. The two-level metric separates the families with a wide margin (validated): square/pulse/real ≥ 0.998; triangle/sawtooth 0.30; sine 0.51.

## Testing (deliberately lean)

The suite is already ~1031 tests, so this adds exactly **+1**: a single table-driven battery test (`tests/test_signal_type_classification.py`) that classifies sine / square / triangle / sawtooth (≥5 periods) / pulse-20% / pulse-80% / white-noise / DC / sine+noise, collects any mismatches, and asserts none. It both verifies the fix (RED against the old code: pulse → sawtooth) and guards the whole classifier against future drift. The real cal-square classification stays covered by the existing `test_real_capture_fixture.py` (not duplicated).

Full suite: **1014 passed, 19 skipped** (+1 test). The reviewer independently recomputed the two-level fractions and re-ran the test.

## Known limitation (documented, not fixed here)

A single-period sine misclassifies as triangle (one cycle → poor FFT resolution); multi-period sine is correct, and real captures span many periods. Noted in the test; out of scope.

## Scope

`_is_two_level` + the small two-level branch in `detect_signal_type`, one battery test, and CHANGELOG. The scorers/THD/other methods are untouched. Non-breaking; signature unchanged.
