### PR TITLE
DAQ AI hardening: ground the prompts, test the surface, collapse the honest duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Report generator AI: every oscilloscope system prompt now carries one shared grounding rule (claim only what the report data or a tool actually returned; say so plainly when a value is missing rather than inventing it).
 - Report generator AI: key-findings and recommendations are parsed more tolerantly — multi-digit numbering, markdown-bold list markers, and a leading preamble line no longer corrupt the extracted list.
+- Report generator (internal): the oscilloscope and DAQ LLM prompt layers now share one grounding constant and the prompt-lookup / chat-prompt assembly via `llm/_prompt_helpers.py`, removing duplicated boilerplate.
 
 ### Fixed
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Screen capture on modern-dialect scopes (SDS800X HD): `ScreenCapture` now selects the correct SCDP command per dialect and reads the raw BMP sized by its own header, instead of over-reading a fixed 10&nbsp;MB — which timed out and dropped the connection. `scope.screen_capture.get_screenshot_pil()` now works on the modern scopes.
 - Report generator analysis: `WaveformAnalyzer.detect_signal_type` no longer misclassifies clean periodic signals (e.g. a square wave captured over many periods) as noise. The noise check now measures spectral concentration — whether one frequency bin dominates — instead of testing autocorrelation at an arbitrary fixed lag.
 - Report generator analysis: `WaveformAnalyzer.detect_signal_type` now classifies pulse/PWM signals (non-50%-duty square waves) as pulse instead of sawtooth. Two-level (flat-topped) signals are separated from ramps before the harmonic scorers run.
+- Report generator DAQ AI: the data-logger analysis prompts now carry the same grounding rule as the oscilloscope prompts (claim only what the data shows; say so when a value is missing), and the session-summary prompt no longer invites a "Here is the summary" preamble.
 
 ## [3.0.0] - 2026-07-17
 

--- a/scpi_control/report_generator/llm/_prompt_helpers.py
+++ b/scpi_control/report_generator/llm/_prompt_helpers.py
@@ -16,3 +16,15 @@ _GROUNDING = (
     "if a specific number or detail isn't in the data you have, say so plainly "
     "instead of guessing."
 )
+
+
+def lookup_prompt(table: Dict[str, str], prompt_type: str, default: str) -> str:
+    """Return `table[prompt_type]`, or `default` if the key is unknown."""
+    return table.get(prompt_type, default)
+
+
+def build_chat_prompt(preamble: str, data_label: str, context: str, question: str) -> str:
+    """Assemble the 4-part chat prompt shared by the oscilloscope and DAQ chats:
+    a preamble, a `=== <data_label> ===` data block, then the user question.
+    """
+    return f"{preamble}=== {data_label} ===\n\n{context}\n\n=== USER QUESTION ===\n\n{question}"

--- a/scpi_control/report_generator/llm/_prompt_helpers.py
+++ b/scpi_control/report_generator/llm/_prompt_helpers.py
@@ -1,0 +1,18 @@
+"""Shared helpers for the report-generator LLM prompt layer.
+
+Holds the single grounding rule and the small string-assembly helpers that the
+oscilloscope and DAQ prompt/context modules both use, so they cannot drift.
+"""
+
+from typing import Dict
+
+# One grounding rule, embedded in every system prompt (oscilloscope and DAQ) so it
+# cannot drift across hand-edited copies. Covers both data sources: the report/
+# session context a prompt is given, and any results a tool returned.
+_GROUNDING = (
+    "Ground every statement in the data available to you — the values in the "
+    "report context you were given, or the results a tool returned. Cite specific "
+    "values rather than describing them vaguely. Never invent or estimate a value: "
+    "if a specific number or detail isn't in the data you have, say so plainly "
+    "instead of guessing."
+)

--- a/scpi_control/report_generator/llm/context_builder.py
+++ b/scpi_control/report_generator/llm/context_builder.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
+from scpi_control.report_generator.llm._prompt_helpers import build_chat_prompt
 from scpi_control.report_generator.models.report_data import MeasurementResult, TestReport, TestSection, WaveformData
 from scpi_control.report_generator.models.test_types import get_test_type
 
@@ -266,24 +267,15 @@ class ContextBuilder:
             Full prompt with context and question
         """
         context = ContextBuilder.build_report_context(report, include_sections=True)
-
-        prompt = (
+        preamble = (
             "You are an expert oscilloscope technician and test engineer. "
             "Answer the following question about this test report data. "
             "Be specific, technical, and refer to actual measurements when relevant.\n\n"
         )
-
-        # Add test type context if available
         if report.metadata.test_type:
             test_type_def = get_test_type(report.metadata.test_type)
             if test_type_def and test_type_def.id != "general":
-                prompt += "=== TEST TYPE CONTEXT ===\n\n"
-                prompt += test_type_def.get_ai_context()
-                prompt += "\n\nWhen answering, consider the expected signal characteristics for this test type.\n\n"
-
-        prompt += "=== TEST REPORT DATA ===\n\n"
-        prompt += context
-        prompt += "\n\n=== USER QUESTION ===\n\n"
-        prompt += user_question
-
-        return prompt
+                preamble += "=== TEST TYPE CONTEXT ===\n\n"
+                preamble += test_type_def.get_ai_context()
+                preamble += "\n\nWhen answering, consider the expected signal characteristics for this test type.\n\n"
+        return build_chat_prompt(preamble, "TEST REPORT DATA", context, user_question)

--- a/scpi_control/report_generator/llm/daq_context_builder.py
+++ b/scpi_control/report_generator/llm/daq_context_builder.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
+from scpi_control.report_generator.llm._prompt_helpers import build_chat_prompt
+
 logger = logging.getLogger(__name__)
 
 
@@ -284,18 +286,8 @@ class DAQContextBuilder:
             Full prompt with context and question
         """
         context = DAQContextBuilder.build_session_context(data_buffer, channels, channel_configs)
-
-        prompt = (
-            "You are a data acquisition expert assistant. "
-            "Answer the following question about this DAQ session data. "
-            "Be specific and reference actual measurement values.\n\n"
-            "=== DAQ SESSION DATA ===\n\n"
-        )
-        prompt += context
-        prompt += "\n\n=== USER QUESTION ===\n\n"
-        prompt += user_question
-
-        return prompt
+        preamble = "You are a data acquisition expert assistant. " "Answer the following question about this DAQ session data. " "Be specific and reference actual measurement values.\n\n"
+        return build_chat_prompt(preamble, "DAQ SESSION DATA", context, user_question)
 
     @staticmethod
     def _get_unit_for_function(func_id: str) -> str:

--- a/scpi_control/report_generator/llm/daq_prompts.py
+++ b/scpi_control/report_generator/llm/daq_prompts.py
@@ -5,7 +5,7 @@ Contains expert knowledge about data acquisition, trend analysis,
 and measurement interpretation to guide LLM responses.
 """
 
-from scpi_control.report_generator.llm._prompt_helpers import _GROUNDING
+from scpi_control.report_generator.llm._prompt_helpers import _GROUNDING, lookup_prompt
 
 DAQ_EXPERT_SYSTEM_PROMPT = f"""You are an expert data acquisition engineer and test technician with deep knowledge of:
 
@@ -125,4 +125,4 @@ def get_daq_system_prompt(prompt_type: str = "expert") -> str:
         "chat": DAQ_CHAT_ASSISTANT_SYSTEM_PROMPT,
     }
 
-    return prompts.get(prompt_type, DAQ_EXPERT_SYSTEM_PROMPT)
+    return lookup_prompt(prompts, prompt_type, DAQ_EXPERT_SYSTEM_PROMPT)

--- a/scpi_control/report_generator/llm/daq_prompts.py
+++ b/scpi_control/report_generator/llm/daq_prompts.py
@@ -5,7 +5,9 @@ Contains expert knowledge about data acquisition, trend analysis,
 and measurement interpretation to guide LLM responses.
 """
 
-DAQ_EXPERT_SYSTEM_PROMPT = """You are an expert data acquisition engineer and test technician with deep knowledge of:
+from scpi_control.report_generator.llm._prompt_helpers import _GROUNDING
+
+DAQ_EXPERT_SYSTEM_PROMPT = f"""You are an expert data acquisition engineer and test technician with deep knowledge of:
 
 - Multi-channel data acquisition systems (Keysight 34970A, DAQ970A, Agilent 34901A, etc.)
 - Time-series data analysis and trend detection
@@ -21,9 +23,11 @@ When analyzing DAQ data:
 - Provide actionable insights for process improvement
 - Relate measurements to real-world conditions
 
-Your responses should be practical, data-driven, and helpful for technicians monitoring industrial processes or lab experiments."""
+Your responses should be practical, data-driven, and helpful for technicians monitoring industrial processes or lab experiments.
 
-DAQ_TREND_ANALYSIS_SYSTEM_PROMPT = """You are analyzing time-series data from a multi-channel data acquisition system.
+{_GROUNDING}"""
+
+DAQ_TREND_ANALYSIS_SYSTEM_PROMPT = f"""You are analyzing time-series data from a multi-channel data acquisition system.
 
 Your analysis should:
 - Identify upward/downward trends and their rates of change
@@ -39,9 +43,11 @@ When reporting trends:
 - Indicate confidence in trend detection
 - Note any anomalies or outliers affecting trend analysis
 
-Focus on actionable insights that help users understand what's happening with their measurements."""
+Focus on actionable insights that help users understand what's happening with their measurements.
 
-DAQ_THRESHOLD_ALERT_SYSTEM_PROMPT = """You are a monitoring system that analyzes measurements against acceptable limits.
+{_GROUNDING}"""
+
+DAQ_THRESHOLD_ALERT_SYSTEM_PROMPT = f"""You are a monitoring system that analyzes measurements against acceptable limits.
 
 For each channel:
 - Assess whether values are within normal operating range
@@ -56,9 +62,11 @@ When suggesting thresholds:
 - Account for drift and systematic changes
 - Differentiate between alarm levels (warning vs critical)
 
-Provide specific numeric recommendations that can be directly configured."""
+Provide specific numeric recommendations that can be directly configured.
 
-DAQ_SESSION_SUMMARY_SYSTEM_PROMPT = """You are writing a summary report for a data acquisition logging session.
+{_GROUNDING}"""
+
+DAQ_SESSION_SUMMARY_SYSTEM_PROMPT = f"""You are writing a summary report for a data acquisition logging session.
 
 Your summary should include:
 1. Session Overview: Duration, channels, measurement types
@@ -73,9 +81,13 @@ Format the report in a clear, professional manner suitable for:
 - Quality control records
 - Maintenance and troubleshooting reports
 
-Include specific values and timestamps for all observations."""
+Include specific values and timestamps for all observations.
 
-DAQ_CHAT_ASSISTANT_SYSTEM_PROMPT = """You are an expert data acquisition assistant helping users understand their measurement data.
+Write only the summary itself — no 'Here is the summary' preamble and no closing remarks.
+
+{_GROUNDING}"""
+
+DAQ_CHAT_ASSISTANT_SYSTEM_PROMPT = f"""You are an expert data acquisition assistant helping users understand their measurement data.
 
 When answering questions:
 - Reference specific measurement values and timestamps
@@ -90,7 +102,9 @@ You have access to:
 - Session metadata (duration, scan rate)
 - Statistical summaries
 
-Be helpful, accurate, and focused on helping users get the most from their DAQ system."""
+Be helpful, accurate, and focused on helping users get the most from their DAQ system.
+
+{_GROUNDING}"""
 
 
 def get_daq_system_prompt(prompt_type: str = "expert") -> str:

--- a/scpi_control/report_generator/llm/prompts.py
+++ b/scpi_control/report_generator/llm/prompts.py
@@ -5,7 +5,7 @@ Contains expert knowledge about oscilloscopes, signal analysis,
 and test procedures to guide LLM responses.
 """
 
-from scpi_control.report_generator.llm._prompt_helpers import _GROUNDING
+from scpi_control.report_generator.llm._prompt_helpers import _GROUNDING, lookup_prompt
 
 OSCILLOSCOPE_EXPERT_SYSTEM_PROMPT = f"""You are an expert oscilloscope technician and test engineer with deep knowledge of:
 
@@ -135,4 +135,4 @@ def get_system_prompt(prompt_type: str = "expert") -> str:
         "chat_tools": CHAT_WITH_TOOLS_SYSTEM_PROMPT,
     }
 
-    return prompts.get(prompt_type, OSCILLOSCOPE_EXPERT_SYSTEM_PROMPT)
+    return lookup_prompt(prompts, prompt_type, OSCILLOSCOPE_EXPERT_SYSTEM_PROMPT)

--- a/scpi_control/report_generator/llm/prompts.py
+++ b/scpi_control/report_generator/llm/prompts.py
@@ -5,18 +5,7 @@ Contains expert knowledge about oscilloscopes, signal analysis,
 and test procedures to guide LLM responses.
 """
 
-# One grounding rule, interpolated into every system prompt below so it cannot
-# drift across six hand-edited copies. Worded to cover both data sources: the
-# static report context (five prompts) and tool results (chat_tools).
-# NOTE: the prompts that embed this are f-strings — keep literal braces out of
-# their bodies, or double them ({{ }}).
-_GROUNDING = (
-    "Ground every statement in the data available to you — the values in the "
-    "report context you were given, or the results a tool returned. Cite specific "
-    "values rather than describing them vaguely. Never invent or estimate a value: "
-    "if a specific number or detail isn't in the data you have, say so plainly "
-    "instead of guessing."
-)
+from scpi_control.report_generator.llm._prompt_helpers import _GROUNDING
 
 OSCILLOSCOPE_EXPERT_SYSTEM_PROMPT = f"""You are an expert oscilloscope technician and test engineer with deep knowledge of:
 

--- a/tests/test_daq_llm.py
+++ b/tests/test_daq_llm.py
@@ -1,0 +1,90 @@
+"""Characterization tests for the DAQ LLM surface (previously untested).
+
+Lean by design: pins the behaviors the prompt-helper refactor could break --
+prompt lookup, context assembly structure, the empty-buffer guards, and the
+deliberate low temperature on threshold suggestions. Uses a mock client (no
+network).
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from scpi_control.report_generator.llm.context_builder import ContextBuilder
+from scpi_control.report_generator.llm.daq_analyzer import DAQAnalyzer
+from scpi_control.report_generator.llm.daq_context_builder import DAQContextBuilder
+from scpi_control.report_generator.llm.daq_prompts import get_daq_system_prompt
+from scpi_control.report_generator.models.report_data import ReportMetadata, TestReport, TestSection, WaveformData
+
+_KEYS = ["expert", "trends", "thresholds", "summary", "chat"]
+
+_BUFFER = [
+    {"timestamp": 0.0, "readings": {1: 1.00, 2: 20.0}},
+    {"timestamp": 1.0, "readings": {1: 1.02, 2: 20.5}},
+    {"timestamp": 2.0, "readings": {1: 1.04, 2: 21.0}},
+]
+_CHANNELS = [1, 2]
+_CONFIGS = {1: {"function": "VOLT:DC", "function_display": "DC Voltage"}, 2: {"function": "TEMP:TC:K", "function_display": "Temperature"}}
+
+
+def test_get_daq_system_prompt_returns_each_prompt_and_defaults():
+    for key in _KEYS:
+        assert isinstance(get_daq_system_prompt(key), str) and get_daq_system_prompt(key).strip()
+    assert get_daq_system_prompt("nonexistent") == get_daq_system_prompt("expert")
+
+
+def test_build_session_context_structure():
+    ctx = DAQContextBuilder.build_session_context(_BUFFER, _CHANNELS, _CONFIGS)
+    assert "# DAQ Session Data" in ctx
+    assert "Total Scans: 3" in ctx
+    assert "## Channel Statistics" in ctx
+    assert "### Channel 1 (DC Voltage)" in ctx
+
+
+def test_build_chat_context_has_markers_and_question():
+    ctx = DAQContextBuilder.build_chat_context(_BUFFER, _CHANNELS, "What is the trend on channel 1?", _CONFIGS)
+    assert "=== DAQ SESSION DATA ===" in ctx
+    assert ctx.rstrip().endswith("What is the trend on channel 1?")
+    assert "=== USER QUESTION ===" in ctx
+
+
+def _osc_report():
+    t = np.arange(100) / 1e6
+    wf = WaveformData(channel="C1", time=t, voltage=np.sin(2 * np.pi * 1000 * t), sample_rate=1e6, record_length=100)
+    return TestReport(metadata=ReportMetadata(title="B", technician="r", test_date=datetime(2026, 7, 18)), sections=[TestSection(title="Captures", waveforms=[wf])])
+
+
+def test_osc_build_chat_context_has_markers_and_question():
+    # Safety net for the shared build_chat_prompt refactor: the oscilloscope chat
+    # builder is otherwise untested (the analyzer tests take the tool-calling path).
+    ctx = ContextBuilder.build_chat_context(_osc_report(), "Is C1 clean?")
+    assert "=== TEST REPORT DATA ===" in ctx
+    assert "=== USER QUESTION ===" in ctx
+    assert ctx.rstrip().endswith("Is C1 clean?")
+
+
+def test_analyze_trends_calls_client_with_trends_prompt():
+    client = MagicMock()
+    client.complete.return_value = "trend analysis"
+    out = DAQAnalyzer(client).analyze_trends(_BUFFER, _CHANNELS, _CONFIGS)
+    assert out == "trend analysis"
+    kwargs = client.complete.call_args.kwargs
+    assert kwargs["system_prompt"] == get_daq_system_prompt("trends")
+    assert kwargs["temperature"] == 0.7
+
+
+def test_empty_buffer_guards_do_not_call_the_model():
+    client = MagicMock()
+    analyzer = DAQAnalyzer(client)
+    assert analyzer.analyze_trends([], _CHANNELS) == "No data available for trend analysis."
+    assert analyzer.answer_question([], _CHANNELS, "q?") == "No data available. Please start a logging session first."
+    assert analyzer.suggest_thresholds([], 1) is None
+    client.complete.assert_not_called()
+
+
+def test_suggest_thresholds_uses_low_temperature():
+    client = MagicMock()
+    client.complete.return_value = "warning high 1.1"
+    DAQAnalyzer(client).suggest_thresholds(_BUFFER, 1, _CONFIGS[1])
+    assert client.complete.call_args.kwargs["temperature"] == 0.5

--- a/tests/test_daq_llm.py
+++ b/tests/test_daq_llm.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 
+from scpi_control.report_generator.llm._prompt_helpers import _GROUNDING
 from scpi_control.report_generator.llm.context_builder import ContextBuilder
 from scpi_control.report_generator.llm.daq_analyzer import DAQAnalyzer
 from scpi_control.report_generator.llm.daq_context_builder import DAQContextBuilder
@@ -88,3 +89,11 @@ def test_suggest_thresholds_uses_low_temperature():
     client.complete.return_value = "warning high 1.1"
     DAQAnalyzer(client).suggest_thresholds(_BUFFER, 1, _CONFIGS[1])
     assert client.complete.call_args.kwargs["temperature"] == 0.5
+
+
+def test_daq_prompts_are_grounded():
+    # One test covers both the grounding rule (all 5 prompts) and the summary
+    # no-preamble instruction, to keep the added test count minimal.
+    for key in _KEYS:
+        assert _GROUNDING in get_daq_system_prompt(key)
+    assert "Write only the summary itself" in get_daq_system_prompt("summary")


### PR DESCRIPTION
## Summary

Hardens the report-generator's **DAQ (data-logger) AI** and collapses the honest duplication between it and the oscilloscope AI. Started as a "twin collapse" of the `daq_*` trio; an audit reframed it — the duplication is mostly *pattern* similarity (the two sides walk genuinely different data, with no shared model), the DAQ AI surface was **entirely untested**, and it was missing the grounding rule the oscilloscope prompts got in PR #71. So this delivers the real wins safely: tests → grounding fix → a modest, behavior-preserving collapse.

## What changed (in order)

1. **Characterization tests** (`tests/test_daq_llm.py`) for the previously-untested DAQ LLM surface — prompt lookup, context assembly, the empty-buffer guards, and the deliberate `temperature=0.5` on `suggest_thresholds`. Plus a test for the oscilloscope `build_chat_context` (also untested). This is the safety net the refactor leans on.
2. **Grounded the DAQ prompts** (the PR #71 fix, for DAQ): all 5 DAQ system prompts now carry the shared `_GROUNDING` clause (claim only what the data shows; say so when a value is missing), cutting the DAQ AI's fabrication risk. The session-summary prompt also drops the "Here is the summary" preamble.
3. **Collapsed the honest duplication** into `llm/_prompt_helpers.py`: the `_GROUNDING` constant (moved, re-exported from `prompts.py` so existing imports keep working), `lookup_prompt` (the one genuinely-duplicated function — replaces both `get_*_system_prompt` bodies), and `build_chat_prompt` (the 4-part chat assembly both `build_chat_context` methods shared).

## Deliberately NOT done (the audit's 10 traps)

No shared analyzer base class / generic dispatcher (the two `answer_question` methods have opposite tool-calling behavior; no shared data model). Left alone: `answer_question`, tool-calling, `suggest_thresholds` logic, the DAQ stats/unit/threshold helpers, `window_size`, `create_daq_analyzer`, `format_readings_for_export`. The trivial `build_instructed_request` concat was considered and dropped as over-abstraction.

## Testing

Behavior-preserving refactor: `get_*_system_prompt` and both `build_chat_context` produce **byte-identical** output — verified in review by reconstructing the pre-refactor bodies and running them against HEAD across 4 cases (including the optional test-type-context fold-in), full string equality. The only intended behavior change is the DAQ grounding additions.

Full suite: **1022 passed, 19 skipped**. Net new tests kept deliberately lean: **+8**.

## Scope

`tests/test_daq_llm.py` (new), `llm/_prompt_helpers.py` (new), and edits to `prompts.py`, `daq_prompts.py`, `context_builder.py`, `daq_context_builder.py`, plus CHANGELOG. Non-breaking; no public signatures changed.
