### PR TITLE
fix: keep PDF report text within the built-in font's renderable characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report generator analysis: `WaveformAnalyzer.detect_signal_type` no longer misclassifies clean periodic signals (e.g. a square wave captured over many periods) as noise. The noise check now measures spectral concentration — whether one frequency bin dominates — instead of testing autocorrelation at an arbitrary fixed lag.
 - Report generator analysis: `WaveformAnalyzer.detect_signal_type` now classifies pulse/PWM signals (non-50%-duty square waves) as pulse instead of sawtooth. Two-level (flat-topped) signals are separated from ramps before the harmonic scorers run.
 - Report generator DAQ AI: the data-logger analysis prompts now carry the same grounding rule as the oscilloscope prompts (claim only what the data shows; say so when a value is missing), and the session-summary prompt no longer invites a "Here is the summary" preamble.
+- Report generator PDF: characters outside the built-in font's range (⚠, ✓/✗, σ, Ω, …) no longer render as blank boxes — they are normalized to readable text, with a catch-all so any unexpected glyph can never box out.
 
 ## [3.0.0] - 2026-07-17
 

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -297,6 +297,23 @@ class PDFReportGenerator(BaseReportGenerator):
         text = text.replace("\u2103", " C")  # degree celsius
         text = text.replace("\u2109", " F")  # degree fahrenheit
 
+        # Report/analysis symbols the built-in Type-1 font cannot draw
+        text = text.replace("\u26a0", "!")  # warning sign
+        text = text.replace("\u2713", "[OK]")  # check mark
+        text = text.replace("\u2705", "[OK]")  # heavy/white check mark
+        text = text.replace("\u2714", "[OK]")  # heavy check mark
+        text = text.replace("\u2717", "[X]")  # ballot x
+        text = text.replace("\u2718", "[X]")  # heavy ballot x
+        text = text.replace("\u274c", "[X]")  # cross mark
+        text = text.replace("\u03c3", "sigma")  # greek small sigma
+        text = text.replace("\u03a9", "ohm")  # greek capital omega (ohms)
+        text = text.replace("\u2139", "i")  # information source
+        text = text.replace("\ufe0f", "")  # emoji variation selector (remove)
+
+        # Catch-all: anything still outside the built-in font's WinAnsi/cp1252
+        # coverage is replaced so it can never render as a blank box in the PDF.
+        text = text.encode("cp1252", "replace").decode("cp1252")
+
         # Store markdown patterns before escaping
         # We'll process them in order to avoid conflicts
 
@@ -833,7 +850,7 @@ class PDFReportGenerator(BaseReportGenerator):
         # Flatness
         if region.flatness is not None:
             flatness_formatted = f"{region.flatness*1e3:.2f} mV"
-            analysis_data.append(["Flatness (σ):", flatness_formatted])
+            analysis_data.append(["Flatness (std):", flatness_formatted])
 
         # Noise level
         if region.noise_level is not None:
@@ -856,7 +873,7 @@ class PDFReportGenerator(BaseReportGenerator):
 
         # Pass/fail status
         if region.passes_spec is not None:
-            status = "✓ PASS" if region.passes_spec else "✗ FAIL"
+            status = "PASS" if region.passes_spec else "FAIL"
             analysis_data.append(["Spec Check:", status])
 
         # Create analysis table

--- a/tests/test_pdf_unicode_safety.py
+++ b/tests/test_pdf_unicode_safety.py
@@ -1,0 +1,28 @@
+"""The PDF generator's text sanitizer keeps output within the built-in font's
+WinAnsi/cp1252 coverage, so no glyph renders as a blank box.
+
+reportlab's built-in Type-1 fonts (Helvetica) can only draw WinAnsi/cp1252
+characters; anything outside that (warning sign, check/ballot-x, Greek letters,
+CJK, ...) renders as an empty box. `_markdown_to_reportlab` must map or replace
+those so the PDF never shows a missing glyph.
+"""
+
+import pytest
+
+pytest.importorskip("reportlab")
+
+from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator  # noqa: E402
+
+
+def test_markdown_to_reportlab_output_is_winansi_safe():
+    gen = PDFReportGenerator()
+    # Glyphs the built-in font cannot draw: warning sign, check mark, ballot-x,
+    # Greek sigma/omega, plus an arbitrary CJK char to exercise the catch-all.
+    problem = "⚠ warn ✓ ok ✗ bad σ sd Ω ohm 你 cjk"
+    out = gen._markdown_to_reportlab(problem)
+
+    # Everything the built-in PDF font will be asked to draw must be cp1252-encodable.
+    out.encode("cp1252")  # raises UnicodeEncodeError if an un-renderable glyph survived
+
+    # And the known symbols are mapped to readable text, not silently dropped.
+    assert "!" in out  # warning sign -> "!"


### PR DESCRIPTION
## Summary

Some characters were rendering as blank boxes in generated PDF reports. Root cause: reportlab's built-in Type-1 fonts (Helvetica) can only draw **WinAnsi/cp1252** glyphs, and `_markdown_to_reportlab`'s sanitizer whitelist didn't cover several symbols the analysis pipeline emits — the warning sign (⚠), check/ballot-x marks (✓ ✗), Greek sigma/omega (σ Ω), the info source (ℹ), and emoji variation selectors. Two labels also bypassed the sanitizer entirely with hardcoded non-ASCII literals.

## What changed

- **Extended the sanitizer whitelist** in `_markdown_to_reportlab` to map the report/analysis symbols to readable ASCII: ⚠→`!`, ✓/✔/✅→`[OK]`, ✗/✘/❌→`[X]`, σ→`sigma`, Ω→`ohm`, ℹ→`i`, and stripping the emoji variation selector.
- **Added a catch-all** — `text.encode("cp1252", "replace").decode("cp1252")` — so *any* future glyph outside the built-in font's coverage becomes `?` instead of a blank box. This runs before XML escaping and markup insertion, so it can't corrupt reportlab tags, and the roundtrip is lossless (can't raise).
- **Fixed two hardcoded bypasses** that skipped the sanitizer: the region flatness label (`Flatness (σ):` → `Flatness (std):`) and the region pass/fail badge (`✓ PASS`/`✗ FAIL` → `PASS`/`FAIL`).

Untouched on purpose: the `if "✓"/"⚠" in region.calibration_recommendation` checks that pick a box *color* — they inspect the raw recommendation string and are never rendered.

## Testing

- New lean safety-net test (`tests/test_pdf_unicode_safety.py`, +1 test): asserts `_markdown_to_reportlab` output is fully cp1252-encodable, so no un-renderable glyph can survive.
- **End-to-end verification against real hardware data:** generated a probe-calibration PDF from the real `cal_square_sds824x.npz` capture (9 plateau regions, a recommendation containing the ✓ that was boxing), extracted its text with pypdf, and confirmed **zero** un-renderable characters in the output.
- Full suite: **1023 passed, 19 skipped**. Net new tests: **+1**.

## Scope

`scpi_control/report_generator/generators/pdf_generator.py`, `tests/test_pdf_unicode_safety.py`, CHANGELOG. Non-breaking.
