### PR TITLE
feat: acquisition provenance in saved waveforms + raw-data extraction (load_waveform, scpi-extract)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ waveform_*.h5
 waveform_*.npy
 waveform_*.bin
 my_circle_*.csv
+provenance_demo.npz
 *.waveform
 
 # AI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples: four new runnable, no-hardware examples — `report_ai_qa.py` (local-LLM tool-calling Q&A over a report), `network_discovery.py` (scan the network for SCPI instruments), `report_branding.py` (apply company branding/colours to a report), and `report_computed_analysis.py` (deterministic, LLM-free report analysis).
 - Examples: a `tests/test_examples_smoke.py` guard that executes the no-hardware examples, compile-checks the rest, and blocks known-stale tokens from reappearing.
 - Docs: a real screen capture and a real 1&nbsp;kHz calibration-square-wave plot from a Siglent SDS824X HD (in `docs/images/`), plus the raw capture committed as a test fixture (`tests/fixtures/cal_square_sds824x.npz`) that exercises the analyzer against genuine hardware data.
+- Acquisition provenance: waveforms captured with `acquire()`/`get_waveform()` now record the instrument identity, per-channel settings, trigger configuration, timebase, and UTC timestamp, embedded in every save format (new keys only — existing files and keys are unchanged; pass `provenance=False` to skip the snapshot on high-rate paths).
+- `scpi_control.waveform_io.load_waveform()`: public parser that reads all five waveform file formats (old and new files) into numpy arrays plus normalized metadata/provenance, with an optional `to_dataframe()` pandas helper.
+- `scpi-extract` CLI: inspect provenance (`--info`), dump raw data (`--csv`), or emit machine-readable metadata (`--json`) from any saved waveform file.
+- Waveform savers now persist the previously dropped `timebase`, `voltage_scale`, and `voltage_offset` fields; plain CSV gains a `#`-commented provenance header (channel, sample rate, scales, instrument, timestamp) (suppress with `save_waveform(..., bare=True)`).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A universal Python library for controlling SCPI-compatible test equipment via Et
 - **Automation & Data Collection**: High-level API for batch capture, continuous monitoring, and analysis
 - **GUI Application**: Modern PyQt6-based graphical interface
 - **Waveform Acquisition**: Capture and download waveform data in multiple formats (NPZ, CSV, MAT, HDF5)
+- **Acquisition Provenance**: every saved waveform records the instrument, settings, and timestamp that produced it; extract raw data from any saved file with load_waveform() or the scpi-extract CLI
 - **Channel Configuration**: Control voltage scale, coupling, offset, bandwidth
 - **Trigger Settings**: Configure trigger modes, levels, edge detection
 - **Advanced Analysis**: Built-in FFT, SNR, THD, and statistical analysis tools

--- a/docs/user-guide/data-provenance.md
+++ b/docs/user-guide/data-provenance.md
@@ -1,0 +1,176 @@
+# Data Provenance
+
+Every waveform you save now carries a record of the instrument and settings
+that produced it. This guide covers what that record contains, where it
+lives in each file format, and how to get it (and your raw data) back out
+with `load_waveform()` or the `scpi-extract` command-line tool.
+
+## What Provenance Is
+
+When you acquire a waveform, the library snapshots the instrument state at
+that moment and attaches it to the returned `WaveformData`:
+
+- **Instrument**: manufacturer, model, serial number, firmware
+- **Channel settings**: enabled, coupling, voltage scale, voltage offset,
+  probe ratio, bandwidth limit, unit -- for the channel(s) acquired
+- **Trigger settings**: mode, type, source, level, slope, coupling, holdoff
+- **Timebase and sample rate**
+- **`acquired_at`**: a UTC ISO-8601 timestamp
+- **Connection details**: instrument address, SCPI dialect
+- **Library version** that produced the file
+
+```python
+from scpi_control import Oscilloscope
+
+with Oscilloscope('192.168.1.100') as scope:
+    waveform = scope.get_waveform(channel=1)  # provenance=True by default
+
+    prov = waveform.provenance
+    print(prov.instrument.model)              # e.g. 'SDS824X HD'
+    print(prov.channels[1].probe_ratio)        # e.g. 10.0
+    print(prov.acquired_at)                    # UTC timestamp
+```
+
+The snapshot is taken at acquisition time, so it reflects the settings that
+actually produced the trace -- not whatever the scope happens to be set to
+later. Individual fields that a model can't answer come back as `None`
+rather than failing the acquisition, and if the snapshot itself fails (a
+communication hiccup, an unsupported query), the library logs a warning and
+returns the waveform with `provenance=None` instead of losing the capture.
+
+### Skipping Provenance
+
+High-rate paths -- live view, streaming -- pass `provenance=False` to skip
+the extra queries:
+
+```python
+waveform = scope.get_waveform(channel=1, provenance=False)
+# or, calling the lower-level API directly:
+waveform = scope.waveform.acquire(channel=1, provenance=False)
+```
+
+## Where It Lives in Each Format
+
+Provenance is stored additively -- existing readers of these files (your own
+scripts, other tools) that don't know about it simply ignore the new keys.
+
+| Format | Where | Key/Field |
+| --- | --- | --- |
+| NPZ | Array key | `provenance_json` (JSON string) |
+| MAT | Struct key | `provenance_json` (JSON string) |
+| HDF5 | File attribute | `provenance_json` (JSON string) |
+| Enhanced CSV (`CSV_ENHANCED`) | Header comment line | `# Provenance-JSON: {...}` |
+| Plain CSV | Header comment line (only when provenance is present) | `# Provenance-JSON: {...}` |
+
+All formats also gained three scale fields, written alongside the existing
+`time`, `voltage`, `channel`, and `sample_rate` data:
+
+| Field | NPZ/MAT/HDF5 key | CSV header line |
+| --- | --- | --- |
+| Timebase (s/div) | `timebase` | `# Timebase: <value> s/div` |
+| Voltage scale (V/div) | `voltage_scale` | `# Voltage Scale: <value> V/div` |
+| Voltage offset (V) | `voltage_offset` | `# Voltage Offset: <value> V` |
+
+The binary formats (NPZ, MAT, HDF5) always write the scale fields. Plain CSV
+only writes its header block -- title, `# Channel:`, `# Sample Rate:`, the
+scale lines, `# Instrument:`, `# Acquired (UTC):`, and `# Provenance-JSON:`
+-- when the waveform actually carries a provenance object. A capture saved
+with `provenance=False` produces a plain CSV that is byte-for-byte identical
+to what the library wrote before this feature existed.
+
+### Restoring the Legacy CSV Layout
+
+If you need the fully headerless plain-CSV layout regardless of whether
+provenance is present -- for a downstream tool that chokes on comment
+lines, for example -- pass `bare=True`:
+
+```python
+scope.waveform.save_waveform(waveform, "capture.csv", format="CSV", bare=True)
+```
+
+## Extracting Your Data
+
+`scpi_control.waveform_io.load_waveform()` reads all five saved formats --
+NPZ, plain CSV, enhanced CSV, MAT, HDF5 -- whether or not they carry
+provenance:
+
+```python
+from scpi_control.waveform_io import load_waveform
+
+lw = load_waveform("capture.npz")          # any of the 5 formats, old or new
+lw.time, lw.voltage                        # numpy arrays
+lw.provenance.instrument.model             # 'SDS824X HD'
+lw.provenance.channels[1].probe_ratio      # 10.0
+df = lw.to_dataframe()                     # pandas; metadata in df.attrs
+```
+
+`load_waveform()` auto-detects the format from the file extension
+(`.npz`/`.npy`, `.csv`, `.mat`, `.h5`/`.hdf5`); pass `format="CSV"` (etc.) to
+override it. The returned `LoadedWaveform` normalizes the three binary
+formats' differing metadata conventions into one flat `metadata` dict, plus
+`time`, `voltage`, `channel`, `sample_rate`, `provenance`, `source_format`,
+and `source_path`.
+
+`to_dataframe()` needs pandas installed (`pip install pandas`); it raises
+`ImportError` with an install hint if it's missing.
+
+## The `scpi-extract` Command
+
+`scpi-extract` inspects and exports saved waveform files without writing any
+Python:
+
+```bash
+scpi-extract capture.npz
+```
+
+```text
+File:        capture.npz (NPZ)
+Channel:     1
+Samples:     256
+Sample rate: 1000.0
+Instrument:  Siglent Technologies SDS1104X-E (serial MOCK0001, firmware 1.0.0.0)
+Acquired:    2026-07-21T16:09:04.840835+00:00
+Address:     mock:5025  Dialect: legacy  Library: v3.0.0
+Channel 1:   scale=1.0 V/div offset=0.0 V coupling=DC probe=10.0x bw=OFF
+Timebase:    0.001 s/div
+Metadata:
+  timebase: 0.001
+  timestamp: 2026-07-21T09:09:04.840835
+  voltage_offset: 0.0
+  voltage_scale: 1.0
+```
+
+`--info` (the default when no other flag is given) prints that summary.
+`--csv OUT` dumps the raw `time,voltage` rows to a new CSV file:
+
+```bash
+scpi-extract capture.mat --csv out.csv
+```
+
+`--json` prints metadata and provenance as machine-readable JSON, for
+piping into other tools:
+
+```bash
+scpi-extract capture.h5 --json
+```
+
+`--format {NPZ,CSV,MAT,HDF5}` overrides format auto-detection when a file's
+extension doesn't match its contents. Errors (missing file, unparseable
+format, missing optional dependency) print to stderr and exit with status 1.
+
+## Legacy Files
+
+Any file saved before this release loads exactly as before -- `load_waveform()`
+and `scpi-extract` both handle it, and `provenance` simply comes back `None`:
+
+```python
+lw = load_waveform("old_capture.npz")
+assert lw.provenance is None   # file predates provenance capture
+lw.time, lw.voltage            # still there
+```
+
+## See Also
+
+- [Waveform Capture](waveform-capture.md) for acquisition and saving basics
+- `examples/waveform_provenance_and_extract.py` for a runnable, hardware-free
+  walkthrough of this entire flow

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,6 +34,7 @@ pip install "SCPI-Instrument-Control"
 | `advanced_analysis.py` | Advanced waveform analysis and visualization: FFT analysis, statistical analysis, and matplotlib plots. | Oscilloscope on the network, matplotlib |
 | `probe_calibration_analysis.py` | Waveform region extraction for probe compensation analysis: plateau detection, slope analysis, calibration guidance, and zoomed PDF report plots. | `SCPI-Instrument-Control[report-generator]` (no hardware — fully synthetic) |
 | `dialect_override_example.py` | SCPI dialect auto-detection from `*IDN?` and the `dialect=` override for forcing a command set; runs entirely on mock connections. | Core install only (no hardware) |
+| `waveform_provenance_and_extract.py` | Acquisition provenance: capturing a waveform with the instrument/settings snapshot attached, saving NPZ and CSV, and reading them back with `load_waveform()`; runs entirely against a mock connection -- no instrument needed. | Core install only (no hardware) |
 
 ## Web Gateway
 
@@ -87,9 +88,10 @@ the file — update it to match your instrument. To find an oscilloscope's
 LAN address: **Utility → I/O → LAN** on the instrument's front panel.
 
 The scripts marked "no hardware" above (`dialect_override_example.py`,
-`trend_logging_walkthrough.py`, `psu_gui_test.py`, `probe_calibration_analysis.py`,
-`psu_advanced_features.py`, `network_discovery.py`, `report_computed_analysis.py`,
-`report_branding.py`, `report_ai_qa.py`) use mock connections and run as-is.
+`waveform_provenance_and_extract.py`, `trend_logging_walkthrough.py`, `psu_gui_test.py`,
+`probe_calibration_analysis.py`, `psu_advanced_features.py`, `network_discovery.py`,
+`report_computed_analysis.py`, `report_branding.py`, `report_ai_qa.py`) use mock
+connections and run as-is.
 
 ## Running an example
 

--- a/examples/waveform_provenance_and_extract.py
+++ b/examples/waveform_provenance_and_extract.py
@@ -22,7 +22,7 @@ from scpi_control.connection import MockConnection
 from scpi_control.oscilloscope import Oscilloscope
 from scpi_control.waveform_io import load_waveform
 
-OUTPUT_DIR = Path(__file__).parent
+OUTPUT_DIR = Path.cwd()
 NPZ_PATH = OUTPUT_DIR / "provenance_demo.npz"
 CSV_PATH = OUTPUT_DIR / "provenance_demo.csv"
 

--- a/examples/waveform_provenance_and_extract.py
+++ b/examples/waveform_provenance_and_extract.py
@@ -1,0 +1,85 @@
+"""Acquisition provenance and the load_waveform() / scpi-extract workflow.
+
+Every saved waveform now embeds a snapshot of the instrument state that
+produced it: instrument IDN, per-channel settings (scale, coupling, probe
+ratio), trigger configuration, timebase, sample rate, and a UTC timestamp.
+This example acquires from a mock oscilloscope (no hardware required), saves
+NPZ and CSV, then reads both back with scpi_control.waveform_io.load_waveform()
+and prints the instrument model, channel scale, and first few samples --
+exactly what scpi-extract does from the command line.
+
+To inspect the saved files yourself:
+    scpi-extract provenance_demo.npz
+    scpi-extract provenance_demo.csv --json
+
+Requirements: SCPI-Instrument-Control (core install) -- runs entirely against
+a mock connection, no instrument needed.
+"""
+
+from pathlib import Path
+
+from scpi_control.connection import MockConnection
+from scpi_control.oscilloscope import Oscilloscope
+from scpi_control.waveform_io import load_waveform
+
+OUTPUT_DIR = Path(__file__).parent
+NPZ_PATH = OUTPUT_DIR / "provenance_demo.npz"
+CSV_PATH = OUTPUT_DIR / "provenance_demo.csv"
+
+
+def acquire_and_save() -> None:
+    """Connect to a mock scope, acquire channel 1 with provenance, and save it."""
+    conn = MockConnection(
+        "mock",
+        idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0",
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=1_000.0,
+        timebase=1e-3,
+        waveform_payloads={1: bytes(range(256))},
+        # The base mock doesn't answer every legacy-dialect query (e.g. probe
+        # ratio); fill in the ones the provenance snapshot reads so channel 1
+        # comes back fully populated instead of silently falling back to None.
+        custom_responses={"C1:ATTN?": "10", "C1:BWL?": "OFF", "C1:UNIT?": "V"},
+    )
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    try:
+        # provenance=True is the default; shown here for clarity.
+        waveform = scope.get_waveform(1, provenance=True)
+        scope.waveform.save_waveform(waveform, str(NPZ_PATH), format="NPY")
+        scope.waveform.save_waveform(waveform, str(CSV_PATH), format="CSV")
+        print(f"Saved {NPZ_PATH.name} and {CSV_PATH.name}")
+    finally:
+        scope.disconnect()
+
+
+def inspect(path: Path) -> None:
+    """Reload a saved waveform and print what its provenance records."""
+    loaded = load_waveform(path)
+    print(f"\n--- {path.name} ({loaded.source_format}) ---")
+
+    prov = loaded.provenance
+    if prov is None:
+        print("No provenance recorded (file predates this feature).")
+        return
+
+    if prov.instrument is not None:
+        print(f"Instrument model: {prov.instrument.model}")
+
+    channel_settings = prov.channels.get(loaded.channel) or prov.channels.get(1)
+    if channel_settings is not None:
+        print(f"Channel {channel_settings.channel} scale: {channel_settings.voltage_scale} V/div (probe {channel_settings.probe_ratio}x)")
+
+    print(f"Acquired (UTC): {prov.acquired_at}")
+    print(f"First 5 samples (V): {loaded.voltage[:5].tolist()}")
+
+
+def main() -> None:
+    acquire_and_save()
+    inspect(NPZ_PATH)
+    inspect(CSV_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,7 @@ nav:
       - Basic Usage: user-guide/basic-usage.md
       - SCPI Dialects: user-guide/scpi-dialects.md
       - Waveform Capture: user-guide/waveform-capture.md
+      - Data Provenance: user-guide/data-provenance.md
       - Measurements: user-guide/measurements.md
       - Trigger Control: user-guide/trigger-control.md
       - Advanced Features: user-guide/advanced-features.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ all = [
 siglent-gui = "scpi_control.gui.app:main"
 siglent-report-generator = "scpi_control.report_generator.app:main"
 scpi-web = "scpi_control.server.__main__:main"
+scpi-extract = "scpi_control.scpi_extract:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/scpi_control/gui/live_view_worker.py
+++ b/scpi_control/gui/live_view_worker.py
@@ -140,7 +140,7 @@ class LiveViewWorker(QThread):
             try:
                 self.status_update.emit(f"Acquiring CH{ch_num}...")
                 logger.debug(f"Worker acquiring waveform from channel {ch_num}")
-                waveform = self.scope.get_waveform(ch_num)
+                waveform = self.scope.get_waveform(ch_num, provenance=False)
                 if waveform:
                     waveforms.append(waveform)
                     logger.debug(f"Worker got {len(waveform.voltage)} samples from CH{ch_num}")

--- a/scpi_control/oscilloscope.py
+++ b/scpi_control/oscilloscope.py
@@ -370,18 +370,20 @@ class Oscilloscope:
         """Perform automatic setup."""
         self.write(self._get_command("auto_setup"))
 
-    def get_waveform(self, channel: int) -> WaveformData:
+    def get_waveform(self, channel: int, provenance: bool = True) -> WaveformData:
         """Acquire waveform data from a channel.
 
         Convenience method that calls waveform.acquire().
 
         Args:
             channel: Channel number (1-4)
+            provenance: Snapshot instrument settings alongside the data
+                (default True; pass False on high-rate paths)
 
         Returns:
             WaveformData object with time and voltage arrays
         """
-        return self.waveform.acquire(channel)
+        return self.waveform.acquire(channel, provenance=provenance)
 
     @property
     def device_info(self) -> Optional[Dict[str, str]]:

--- a/scpi_control/provenance.py
+++ b/scpi_control/provenance.py
@@ -1,0 +1,177 @@
+"""Acquisition provenance: which instrument produced a waveform, configured how.
+
+Snapshots are taken at acquisition time so the recorded settings reflect the
+state that actually produced the trace. Every field is Optional: a model that
+cannot answer a query records None instead of failing the acquisition.
+"""
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class InstrumentInfo:
+    manufacturer: Optional[str] = None
+    model: Optional[str] = None
+    serial: Optional[str] = None
+    firmware: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ChannelSettings:
+    channel: Optional[int] = None
+    enabled: Optional[bool] = None
+    coupling: Optional[str] = None
+    voltage_scale: Optional[float] = None
+    voltage_offset: Optional[float] = None
+    probe_ratio: Optional[float] = None
+    bandwidth_limit: Optional[str] = None
+    unit: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class TriggerSettings:
+    mode: Optional[str] = None
+    trigger_type: Optional[str] = None
+    source: Optional[str] = None
+    level: Optional[float] = None
+    slope: Optional[str] = None
+    coupling: Optional[str] = None
+    holdoff: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class AcquisitionProvenance:
+    schema_version: int = SCHEMA_VERSION
+    instrument: Optional[InstrumentInfo] = None
+    channels: Dict[int, ChannelSettings] = field(default_factory=dict)
+    trigger: Optional[TriggerSettings] = None
+    timebase: Optional[float] = None
+    sample_rate: Optional[float] = None
+    acquired_at: Optional[str] = None
+    address: Optional[str] = None
+    dialect: Optional[str] = None
+    library_version: Optional[str] = None
+
+    @classmethod
+    def from_scope(cls, scope: Any, channels: Optional[List[int]] = None) -> "AcquisitionProvenance":
+        """Snapshot the scope's current state. Never raises: unavailable settings become None."""
+        instrument = None
+        info = getattr(scope, "device_info", None)
+        if info:
+            instrument = InstrumentInfo(manufacturer=info.get("manufacturer"), model=info.get("model"), serial=info.get("serial"), firmware=info.get("firmware"))
+
+        channel_settings: Dict[int, ChannelSettings] = {}
+        for n in channels or []:
+            config = None
+            try:
+                ch = scope.get_channel(n)
+                if ch is not None:
+                    config = ch.get_configuration()
+            except Exception:
+                logger.debug("Provenance: channel %s configuration unavailable", n, exc_info=True)
+            if config is None:
+                channel_settings[n] = ChannelSettings(channel=n)
+            else:
+                channel_settings[n] = ChannelSettings(
+                    channel=n,
+                    enabled=config.get("enabled"),
+                    coupling=config.get("coupling"),
+                    voltage_scale=config.get("voltage_scale"),
+                    voltage_offset=config.get("voltage_offset"),
+                    probe_ratio=config.get("probe_ratio"),
+                    bandwidth_limit=config.get("bandwidth_limit"),
+                    unit=config.get("unit"),
+                )
+
+        trigger = None
+        try:
+            tconf = scope.trigger.get_configuration()
+            trigger = TriggerSettings(
+                mode=tconf.get("mode"),
+                trigger_type=tconf.get("type"),
+                source=tconf.get("source"),
+                level=tconf.get("level"),
+                slope=tconf.get("slope"),
+                coupling=tconf.get("coupling"),
+                holdoff=tconf.get("holdoff"),
+            )
+        except Exception:
+            logger.debug("Provenance: trigger configuration unavailable", exc_info=True)
+
+        timebase = None
+        try:
+            timebase = scope.timebase
+        except Exception:
+            logger.debug("Provenance: timebase unavailable", exc_info=True)
+
+        sample_rate = None
+        try:
+            sample_rate = scope.waveform._get_sample_rate()
+        except Exception:
+            logger.debug("Provenance: sample rate unavailable", exc_info=True)
+
+        address = None
+        host = getattr(scope, "host", None)
+        if host:
+            address = "{0}:{1}".format(host, getattr(scope, "port", ""))
+
+        from scpi_control import __version__
+
+        return cls(
+            instrument=instrument,
+            channels=channel_settings,
+            trigger=trigger,
+            timebase=timebase,
+            sample_rate=sample_rate,
+            acquired_at=datetime.now(timezone.utc).isoformat(),
+            address=address,
+            dialect=getattr(scope, "dialect", None),
+            library_version=__version__,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "instrument": asdict(self.instrument) if self.instrument is not None else None,
+            "channels": {str(n): asdict(cs) for n, cs in self.channels.items()},
+            "trigger": asdict(self.trigger) if self.trigger is not None else None,
+            "timebase": self.timebase,
+            "sample_rate": self.sample_rate,
+            "acquired_at": self.acquired_at,
+            "address": self.address,
+            "dialect": self.dialect,
+            "library_version": self.library_version,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AcquisitionProvenance":
+        instrument = InstrumentInfo(**data["instrument"]) if data.get("instrument") else None
+        trigger = TriggerSettings(**data["trigger"]) if data.get("trigger") else None
+        channels = {int(n): ChannelSettings(**cs) for n, cs in (data.get("channels") or {}).items()}
+        return cls(
+            schema_version=data.get("schema_version", SCHEMA_VERSION),
+            instrument=instrument,
+            channels=channels,
+            trigger=trigger,
+            timebase=data.get("timebase"),
+            sample_rate=data.get("sample_rate"),
+            acquired_at=data.get("acquired_at"),
+            address=data.get("address"),
+            dialect=data.get("dialect"),
+            library_version=data.get("library_version"),
+        )
+
+    @classmethod
+    def from_json(cls, text: str) -> "AcquisitionProvenance":
+        return cls.from_dict(json.loads(text))

--- a/scpi_control/report_generator/utils/waveform_loader.py
+++ b/scpi_control/report_generator/utils/waveform_loader.py
@@ -13,6 +13,7 @@ import numpy as np
 
 from scpi_control import waveform_schema as ws
 from scpi_control.report_generator.models.report_data import WaveformData
+from scpi_control.waveform_io import load_waveform as _load_native
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,27 @@ def _require_numeric_time(time_data: np.ndarray, filepath: Path) -> np.ndarray:
     if not np.issubdtype(time_data.dtype, np.number):
         raise ValueError(f"Time data in {filepath} is not numeric (found dtype {time_data.dtype})")
     return time_data
+
+
+def _from_loaded(loaded) -> WaveformData:
+    """Adapt a waveform_io.LoadedWaveform into the report generator's model."""
+    voltage = np.asarray(loaded.voltage)
+    time_data = _require_numeric_time(np.asarray(loaded.time), loaded.source_path)
+    if loaded.sample_rate:
+        sample_rate = float(loaded.sample_rate)
+    else:
+        sample_rate = WaveformLoader._rate_from_time(time_data)
+    # Foreign HDF5 files can carry time/voltage datasets without a channel
+    # attr; the old ours-branch fell back to "voltage" (line 319) — keep that.
+    channel = str(loaded.channel) if loaded.channel is not None else ws.VOLTAGE
+    return WaveformData(
+        channel=channel,
+        time=time_data,
+        voltage=voltage,
+        sample_rate=sample_rate,
+        record_length=len(voltage),
+        source_file=loaded.source_path,
+    )
 
 
 class WaveformLoader:
@@ -86,21 +108,8 @@ class WaveformLoader:
         data = np.load(filepath, allow_pickle=True)
 
         if _looks_like_ours(data.files):
-            return [WaveformLoader._npz_from_schema(data, filepath)]
+            return [_from_loaded(_load_native(filepath))]
         return WaveformLoader._npz_heuristic(data, filepath)
-
-    @staticmethod
-    def _npz_from_schema(data, filepath: Path) -> WaveformData:
-        """Read an NPZ written by scpi_control.waveform's _save_npy."""
-        voltage = np.asarray(data[ws.VOLTAGE])
-        return WaveformData(
-            channel=str(data[ws.CHANNEL]),
-            time=np.asarray(data[ws.TIME]),
-            voltage=voltage,
-            sample_rate=float(data[ws.SAMPLE_RATE]),
-            record_length=len(voltage),
-            source_file=filepath,
-        )
 
     @staticmethod
     def _npz_heuristic(data, filepath: Path) -> List[WaveformData]:
@@ -262,18 +271,7 @@ class WaveformLoader:
         keys = [k for k in data.keys() if not k.startswith("__")]
 
         if _looks_like_ours(keys):
-            voltage = np.asarray(data[ws.VOLTAGE]).flatten()
-            # loadmat returns even scalars as 2-D arrays; .item() unwraps them.
-            return [
-                WaveformData(
-                    channel=str(np.asarray(data[ws.CHANNEL]).item()),
-                    time=np.asarray(data[ws.TIME]).flatten(),
-                    voltage=voltage,
-                    sample_rate=float(np.asarray(data[ws.SAMPLE_RATE]).item()),
-                    record_length=len(voltage),
-                    source_file=filepath,
-                )
-            ]
+            return [_from_loaded(_load_native(filepath, format="MAT"))]
 
         time_key = WaveformLoader._pick_time_key(keys)
         voltage_keys = [k for k in keys if k != time_key and np.issubdtype(np.asarray(data[k]).dtype, np.number) and np.asarray(data[k]).size > 1]
@@ -310,29 +308,7 @@ class WaveformLoader:
             datasets = [k for k in f.keys() if isinstance(f[k], h5py.Dataset)]
 
             if ws.TIME in datasets and ws.VOLTAGE in datasets:
-                # Core fields live on the FILE's attrs, not the dataset's.
-                attrs = dict(f.attrs)
-                voltage = f[ws.VOLTAGE][:]
-                # Foreign files can name a dataset 'time' and fill it with strings;
-                # the sample_rate default below feeds it to `_rate_from_time`.
-                time_data = _require_numeric_time(f[ws.TIME][:], filepath)
-                channel = attrs.get(ws.CHANNEL, ws.VOLTAGE)
-                if isinstance(channel, bytes):
-                    channel = channel.decode()
-                return [
-                    WaveformData(
-                        channel=str(channel),
-                        time=time_data,
-                        voltage=voltage,
-                        # Foreign files can name datasets 'time'/'voltage' without
-                        # carrying our sample_rate attr; derive it from the
-                        # numeric time axis instead of silently reporting 0.0,
-                        # matching the heuristic path below.
-                        sample_rate=float(attrs.get(ws.SAMPLE_RATE, WaveformLoader._rate_from_time(time_data))),
-                        record_length=len(voltage),
-                        source_file=filepath,
-                    )
-                ]
+                return [_from_loaded(_load_native(filepath, format="HDF5"))]
 
             time_key = WaveformLoader._pick_time_key(datasets)
             if time_key is None:

--- a/scpi_control/scpi_extract.py
+++ b/scpi_control/scpi_extract.py
@@ -1,0 +1,89 @@
+"""scpi-extract: inspect and export saved waveform files from the command line.
+
+Examples:
+    scpi-extract capture.npz                 # provenance + metadata summary
+    scpi-extract capture.mat --csv out.csv   # dump raw time/voltage rows
+    scpi-extract capture.h5 --json           # machine-readable metadata
+"""
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from scpi_control.waveform_io import LoadedWaveform, load_waveform
+
+
+def _info_lines(loaded: LoadedWaveform) -> List[str]:
+    lines = [
+        f"File:        {loaded.source_path} ({loaded.source_format})",
+        f"Channel:     {loaded.channel}",
+        f"Samples:     {len(loaded.voltage)}",
+        f"Sample rate: {loaded.sample_rate}",
+    ]
+    prov = loaded.provenance
+    if prov is None:
+        lines.append("Provenance:  (none — file predates provenance capture)")
+    else:
+        if prov.instrument is not None:
+            lines.append(f"Instrument:  {prov.instrument.manufacturer} {prov.instrument.model} (serial {prov.instrument.serial}, firmware {prov.instrument.firmware})")
+        lines.append(f"Acquired:    {prov.acquired_at}")
+        lines.append(f"Address:     {prov.address}  Dialect: {prov.dialect}  Library: v{prov.library_version}")
+        for n, ch in sorted(prov.channels.items()):
+            lines.append(f"Channel {n}:   scale={ch.voltage_scale} V/div offset={ch.voltage_offset} V coupling={ch.coupling} probe={ch.probe_ratio}x bw={ch.bandwidth_limit}")
+        if prov.trigger is not None:
+            lines.append(f"Trigger:     {prov.trigger.trigger_type} {prov.trigger.slope} on {prov.trigger.source} @ {prov.trigger.level} V ({prov.trigger.mode})")
+        if prov.timebase is not None:
+            lines.append(f"Timebase:    {prov.timebase} s/div")
+    if loaded.metadata:
+        lines.append("Metadata:")
+        for key, value in sorted(loaded.metadata.items()):
+            lines.append(f"  {key}: {value}")
+    return lines
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="scpi-extract", description="Extract raw data and acquisition provenance from waveform files saved by SCPI Instrument Control.")
+    parser.add_argument("file", type=Path, help="waveform file (.npz/.csv/.mat/.h5/.hdf5)")
+    parser.add_argument("--format", choices=["NPZ", "CSV", "MAT", "HDF5"], help="override format auto-detection")
+    parser.add_argument("--info", action="store_true", help="print a provenance/metadata summary (default when no other flag is given)")
+    parser.add_argument("--csv", metavar="OUT", type=Path, help="write raw time,voltage rows to OUT")
+    parser.add_argument("--json", action="store_true", help="print metadata + provenance as JSON")
+    args = parser.parse_args(argv)
+
+    try:
+        loaded = load_waveform(args.file, format=args.format)
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    acted = False
+    if args.csv is not None:
+        with open(args.csv, "w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["Time (s)", "Voltage (V)"])
+            for t, v in zip(loaded.time, loaded.voltage):
+                writer.writerow([t, v])
+        print(f"Wrote {len(loaded.voltage)} samples to {args.csv}")
+        acted = True
+    if args.json:
+        payload = {
+            "file": str(loaded.source_path),
+            "format": loaded.source_format,
+            "channel": loaded.channel,
+            "samples": len(loaded.voltage),
+            "sample_rate": loaded.sample_rate,
+            "metadata": loaded.metadata,
+            "provenance": loaded.provenance.to_dict() if loaded.provenance is not None else None,
+        }
+        print(json.dumps(payload, indent=2, default=str))
+        acted = True
+    if args.info or not acted:
+        print("\n".join(_info_lines(loaded)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scpi_control/scpi_extract.py
+++ b/scpi_control/scpi_extract.py
@@ -25,7 +25,7 @@ def _info_lines(loaded: LoadedWaveform) -> List[str]:
     ]
     prov = loaded.provenance
     if prov is None:
-        lines.append("Provenance:  (none — file predates provenance capture)")
+        lines.append("Provenance:  (none - file predates provenance capture)")
     else:
         if prov.instrument is not None:
             lines.append(f"Instrument:  {prov.instrument.manufacturer} {prov.instrument.model} (serial {prov.instrument.serial}, firmware {prov.instrument.firmware})")

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -78,7 +78,7 @@ def _decimate_frame(channel, time_axis, voltage) -> Dict[str, Any]:
 
 
 def _waveform_frame(scope: Oscilloscope, channel: int) -> Dict[str, Any]:
-    data = scope.get_waveform(channel)
+    data = scope.get_waveform(channel, provenance=False)
     return _decimate_frame(channel, data.time, data.voltage)
 
 
@@ -306,7 +306,7 @@ class InstrumentSession:
             for n in scope.supported_channels:
                 ch = scope.get_channel(n)
                 if ch is not None and _safe(lambda: ch.enabled, default=False):
-                    data = scope.get_waveform(n)
+                    data = scope.get_waveform(n, provenance=False)
                     acquired["C{0}".format(n)] = data
                     self.publish(_decimate_frame(n, data.time, data.voltage))
             shown_now = set()

--- a/scpi_control/waveform.py
+++ b/scpi_control/waveform.py
@@ -10,6 +10,7 @@ import numpy as np
 from scpi_control import exceptions
 from scpi_control import waveform_schema as ws
 from scpi_control.models import validate_channel
+from scpi_control.provenance import AcquisitionProvenance
 from scpi_control.scpi_commands import BARE_NR3_DIALECTS
 
 if TYPE_CHECKING:
@@ -37,6 +38,7 @@ class WaveformData:
         timebase: Timebase setting (seconds/division)
         voltage_scale: Voltage scale (volts/division)
         voltage_offset: Voltage offset in volts
+        provenance: Instrument settings snapshot at acquisition time (optional)
     """
 
     time: np.ndarray
@@ -47,6 +49,7 @@ class WaveformData:
     timebase: Optional[float] = None
     voltage_scale: Optional[float] = None
     voltage_offset: float = 0.0
+    provenance: Optional[AcquisitionProvenance] = None
 
     def __len__(self) -> int:
         """Get number of samples."""
@@ -94,12 +97,14 @@ class Waveform:
         """Wire dialect of the parent scope; defaults to legacy before connect."""
         return getattr(self._scope, "dialect", None) or "legacy"
 
-    def acquire(self, channel: int, format: str = "BYTE") -> WaveformData:
+    def acquire(self, channel: int, format: str = "BYTE", provenance: bool = True) -> WaveformData:
         """Acquire waveform data from a channel.
 
         Args:
             channel: Channel number (1-4)
             format: Data format - 'BYTE' or 'WORD' (default: 'BYTE')
+            provenance: Snapshot instrument settings alongside the data
+                (default True; pass False on high-rate paths)
 
         Returns:
             WaveformData object with time and voltage arrays
@@ -114,7 +119,13 @@ class Waveform:
 
         from scpi_control.waveform_transfer import make_transfer
 
-        return make_transfer(self._scope).acquire(channel, format)
+        data = make_transfer(self._scope).acquire(channel, format)
+        if provenance:
+            try:
+                data.provenance = AcquisitionProvenance.from_scope(self._scope, channels=[channel])
+            except Exception:
+                logger.warning("Provenance snapshot failed; waveform returned without provenance", exc_info=True)
+        return data
 
     def _get_voltage_scale(self, channel: str) -> float:
         """Get voltage scale for channel.

--- a/scpi_control/waveform.py
+++ b/scpi_control/waveform.py
@@ -417,6 +417,8 @@ class Waveform:
                 f.write(f"{ws.CSV_COMMENT}\n")
             elif not bare and waveform.provenance is not None:
                 f.write(f"{ws.CSV_COMMENT} SCPI Instrument Control Waveform Data\n")
+                f.write(f"{ws.CSV_COMMENT} {ws.CSV_HEADER_CHANNEL}: {waveform.channel}\n")
+                f.write(f"{ws.CSV_COMMENT} {ws.CSV_HEADER_SAMPLE_RATE}: {waveform.sample_rate} Sa/s\n")
                 self._write_provenance_header(f, waveform)
                 f.write(f"{ws.CSV_COMMENT}\n")
 

--- a/scpi_control/waveform.py
+++ b/scpi_control/waveform.py
@@ -307,6 +307,7 @@ class Waveform:
         filename: str,
         format: Optional[str] = None,
         metadata: Optional[dict] = None,
+        bare: bool = False,
     ) -> None:
         """Save waveform data to file.
 
@@ -316,6 +317,8 @@ class Waveform:
             format: File format - 'CSV', 'CSV_ENHANCED', 'NPY', 'MAT', 'HDF5'
                    If None, auto-detect from file extension
             metadata: Optional metadata dictionary to include in file
+            bare: CSV only: suppress the provenance comment header, reproducing the
+                  fully headerless legacy layout (default: False)
 
         Supported formats:
             - CSV: Simple CSV with time and voltage columns
@@ -343,7 +346,7 @@ class Waveform:
         format = format.upper()
 
         if format == "CSV":
-            self._save_csv(waveform, filename, include_metadata=False, metadata=metadata)
+            self._save_csv(waveform, filename, include_metadata=False, metadata=metadata, bare=bare)
 
         elif format == "CSV_ENHANCED":
             self._save_csv(waveform, filename, include_metadata=True, metadata=metadata)
@@ -360,12 +363,29 @@ class Waveform:
         else:
             raise exceptions.InvalidParameterError(f"Invalid format: {format}. Supported: CSV, CSV_ENHANCED, NPY, MAT, HDF5")
 
+    def _write_provenance_header(self, f, waveform: WaveformData) -> None:
+        """Append provenance comment lines. Purely additive: called after any legacy header lines."""
+        prov = waveform.provenance
+        if waveform.timebase is not None:
+            f.write(f"{ws.CSV_COMMENT} {ws.CSV_HEADER_TIMEBASE}: {waveform.timebase} s/div\n")
+        if waveform.voltage_scale is not None:
+            f.write(f"{ws.CSV_COMMENT} {ws.CSV_HEADER_VOLTAGE_SCALE}: {waveform.voltage_scale} V/div\n")
+        f.write(f"{ws.CSV_COMMENT} {ws.CSV_HEADER_VOLTAGE_OFFSET}: {waveform.voltage_offset} V\n")
+        if prov is None:
+            return
+        if prov.instrument is not None:
+            f.write(f"{ws.CSV_COMMENT} Instrument: {prov.instrument.manufacturer} {prov.instrument.model} (serial {prov.instrument.serial}, firmware {prov.instrument.firmware})\n")
+        if prov.acquired_at:
+            f.write(f"{ws.CSV_COMMENT} Acquired (UTC): {prov.acquired_at}\n")
+        f.write(f"{ws.CSV_COMMENT} {ws.CSV_HEADER_PROVENANCE}: {prov.to_json()}\n")
+
     def _save_csv(
         self,
         waveform: WaveformData,
         filename: str,
         include_metadata: bool = False,
         metadata: Optional[dict] = None,
+        bare: bool = False,
     ) -> None:
         """Save waveform as CSV file.
 
@@ -374,6 +394,7 @@ class Waveform:
             filename: Output filename
             include_metadata: Whether to include metadata header
             metadata: Optional additional metadata
+            bare: Suppress provenance header (CSV format only)
         """
         import csv
         from datetime import datetime
@@ -392,6 +413,11 @@ class Waveform:
                     for key, value in metadata.items():
                         f.write(f"{ws.CSV_COMMENT} {key}: {value}\n")
 
+                self._write_provenance_header(f, waveform)
+                f.write(f"{ws.CSV_COMMENT}\n")
+            elif not bare and waveform.provenance is not None:
+                f.write(f"{ws.CSV_COMMENT} SCPI Instrument Control Waveform Data\n")
+                self._write_provenance_header(f, waveform)
                 f.write(f"{ws.CSV_COMMENT}\n")
 
             # Write data
@@ -420,6 +446,15 @@ class Waveform:
             ws.SAMPLE_RATE: waveform.sample_rate,
             ws.TIMESTAMP: datetime.now().isoformat(),
         }
+
+        # Add scale fields (additive)
+        for key, value in ((ws.TIMEBASE, waveform.timebase), (ws.VOLTAGE_SCALE, waveform.voltage_scale), (ws.VOLTAGE_OFFSET, waveform.voltage_offset)):
+            if value is not None:
+                data[key] = value
+
+        # Add provenance if present
+        if waveform.provenance is not None:
+            data[ws.PROVENANCE_JSON] = waveform.provenance.to_json()
 
         # Add optional metadata
         if metadata:
@@ -457,6 +492,15 @@ class Waveform:
             ws.SAMPLE_RATE: waveform.sample_rate,
             ws.TIMESTAMP: datetime.now().isoformat(),
         }
+
+        # Add scale fields (additive)
+        for key, value in ((ws.TIMEBASE, waveform.timebase), (ws.VOLTAGE_SCALE, waveform.voltage_scale), (ws.VOLTAGE_OFFSET, waveform.voltage_offset)):
+            if value is not None:
+                data[key] = value
+
+        # Add provenance if present
+        if waveform.provenance is not None:
+            data[ws.PROVENANCE_JSON] = waveform.provenance.to_json()
 
         # Add metadata
         if metadata:
@@ -499,6 +543,15 @@ class Waveform:
             f.attrs[ws.SAMPLE_RATE] = waveform.sample_rate
             f.attrs[ws.HDF5_NUM_SAMPLES] = len(waveform.time)
             f.attrs[ws.TIMESTAMP] = datetime.now().isoformat()
+
+            # Add scale fields (additive)
+            for key, value in ((ws.TIMEBASE, waveform.timebase), (ws.VOLTAGE_SCALE, waveform.voltage_scale), (ws.VOLTAGE_OFFSET, waveform.voltage_offset)):
+                if value is not None:
+                    f.attrs[key] = value
+
+            # Add provenance if present
+            if waveform.provenance is not None:
+                f.attrs[ws.PROVENANCE_JSON] = waveform.provenance.to_json()
 
             # Add optional metadata
             if metadata:

--- a/scpi_control/waveform_io.py
+++ b/scpi_control/waveform_io.py
@@ -1,0 +1,246 @@
+"""Read saved waveform files back into numpy arrays + normalized metadata.
+
+The public entry point for users who want their raw data out of the library's
+five on-disk formats (NPZ, plain CSV, enhanced CSV, MAT, HDF5) for their own
+analysis. Reads files written before provenance existed (provenance is then
+None) and normalizes the three binary formats' differing metadata
+conventions (see scpi_control.waveform_schema) into one flat dict.
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+import numpy as np
+
+from scpi_control import waveform_schema as ws
+from scpi_control.provenance import AcquisitionProvenance
+
+logger = logging.getLogger(__name__)
+
+_EXTENSION_FORMATS = {".npz": "NPZ", ".npy": "NPZ", ".csv": "CSV", ".mat": "MAT", ".h5": "HDF5", ".hdf5": "HDF5"}
+
+
+@dataclass
+class LoadedWaveform:
+    """One waveform read back from disk, format differences normalized away."""
+
+    time: np.ndarray
+    voltage: np.ndarray
+    channel: Optional[Union[int, str]]
+    sample_rate: Optional[float]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    provenance: Optional[AcquisitionProvenance] = None
+    source_format: str = "NPZ"
+    source_path: Optional[Path] = None
+
+    def to_dataframe(self):
+        """Return a pandas DataFrame (columns: time, voltage; metadata in .attrs)."""
+        try:
+            import pandas as pd
+        except ImportError:
+            raise ImportError("pandas is required for to_dataframe(). Install with: pip install pandas")
+        df = pd.DataFrame({"time": self.time, "voltage": self.voltage})
+        df.attrs["channel"] = self.channel
+        df.attrs["sample_rate"] = self.sample_rate
+        df.attrs["metadata"] = dict(self.metadata)
+        if self.provenance is not None:
+            df.attrs["provenance"] = self.provenance.to_dict()
+        return df
+
+
+def load_waveform(path: Union[str, Path], format: Optional[str] = None) -> LoadedWaveform:
+    """Load a waveform file saved by scpi_control (any version, any format).
+
+    Args:
+        path: File to read.
+        format: Force a format ("NPZ", "CSV", "MAT", "HDF5"); None auto-detects
+            from the extension.
+
+    Raises:
+        FileNotFoundError: If path does not exist.
+        ValueError: If the format is unknown or the file cannot be parsed.
+        ImportError: If the format needs an uninstalled optional dependency.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Waveform file not found: {path}")
+    if format is None:
+        format = _EXTENSION_FORMATS.get(path.suffix.lower())
+        if format is None:
+            raise ValueError(f"Cannot detect format from extension {path.suffix!r}. Pass format= explicitly (NPZ, CSV, MAT, HDF5).")
+    format = format.upper()
+    if format in ("NPY", "NPZ"):
+        return _load_npz(path)
+    if format in ("CSV", "CSV_ENHANCED"):
+        return _load_csv(path)
+    if format == "MAT":
+        return _load_mat(path)
+    if format == "HDF5":
+        return _load_hdf5(path)
+    raise ValueError(f"Unknown format: {format}. Supported: NPZ, CSV, MAT, HDF5")
+
+
+def _parse_provenance(text: Optional[str]) -> Optional[AcquisitionProvenance]:
+    if not text:
+        return None
+    try:
+        return AcquisitionProvenance.from_json(str(text))
+    except Exception:
+        logger.warning("Corrupt provenance block ignored", exc_info=True)
+        return None
+
+
+def _scalar(value: Any) -> Any:
+    """Collapse the 0-d / 1x1 array wrappers numpy and scipy.io put around scalars."""
+    arr = np.asarray(value)
+    if arr.size == 1:
+        item = arr.reshape(-1)[0]
+        if isinstance(item, np.generic):
+            item = item.item()
+        if isinstance(item, bytes):
+            item = item.decode()
+        return item
+    return arr
+
+
+def _channel_value(raw: Any) -> Optional[Union[int, str]]:
+    value = _scalar(raw)
+    if value is None:
+        return None
+    text = str(value)
+    return int(text) if text.isdigit() else text
+
+
+def _load_npz(path: Path) -> LoadedWaveform:
+    data = np.load(path, allow_pickle=True)
+    if ws.TIME not in data.files or ws.VOLTAGE not in data.files:
+        raise ValueError(f"{path} does not contain '{ws.TIME}'/'{ws.VOLTAGE}' arrays; not a scpi_control waveform file")
+    metadata: Dict[str, Any] = {}
+    for key in data.files:
+        if key.startswith(ws.NPZ_META_PREFIX):
+            metadata[key[len(ws.NPZ_META_PREFIX) :]] = _scalar(data[key])
+    for key in (ws.TIMESTAMP,) + ws.SCALE_FIELDS:
+        if key in data.files:
+            metadata[key] = _scalar(data[key])
+    sample_rate = _scalar(data[ws.SAMPLE_RATE]) if ws.SAMPLE_RATE in data.files else None
+    return LoadedWaveform(
+        time=np.asarray(data[ws.TIME]),
+        voltage=np.asarray(data[ws.VOLTAGE]),
+        channel=_channel_value(data[ws.CHANNEL]) if ws.CHANNEL in data.files else None,
+        sample_rate=float(sample_rate) if sample_rate is not None else None,
+        metadata=metadata,
+        provenance=_parse_provenance(_scalar(data[ws.PROVENANCE_JSON]) if ws.PROVENANCE_JSON in data.files else None),
+        source_format="NPZ",
+        source_path=path,
+    )
+
+
+def _load_csv(path: Path) -> LoadedWaveform:
+    header: Dict[str, str] = {}
+    times, volts = [], []
+    with open(path, "r", newline="") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith(ws.CSV_COMMENT):
+                text = line[len(ws.CSV_COMMENT) :].strip()
+                key, sep, value = text.partition(":")
+                if sep:
+                    header[key.strip()] = value.strip()
+                continue
+            first = line.split(",", 1)[0]
+            try:
+                t = float(first)
+            except ValueError:
+                continue  # the "Time (s),Voltage (V)" column-header row
+            _, _, rest = line.partition(",")
+            times.append(t)
+            volts.append(float(rest.split(",", 1)[0]))
+    if not times:
+        raise ValueError(f"No numeric data rows found in {path}")
+
+    def _header_float(name: str) -> Optional[float]:
+        raw = header.get(name)
+        if raw is None:
+            return None
+        try:
+            return float(raw.split()[0])
+        except (ValueError, IndexError):
+            return None
+
+    metadata = {k: v for k, v in header.items() if k not in (ws.CSV_HEADER_PROVENANCE,)}
+    for name, key in ((ws.CSV_HEADER_TIMEBASE, ws.TIMEBASE), (ws.CSV_HEADER_VOLTAGE_SCALE, ws.VOLTAGE_SCALE), (ws.CSV_HEADER_VOLTAGE_OFFSET, ws.VOLTAGE_OFFSET)):
+        value = _header_float(name)
+        if value is not None:
+            metadata[key] = value
+    channel_raw = header.get(ws.CSV_HEADER_CHANNEL)
+    return LoadedWaveform(
+        time=np.asarray(times),
+        voltage=np.asarray(volts),
+        channel=_channel_value(channel_raw) if channel_raw is not None else None,
+        sample_rate=_header_float(ws.CSV_HEADER_SAMPLE_RATE),
+        metadata=metadata,
+        provenance=_parse_provenance(header.get(ws.CSV_HEADER_PROVENANCE)),
+        source_format="CSV",
+        source_path=path,
+    )
+
+
+def _load_mat(path: Path) -> LoadedWaveform:
+    try:
+        from scipy.io import loadmat
+    except ImportError:
+        raise ImportError("scipy is required to load MAT files. Install with: pip install scipy")
+    mat = loadmat(str(path), squeeze_me=True)
+    if ws.TIME not in mat or ws.VOLTAGE not in mat:
+        raise ValueError(f"{path} does not contain '{ws.TIME}'/'{ws.VOLTAGE}' arrays; not a scpi_control waveform file")
+    metadata: Dict[str, Any] = {}
+    raw_meta = mat.get(ws.MAT_META_KEY)
+    if raw_meta is not None and getattr(raw_meta, "dtype", None) is not None and raw_meta.dtype.names:
+        for name in raw_meta.dtype.names:
+            metadata[name] = _scalar(raw_meta[name])
+    for key in (ws.TIMESTAMP,) + ws.SCALE_FIELDS:
+        if key in mat:
+            metadata[key] = _scalar(mat[key])
+    sample_rate = _scalar(mat[ws.SAMPLE_RATE]) if ws.SAMPLE_RATE in mat else None
+    return LoadedWaveform(
+        time=np.asarray(mat[ws.TIME]).flatten(),
+        voltage=np.asarray(mat[ws.VOLTAGE]).flatten(),
+        channel=_channel_value(mat[ws.CHANNEL]) if ws.CHANNEL in mat else None,
+        sample_rate=float(sample_rate) if sample_rate is not None else None,
+        metadata=metadata,
+        provenance=_parse_provenance(_scalar(mat[ws.PROVENANCE_JSON]) if ws.PROVENANCE_JSON in mat else None),
+        source_format="MAT",
+        source_path=path,
+    )
+
+
+def _load_hdf5(path: Path) -> LoadedWaveform:
+    try:
+        import h5py
+    except ImportError:
+        raise ImportError("h5py is required to load HDF5 files. Install with: pip install h5py")
+    with h5py.File(path, "r") as f:
+        if ws.TIME not in f or ws.VOLTAGE not in f:
+            raise ValueError(f"{path} does not contain '{ws.TIME}'/'{ws.VOLTAGE}' datasets; not a scpi_control waveform file")
+        attrs = {k: _scalar(v) for k, v in f.attrs.items()}
+        metadata: Dict[str, Any] = {}
+        if ws.HDF5_META_GROUP in f and isinstance(f[ws.HDF5_META_GROUP], h5py.Group):
+            metadata.update({k: _scalar(v) for k, v in f[ws.HDF5_META_GROUP].attrs.items()})
+        for key in (ws.TIMESTAMP, ws.HDF5_NUM_SAMPLES) + ws.SCALE_FIELDS:
+            if key in attrs:
+                metadata[key] = attrs[key]
+        return LoadedWaveform(
+            time=np.asarray(f[ws.TIME][:]),
+            voltage=np.asarray(f[ws.VOLTAGE][:]),
+            channel=_channel_value(attrs[ws.CHANNEL]) if ws.CHANNEL in attrs else None,
+            sample_rate=float(attrs[ws.SAMPLE_RATE]) if ws.SAMPLE_RATE in attrs else None,
+            metadata=metadata,
+            provenance=_parse_provenance(attrs.get(ws.PROVENANCE_JSON)),
+            source_format="HDF5",
+            source_path=path,
+        )

--- a/scpi_control/waveform_io.py
+++ b/scpi_control/waveform_io.py
@@ -7,7 +7,6 @@ None) and normalizes the three binary formats' differing metadata
 conventions (see scpi_control.waveform_schema) into one flat dict.
 """
 
-import json
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/scpi_control/waveform_schema.py
+++ b/scpi_control/waveform_schema.py
@@ -53,6 +53,9 @@ SCALE_FIELDS: Tuple[str, ...] = (TIMEBASE, VOLTAGE_SCALE, VOLTAGE_OFFSET)
 # One JSON document (scpi_control.provenance.AcquisitionProvenance.to_json()).
 # NPZ/MAT: a string under this key. HDF5: a FILE attr. CSV (both variants):
 # a "# Provenance-JSON: {...}" comment line.
+# Plain CSV writes scale fields and provenance ONLY when the waveform carries
+# a provenance object; a provenance-less save stays byte-identical to the
+# legacy headerless layout. The binary formats write scale fields regardless.
 PROVENANCE_JSON = "provenance_json"
 CSV_HEADER_PROVENANCE = "Provenance-JSON"
 CSV_HEADER_TIMEBASE = "Timebase"

--- a/scpi_control/waveform_schema.py
+++ b/scpi_control/waveform_schema.py
@@ -53,9 +53,10 @@ SCALE_FIELDS: Tuple[str, ...] = (TIMEBASE, VOLTAGE_SCALE, VOLTAGE_OFFSET)
 # One JSON document (scpi_control.provenance.AcquisitionProvenance.to_json()).
 # NPZ/MAT: a string under this key. HDF5: a FILE attr. CSV (both variants):
 # a "# Provenance-JSON: {...}" comment line.
-# Plain CSV writes scale fields and provenance ONLY when the waveform carries
-# a provenance object; a provenance-less save stays byte-identical to the
-# legacy headerless layout. The binary formats write scale fields regardless.
+# Plain CSV writes channel, sample rate, scale fields, and provenance ONLY when
+# the waveform carries a provenance object; a provenance-less save stays
+# byte-identical to the legacy headerless layout. The binary formats write
+# scale fields regardless.
 PROVENANCE_JSON = "provenance_json"
 CSV_HEADER_PROVENANCE = "Provenance-JSON"
 CSV_HEADER_TIMEBASE = "Timebase"

--- a/scpi_control/waveform_schema.py
+++ b/scpi_control/waveform_schema.py
@@ -42,3 +42,19 @@ HDF5_FILE_ATTRS: Tuple[str, ...] = (CHANNEL, SAMPLE_RATE, HDF5_NUM_SAMPLES, TIME
 CSV_COMMENT = "#"
 CSV_HEADER_CHANNEL = "Channel"
 CSV_HEADER_SAMPLE_RATE = "Sample Rate"
+
+# ---- Acquisition scale fields (added 2026-07; additive, may be absent) -----
+TIMEBASE = "timebase"
+VOLTAGE_SCALE = "voltage_scale"
+VOLTAGE_OFFSET = "voltage_offset"
+SCALE_FIELDS: Tuple[str, ...] = (TIMEBASE, VOLTAGE_SCALE, VOLTAGE_OFFSET)
+
+# ---- Provenance (added 2026-07; additive, may be absent) -------------------
+# One JSON document (scpi_control.provenance.AcquisitionProvenance.to_json()).
+# NPZ/MAT: a string under this key. HDF5: a FILE attr. CSV (both variants):
+# a "# Provenance-JSON: {...}" comment line.
+PROVENANCE_JSON = "provenance_json"
+CSV_HEADER_PROVENANCE = "Provenance-JSON"
+CSV_HEADER_TIMEBASE = "Timebase"
+CSV_HEADER_VOLTAGE_SCALE = "Voltage Scale"
+CSV_HEADER_VOLTAGE_OFFSET = "Voltage Offset"

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -40,6 +40,7 @@ EXECUTE = [
     ("report_branding.py", None),
     ("network_discovery.py", None),
     ("report_ai_qa.py", "requests"),
+    ("waveform_provenance_and_extract.py", None),
 ]
 
 _TIMEOUTS = {"report_ai_qa.py": 240}

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,108 @@
+"""Tests for acquisition provenance snapshots."""
+
+from unittest.mock import Mock
+
+from scpi_control.provenance import (
+    SCHEMA_VERSION,
+    AcquisitionProvenance,
+    ChannelSettings,
+    InstrumentInfo,
+    TriggerSettings,
+)
+
+
+def _fake_scope():
+    scope = Mock()
+    scope.device_info = {"manufacturer": "Siglent Technologies", "model": "SDS824X HD", "serial": "SER123", "firmware": "1.0.0.0"}
+    scope.host = "192.168.1.50"
+    scope.port = 5025
+    scope.dialect = "modern"
+    scope.timebase = 1e-3
+    scope.waveform._get_sample_rate.return_value = 1_000_000.0
+    channel = Mock()
+    channel.get_configuration.return_value = {
+        "channel": 1,
+        "enabled": True,
+        "coupling": "DC",
+        "voltage_scale": 0.5,
+        "voltage_offset": 0.0,
+        "probe_ratio": 10.0,
+        "bandwidth_limit": "OFF",
+        "unit": "V",
+    }
+    scope.get_channel.return_value = channel
+    scope.trigger.get_configuration.return_value = {
+        "mode": "AUTO",
+        "type": "EDGE",
+        "source": "C1",
+        "level": 0.1,
+        "slope": "RISING",
+        "coupling": "DC",
+        "holdoff": None,
+    }
+    return scope
+
+
+class _BrokenScope:
+    device_info = None
+    host = None
+    dialect = None
+
+    @property
+    def timebase(self):
+        raise RuntimeError("no timebase")
+
+    def get_channel(self, n):
+        raise RuntimeError("boom")
+
+    class _T:
+        def get_configuration(self):
+            raise NotImplementedError()
+
+    trigger = _T()
+
+    class _W:
+        def _get_sample_rate(self):
+            raise RuntimeError("boom")
+
+    waveform = _W()
+
+
+def test_from_scope_snapshots_everything():
+    prov = AcquisitionProvenance.from_scope(_fake_scope(), channels=[1])
+    assert prov.schema_version == SCHEMA_VERSION
+    assert prov.instrument.model == "SDS824X HD"
+    assert prov.channels[1].voltage_scale == 0.5
+    assert prov.channels[1].probe_ratio == 10.0
+    assert prov.trigger.source == "C1"
+    assert prov.trigger.trigger_type == "EDGE"
+    assert prov.timebase == 1e-3
+    assert prov.sample_rate == 1_000_000.0
+    assert prov.address == "192.168.1.50:5025"
+    assert prov.dialect == "modern"
+    assert prov.library_version
+    assert prov.acquired_at  # ISO-8601 UTC string
+
+
+def test_from_scope_tolerates_every_failure():
+    scope = _BrokenScope()
+    prov = AcquisitionProvenance.from_scope(scope, channels=[1])
+    assert prov.instrument is None
+    assert prov.channels[1] == ChannelSettings(channel=1)
+    assert prov.trigger is None
+    assert prov.timebase is None
+    assert prov.sample_rate is None
+    assert prov.address is None
+
+
+def test_json_round_trip():
+    prov = AcquisitionProvenance.from_scope(_fake_scope(), channels=[1])
+    restored = AcquisitionProvenance.from_json(prov.to_json())
+    assert restored == prov
+
+
+def test_from_dict_tolerates_missing_keys():
+    prov = AcquisitionProvenance.from_dict({"schema_version": 1})
+    assert prov.instrument is None
+    assert prov.channels == {}
+    assert prov.trigger is None

--- a/tests/test_provenance_acquire.py
+++ b/tests/test_provenance_acquire.py
@@ -1,0 +1,48 @@
+"""Acquire attaches provenance; hot paths and failures skip it safely."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from scpi_control.connection import MockConnection
+from scpi_control.oscilloscope import Oscilloscope
+
+
+@pytest.fixture
+def mock_scope():
+    conn = MockConnection(
+        "mock",
+        idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0",
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=1_000.0,
+        timebase=1e-3,
+        waveform_payloads={1: bytes(range(256))},
+    )
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    yield scope
+    scope.disconnect()
+
+
+def test_acquire_attaches_provenance(mock_scope):
+    data = mock_scope.get_waveform(1)
+    assert data.provenance is not None
+    assert data.provenance.instrument.model == "SDS1104X-E"
+    assert 1 in data.provenance.channels
+    assert data.provenance.acquired_at
+
+
+def test_acquire_provenance_false_skips_snapshot(mock_scope):
+    data = mock_scope.get_waveform(1, provenance=False)
+    assert data.provenance is None
+
+
+def test_snapshot_failure_never_breaks_acquire(mock_scope, caplog):
+    with patch("scpi_control.waveform.AcquisitionProvenance.from_scope", side_effect=RuntimeError("boom")):
+        with caplog.at_level(logging.WARNING):
+            data = mock_scope.get_waveform(1)
+    assert data.provenance is None
+    assert len(data.voltage) > 0
+    assert any("provenance" in r.message.lower() for r in caplog.records)

--- a/tests/test_provenance_savers.py
+++ b/tests/test_provenance_savers.py
@@ -102,3 +102,20 @@ def test_enhanced_csv_appends_provenance_lines(saver, tmp_path):
     assert "operator: robin" in text
     assert ws.CSV_HEADER_TIMEBASE in text
     assert ws.CSV_HEADER_PROVENANCE in text
+
+
+def test_binary_formats_write_scales_even_without_provenance(saver, tmp_path):
+    out = tmp_path / "wf.npz"
+    saver.save_waveform(_waveform(with_provenance=False), str(out))
+    data = np.load(out)
+    assert float(data[ws.TIMEBASE]) == 1e-4
+    assert float(data[ws.VOLTAGE_SCALE]) == 0.5
+    assert float(data[ws.VOLTAGE_OFFSET]) == 0.1
+
+
+def test_plain_csv_without_provenance_stays_headerless(saver, tmp_path):
+    """Documented contract: plain CSV carries scale fields only inside the
+    provenance header; a provenance-less save is byte-identical legacy output."""
+    out = tmp_path / "wf.csv"
+    saver.save_waveform(_waveform(with_provenance=False), str(out), format="CSV")
+    assert not out.read_text().startswith(ws.CSV_COMMENT)

--- a/tests/test_provenance_savers.py
+++ b/tests/test_provenance_savers.py
@@ -1,0 +1,104 @@
+"""Savers embed provenance additively; legacy output stays byte-identical."""
+
+import json
+
+import numpy as np
+import pytest
+
+from scpi_control import waveform_schema as ws
+from scpi_control.provenance import AcquisitionProvenance, ChannelSettings, InstrumentInfo
+from scpi_control.waveform import Waveform, WaveformData
+
+
+def _waveform(with_provenance=True):
+    time = np.linspace(0.0, 1e-3, 100)
+    voltage = np.sin(2 * np.pi * 1000 * time)
+    prov = None
+    if with_provenance:
+        prov = AcquisitionProvenance(
+            instrument=InstrumentInfo(manufacturer="Siglent Technologies", model="SDS824X HD", serial="S1", firmware="1.0"),
+            channels={1: ChannelSettings(channel=1, voltage_scale=0.5, probe_ratio=10.0)},
+            acquired_at="2026-07-21T00:00:00+00:00",
+        )
+    return WaveformData(time=time, voltage=voltage, channel=1, sample_rate=100_000.0, timebase=1e-4, voltage_scale=0.5, voltage_offset=0.1, provenance=prov)
+
+
+@pytest.fixture
+def saver():
+    from unittest.mock import Mock
+
+    return Waveform(Mock())
+
+
+def test_npz_embeds_provenance_and_scales(saver, tmp_path):
+    out = tmp_path / "wf.npz"
+    saver.save_waveform(_waveform(), str(out))
+    data = np.load(out, allow_pickle=True)
+    prov = AcquisitionProvenance.from_json(str(data[ws.PROVENANCE_JSON]))
+    assert prov.instrument.model == "SDS824X HD"
+    assert float(data[ws.TIMEBASE]) == 1e-4
+    assert float(data[ws.VOLTAGE_SCALE]) == 0.5
+    assert float(data[ws.VOLTAGE_OFFSET]) == 0.1
+    for key in ws.CORE_FIELDS:  # legacy keys untouched
+        assert key in data.files
+
+
+def test_npz_without_provenance_has_no_provenance_key(saver, tmp_path):
+    out = tmp_path / "wf.npz"
+    saver.save_waveform(_waveform(with_provenance=False), str(out))
+    assert ws.PROVENANCE_JSON not in np.load(out).files
+
+
+def test_mat_embeds_provenance(saver, tmp_path):
+    scipy = pytest.importorskip("scipy")
+    from scipy.io import loadmat
+
+    out = tmp_path / "wf.mat"
+    saver.save_waveform(_waveform(), str(out))
+    mat = loadmat(str(out), squeeze_me=True)
+    prov = AcquisitionProvenance.from_json(str(mat[ws.PROVENANCE_JSON]))
+    assert prov.channels[1].probe_ratio == 10.0
+    assert float(np.asarray(mat[ws.TIMEBASE])) == 1e-4
+
+
+def test_hdf5_embeds_provenance(saver, tmp_path):
+    h5py = pytest.importorskip("h5py")
+
+    out = tmp_path / "wf.h5"
+    saver.save_waveform(_waveform(), str(out))
+    with h5py.File(out, "r") as f:
+        prov = AcquisitionProvenance.from_json(str(f.attrs[ws.PROVENANCE_JSON]))
+        assert prov.instrument.serial == "S1"
+        assert float(f.attrs[ws.TIMEBASE]) == 1e-4
+
+
+def test_plain_csv_gains_commented_header(saver, tmp_path):
+    out = tmp_path / "wf.csv"
+    saver.save_waveform(_waveform(), str(out), format="CSV")
+    text = out.read_text()
+    assert text.startswith(ws.CSV_COMMENT)
+    json_line = [ln for ln in text.splitlines() if ws.CSV_HEADER_PROVENANCE in ln][0]
+    payload = json_line.split(":", 1)[1].strip()
+    assert json.loads(payload)["instrument"]["model"] == "SDS824X HD"
+    # numpy still reads it out of the box
+    arr = np.loadtxt(out, delimiter=",", comments=ws.CSV_COMMENT, skiprows=len([ln for ln in text.splitlines() if ln.startswith(ws.CSV_COMMENT)]) + 1)
+    assert arr.shape == (100, 2)
+
+
+def test_plain_csv_bare_is_byte_identical_to_legacy(saver, tmp_path):
+    bare = tmp_path / "bare.csv"
+    legacy = tmp_path / "legacy.csv"
+    saver.save_waveform(_waveform(), str(bare), format="CSV", bare=True)
+    saver.save_waveform(_waveform(with_provenance=False), str(legacy), format="CSV")
+    assert bare.read_bytes() == legacy.read_bytes()
+    assert not bare.read_text().startswith(ws.CSV_COMMENT)
+
+
+def test_enhanced_csv_appends_provenance_lines(saver, tmp_path):
+    out = tmp_path / "wf.csv"
+    saver.save_waveform(_waveform(), str(out), format="CSV_ENHANCED", metadata={"operator": "robin"})
+    text = out.read_text()
+    assert f"{ws.CSV_HEADER_CHANNEL}: 1" in text  # legacy lines intact
+    assert "operator: robin" in text
+    assert ws.CSV_HEADER_TIMEBASE in text
+    assert ws.CSV_HEADER_PROVENANCE in text

--- a/tests/test_report_loader_provenance.py
+++ b/tests/test_report_loader_provenance.py
@@ -1,0 +1,37 @@
+"""Report-generator loader handles provenance-bearing files and delegates schema paths."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from scpi_control.provenance import AcquisitionProvenance, InstrumentInfo
+from scpi_control.report_generator.utils.waveform_loader import WaveformLoader
+from scpi_control.waveform import Waveform, WaveformData
+
+
+def _waveform():
+    time = np.linspace(0.0, 1e-3, 80)
+    return WaveformData(
+        time=time,
+        voltage=np.sin(2 * np.pi * 1000 * time),
+        channel=1,
+        sample_rate=80_000.0,
+        provenance=AcquisitionProvenance(instrument=InstrumentInfo(model="SDS824X HD")),
+    )
+
+
+@pytest.mark.parametrize("filename,format", [("wf.npz", None), ("wf.mat", None), ("wf.h5", None), ("wf.csv", "CSV"), ("wf_enh.csv", "CSV_ENHANCED")])
+def test_loader_reads_provenance_bearing_files(tmp_path, filename, format):
+    if filename.endswith(".mat"):
+        pytest.importorskip("scipy")
+    if filename.endswith(".h5"):
+        pytest.importorskip("h5py")
+    out = tmp_path / filename
+    Waveform(Mock()).save_waveform(_waveform(), str(out), format=format)
+    loaded = WaveformLoader.load(out)
+    assert len(loaded) == 1
+    assert len(loaded[0].voltage) == 80
+    assert loaded[0].sample_rate == pytest.approx(80_000.0)
+    assert loaded[0].channel == "1"

--- a/tests/test_report_waveform_model.py
+++ b/tests/test_report_waveform_model.py
@@ -92,6 +92,7 @@ def test_field_order_is_the_library_core_then_report_concerns():
         "timebase",
         "voltage_scale",
         "voltage_offset",
+        "provenance",
         "probe_ratio",
         "coupling",
         "source_file",

--- a/tests/test_scpi_extract.py
+++ b/tests/test_scpi_extract.py
@@ -1,0 +1,52 @@
+"""scpi-extract CLI: --info, --csv, --json, error exit codes."""
+
+import json
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from scpi_control.provenance import AcquisitionProvenance, InstrumentInfo
+from scpi_control.scpi_extract import main
+from scpi_control.waveform import Waveform, WaveformData
+
+
+@pytest.fixture
+def npz_file(tmp_path):
+    time = np.linspace(0.0, 1e-3, 50)
+    wf = WaveformData(
+        time=time,
+        voltage=np.sin(2 * np.pi * 1000 * time),
+        channel=1,
+        sample_rate=50_000.0,
+        provenance=AcquisitionProvenance(instrument=InstrumentInfo(model="SDS824X HD"), acquired_at="2026-07-21T00:00:00+00:00"),
+    )
+    out = tmp_path / "wf.npz"
+    Waveform(Mock()).save_waveform(wf, str(out))
+    return out
+
+
+def test_info_is_default(npz_file, capsys):
+    assert main([str(npz_file)]) == 0
+    out = capsys.readouterr().out
+    assert "SDS824X HD" in out
+    assert "50" in out  # sample count
+
+
+def test_csv_export(npz_file, tmp_path, capsys):
+    dest = tmp_path / "out.csv"
+    assert main([str(npz_file), "--csv", str(dest)]) == 0
+    arr = np.loadtxt(dest, delimiter=",", skiprows=1)
+    assert arr.shape == (50, 2)
+
+
+def test_json_output(npz_file, capsys):
+    assert main([str(npz_file), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["provenance"]["instrument"]["model"] == "SDS824X HD"
+    assert payload["samples"] == 50
+
+
+def test_missing_file_exits_nonzero(capsys):
+    assert main(["no_such_file.npz"]) == 1
+    assert "error" in capsys.readouterr().err.lower()

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -110,7 +110,7 @@ class _StubScope:
     def __init__(self, n):
         self._data = WaveformData(time=np.linspace(0.0, 1.0, n), voltage=np.zeros(n), channel=1)
 
-    def get_waveform(self, channel):
+    def get_waveform(self, channel, provenance=True):
         return self._data
 
 

--- a/tests/test_waveform_io.py
+++ b/tests/test_waveform_io.py
@@ -1,5 +1,6 @@
 """load_waveform round-trips every saver format, old files included."""
 
+import logging
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -93,3 +94,15 @@ def test_to_dataframe(saver, tmp_path):
     df = load_waveform(out).to_dataframe()
     assert list(df.columns) == ["time", "voltage"]
     assert df.attrs["provenance"]["instrument"]["model"] == "SDS824X HD"
+
+
+def test_corrupt_provenance_yields_none_with_warning(tmp_path, caplog):
+    from scpi_control import waveform_schema as ws
+
+    out = tmp_path / "wf.npz"
+    np.savez(out, **{ws.TIME: np.linspace(0.0, 1.0, 10), ws.VOLTAGE: np.zeros(10), ws.CHANNEL: 1, ws.SAMPLE_RATE: 10.0, ws.PROVENANCE_JSON: "{not valid json"})
+    with caplog.at_level(logging.WARNING):
+        loaded = load_waveform(out)
+    assert loaded.provenance is None
+    assert len(loaded.voltage) == 10
+    assert any("provenance" in record.message.lower() for record in caplog.records)

--- a/tests/test_waveform_io.py
+++ b/tests/test_waveform_io.py
@@ -1,0 +1,95 @@
+"""load_waveform round-trips every saver format, old files included."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from scpi_control.provenance import AcquisitionProvenance, ChannelSettings, InstrumentInfo
+from scpi_control.waveform import Waveform, WaveformData
+from scpi_control.waveform_io import LoadedWaveform, load_waveform
+
+FIXTURE = Path(__file__).parent / "fixtures" / "cal_square_sds824x.npz"
+
+
+def _waveform():
+    time = np.linspace(0.0, 1e-3, 100)
+    voltage = np.sin(2 * np.pi * 1000 * time)
+    prov = AcquisitionProvenance(
+        instrument=InstrumentInfo(manufacturer="Siglent Technologies", model="SDS824X HD", serial="S1", firmware="1.0"),
+        channels={1: ChannelSettings(channel=1, voltage_scale=0.5)},
+        acquired_at="2026-07-21T00:00:00+00:00",
+    )
+    return WaveformData(time=time, voltage=voltage, channel=1, sample_rate=100_000.0, timebase=1e-4, voltage_scale=0.5, provenance=prov)
+
+
+@pytest.fixture
+def saver():
+    return Waveform(Mock())
+
+
+@pytest.mark.parametrize(
+    "filename,format,source_format",
+    [
+        ("wf.npz", None, "NPZ"),
+        ("wf.csv", "CSV", "CSV"),
+        ("wf_enh.csv", "CSV_ENHANCED", "CSV"),
+        ("wf.mat", None, "MAT"),
+        ("wf.h5", None, "HDF5"),
+    ],
+)
+def test_round_trip_every_format(saver, tmp_path, filename, format, source_format):
+    if filename.endswith(".mat"):
+        pytest.importorskip("scipy")
+    if filename.endswith(".h5"):
+        pytest.importorskip("h5py")
+    wf = _waveform()
+    out = tmp_path / filename
+    saver.save_waveform(wf, str(out), format=format)
+
+    loaded = load_waveform(out)
+    assert isinstance(loaded, LoadedWaveform)
+    assert loaded.source_format == source_format
+    np.testing.assert_allclose(loaded.time, wf.time, rtol=1e-6)
+    np.testing.assert_allclose(loaded.voltage, wf.voltage, rtol=1e-5)
+    assert loaded.provenance is not None
+    assert loaded.provenance.instrument.model == "SDS824X HD"
+    assert loaded.provenance.channels[1].voltage_scale == 0.5
+    assert loaded.metadata.get("timebase") == pytest.approx(1e-4)
+
+
+def test_legacy_fixture_loads_without_provenance():
+    loaded = load_waveform(FIXTURE)
+    assert loaded.provenance is None
+    assert len(loaded.voltage) > 0
+    assert loaded.sample_rate and loaded.sample_rate > 0
+
+
+def test_user_metadata_survives_npz(saver, tmp_path):
+    out = tmp_path / "wf.npz"
+    saver.save_waveform(_waveform(), str(out), metadata={"operator": "robin", "run": 7})
+    loaded = load_waveform(out)
+    assert loaded.metadata["operator"] == "robin"
+    assert int(loaded.metadata["run"]) == 7
+
+
+def test_missing_file_raises():
+    with pytest.raises(FileNotFoundError):
+        load_waveform(Path("does_not_exist.npz"))
+
+
+def test_unknown_extension_raises(tmp_path):
+    bad = tmp_path / "wf.xyz"
+    bad.write_text("nope")
+    with pytest.raises(ValueError):
+        load_waveform(bad)
+
+
+def test_to_dataframe(saver, tmp_path):
+    pd = pytest.importorskip("pandas")
+    out = tmp_path / "wf.npz"
+    saver.save_waveform(_waveform(), str(out))
+    df = load_waveform(out).to_dataframe()
+    assert list(df.columns) == ["time", "voltage"]
+    assert df.attrs["provenance"]["instrument"]["model"] == "SDS824X HD"

--- a/tests/test_waveform_metadata_honesty.py
+++ b/tests/test_waveform_metadata_honesty.py
@@ -107,4 +107,5 @@ def test_the_canonical_field_set_is_exactly_the_shared_core():
         "timebase",
         "voltage_scale",
         "voltage_offset",
+        "provenance",
     ]


### PR DESCRIPTION
## Summary

Makes every saved waveform reproducibility-grade and gives users a first-class way to get their raw data back out.

- **Acquisition provenance**: `acquire()` / `get_waveform()` now snapshot the instrument identity (`*IDN?`), per-channel settings (scale, offset, coupling, probe, bandwidth), trigger configuration, timebase, sample rate, UTC timestamp, connection address, SCPI dialect, and library version into `WaveformData.provenance` (`scpi_control/provenance.py`, typed dataclasses, `schema_version: 1`). Snapshot failures log a warning and never break an acquisition; high-rate paths (GUI live view, gateway streaming) skip the snapshot via `provenance=False`.
- **Every save format embeds it, additively**: NPZ/MAT get a `provenance_json` key, HDF5 a file attribute, enhanced CSV extra header lines, and plain CSV gains a `#`-commented header (channel, sample rate, scales, instrument, timestamp, provenance JSON) — only when provenance is present. `save_waveform(..., bare=True)` restores the fully headerless legacy CSV; provenance-less saves are **byte-identical** to the old writer (pinned by tests). The previously dropped `timebase` / `voltage_scale` / `voltage_offset` fields are now persisted in every format.
- **Public parser**: `scpi_control.waveform_io.load_waveform()` reads all five formats — old files and new — into numpy arrays plus normalized metadata and parsed provenance (`None` for legacy files), with an optional pandas `to_dataframe()` helper.
- **`scpi-extract` CLI**: `--info` (default) pretty-prints provenance/metadata, `--csv` dumps raw rows, `--json` emits machine-readable output; ASCII-safe on narrow Windows codepages.
- **One loader, not two**: the report generator's `WaveformLoader` now delegates its native-format schema paths to `waveform_io` (heuristic foreign-file paths untouched), deleting ~60 lines of triplicated parsing.
- Docs page (`docs/user-guide/data-provenance.md`), mock-driven runnable example (no instrument needed, enrolled in the examples smoke tests), and changelog entry (MINOR — fully additive, no breaking changes).

## Test plan

- [x] Full suite: 1062 passed / 19 skipped (baseline before branch: 1024 / 19; +38 tests)
- [x] Byte-identity regression tests for legacy plain-CSV output (`bare=True` and provenance-less saves)
- [x] Round-trip tests for all five formats, including provenance field equality
- [x] Legacy-file test against the real capture fixture `tests/fixtures/cal_square_sds824x.npz` (loads with `provenance=None`)
- [x] Corrupt-provenance tolerance (warning + `None`, never an exception)
- [x] `black --check --line-length 200` and `flake8 --select=E9,F63,F7,F82` clean
- [x] Example executes end-to-end against the mock connection in the smoke suite
