### PR TITLE
chore(release): 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-07-21
+
 ### Added
 
 - Report generator: a built-in **probe-calibration template preset** (`ReportTemplate.create_probe_calibration_template()`, seedable from the Template Manager via "Create Probe Cal Template") — probe_calibration test type, a compensation procedure, and overshoot/undershoot/ringing/flatness pass/fail limits.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "3.0.0"
+version = "3.1.0"
 description = "Universal Python library for controlling SCPI-compatible test equipment via Ethernet/LAN. Supports oscilloscopes (Siglent SDS series, generic SCPI scopes), function generators/AWGs (Siglent SDG series, generic SCPI AWGs), and power supplies (Siglent SPD series, generic SCPI PSUs). Features include waveform capture, measurements, FFT analysis, PyQt6 GUI, automated report generation with AI analysis, and comprehensive SCPI command abstraction."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
## Release 3.1.0

MINOR release: acquisition provenance + raw-data extraction (PR #84), probe-calibration template preset, DAQ AI grounding, PDF glyph and analyzer fixes. Full changelog under the 3.1.0 heading in CHANGELOG.md. No breaking changes.

- Version bumped in pyproject.toml and scpi_control/__init__.py
- CHANGELOG: [Unreleased] promoted to [3.1.0] - 2026-07-21
- Verified: 1062 passed / 19 skipped; black + flake8 gates clean
