### PR TITLE
feat: synthetic-signal generators and state-coupled mock waveform synthesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ waveform_*.npy
 waveform_*.bin
 my_circle_*.csv
 provenance_demo.npz
+synthetic_demo.npz
 *.waveform
 
 # AI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Synthetic signals: a public generator API — `SignalSpec` plus `synthesize()`/`make_waveform()` in `scpi_control.signal_synth` — producing sine, square (with duty cycle), triangle, ramp, DC, and Gaussian-noise waveforms as numpy arrays or ready-to-analyze `WaveformData`, with seedable reproducibility.
+- Mock scopes now synthesize realistic waveforms by default (all vendor personalities): traces are computed from the mock's live timebase, V/div, offset, and trigger state at every acquisition — over-range clips at 8-bit full scale, the trigger level/slope aligns the edge at the window center, and unseeded captures animate with fresh noise. Pass `signals={ch: SignalSpec(...)}` to choose the signal, or `waveform_payloads` bytes for the old fixed-payload behavior (unchanged). Web-gateway mock sessions stream synthesized signals out of the box.
+
+### Changed
+
+- MockConnection's default (no `waveform_payloads` given) no longer serves a fixed 4-byte payload — channels synthesize state-coupled signals instead.
 
 ## [3.1.0] - 2026-07-21
 
@@ -1360,3 +1369,4 @@ pip install "Siglent-Oscilloscope[power-supply-beta,usb]==0.4.0-beta.1"
 - Comprehensive error handling with custom exceptions
 
 [0.1.0]: https://github.com/siglent-control/siglent/releases/tag/v0.1.0
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -1369,4 +1369,3 @@ pip install "Siglent-Oscilloscope[power-supply-beta,usb]==0.4.0-beta.1"
 - Comprehensive error handling with custom exceptions
 
 [0.1.0]: https://github.com/siglent-control/siglent/releases/tag/v0.1.0
-

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A universal Python library for controlling SCPI-compatible test equipment via Et
 - **GUI Application**: Modern PyQt6-based graphical interface
 - **Waveform Acquisition**: Capture and download waveform data in multiple formats (NPZ, CSV, MAT, HDF5)
 - **Acquisition Provenance**: every saved waveform records the instrument, settings, and timestamp that produced it; extract raw data from any saved file with load_waveform() or the scpi-extract CLI
+- **Synthetic Signals & Realistic Mock**: generate parameterized test waveforms (sine/square/triangle/ramp/DC/noise) with SignalSpec/make_waveform, and develop without hardware against a mock scope that synthesizes state-coupled, trigger-aligned waveforms by default
 - **Channel Configuration**: Control voltage scale, coupling, offset, bandwidth
 - **Trigger Settings**: Configure trigger modes, levels, edge detection
 - **Advanced Analysis**: Built-in FFT, SNR, THD, and statistical analysis tools

--- a/docs/user-guide/synthetic-signals.md
+++ b/docs/user-guide/synthetic-signals.md
@@ -1,0 +1,192 @@
+# Synthetic Signals
+
+Every mock oscilloscope channel now produces a real, parameterized waveform
+instead of a fixed byte pattern -- and the same signal engine is available
+directly, for generating test data with no instrument (or mock) involved at
+all. This guide covers `SignalSpec`, `synthesize()`/`make_waveform()`, and
+how `MockConnection` uses them to synthesize state-coupled, trigger-aligned
+captures.
+
+## Why
+
+- **Develop and test without hardware.** Write and exercise capture,
+  analysis, and reporting code against realistic waveforms -- sine, square,
+  triangle, ramp, DC, noise -- before an instrument is available.
+- **Reproducible test data.** A seeded `SignalSpec` produces the exact same
+  samples every run, which makes it useful for regression tests and
+  deterministic examples/demos.
+- **A mock that behaves like a scope.** `MockConnection` channels synthesize
+  from their current state by default, so SCPI commands that change the
+  timebase, voltage scale, or trigger settings visibly change the next
+  capture -- the mock reacts the way real hardware would, instead of always
+  returning the same bytes.
+
+## `SignalSpec`
+
+`scpi_control.signal_synth.SignalSpec` is a frozen dataclass describing one
+signal:
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `kind` | `"sine"` | `"sine"`, `"square"`, `"triangle"`, `"ramp"`, `"dc"`, or `"noise"` |
+| `frequency` | `1000.0` | Repetition rate in Hz (periodic kinds only) |
+| `amplitude` | `1.0` | Peak amplitude in volts (Vpp = `2 * amplitude`); for `"noise"`, the standard deviation; ignored for `"dc"` |
+| `offset` | `0.0` | DC offset in volts, added to every kind (`"dc"` outputs exactly this level) |
+| `phase` | `0.0` | Phase in radians (periodic kinds only) |
+| `duty` | `0.5` | High fraction of a `"square"` period, `0 < duty < 1` (pulse/PWM) |
+| `noise_rms` | `0.0` | Std-dev of additive Gaussian noise laid on top of any kind |
+| `seed` | `None` | `None` for fresh randomness on every call; an `int` for reproducible output |
+
+`"square"`'s `duty` is the fraction of each period spent high, so a
+`SignalSpec(kind="square", duty=0.2)` is a 20%-duty pulse/PWM waveform, not
+just a symmetric square wave. `"dc"` ignores `amplitude` entirely and always
+outputs `offset`. `"noise"` uses `amplitude` as the Gaussian standard
+deviation rather than a peak value. An invalid `kind` or an out-of-range
+parameter (non-positive `frequency` on a periodic kind, `duty` outside
+`(0, 1)`, negative `noise_rms`) raises `InvalidParameterError` -- no partial
+or silently-clamped signal is ever returned.
+
+## Generating Signals Directly
+
+```python
+from scpi_control.signal_synth import SignalSpec, synthesize, make_waveform
+
+spec = SignalSpec(kind="sine", frequency=1_000.0, amplitude=0.8, noise_rms=0.02, seed=42)
+
+# Raw voltage samples, as a numpy array
+volts = synthesize(spec, sample_rate=100_000.0, n_points=1_000)
+
+# A full WaveformData, ready for analysis, saving, or the report generator
+waveform = make_waveform(spec, sample_rate=100_000.0, n_points=1_000, channel=1)
+waveform.voltage, waveform.time, waveform.sample_rate
+```
+
+`synthesize()` returns a `float64` array of `n_points` voltage samples;
+`t0` shifts the start time, which matters for periodic kinds (it's how the
+mock aligns a capture to a trigger crossing -- see below). `make_waveform()`
+wraps the same samples in a `WaveformData` with a matching `time` axis, so it
+composes directly with the rest of the library:
+
+```python
+waveform = make_waveform(SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0), sample_rate=1_000_000.0, n_points=10_000)
+# waveform.voltage / waveform.time feed analysis, plotting, or a report exactly
+# like a captured waveform would -- see docs/report-generator/ for the reporting
+# side of that chain.
+```
+
+Two calls with `seed=None` (the default) produce different noise and, for
+`"noise"` itself, different signal on every call. Pass an `int` seed to get
+byte-identical output across runs.
+
+## Mock Oscilloscope Synthesis
+
+`MockConnection` synthesizes each channel's waveform from its current state
+at every acquisition, instead of returning fixed bytes -- unless that channel
+has an explicit payload (see [Precedence](#precedence-vs-waveform_payloads)
+below).
+
+### Per-channel defaults
+
+If a channel has no `signals=` entry, it falls back to a built-in default:
+
+| Channel | Kind | Frequency | Amplitude | Noise (RMS) |
+| --- | --- | --- | --- | --- |
+| 1 | square | 1 kHz | 2 Vpp (`amplitude=1.0`) | 0.01 |
+| 2 | sine | 2 kHz | 1 Vpp (`amplitude=0.5`) | 0.01 |
+| 3 | sine | 5 kHz | 0.5 Vpp (`amplitude=0.25`) | 0.01 |
+| 4 | sine | 10 kHz | 0.25 Vpp (`amplitude=0.125`) | 0.01 |
+
+Any channel number outside 1-4 that still needs synthesis falls back to a
+1 kHz, 1 V-amplitude sine with `noise_rms=0.01`.
+
+### Choosing signals with `signals=`
+
+Pass a `signals={channel: SignalSpec(...)}` dict to `MockConnection` to
+override the defaults for specific channels; channels you don't mention keep
+their built-in default:
+
+```python
+from scpi_control.connection import MockConnection
+from scpi_control.oscilloscope import Oscilloscope
+from scpi_control.signal_synth import SignalSpec
+
+conn = MockConnection(
+    "mock",
+    idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0",
+    channel_states={1: True, 2: False, 3: False, 4: False},
+    trigger_status=["Stop"],
+    sample_rate=1_000_000.0,
+    timebase=1e-3,
+    signals={1: SignalSpec(kind="sine", frequency=2_000.0, amplitude=0.8, noise_rms=0.02, seed=42)},
+)
+scope = Oscilloscope("mock", connection=conn)
+scope.connect()
+waveform = scope.get_waveform(1)
+scope.disconnect()
+```
+
+### State coupling
+
+The next capture reflects the mock's *current* SCPI state, so writes made
+before an acquisition change what comes back:
+
+- **Capture length.** The window is 14 divisions times the timebase; the
+  point count is `round(sample_rate * window)`, clamped to `[2, 14000]`.
+  `scope.write("TDIV 1e-4")` shrinks the window (and therefore the point
+  count) on the next capture.
+- **Clipping.** Samples are converted to int8 codes at 25 codes/division and
+  clipped at +/-127 -- an 8-bit ADC over-ranging exactly like real hardware.
+  `scope.write("C1:VDIV 0.1")` narrows the voltage range a division
+  represents, so a signal whose amplitude no longer fits clips at the new
+  ceiling (`127 * vdiv / 25` volts).
+- **Trigger alignment.** For periodic kinds, the mock finds where the ideal
+  signal crosses the configured trigger level in the trigger's slope
+  direction and places that crossing at the center of the capture window --
+  the same edge a real scope would trigger on. A **triggered, noise-free**
+  capture is therefore bit-identical across repeated acquisitions at
+  unchanged settings. If the configured trigger level/slope combination is
+  unattainable for the signal (e.g. a level outside its range), the mock
+  free-runs instead: each acquisition's window drifts forward by a fixed
+  fraction of the window, so consecutive captures visibly shift rather than
+  repeating.
+
+### Precedence vs. `waveform_payloads`
+
+`waveform_payloads={channel: bytes}` bypasses synthesis entirely for that
+channel -- if a channel has an explicit payload, those bytes are always
+returned regardless of `signals=` or SCPI state, which keeps existing
+byte-identical tests unaffected by this feature.
+
+### Seeding rules
+
+- `seed=None` (the default): every acquisition re-rolls fresh noise (and,
+  for `"noise"`, a fresh signal).
+- `seed=<int>`: the *first* acquisition for that channel uses exactly that
+  seed; each subsequent acquisition on the same channel advances the seed by
+  one (`seed + 1`, `seed + 2`, ...), so repeated captures are each
+  individually reproducible but not identical to one another -- matching how
+  a real, noisy instrument produces a different (but statistically
+  consistent) trace on every trigger.
+
+### Web gateway default
+
+Mock sessions created through the web gateway now default to
+`sample_rate=1_000_000.0`, so a default mock session's captures are 14,000
+points long (14 divisions x 1 ms/div timebase) instead of the much shorter
+traces earlier default sample rates produced.
+
+## Extensibility
+
+Signal kinds live in a small dispatch table (`kind -> generator function`)
+inside `scpi_control/signal_synth.py`. The mock's state-coupling and
+volts-to-codes conversion are kind-agnostic, so adding a new kind is: one new
+generator function, a table entry, and matching docs/tests -- no changes to
+`MockConnection` or the waveform code path.
+
+## See Also
+
+- [Data Provenance](data-provenance.md) for what gets attached to a saved
+  waveform (including one synthesized by the mock) and how to read it back
+- `examples/synthetic_signals.py` for a runnable, hardware-free walkthrough
+  of `make_waveform()`, a mock session reacting to SCPI writes, and the
+  save/reload round trip

--- a/docs/user-guide/synthetic-signals.md
+++ b/docs/user-guide/synthetic-signals.md
@@ -148,7 +148,9 @@ before an acquisition change what comes back:
   unattainable for the signal (e.g. a level outside its range), the mock
   free-runs instead: each acquisition's window drifts forward by a fixed
   fraction of the window, so consecutive captures visibly shift rather than
-  repeating.
+  repeating. Each channel aligns to its own trigger level and signal; the
+  mock does not model `trigger_source` routing (triggering one channel off
+  another channel's crossing) between channels.
 
 ### Precedence vs. `waveform_payloads`
 
@@ -172,8 +174,8 @@ byte-identical tests unaffected by this feature.
 
 Mock sessions created through the web gateway now default to
 `sample_rate=1_000_000.0`, so a default mock session's captures are 14,000
-points long (14 divisions x 1 ms/div timebase) instead of the much shorter
-traces earlier default sample rates produced.
+points long (14 divisions x 1 ms/div timebase) instead of the fixed 256-byte
+explicit ramp payloads earlier sessions served.
 
 ## Extensibility
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,7 @@ pip install "SCPI-Instrument-Control"
 | `probe_calibration_analysis.py` | Waveform region extraction for probe compensation analysis: plateau detection, slope analysis, calibration guidance, and zoomed PDF report plots. | `SCPI-Instrument-Control[report-generator]` (no hardware — fully synthetic) |
 | `dialect_override_example.py` | SCPI dialect auto-detection from `*IDN?` and the `dialect=` override for forcing a command set; runs entirely on mock connections. | Core install only (no hardware) |
 | `waveform_provenance_and_extract.py` | Acquisition provenance: capturing a waveform with the instrument/settings snapshot attached, saving NPZ and CSV, and reading them back with `load_waveform()`; runs entirely against a mock connection -- no instrument needed. | Core install only (no hardware) |
+| `synthetic_signals.py` | Generating parameterized test waveforms with `SignalSpec`/`make_waveform`, and a mock oscilloscope session whose captures respond to SCPI writes (timebase, voltage scale) via state-coupled synthesis; runs entirely against a mock connection - no instrument needed. | Core install only (no hardware) |
 
 ## Web Gateway
 
@@ -88,7 +89,7 @@ the file — update it to match your instrument. To find an oscilloscope's
 LAN address: **Utility → I/O → LAN** on the instrument's front panel.
 
 The scripts marked "no hardware" above (`dialect_override_example.py`,
-`waveform_provenance_and_extract.py`, `trend_logging_walkthrough.py`, `psu_gui_test.py`,
+`waveform_provenance_and_extract.py`, `synthetic_signals.py`, `trend_logging_walkthrough.py`, `psu_gui_test.py`,
 `probe_calibration_analysis.py`, `psu_advanced_features.py`, `network_discovery.py`,
 `report_computed_analysis.py`, `report_branding.py`, `report_ai_qa.py`) use mock
 connections and run as-is.

--- a/examples/synthetic_signals.py
+++ b/examples/synthetic_signals.py
@@ -1,0 +1,114 @@
+"""Synthetic signal generation: parameterized test waveforms, and the mock
+oscilloscope's state-coupled synthesis.
+
+scpi_control.signal_synth.SignalSpec describes a waveform (kind, frequency,
+amplitude, offset, phase, duty, additive noise, and an optional seed for
+reproducibility); synthesize()/make_waveform() turn a spec into a numpy array
+or a full WaveformData ready for analysis, saving, or the report generator.
+The same engine powers MockConnection: channels without an explicit
+waveform_payloads entry synthesize live from the mock's current state, so
+SCPI commands that change the timebase or voltage scale visibly change the
+next capture -- exactly like a real scope.
+
+This example (1) generates a few signal kinds directly and prints basic
+stats, (2) opens a mock oscilloscope session, acquires, then changes TDIV and
+VDIV over SCPI to show the capture's length and clipping respond, and (3)
+saves one synthesized capture and reloads it with load_waveform() to show the
+chain composes.
+
+Requirements: SCPI-Instrument-Control (core install) -- runs entirely against
+a mock connection, no instrument needed.
+"""
+
+from pathlib import Path
+
+from scpi_control.connection import MockConnection
+from scpi_control.oscilloscope import Oscilloscope
+from scpi_control.signal_synth import SignalSpec, make_waveform
+from scpi_control.waveform_io import load_waveform
+
+OUTPUT_DIR = Path.cwd()
+NPZ_PATH = OUTPUT_DIR / "synthetic_demo.npz"
+
+# 8-bit code path constants the mock synthesizer uses internally
+# (scpi_control/connection/mock/synth.py) -- reused here only to predict the
+# voltage ceiling a given V/div setting clips at.
+CODES_PER_DIV = 25
+CODE_LIMIT = 127
+
+
+def _print_stats(label: str, voltage) -> None:
+    vpp = float(voltage.max() - voltage.min())
+    print(f"{label:12s}: Vpp={vpp:.4f} V  mean={voltage.mean():.4f} V  std={voltage.std():.4f} V  n={len(voltage)}")
+
+
+def demo_make_waveform() -> None:
+    """Generate a few signal kinds directly and print basic stats."""
+    print("=== Part 1: make_waveform() -- basic stats per kind ===")
+    kinds = [
+        ("square", SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, duty=0.5)),
+        ("sine", SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0)),
+        ("noisy sine", SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.05, seed=7)),
+    ]
+    for label, spec in kinds:
+        waveform = make_waveform(spec, sample_rate=100_000.0, n_points=1_000)
+        _print_stats(label, waveform.voltage)
+
+
+def demo_mock_session() -> None:
+    """Open a mock scope session and show SCPI writes change the next capture."""
+    print()
+    print("=== Part 2: mock oscilloscope session -- state-coupled synthesis ===")
+    conn = MockConnection(
+        "mock",
+        idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0",
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=1_000_000.0,
+        timebase=1e-3,
+        signals={1: SignalSpec(kind="sine", frequency=2_000.0, amplitude=0.8, noise_rms=0.02, seed=42)},
+    )
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    try:
+        waveform = scope.get_waveform(1, provenance=False)
+        print(f"Initial capture (TDIV=1e-3, C1:VDIV=1.0): {len(waveform.voltage)} points, " f"Vpp={float(waveform.voltage.max() - waveform.voltage.min()):.3f} V")
+
+        # Shrinking the timebase shrinks the acquisition window (14 divisions
+        # x timebase), so fewer points come back at the same sample rate.
+        scope.write("TDIV 1e-4")
+        shorter = scope.get_waveform(1, provenance=False)
+        print(f"After TDIV 1e-4: {len(shorter.voltage)} points (window shrank from 14 ms to 1.4 ms)")
+
+        # Tightening the voltage scale below the signal's amplitude clips the
+        # capture, just like an 8-bit scope's ADC would over-range.
+        scope.write("C1:VDIV 0.1")
+        clipped = scope.get_waveform(1, provenance=False)
+        clip_ceiling = CODE_LIMIT * 0.1 / CODES_PER_DIV
+        peak = float(max(abs(clipped.voltage.max()), abs(clipped.voltage.min())))
+        print(f"After C1:VDIV 0.1: peak |V| = {peak:.3f} V (signal amplitude is 0.8 V, " f"but the 8-bit code path ceilings at ~{clip_ceiling:.3f} V for this V/div)")
+
+        print()
+        print("=== Part 3: save + load_waveform() -- the chain composes ===")
+        final = scope.get_waveform(1, provenance=True)
+        scope.waveform.save_waveform(final, str(NPZ_PATH))
+        print(f"Saved {NPZ_PATH.name} ({len(final.voltage)} points)")
+    finally:
+        scope.disconnect()
+
+
+def demo_reload() -> None:
+    """Reload the saved capture and show the raw data survives the round trip."""
+    loaded = load_waveform(NPZ_PATH)
+    print(f"Reloaded {NPZ_PATH.name} ({loaded.source_format}): {len(loaded.voltage)} points, " f"channel {loaded.channel}, sample_rate {loaded.sample_rate}")
+    print(f"First 5 samples (V): {loaded.voltage[:5].tolist()}")
+
+
+def main() -> None:
+    demo_make_waveform()
+    demo_mock_session()
+    demo_reload()
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
       - SCPI Dialects: user-guide/scpi-dialects.md
       - Waveform Capture: user-guide/waveform-capture.md
       - Data Provenance: user-guide/data-provenance.md
+      - Synthetic Signals: user-guide/synthetic-signals.md
       - Measurements: user-guide/measurements.md
       - Trigger Control: user-guide/trigger-control.md
       - Advanced Features: user-guide/advanced-features.md

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -4,13 +4,16 @@ and personality dispatch to the vendor-specific scope write/query/waveform modul
 from __future__ import annotations
 
 import re
-from typing import Dict, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Union
 
 from scpi_control import exceptions
 from scpi_control.connection.base import BaseConnection
 from scpi_control.connection.mock.helpers import MOCK_SCREENSHOT_BMP, _build_ieee_block
 from scpi_control.connection.mock import lecroy, siglent, tektronix
 from scpi_control.models import detect_model_from_idn
+
+if TYPE_CHECKING:
+    from scpi_control.signal_synth import SignalSpec
 
 _PERSONALITIES = {
     "siglent": siglent,
@@ -24,7 +27,10 @@ class MockConnection(BaseConnection):
 
     The mock is designed for offline tests that want to exercise the full
     oscilloscope/automation stack without touching networked hardware. It keeps
-    lightweight internal state for common SCPI queries and waveforms.
+    lightweight internal state for common SCPI queries and waveforms. Waveform
+    bytes are state-coupled synthesis by default (see connection/mock/synth.py),
+    driven by each channel's SignalSpec (or a built-in default); explicit
+    waveform_payloads bytes for a channel always take precedence.
     """
 
     def __init__(
@@ -38,6 +44,7 @@ class MockConnection(BaseConnection):
         voltage_scales: Optional[Dict[int, float]] = None,
         voltage_offsets: Optional[Dict[int, float]] = None,
         waveform_payloads: Optional[Dict[int, bytes]] = None,
+        signals: Optional[Dict[int, "SignalSpec"]] = None,
         sample_rate: float = 1_000.0,
         timebase: float = 1e-3,
         trigger_status: Optional[List[str]] = None,
@@ -67,7 +74,11 @@ class MockConnection(BaseConnection):
         self._channel_enabled: Dict[int, bool] = {ch: channel_states.get(ch, True) if channel_states else True for ch in channels}
         self._voltage_scales: Dict[int, float] = {ch: voltage_scales.get(ch, 1.0) if voltage_scales else 1.0 for ch in channels}
         self._voltage_offsets: Dict[int, float] = {ch: voltage_offsets.get(ch, 0.0) if voltage_offsets else 0.0 for ch in channels}
-        self._waveform_payloads: Dict[int, bytes] = {ch: (waveform_payloads.get(ch, bytes([0, 25, 50, 75])) if waveform_payloads else bytes([0, 25, 50, 75])) for ch in channels}
+        # Explicit payloads only; channels without one get state-coupled synthesis
+        # (connection/mock/synth.py). The old fixed 4-byte default is gone.
+        self._waveform_payloads: Dict[int, bytes] = dict(waveform_payloads) if waveform_payloads else {}
+        self._signals: Dict[int, "SignalSpec"] = dict(signals) if signals else {}
+        self._acquisition_counts: Dict[int, int] = {}
         self._channel_coupling: Dict[int, str] = {ch: "D1M" for ch in channels}
 
         self.sample_rate = sample_rate

--- a/scpi_control/connection/mock/lecroy.py
+++ b/scpi_control/connection/mock/lecroy.py
@@ -8,6 +8,7 @@ import re
 import struct
 from typing import Optional
 
+from scpi_control.connection.mock import synth as mock_synth
 from scpi_control.connection.mock.helpers import _build_ieee_block, _format_nr3
 from scpi_control.connection.mock.siglent import _MOCK_PAVA_VALUES, handle_write as _legacy_write
 
@@ -75,8 +76,8 @@ def handle_query(conn, command: str) -> Optional[str]:
 
 def build_waveform_response(conn) -> bytes:
     """Construct a LeCroy WAVEDESC + sample-array block (WF? ALL, CORD LO)."""
-    channel = conn._last_waveform_channel or next(iter(conn._waveform_payloads))
-    codes = conn._waveform_payloads.get(channel, bytes())
+    channel = conn._last_waveform_channel or 1
+    codes = mock_synth.payload_for(conn, channel, include_offset=True)
     gain = conn._voltage_scales.get(channel, 1.0) / 25.0  # mirror Siglent scaling for comparable volts
     desc = bytearray(346)
     desc[0:8] = b"WAVEDESC"

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -7,6 +7,7 @@ import re
 from typing import Dict, Optional, Tuple
 
 from scpi_control.connection.mock.helpers import _build_ieee_block, _format_nr3, _format_scientific
+from scpi_control.connection.mock import synth as mock_synth
 
 # Canonical PAVA? measurement values for the legacy dialect (mirrors real
 # hardware where PAVA? is legacy-only; the modern dialect has no equivalent).
@@ -230,6 +231,6 @@ def handle_query(conn, command: str) -> Optional[str]:
 
 def build_waveform_response(conn) -> bytes:
     """Construct a minimal Siglent-style waveform block response."""
-    channel = conn._last_waveform_channel or next(iter(conn._waveform_payloads.keys()))
-    payload = conn._waveform_payloads.get(channel, bytes())
+    channel = conn._last_waveform_channel or next(iter(conn._waveform_payloads), 1)
+    payload = mock_synth.payload_for(conn, channel, include_offset=True)
     return b"DESC," + _build_ieee_block(payload)

--- a/scpi_control/connection/mock/synth.py
+++ b/scpi_control/connection/mock/synth.py
@@ -1,0 +1,66 @@
+"""State-coupled waveform synthesis for MockConnection.
+
+Computes int8 sample codes from the mock's *current* state (timebase, V/div,
+offset, trigger) via scpi_control.signal_synth, so SCPI SET commands visibly
+change the next capture. Explicit waveform_payloads bytes always win. The
+volts->codes inverse mirrors waveform_transfer's converters: Siglent/LeCroy
+subtract the channel offset on read (codes add it back); the Tek mock preamble
+does not model offset (include_offset=False).
+"""
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, Dict
+
+import numpy as np
+
+from scpi_control.signal_synth import SignalSpec, synthesize
+
+if TYPE_CHECKING:
+    from scpi_control.connection.mock.base import MockConnection
+
+DIVISIONS = 14  # horizontal grid, matches SiglentTransfer._generate_time_axis
+MAX_POINTS = 14_000
+CODES_PER_DIV = 25  # int8 path, matches WAVEFORM_CODE_PER_DIV_8BIT
+CODE_LIMIT = 127
+_DRIFT_FRACTION = 0.137  # free-run phase drift per acquisition (non-period-aligned)
+
+_DEFAULT_SPECS: Dict[int, SignalSpec] = {
+    1: SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, noise_rms=0.01),
+    2: SignalSpec(kind="sine", frequency=2_000.0, amplitude=0.5, noise_rms=0.01),
+    3: SignalSpec(kind="sine", frequency=5_000.0, amplitude=0.25, noise_rms=0.01),
+    4: SignalSpec(kind="sine", frequency=10_000.0, amplitude=0.125, noise_rms=0.01),
+}
+_FALLBACK_SPEC = SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.01)
+
+
+def spec_for(conn: "MockConnection", channel: int) -> SignalSpec:
+    """The signal a channel 'sees': user-specified, else the channel default."""
+    return conn._signals.get(channel) or _DEFAULT_SPECS.get(channel, _FALLBACK_SPEC)
+
+
+def point_count(conn: "MockConnection", channel: int) -> int:
+    """Sample count the next waveform response will carry."""
+    explicit = conn._waveform_payloads.get(channel)
+    if explicit is not None:
+        return len(explicit)
+    window = DIVISIONS * conn.timebase
+    return max(2, min(MAX_POINTS, int(round(conn.sample_rate * window))))
+
+
+def payload_for(conn: "MockConnection", channel: int, *, include_offset: bool) -> bytes:
+    """int8 code bytes for a channel: explicit payload if given, else synthesized."""
+    explicit = conn._waveform_payloads.get(channel)
+    if explicit is not None:
+        return explicit
+    spec = spec_for(conn, channel)
+    n = point_count(conn, channel)
+    count = conn._acquisition_counts.get(channel, 0)
+    conn._acquisition_counts[channel] = count + 1
+    window = DIVISIONS * conn.timebase
+    t0 = count * window * _DRIFT_FRACTION  # free-run; Task 5 adds trigger alignment
+    per_acquisition = spec if spec.seed is None else replace(spec, seed=spec.seed + count)
+    volts = synthesize(per_acquisition, conn.sample_rate, n, t0=t0)
+    vdiv = conn._voltage_scales.get(channel, 1.0)
+    voffset = conn._voltage_offsets.get(channel, 0.0) if include_offset else 0.0
+    codes = np.clip(np.rint((volts + voffset) * CODES_PER_DIV / vdiv), -CODE_LIMIT, CODE_LIMIT)
+    return codes.astype(np.int8).tobytes()

--- a/scpi_control/connection/mock/synth.py
+++ b/scpi_control/connection/mock/synth.py
@@ -85,7 +85,7 @@ def payload_for(conn: "MockConnection", channel: int, *, include_offset: bool) -
     window = DIVISIONS * conn.timebase
     crossing = _trigger_crossing(spec, conn.trigger_level.get(channel, 0.0), _is_rising(conn.trigger_slope))
     if crossing is not None:
-        t0 = crossing - window / 2.0  # matching edge lands at the window center
+        t0 = crossing - (n / conn.sample_rate) / 2.0  # center of the SAMPLED span (may be shorter than the nominal window when MAX_POINTS clamps)
     else:
         t0 = count * window * _DRIFT_FRACTION  # untriggerable: free-run drift
     per_acquisition = spec if spec.seed is None else replace(spec, seed=spec.seed + count)

--- a/scpi_control/connection/mock/synth.py
+++ b/scpi_control/connection/mock/synth.py
@@ -9,11 +9,11 @@ does not model offset (include_offset=False).
 """
 
 from dataclasses import replace
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Dict, Optional
 
 import numpy as np
 
-from scpi_control.signal_synth import SignalSpec, synthesize
+from scpi_control.signal_synth import PERIODIC_KINDS, SignalSpec, synthesize
 
 if TYPE_CHECKING:
     from scpi_control.connection.mock.base import MockConnection
@@ -31,6 +31,32 @@ _DEFAULT_SPECS: Dict[int, SignalSpec] = {
     4: SignalSpec(kind="sine", frequency=10_000.0, amplitude=0.125, noise_rms=0.01),
 }
 _FALLBACK_SPEC = SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.01)
+
+
+def _is_rising(slope_token) -> bool:
+    """Normalize per-dialect slope tokens: POS/RISing/RISE vs NEG/FALLing/FALL."""
+    token = str(slope_token).upper()
+    return not (token.startswith("NEG") or token.startswith("FALL"))
+
+
+def _trigger_crossing(spec: SignalSpec, level: float, rising: bool) -> Optional[float]:
+    """Time within one period where the ideal signal crosses `level`, or None."""
+    if spec.kind not in PERIODIC_KINDS:
+        return None
+    period = 1.0 / spec.frequency
+    n = 4096
+    ideal = synthesize(replace(spec, noise_rms=0.0, seed=0), sample_rate=n / period, n_points=n)
+    above = ideal >= level
+    # np.roll makes the comparison periodic: a crossing at the period boundary
+    # (e.g. a zero-phase sine rising through 0 at t=0/t=P) is not missed.
+    nxt = np.roll(above, -1)
+    if rising:
+        indices = np.flatnonzero(~above & nxt)
+    else:
+        indices = np.flatnonzero(above & ~nxt)
+    if indices.size == 0:
+        return None
+    return float(indices[0] + 1) * (period / n)
 
 
 def spec_for(conn: "MockConnection", channel: int) -> SignalSpec:
@@ -57,7 +83,11 @@ def payload_for(conn: "MockConnection", channel: int, *, include_offset: bool) -
     count = conn._acquisition_counts.get(channel, 0)
     conn._acquisition_counts[channel] = count + 1
     window = DIVISIONS * conn.timebase
-    t0 = count * window * _DRIFT_FRACTION  # free-run; Task 5 adds trigger alignment
+    crossing = _trigger_crossing(spec, conn.trigger_level.get(channel, 0.0), _is_rising(conn.trigger_slope))
+    if crossing is not None:
+        t0 = crossing - window / 2.0  # matching edge lands at the window center
+    else:
+        t0 = count * window * _DRIFT_FRACTION  # untriggerable: free-run drift
     per_acquisition = spec if spec.seed is None else replace(spec, seed=spec.seed + count)
     volts = synthesize(per_acquisition, conn.sample_rate, n, t0=t0)
     vdiv = conn._voltage_scales.get(channel, 1.0)

--- a/scpi_control/connection/mock/tektronix.py
+++ b/scpi_control/connection/mock/tektronix.py
@@ -7,6 +7,7 @@ responses use HEADer OFF format (bare values), matching CONNECT_SETUP.
 import re
 from typing import Optional
 
+from scpi_control.connection.mock import synth as mock_synth
 from scpi_control.connection.mock.helpers import _build_ieee_block, _format_nr3
 
 # Immediate-measurement values mirror _MOCK_PAVA_VALUES semantically (same
@@ -191,7 +192,7 @@ def handle_query(conn, command: str) -> Optional[str]:
     if upper == "TRIGGER:A:HOLDOFF:TIME?":
         return _format_nr3(conn.holdoff_time)
     if upper == "WFMOUTPRE:NR_PT?":
-        return str(len(conn._waveform_payloads.get(conn.data_source, b"")))
+        return str(mock_synth.point_count(conn, conn.data_source))
     if upper == "WFMOUTPRE:XINCR?":
         return _format_nr3(1.0 / conn.sample_rate)
     if upper == "WFMOUTPRE:XZERO?":
@@ -222,5 +223,7 @@ def handle_query(conn, command: str) -> Optional[str]:
 
 
 def build_waveform_response(conn) -> bytes:
-    payload = conn._waveform_payloads.get(conn.data_source, bytes())
+    # Tek's converter is (code - yoff)*ymult + yzero with yoff=yzero=0 here, so
+    # codes carry no channel-offset term (include_offset=False).
+    payload = mock_synth.payload_for(conn, conn.data_source, include_offset=False)
     return _build_ieee_block(payload)  # CURVe? responses are a bare IEEE block

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -93,8 +93,9 @@ class SessionError(RuntimeError):
 
 def _make_mock_connection(model: Optional[str]) -> MockConnection:
     idn = DEFAULT_MOCK_IDN if model is None else "Siglent Technologies,{0},MOCK0001,1.0.0.0".format(model)
-    waveform_payloads = {1: bytes(range(256)), 2: bytes(range(256)), 3: bytes(range(256)), 4: bytes(range(256))}
-    return MockConnection("mock", idn=idn, channel_states={1: True, 2: False, 3: False, 4: False}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3, waveform_payloads=waveform_payloads)
+    # No explicit waveform_payloads: channels serve state-coupled synthesized
+    # signals (connection/mock/synth.py). 1 MSa/s x 14 div x 1 ms/div = 14k points.
+    return MockConnection("mock", idn=idn, channel_states={1: True, 2: False, 3: False, 4: False}, trigger_status=["Stop"], sample_rate=1_000_000.0, timebase=1e-3)
 
 
 class InstrumentSession:

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -1,0 +1,129 @@
+"""Synthetic signal generation: parameterized waveforms as numpy arrays or WaveformData.
+
+Public API for users who want synthetic data for testing and analysis, and the
+engine behind MockConnection's state-coupled waveform synthesis. Kinds live in a
+dispatch table of generator functions -- adding a kind is one new generator plus
+docs and tests; the mock coupling and code-conversion layers are kind-agnostic.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+import numpy as np
+
+from scpi_control import exceptions
+
+
+@dataclass(frozen=True)
+class SignalSpec:
+    """Parameters of one synthetic signal.
+
+    Attributes:
+        kind: One of "sine", "square", "triangle", "ramp", "dc", "noise".
+        frequency: Repetition rate in Hz (periodic kinds only).
+        amplitude: Peak amplitude in volts (Vpp = 2*amplitude); for "noise",
+            the standard deviation. Ignored for "dc".
+        offset: DC offset in volts, added to every kind ("dc" outputs exactly
+            this level).
+        phase: Phase in radians (periodic kinds only).
+        duty: High fraction of a "square" period, 0 < duty < 1 (pulse/PWM).
+        noise_rms: Std-dev of additive Gaussian noise laid on any kind.
+        seed: None for fresh randomness per call; an int for reproducibility.
+    """
+
+    kind: str = "sine"
+    frequency: float = 1_000.0
+    amplitude: float = 1.0
+    offset: float = 0.0
+    phase: float = 0.0
+    duty: float = 0.5
+    noise_rms: float = 0.0
+    seed: Optional[int] = None
+
+
+def _cycle_fraction(spec: SignalSpec, t: np.ndarray) -> np.ndarray:
+    return (spec.frequency * t + spec.phase / (2.0 * np.pi)) % 1.0
+
+
+def _sine(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    return spec.amplitude * np.sin(2.0 * np.pi * spec.frequency * t + spec.phase)
+
+
+def _square(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    return np.where(_cycle_fraction(spec, t) < spec.duty, spec.amplitude, -spec.amplitude)
+
+
+def _triangle(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    return spec.amplitude * (1.0 - 4.0 * np.abs(_cycle_fraction(spec, t) - 0.5))
+
+
+def _ramp(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    return spec.amplitude * (2.0 * _cycle_fraction(spec, t) - 1.0)
+
+
+def _dc(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    return np.zeros_like(t)
+
+
+def _noise(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    return rng.normal(0.0, spec.amplitude, t.shape)
+
+
+_GENERATORS: Dict[str, Callable[[SignalSpec, np.ndarray, np.random.Generator], np.ndarray]] = {
+    "sine": _sine,
+    "square": _square,
+    "triangle": _triangle,
+    "ramp": _ramp,
+    "dc": _dc,
+    "noise": _noise,
+}
+
+PERIODIC_KINDS = ("sine", "square", "triangle", "ramp")
+
+
+def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
+    if spec.kind not in _GENERATORS:
+        raise exceptions.InvalidParameterError(f"Unknown signal kind: {spec.kind!r}. Supported: {', '.join(sorted(_GENERATORS))}")
+    if sample_rate <= 0:
+        raise exceptions.InvalidParameterError(f"sample_rate must be positive: {sample_rate}")
+    if n_points < 1:
+        raise exceptions.InvalidParameterError(f"n_points must be at least 1: {n_points}")
+    if spec.kind in PERIODIC_KINDS and spec.frequency <= 0:
+        raise exceptions.InvalidParameterError(f"frequency must be positive for {spec.kind!r}: {spec.frequency}")
+    if spec.kind == "square" and not 0.0 < spec.duty < 1.0:
+        raise exceptions.InvalidParameterError(f"duty must be strictly between 0 and 1: {spec.duty}")
+    if spec.noise_rms < 0:
+        raise exceptions.InvalidParameterError(f"noise_rms must be non-negative: {spec.noise_rms}")
+
+
+def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 0.0) -> np.ndarray:
+    """Generate voltage samples for a signal spec.
+
+    Args:
+        spec: Signal parameters.
+        sample_rate: Samples per second.
+        n_points: Number of samples.
+        t0: Time of the first sample in seconds (shifts periodic signals).
+
+    Returns:
+        float64 voltage array of length n_points.
+    """
+    _validate(spec, sample_rate, n_points)
+    rng = np.random.default_rng(spec.seed)
+    t = t0 + np.arange(n_points) / sample_rate
+    samples = _GENERATORS[spec.kind](spec, t, rng) + spec.offset
+    if spec.noise_rms > 0:
+        samples = samples + rng.normal(0.0, spec.noise_rms, n_points)
+    return samples
+
+
+def make_waveform(spec: SignalSpec, sample_rate: float, n_points: int, channel: int = 1):
+    """Generate a WaveformData ready for analysis, saving, or reporting."""
+    # Function-level import: keeps `import scpi_control.connection` (which pulls
+    # the mock package, which pulls this module) from importing waveform.py
+    # mid-initialization.
+    from scpi_control.waveform import WaveformData
+
+    voltage = synthesize(spec, sample_rate, n_points)
+    time = np.arange(n_points) / sample_rate
+    return WaveformData(time=time, voltage=voltage, channel=channel, sample_rate=sample_rate)

--- a/tests/test_dialect_matrix.py
+++ b/tests/test_dialect_matrix.py
@@ -64,7 +64,18 @@ WIRE = {
 @pytest.fixture(params=["legacy", "modern", "tektronix", "lecroy"])
 def rig(request):
     dialect = request.param
-    conn = MockConnection("mock", idn=IDN[dialect], channel_states={1: True, 2: True}, trigger_status=["Ready", "Trig'd", "Stop"], sample_rate=1_000.0, timebase=1e-3)
+    # Explicit payloads keep the waveform assertions dialect-agnostic: legacy/modern
+    # (Siglent) would otherwise get state-coupled synthesis while tektronix/lecroy
+    # (not wired to the synthesizer until Task 4) would see no payload at all.
+    conn = MockConnection(
+        "mock",
+        idn=IDN[dialect],
+        channel_states={1: True, 2: True},
+        trigger_status=["Ready", "Trig'd", "Stop"],
+        sample_rate=1_000.0,
+        timebase=1e-3,
+        waveform_payloads={1: bytes([0, 25, 50, 75]), 2: bytes([0, 25, 50, 75])},
+    )
     scope = Oscilloscope("mock", connection=conn)
     scope.connect()
     yield dialect, scope, conn

--- a/tests/test_dialect_matrix.py
+++ b/tests/test_dialect_matrix.py
@@ -64,9 +64,10 @@ WIRE = {
 @pytest.fixture(params=["legacy", "modern", "tektronix", "lecroy"])
 def rig(request):
     dialect = request.param
-    # Explicit payloads keep the waveform assertions dialect-agnostic: legacy/modern
-    # (Siglent) would otherwise get state-coupled synthesis while tektronix/lecroy
-    # (not wired to the synthesizer until Task 4) would see no payload at all.
+    # Explicit payloads keep this test's expectations deterministic at the wire
+    # level, independent of synthesis: legacy/modern (Siglent) would otherwise
+    # get state-coupled synthesis while tektronix/lecroy would see no payload
+    # at all.
     conn = MockConnection(
         "mock",
         idn=IDN[dialect],

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -41,6 +41,7 @@ EXECUTE = [
     ("network_discovery.py", None),
     ("report_ai_qa.py", "requests"),
     ("waveform_provenance_and_extract.py", None),
+    ("synthetic_signals.py", None),
 ]
 
 _TIMEOUTS = {"report_ai_qa.py": 240}

--- a/tests/test_mock_synthesis.py
+++ b/tests/test_mock_synthesis.py
@@ -195,3 +195,15 @@ def test_unattainable_level_free_runs():
     b = scope.get_waveform(1, provenance=False)
     scope.disconnect()
     assert not np.array_equal(a.voltage, b.voltage)
+
+
+def test_server_mock_connection_synthesizes():
+    from scpi_control.server.sessions import _make_mock_connection
+
+    conn = _make_mock_connection(None)
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    assert len(data.voltage) >= 1_000  # real trace, not the old 256-byte ramp
+    assert np.ptp(data.voltage) > 1.0  # default CH1 square, ~2 Vpp

--- a/tests/test_mock_synthesis.py
+++ b/tests/test_mock_synthesis.py
@@ -1,4 +1,4 @@
-"""State-coupled mock waveform synthesis (Siglent dialects)."""
+"""State-coupled mock waveform synthesis: all vendor personalities, trigger alignment, and server mock sessions."""
 
 import numpy as np
 import pytest
@@ -174,6 +174,21 @@ def test_trigger_falling_slope():
     n = len(data.voltage)
     assert data.voltage[n // 2] == pytest.approx(0.0, abs=0.05)
     assert data.voltage[n // 2 + 20] < data.voltage[n // 2 - 20]  # falling through it
+
+
+def test_trigger_centered_even_when_point_cap_clamps():
+    # TDIV 10 ms/div at 1 MSa/s wants 140k points; MAX_POINTS clamps to 14k,
+    # so the sampled span (14 ms) is shorter than the nominal window (140 ms).
+    # The trigger edge must sit at the center of the SAMPLED span.
+    scope, _ = _scope(signals={1: SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.0, seed=1)})
+    scope.write("TDIV 1e-2")
+    scope.write("C1:TRLV 0.0")
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    n = len(data.voltage)
+    assert n == 14_000
+    assert data.voltage[n // 2] == pytest.approx(0.0, abs=0.05)
+    assert data.voltage[n // 2 + 20] > data.voltage[n // 2 - 20]
 
 
 def test_triggered_display_is_stable():

--- a/tests/test_mock_synthesis.py
+++ b/tests/test_mock_synthesis.py
@@ -89,8 +89,12 @@ def test_explicit_payload_precedence():
     np.testing.assert_allclose(data.voltage, [0.0, 1.0, 2.0, 3.0])
 
 
-def test_unseeded_captures_differ():
-    scope, _ = _scope()  # default specs carry noise_rms=0.01, seed=None
+def test_unseeded_noise_rerolls_each_capture():
+    # The default CH1 spec is trigger-aligned (stable t0), so consecutive
+    # captures differ ONLY because unseeded noise (noise_rms=0.01) re-rolls
+    # each acquisition. Free-run drift is covered separately by
+    # test_unattainable_level_free_runs.
+    scope, _ = _scope()
     a = scope.get_waveform(1, provenance=False)
     b = scope.get_waveform(1, provenance=False)
     scope.disconnect()

--- a/tests/test_mock_synthesis.py
+++ b/tests/test_mock_synthesis.py
@@ -148,3 +148,46 @@ def test_vendor_explicit_payload_precedence():
     data = scope.get_waveform(1, provenance=False)
     scope.disconnect()
     np.testing.assert_allclose(data.voltage, [0.0, 1.0, 2.0, 3.0])
+
+
+def test_trigger_aligns_rising_edge_at_center():
+    scope, _ = _scope(signals={1: SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.0, seed=1)})
+    scope.write("C1:TRLV 0.0")
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    n = len(data.voltage)
+    center = data.voltage[n // 2]
+    assert center == pytest.approx(0.0, abs=0.05)  # crossing sits at window center
+    assert data.voltage[n // 2 + 20] > data.voltage[n // 2 - 20]  # rising through it
+
+
+def test_trigger_falling_slope():
+    scope, _ = _scope(signals={1: SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.0, seed=1)})
+    scope.write("C1:TRLV 0.0")
+    scope.write("C1:TRSL NEG")
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    n = len(data.voltage)
+    assert data.voltage[n // 2] == pytest.approx(0.0, abs=0.05)
+    assert data.voltage[n // 2 + 20] < data.voltage[n // 2 - 20]  # falling through it
+
+
+def test_triggered_display_is_stable():
+    # A real triggered scope shows a stable trace: consecutive noise-free
+    # captures are identical when the trigger aligns them.
+    scope, _ = _scope(signals={1: SignalSpec(kind="sine", frequency=1_000.0, noise_rms=0.0)})
+    scope.write("C1:TRLV 0.0")
+    a = scope.get_waveform(1, provenance=False)
+    b = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    np.testing.assert_array_equal(a.voltage, b.voltage)
+
+
+def test_unattainable_level_free_runs():
+    # Level above the signal: no alignment, so noise-free captures drift.
+    scope, _ = _scope(signals={1: SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.0)})
+    scope.write("C1:TRLV 5.0")
+    a = scope.get_waveform(1, provenance=False)
+    b = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    assert not np.array_equal(a.voltage, b.voltage)

--- a/tests/test_mock_synthesis.py
+++ b/tests/test_mock_synthesis.py
@@ -1,0 +1,112 @@
+"""State-coupled mock waveform synthesis (Siglent dialects)."""
+
+import numpy as np
+import pytest
+
+from scpi_control.connection import MockConnection
+from scpi_control.oscilloscope import Oscilloscope
+from scpi_control.signal_synth import SignalSpec
+
+LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+MODERN_IDN = "Siglent Technologies,SDS824X HD,MOCK0002,3.8.12"
+
+
+def _scope(idn=LEGACY_IDN, **kwargs):
+    conn = MockConnection(
+        "mock",
+        idn=idn,
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=1_000_000.0,
+        timebase=1e-3,
+        **kwargs,
+    )
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    return scope, conn
+
+
+def _measured_frequency(data):
+    v = data.voltage - np.mean(data.voltage)
+    spectrum = np.abs(np.fft.rfft(v))
+    return np.fft.rfftfreq(len(v), 1.0 / data.sample_rate)[np.argmax(spectrum)]
+
+
+@pytest.mark.parametrize("idn", [LEGACY_IDN, MODERN_IDN])
+def test_seeded_square_round_trip(idn):
+    scope, _ = _scope(idn, signals={1: SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, seed=7)})
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    # 14 divisions x 1 ms/div at 1 MSa/s
+    assert len(data.voltage) == 14_000
+    assert np.max(data.voltage) == pytest.approx(1.0, abs=0.1)
+    assert np.min(data.voltage) == pytest.approx(-1.0, abs=0.1)
+    assert _measured_frequency(data) == pytest.approx(1_000.0, rel=0.05)
+
+
+def test_default_specs_without_signals_kwarg():
+    scope, _ = _scope()
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    assert len(data.voltage) == 14_000
+    assert np.ptp(data.voltage) > 1.5  # default CH1: 2 Vpp square (plus small noise)
+
+
+def test_timebase_coupling():
+    scope, _ = _scope(signals={1: SignalSpec(seed=1)})
+    scope.write("TDIV 1e-4")
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    assert len(data.voltage) == 1_400  # 14 divisions x 0.1 ms/div at 1 MSa/s
+
+
+def test_overrange_clips_at_full_scale():
+    # 2 Vpp signal on a 0.1 V/div scale: full scale is 127 codes = 0.508 V
+    scope, _ = _scope(signals={1: SignalSpec(kind="square", amplitude=1.0, seed=2)})
+    scope.write("C1:VDIV 0.1")
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    assert np.max(data.voltage) == pytest.approx(127 * 0.1 / 25, abs=0.01)
+    assert np.min(data.voltage) == pytest.approx(-127 * 0.1 / 25, abs=0.01)
+
+
+def test_vertical_offset_round_trips():
+    scope, _ = _scope(signals={1: SignalSpec(kind="dc", offset=0.5, seed=3)})
+    scope.write("C1:OFST 0.2")
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    # Converter subtracts the channel offset; synthesis adds it back, so the
+    # recovered trace is the signal itself.
+    # One int8 code = 40 mV at 1 V/div, so quantization alone can shift the
+    # recovered level by up to ~20 mV; allow for it.
+    assert np.mean(data.voltage) == pytest.approx(0.5, abs=0.03)
+
+
+def test_explicit_payload_precedence():
+    scope, _ = _scope(waveform_payloads={1: bytes([0, 25, 50, 75])})
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    np.testing.assert_allclose(data.voltage, [0.0, 1.0, 2.0, 3.0])
+
+
+def test_unseeded_captures_differ():
+    scope, _ = _scope()  # default specs carry noise_rms=0.01, seed=None
+    a = scope.get_waveform(1, provenance=False)
+    b = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    assert not np.array_equal(a.voltage, b.voltage)
+
+
+def test_seeded_sequences_reproduce_across_connections():
+    signals = {1: SignalSpec(kind="sine", noise_rms=0.05, seed=11)}
+    scope1, _ = _scope(signals=signals)
+    first_a = scope1.get_waveform(1, provenance=False)
+    second_a = scope1.get_waveform(1, provenance=False)
+    scope1.disconnect()
+    scope2, _ = _scope(signals=signals)
+    first_b = scope2.get_waveform(1, provenance=False)
+    second_b = scope2.get_waveform(1, provenance=False)
+    scope2.disconnect()
+    np.testing.assert_array_equal(first_a.voltage, first_b.voltage)
+    np.testing.assert_array_equal(second_a.voltage, second_b.voltage)
+    assert not np.array_equal(first_a.voltage, second_a.voltage)  # seed advances per acquisition

--- a/tests/test_mock_synthesis.py
+++ b/tests/test_mock_synthesis.py
@@ -110,3 +110,41 @@ def test_seeded_sequences_reproduce_across_connections():
     np.testing.assert_array_equal(first_a.voltage, first_b.voltage)
     np.testing.assert_array_equal(second_a.voltage, second_b.voltage)
     assert not np.array_equal(first_a.voltage, second_a.voltage)  # seed advances per acquisition
+
+
+TEK_IDN = "TEKTRONIX,MSO24,MOCK0100,CF:91.1CT FV:1.28"
+LECROY_IDN = "LECROY,WAVESURFER3024Z,MOCK0200,8.5.0"
+
+
+@pytest.mark.parametrize("idn", [TEK_IDN, LECROY_IDN])
+def test_vendor_round_trip(idn):
+    scope, _ = _scope(idn, signals={1: SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, seed=7)})
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    assert len(data.voltage) == 14_000
+    assert np.max(data.voltage) == pytest.approx(1.0, abs=0.1)
+    assert np.min(data.voltage) == pytest.approx(-1.0, abs=0.1)
+    assert _measured_frequency(data) == pytest.approx(1_000.0, rel=0.05)
+
+
+def test_tek_nr_pt_matches_curve_length():
+    scope, conn = _scope(TEK_IDN, signals={1: SignalSpec(seed=1)})
+    scope.write("HORIZONTAL:SCALE 1.0E-4")
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    assert len(data.voltage) == 1_400  # preamble NR_Pt and CURVe? payload agree
+
+
+def test_lecroy_timebase_coupling():
+    scope, _ = _scope(LECROY_IDN, signals={1: SignalSpec(seed=1)})
+    scope.write("TDIV 1e-4")
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    assert len(data.voltage) == 1_400
+
+
+def test_vendor_explicit_payload_precedence():
+    scope, _ = _scope(TEK_IDN, waveform_payloads={1: bytes([0, 25, 50, 75])})
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    np.testing.assert_allclose(data.voltage, [0.0, 1.0, 2.0, 3.0])

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -286,9 +286,11 @@ def test_set_active_reference_broadcasts_overlay_and_clear():
 
 
 def test_poll_publishes_reference_stats_for_active_reference():
-    session = make_session()
+    # An explicit payload (rather than the default state-coupled synthesis, which
+    # varies each acquisition) keeps the mock replaying the same record every
+    # tick, so the self-compare below is deterministic.
+    session = make_session(waveform_payloads={1: bytes([0, 25, 50, 75])})
     try:
-        # the mock replays the same record every tick -> self-compare is deterministic
         data = session.submit(lambda scope: scope.get_waveform(1)).result(timeout=5)
         session.set_active_reference("golden", 1, {"time": data.time, "voltage": data.voltage})
         msgs = collect(session, "reference_stats", n=1, timeout=8.0)

--- a/tests/test_signal_synth.py
+++ b/tests/test_signal_synth.py
@@ -1,0 +1,120 @@
+"""Public synthetic-signal generators."""
+
+import numpy as np
+import pytest
+
+from scpi_control import exceptions
+from scpi_control.signal_synth import SignalSpec, make_waveform, synthesize
+
+
+def _dominant_frequency(voltage, sample_rate):
+    spectrum = np.abs(np.fft.rfft(voltage - np.mean(voltage)))
+    return np.fft.rfftfreq(len(voltage), 1.0 / sample_rate)[np.argmax(spectrum)]
+
+
+def test_sine_frequency_and_amplitude():
+    spec = SignalSpec(kind="sine", frequency=1_000.0, amplitude=2.0)
+    v = synthesize(spec, sample_rate=1_000_000.0, n_points=10_000)
+    assert v.shape == (10_000,)
+    assert np.max(v) == pytest.approx(2.0, abs=0.01)
+    assert np.min(v) == pytest.approx(-2.0, abs=0.01)
+    assert _dominant_frequency(v, 1_000_000.0) == pytest.approx(1_000.0, rel=0.02)
+
+
+def test_square_duty_cycle():
+    spec = SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, duty=0.25)
+    v = synthesize(spec, sample_rate=1_000_000.0, n_points=10_000)
+    high_fraction = np.mean(v > 0)
+    assert high_fraction == pytest.approx(0.25, abs=0.02)
+    assert set(np.round(np.unique(v), 6)) == {-1.0, 1.0}
+
+
+def test_triangle_and_ramp_shapes():
+    tri = synthesize(SignalSpec(kind="triangle", frequency=100.0, amplitude=1.0), 100_000.0, 5_000)
+    ramp = synthesize(SignalSpec(kind="ramp", frequency=100.0, amplitude=1.0), 100_000.0, 5_000)
+    assert np.max(tri) == pytest.approx(1.0, abs=0.01)
+    assert np.min(tri) == pytest.approx(-1.0, abs=0.01)
+    # A ramp resets once per period: exactly ~5 large negative jumps in 5 periods
+    jumps = np.sum(np.diff(ramp) < -1.0)
+    assert jumps == pytest.approx(5, abs=1)
+
+
+def test_dc_and_offset():
+    v = synthesize(SignalSpec(kind="dc", offset=0.7), 1_000.0, 100)
+    np.testing.assert_allclose(v, 0.7)
+
+
+def test_noise_kind_statistics():
+    v = synthesize(SignalSpec(kind="noise", amplitude=0.5, seed=1), 1_000.0, 50_000)
+    assert np.std(v) == pytest.approx(0.5, rel=0.05)
+    assert np.mean(v) == pytest.approx(0.0, abs=0.02)
+
+
+def test_noise_rms_rides_on_signal():
+    clean = synthesize(SignalSpec(kind="sine", seed=3), 1_000_000.0, 10_000)
+    noisy = synthesize(SignalSpec(kind="sine", noise_rms=0.05, seed=3), 1_000_000.0, 10_000)
+    assert np.std(noisy - clean) == pytest.approx(0.05, rel=0.1)
+
+
+def test_seed_reproducibility():
+    spec = SignalSpec(kind="sine", noise_rms=0.05, seed=42)
+    a = synthesize(spec, 1_000_000.0, 1_000)
+    b = synthesize(spec, 1_000_000.0, 1_000)
+    np.testing.assert_array_equal(a, b)
+    unseeded = SignalSpec(kind="sine", noise_rms=0.05)
+    c = synthesize(unseeded, 1_000_000.0, 1_000)
+    d = synthesize(unseeded, 1_000_000.0, 1_000)
+    assert not np.array_equal(c, d)
+
+
+def test_t0_shifts_phase():
+    spec = SignalSpec(kind="sine", frequency=1_000.0)
+    a = synthesize(spec, 1_000_000.0, 1_000, t0=0.0)
+    b = synthesize(spec, 1_000_000.0, 1_000, t0=0.25e-3)  # quarter period
+    assert not np.allclose(a, b)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"kind": "sawtooth"},
+        {"frequency": 0.0},
+        {"frequency": -5.0},
+        {"kind": "square", "duty": 0.0},
+        {"kind": "square", "duty": 1.0},
+    ],
+)
+def test_invalid_spec_raises(bad):
+    with pytest.raises(exceptions.InvalidParameterError):
+        synthesize(SignalSpec(**bad), 1_000.0, 100)
+
+
+@pytest.mark.parametrize("sample_rate,n_points", [(0.0, 100), (-1.0, 100), (1_000.0, 0)])
+def test_invalid_dimensions_raise(sample_rate, n_points):
+    with pytest.raises(exceptions.InvalidParameterError):
+        synthesize(SignalSpec(), sample_rate, n_points)
+
+
+def test_classifier_smoke():
+    """Synthesized signals exercise the report generator's classifier (spec smoke test).
+
+    NOTE: mirror the report-WaveformData construction and expected labels from
+    tests/test_signal_type_classification.py (its `_wf` helper) if the kwargs
+    below have drifted from that file's current shape.
+    """
+    from scpi_control.report_generator.models.report_data import WaveformData as ReportWaveform
+    from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+    for kind, expected in (("square", "square"), ("sine", "sine")):
+        wf = make_waveform(SignalSpec(kind=kind, frequency=1_000.0, seed=9), sample_rate=1_000_000.0, n_points=20_000)
+        report_wf = ReportWaveform(channel="C1", time=wf.time, voltage=wf.voltage, sample_rate=wf.sample_rate, record_length=len(wf.voltage))
+        got, _confidence = WaveformAnalyzer.detect_signal_type(report_wf)
+        assert got == expected
+
+
+def test_make_waveform():
+    wf = make_waveform(SignalSpec(kind="square", seed=5), sample_rate=100_000.0, n_points=2_000, channel=3)
+    assert wf.channel == 3
+    assert wf.sample_rate == pytest.approx(100_000.0)
+    assert len(wf.time) == len(wf.voltage) == 2_000
+    assert wf.time[1] - wf.time[0] == pytest.approx(1e-5)

--- a/tests/test_tek_families.py
+++ b/tests/test_tek_families.py
@@ -33,6 +33,10 @@ def test_mso58_connects_with_eight_channels():
         "mock",
         idn="TEKTRONIX,MSO58,MOCK0300,CF:91.1CT FV:2.0",
         channel_states={i: True for i in range(1, 9)},
+        # Tek/LeCroy waveform paths aren't wired to the synthesizer yet (Task 4);
+        # channel 8 needs an explicit payload since the removed fixed default
+        # no longer supplies one.
+        waveform_payloads={8: bytes([0, 25, 50, 75])},
     )
     scope = Oscilloscope("mock", connection=conn)
     scope.connect()

--- a/tests/test_tek_families.py
+++ b/tests/test_tek_families.py
@@ -33,9 +33,9 @@ def test_mso58_connects_with_eight_channels():
         "mock",
         idn="TEKTRONIX,MSO58,MOCK0300,CF:91.1CT FV:2.0",
         channel_states={i: True for i in range(1, 9)},
-        # Tek/LeCroy waveform paths aren't wired to the synthesizer yet (Task 4);
-        # channel 8 needs an explicit payload since the removed fixed default
-        # no longer supplies one.
+        # An explicit payload keeps this test's expectations deterministic at
+        # the wire level, independent of synthesis; channel 8 needs one since
+        # the removed fixed default no longer supplies one.
         waveform_payloads={8: bytes([0, 25, 50, 75])},
     )
     scope = Oscilloscope("mock", connection=conn)


### PR DESCRIPTION
## Summary

Adds a public synthetic-signal API and makes the mock layer serve realistic, state-coupled waveforms by default — so the full capture → analysis → report chain is demonstrable and developable with no instrument attached.

- **Public generators** (`scpi_control.signal_synth`): `SignalSpec` (sine, square with duty cycle, triangle, ramp, DC, Gaussian noise; optional `noise_rms` on any kind; `seed` for reproducibility) with `synthesize()` → numpy volts and `make_waveform()` → ready-to-analyze `WaveformData`. Kinds live in a dispatch table, so future kinds are one generator + docs + tests.
- **State-coupled mock synthesis** (all three vendor personalities — Siglent legacy/modern, Tektronix, LeCroy): channels without explicit `waveform_payloads` synthesize from the mock's *live* state at every request — capture window = 14 divisions × timebase (clamped to [2, 14000] points), int8 codes at 25/div clipped at ±127 so over-ranging behaves like a real 8-bit scope, and the trigger level/slope aligns the matching edge at the center of the sampled span. Triggered noise-free captures are bit-identical (stable display, like real hardware); unattainable trigger levels free-run with phase drift; unseeded noise re-rolls per acquisition so live view animates.
- **Defaults that look like a bench**: CH1 serves a 1 kHz 2 Vpp square (cal-output style), CH2–CH4 sines at distinct frequencies. `signals={ch: SignalSpec(...)}` selects signals per channel; explicit `waveform_payloads` bytes remain byte-identical (the old fixed 4-byte constructor default is gone — see changelog "Changed").
- **Web gateway**: mock sessions now stream 14k-point synthesized traces (1 MSa/s) instead of a fixed 256-byte ramp.
- Docs page (`docs/user-guide/synthetic-signals.md`), mock-only runnable example enrolled in the smoke suite's EXECUTE list, changelog entry (MINOR, additive).

## Test plan

- [x] Full suite: 1102 passed / 19 skipped (baseline before branch: 1062 / 19; +40 tests)
- [x] Round-trip through the real transfer layer for Siglent legacy/modern, Tektronix, and LeCroy (FFT-measured frequency, amplitude, clipping ceiling)
- [x] State coupling: TDIV/VDIV/OFST SCPI writes change the next capture; Tek `NR_PT?` always matches `CURVe?` length
- [x] Trigger alignment: rising/falling edge at window center, bit-identical triggered captures, free-run drift on unattainable levels, centered even when the point cap clamps
- [x] Explicit-payload precedence byte-identical (Siglent + Tek)
- [x] Seeded sequences reproduce across connections; seeds advance per acquisition
- [x] `black --check --line-length 200` and `flake8 --select=E9,F63,F7,F82` clean; example executes in the smoke suite; `mkdocs build` clean
