### PR TITLE
chore(release): 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-07-21
+
 ### Added
 
 - Synthetic signals: a public generator API — `SignalSpec` plus `synthesize()`/`make_waveform()` in `scpi_control.signal_synth` — producing sine, square (with duty cycle), triangle, ramp, DC, and Gaussian-noise waveforms as numpy arrays or ready-to-analyze `WaveformData`, with seedable reproducibility.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![GitHub last commit](https://img.shields.io/github/last-commit/little-did-I-know/SCPI-Instrument-Control)](https://github.com/little-did-I-know/SCPI-Instrument-Control/commits/main)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-Support-yellow.svg?style=flat&logo=buy-me-a-coffee)](https://buymeacoffee.com/little.did.i.know)
 
-A universal Python library for controlling SCPI-compatible test equipment via Ethernet/LAN. Supports oscilloscopes, function generators (AWGs), and power supplies with a comprehensive programmatic API and high-performance PyQt6-based GUI application.
+A universal Python library for controlling SCPI-compatible test equipment via Ethernet/LAN (plus USB, GPIB, and serial through the optional VISA backend). It drives oscilloscopes from Siglent, Tektronix, and LeCroy alongside function generators (AWGs), power supplies, and data-acquisition units through one programmatic API — with a high-performance PyQt6 GUI, a browser-based lab gateway, provenance-stamped waveform files, automated PDF/Markdown test reports with local-LLM analysis, and a realistic mock layer that synthesizes state-coupled waveforms so the whole stack can be developed and demoed without an instrument attached.
 
 <p align="center">
   <img src="docs/images/sds824x-hd-cal-square.png" alt="Live screen capture from a Siglent SDS824X HD oscilloscope" width="720">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "3.1.0"
-description = "Universal Python library for controlling SCPI-compatible test equipment via Ethernet/LAN. Supports oscilloscopes (Siglent SDS series, generic SCPI scopes), function generators/AWGs (Siglent SDG series, generic SCPI AWGs), and power supplies (Siglent SPD series, generic SCPI PSUs). Features include waveform capture, measurements, FFT analysis, PyQt6 GUI, automated report generation with AI analysis, and comprehensive SCPI command abstraction."
+version = "3.2.0"
+description = "Universal Python library for controlling SCPI-compatible test equipment via Ethernet/LAN, USB, GPIB, or serial. Drives oscilloscopes (Siglent SDS, Tektronix TBS/MSO, LeCroy MAUI, generic SCPI), function generators/AWGs (Siglent SDG series), power supplies (Siglent SPD series), and data-acquisition units (34970A-style). Features waveform capture with acquisition provenance, raw-data extraction (load_waveform and the scpi-extract CLI), measurements, FFT analysis, a PyQt6 GUI, a browser-based lab gateway, automated PDF/Markdown report generation with local-LLM analysis, synthetic-signal generation, and a realistic mock layer for developing without hardware."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"
 license = { text = "MIT" }

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
## Release 3.2.0

MINOR release: synthetic-signal generators + state-coupled mock waveform synthesis (PR #86). No breaking changes.

- Version bumped in pyproject.toml and scpi_control/__init__.py
- CHANGELOG: [Unreleased] promoted to [3.2.0] - 2026-07-21
- PyPI description and README intro refreshed (multi-vendor scopes, DAQ, web gateway, provenance, local-LLM reports, synthetic mock)
- Verified: 1102 passed / 19 skipped; black + flake8 gates clean; CHANGELOG byte-clean
