### PR TITLE
fix: keep the PyPI summary under the 512-character limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "SCPI-Instrument-Control"
 version = "3.2.0"
-description = "Universal Python library for controlling SCPI-compatible test equipment via Ethernet/LAN, USB, GPIB, or serial. Drives oscilloscopes (Siglent SDS, Tektronix TBS/MSO, LeCroy MAUI, generic SCPI), function generators/AWGs (Siglent SDG series), power supplies (Siglent SPD series), and data-acquisition units (34970A-style). Features waveform capture with acquisition provenance, raw-data extraction (load_waveform and the scpi-extract CLI), measurements, FFT analysis, a PyQt6 GUI, a browser-based lab gateway, automated PDF/Markdown report generation with local-LLM analysis, synthetic-signal generation, and a realistic mock layer for developing without hardware."
+description = "Universal Python library for SCPI test equipment via Ethernet/LAN, USB, GPIB, or serial. Drives oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies, and DAQ units. Waveform capture with acquisition provenance, raw-data extraction (load_waveform, scpi-extract), FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and synthetic-signal mocks for development without hardware."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"
 license = { text = "MIT" }


### PR DESCRIPTION
The v3.2.0 publish failed with '400: summary field must be 512 characters or less' - the refreshed description was 662 chars. Shortened to 424 chars; no other changes. Version 3.2.0 never reached PyPI, so the tag/release will be recreated on the fixed commit after merge.