### PR TITLE
feat: signal_synth.stream() for continuous live-signal simulation; testmon dev tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ site/
 
 # Web gateway frontend build output
 scpi_control/server/static/
+
+# pytest-testmon impact-selection database (local dev only)
+.testmondata*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `signal_synth.stream()`: an infinite or duration-bounded generator of phase-continuous voltage chunks for live-signal simulation — optional wall-clock pacing (`realtime=True`), correct seeded-noise semantics (seed advances per chunk, so seeded streams are reproducible without repeating noise blocks), and eager parameter validation.
+- Dev tooling: `pytest-testmon` in the `dev` extra for impact-based local test selection (`python -m pytest --testmon`); CI and pre-merge checks still run the full suite.
+
 ## [3.2.0] - 2026-07-21
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,27 @@ pytest tests/test_waveform_parsing.py
 pytest tests/ -v
 ```
 
+### Faster Local Runs with testmon
+
+`pytest-testmon` (installed with the `dev` extra) tracks which tests execute
+which lines and re-runs only the tests affected by your changes:
+
+```bash
+python -m pytest --testmon
+```
+
+The first `--testmon` run is slower (it builds the coverage map into a local
+`.testmondata` file, which is git-ignored); later runs select only impacted
+tests. Two caveats: it tracks Python-line dependencies only (changes to data
+files, configuration, or environment are invisible to it), so always finish
+with a plain full run before committing:
+
+```bash
+python -m pytest tests/
+```
+
+CI and pre-merge checks always run the full suite.
+
 ### Writing Tests
 
 - Place tests in the `tests/` directory

--- a/docs/user-guide/synthetic-signals.md
+++ b/docs/user-guide/synthetic-signals.md
@@ -78,6 +78,60 @@ Two calls with `seed=None` (the default) produce different noise and, for
 `"noise"` itself, different signal on every call. Pass an `int` seed to get
 byte-identical output across runs.
 
+## Streaming
+
+`synthesize()` and `make_waveform()` generate one fixed-length block. For
+continuous or live simulation -- feeding a loop, a plot, or a network socket
+indefinitely -- `stream()` does the same phase-continuous generation without
+hand-rolling the `t0` bookkeeping yourself:
+
+```python
+def stream(
+    spec: SignalSpec,
+    sample_rate: float,
+    chunk_size: int,
+    *,
+    start_time: float = 0.0,
+    duration: Optional[float] = None,
+    realtime: bool = False,
+) -> Iterator[np.ndarray]
+```
+
+It returns an iterator of `float64` voltage chunks, each `chunk_size`
+samples long, where every chunk picks up exactly where the previous one left
+off -- no phase discontinuity at chunk boundaries. Validation errors (the
+same ones `SignalSpec` and `synthesize()` raise) happen at call time, before
+the first chunk is produced.
+
+A minimal continuous loop:
+
+```python
+from scpi_control.signal_synth import SignalSpec, stream
+
+spec = SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.02)
+for chunk in stream(spec, sample_rate=1_000_000.0, chunk_size=10_000):
+    process(chunk)  # phase-continuous float64 volts; break when done
+```
+
+By default `stream()` yields chunks as fast as the consumer pulls them. With
+`duration=None` (the default) it streams forever -- `break` out of the loop
+to stop. Passing a positive `duration` bounds the stream to
+`round(duration * sample_rate)` total samples, truncating the final chunk to
+fit; `start_time` shifts the time of the very first sample, the same way
+`t0` does for `synthesize()`.
+
+Set `realtime=True` to pace chunks at wall-clock rate: chunk `k` is withheld
+until `k * chunk_size / sample_rate` seconds after the first chunk was
+produced. Scheduling is absolute (measured from the start, not
+chunk-to-chunk), so timing error never accumulates across a long stream, and
+a consumer slower than real time simply never waits -- it just gets chunks
+later than it asked for them.
+
+Seeding follows the same rule the mock uses per acquisition: `seed=None`
+re-rolls fresh noise on every chunk, while a seeded spec advances the seed
+per chunk (`seed + chunk_index`) so the whole stream is reproducible
+run-to-run without repeating the same noise block over and over.
+
 ## Mock Oscilloscope Synthesis
 
 `MockConnection` synthesizes each channel's waveform from its current state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ Changelog = "https://github.com/little-did-I-know/SCPI-Instrument-Control/blob/m
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0.0",
+    "pytest-testmon>=2.0",
     "codecov>=2.1.0",
     "black>=26.5,<27; python_version >= '3.10'",
     "flake8>=6.0",

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -6,8 +6,9 @@ dispatch table of generator functions -- adding a kind is one new generator plus
 docs and tests; the mock coupling and code-conversion layers are kind-agnostic.
 """
 
-from dataclasses import dataclass
-from typing import Callable, Dict, Optional
+import time
+from dataclasses import dataclass, replace
+from typing import Callable, Dict, Iterator, Optional
 
 import numpy as np
 
@@ -115,6 +116,64 @@ def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 
     if spec.noise_rms > 0:
         samples = samples + rng.normal(0.0, spec.noise_rms, n_points)
     return samples
+
+
+def stream(
+    spec: SignalSpec,
+    sample_rate: float,
+    chunk_size: int,
+    *,
+    start_time: float = 0.0,
+    duration: Optional[float] = None,
+    realtime: bool = False,
+) -> Iterator[np.ndarray]:
+    """Yield phase-continuous voltage chunks for live/continuous simulation.
+
+    Args:
+        spec: Signal parameters. A seeded spec uses seed + chunk_index per
+            chunk (reproducible run-to-run, non-repeating across chunks);
+            seed=None re-rolls noise freshly every chunk.
+        sample_rate: Samples per second.
+        chunk_size: Samples per yielded chunk.
+        start_time: Time of the very first sample in seconds.
+        duration: None streams forever (stop by breaking out); a positive
+            number bounds the stream to round(duration * sample_rate) samples,
+            truncating the final chunk.
+        realtime: When True, chunks arrive at wall-clock rate (chunk k is
+            withheld until k * chunk_size / sample_rate seconds after the
+            first chunk); scheduling is absolute, so timing error never
+            accumulates, and a consumer slower than real time simply never
+            waits.
+
+    Returns:
+        Iterator of float64 voltage arrays. Validation errors raise at call
+        time, before the first chunk.
+    """
+    _validate(spec, sample_rate, chunk_size)
+    if duration is not None and duration <= 0:
+        raise exceptions.InvalidParameterError(f"duration must be positive: {duration}")
+    total = None if duration is None else int(round(duration * sample_rate))
+
+    def _chunks() -> Iterator[np.ndarray]:
+        produced = 0
+        index = 0
+        wall_start = None
+        while total is None or produced < total:
+            n = chunk_size if total is None else min(chunk_size, total - produced)
+            chunk_spec = spec if spec.seed is None else replace(spec, seed=spec.seed + index)
+            chunk = synthesize(chunk_spec, sample_rate, n, t0=start_time + produced / sample_rate)
+            if realtime:
+                if wall_start is None:
+                    wall_start = time.monotonic()
+                else:
+                    delay = wall_start + produced / sample_rate - time.monotonic()
+                    if delay > 0:
+                        time.sleep(delay)
+            yield chunk
+            produced += n
+            index += 1
+
+    return _chunks()
 
 
 def make_waveform(spec: SignalSpec, sample_rate: float, n_points: int, channel: int = 1):

--- a/tests/test_signal_synth.py
+++ b/tests/test_signal_synth.py
@@ -1,10 +1,13 @@
 """Public synthetic-signal generators."""
 
+import itertools
+import time
+
 import numpy as np
 import pytest
 
 from scpi_control import exceptions
-from scpi_control.signal_synth import SignalSpec, make_waveform, synthesize
+from scpi_control.signal_synth import SignalSpec, make_waveform, stream, synthesize
 
 
 def _dominant_frequency(voltage, sample_rate):
@@ -118,3 +121,71 @@ def test_make_waveform():
     assert wf.sample_rate == pytest.approx(100_000.0)
     assert len(wf.time) == len(wf.voltage) == 2_000
     assert wf.time[1] - wf.time[0] == pytest.approx(1e-5)
+
+
+def test_stream_chunks_are_phase_continuous():
+    spec = SignalSpec(kind="sine", frequency=1_000.0)
+    joined = np.concatenate(list(stream(spec, 1_000_000.0, 1_000, duration=0.01)))
+    expected = synthesize(spec, 1_000_000.0, 10_000)
+    assert joined.shape == expected.shape
+    np.testing.assert_allclose(joined, expected, rtol=0, atol=1e-9)
+
+
+def test_stream_duration_yields_partial_final_chunk():
+    chunks = list(stream(SignalSpec(seed=1), 10_000.0, 300, duration=0.1))  # 1000 samples
+    assert [len(c) for c in chunks] == [300, 300, 300, 100]
+
+
+def test_stream_exact_chunk_multiple_has_no_empty_tail():
+    chunks = list(stream(SignalSpec(seed=1), 10_000.0, 250, duration=0.1))  # 1000 samples
+    assert [len(c) for c in chunks] == [250, 250, 250, 250]
+
+
+def test_stream_infinite_by_default():
+    chunks = list(itertools.islice(stream(SignalSpec(seed=1), 10_000.0, 128), 3))
+    assert [len(c) for c in chunks] == [128, 128, 128]
+
+
+def test_stream_seeded_reproducible_and_nonrepeating():
+    spec = SignalSpec(kind="noise", amplitude=0.5, seed=42)
+    a = list(itertools.islice(stream(spec, 10_000.0, 256), 3))
+    b = list(itertools.islice(stream(spec, 10_000.0, 256), 3))
+    for x, y in zip(a, b):
+        np.testing.assert_array_equal(x, y)  # run-to-run reproducible
+    assert not np.array_equal(a[0], a[1])  # non-repeating across chunks
+
+
+def test_stream_unseeded_noise_differs_per_stream():
+    spec = SignalSpec(kind="noise", amplitude=0.5)
+    a = next(iter(stream(spec, 10_000.0, 256)))
+    b = next(iter(stream(spec, 10_000.0, 256)))
+    assert not np.array_equal(a, b)
+
+
+def test_stream_start_time_offsets_the_signal():
+    spec = SignalSpec(kind="sine", frequency=1_000.0)
+    first = next(iter(stream(spec, 1_000_000.0, 500, start_time=0.25e-3)))
+    np.testing.assert_allclose(first, synthesize(spec, 1_000_000.0, 500, t0=0.25e-3), rtol=0, atol=1e-9)
+
+
+def test_stream_realtime_paces_chunks():
+    started = time.monotonic()
+    list(stream(SignalSpec(seed=1), 1_000.0, 50, duration=0.15, realtime=True))  # 3 x 50 ms
+    elapsed = time.monotonic() - started
+    # Chunk 0 is immediate; chunks 1 and 2 wait until 50 ms and 100 ms.
+    assert elapsed >= 0.09
+
+
+def test_stream_not_realtime_is_fast():
+    started = time.monotonic()
+    list(stream(SignalSpec(seed=1), 1_000.0, 50, duration=0.15))
+    assert time.monotonic() - started < 0.05
+
+
+def test_stream_validates_at_call_time():
+    with pytest.raises(exceptions.InvalidParameterError):
+        stream(SignalSpec(), 1_000.0, 0)  # no iteration needed
+    with pytest.raises(exceptions.InvalidParameterError):
+        stream(SignalSpec(), 1_000.0, 100, duration=-1.0)
+    with pytest.raises(exceptions.InvalidParameterError):
+        stream(SignalSpec(kind="sawtooth"), 1_000.0, 100)


### PR DESCRIPTION
## Summary

Adds `signal_synth.stream()` for continuous live-signal simulation, plus `pytest-testmon` as dev tooling for impact-based local test selection.

- **`stream(spec, sample_rate, chunk_size, *, start_time=0.0, duration=None, realtime=False)`** — an infinite (or duration-bounded) generator of phase-continuous float64 voltage chunks:
  - chunks concatenate to match a single `synthesize()` call over the same span (within float rounding; tested at `atol=1e-9`);
  - `duration=` bounds the stream to exactly `round(duration * sample_rate)` samples with a truncated final chunk;
  - `realtime=True` delivers chunk k exactly `k * chunk_size / sample_rate` seconds after the first chunk via absolute monotonic scheduling — timing error never accumulates, and slow consumers never wait;
  - seeded specs advance `seed + chunk_index` per chunk (the same rule the mock uses per acquisition), so seeded streams are reproducible run-to-run **without** repeating the same noise block; unseeded noise re-rolls every chunk;
  - invalid parameters raise `InvalidParameterError` at call time, before the first chunk.
- **Dev tooling**: `pytest-testmon` in the `dev` extra — `python -m pytest --testmon` re-runs only tests affected by your changes (verified: 28 executed → 28 deselected on an unchanged re-run). `.testmondata*` is git-ignored; CONTRIBUTING documents the workflow and its limits; CI and pre-merge checks still run the full suite.
- Docs: a Streaming section on the synthetic-signals page; changelog entry (MINOR, purely additive — `synthesize`/`make_waveform`/mock behavior untouched).

## Test plan

- [x] Full suite: 1112 passed / 19 skipped (baseline 1102 / 19; +10 tests)
- [x] Phase continuity vs one-shot synthesize; duration/partial-final-chunk and exact-multiple cases; infinite default
- [x] Seeded reproducibility across streams + non-repetition across chunks; unseeded streams differ
- [x] Realtime pacing (elapsed >= schedule) and non-realtime speed; eager call-time validation; start_time offset
- [x] testmon two-run selection check; `.testmondata` never appears in `git status`
- [x] `black --check --line-length 200`, `flake8 --select=E9,F63,F7,F82`, `mkdocs build` all clean; CHANGELOG byte-clean (no BOM)
