### PR TITLE
chore(release): 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-07-21
+
 ### Added
 
 - `signal_synth.stream()`: an infinite or duration-bounded generator of phase-continuous voltage chunks for live-signal simulation — optional wall-clock pacing (`realtime=True`), correct seeded-noise semantics (seed advances per chunk, so seeded streams are reproducible without repeating noise blocks), and eager parameter validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "3.2.0"
+version = "3.3.0"
 description = "Universal Python library for SCPI test equipment via Ethernet/LAN, USB, GPIB, or serial. Drives oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies, and DAQ units. Waveform capture with acquisition provenance, raw-data extraction (load_waveform, scpi-extract), FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and synthetic-signal mocks for development without hardware."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
## Release 3.3.0

MINOR release: signal_synth.stream() for continuous live-signal simulation + pytest-testmon dev tooling (PR #89). No breaking changes.

- Version bumped in pyproject.toml and scpi_control/__init__.py
- CHANGELOG: [Unreleased] promoted to [3.3.0] - 2026-07-21
- Verified: 1112 passed / 19 skipped; black + flake8 clean; CHANGELOG byte-clean; PyPI summary length pre-checked (430 <= 512)
