### PR TITLE
docs: full documentation sweep (README, examples, site) + save-format fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `DataCollector.save_data()`/`save_batch()` no longer raise `InvalidParameterError` with their default format — the format is now auto-detected from the filename extension (pass CSV, CSV_ENHANCED, NPY, MAT, or HDF5 explicitly to override).
+- Report-analyzer calibration guidance and example-script output are now ASCII-safe, so they no longer crash on Windows consoles with legacy codepages.
+- Documentation sweep: corrected the README's report-generator sample to the real API, fixed the default SCPI port (5025) and GUI frame-rate claims, repaired all broken links and anchors across README and the docs site, synced the docs changelog page through 3.3.0, and excluded internal planning files from the built documentation site.
+
+### Changed
+
+- README and docs now cover the full current feature set: multi-vendor scopes, DAQ, PSU/AWG models, the web gateway and `usb` extras, all four CLI tools, `load_waveform()`/`scpi-extract` usage, and API reference pages for `signal_synth`, `waveform_io`, `provenance`, and `scpi_extract`. Every example now carries a fully spelled-out docstring (what it shows, what it needs, what to expect).
+
 ## [3.3.0] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- README and docs now cover the full current feature set: multi-vendor scopes, DAQ, PSU/AWG models, the web gateway and `usb` extras, all four CLI tools, `load_waveform()`/`scpi-extract` usage, and API reference pages for `signal_synth`, `waveform_io`, `provenance`, and `scpi_extract`. Every example now carries a fully spelled-out docstring (what it shows, what it needs, what to expect).
+
 ### Fixed
 
 - `DataCollector.save_data()`/`save_batch()` no longer raise `InvalidParameterError` with their default format — the format is now auto-detected from the filename extension (pass CSV, CSV_ENHANCED, NPY, MAT, or HDF5 explicitly to override).
 - Report-analyzer calibration guidance and example-script output are now ASCII-safe, so they no longer crash on Windows consoles with legacy codepages.
 - Documentation sweep: corrected the README's report-generator sample to the real API, fixed the default SCPI port (5025) and GUI frame-rate claims, repaired all broken links and anchors across README and the docs site, synced the docs changelog page through 3.3.0, and excluded internal planning files from the built documentation site.
-
-### Changed
-
-- README and docs now cover the full current feature set: multi-vendor scopes, DAQ, PSU/AWG models, the web gateway and `usb` extras, all four CLI tools, `load_waveform()`/`scpi-extract` usage, and API reference pages for `signal_synth`, `waveform_io`, `provenance`, and `scpi_extract`. Every example now carries a fully spelled-out docstring (what it shows, what it needs, what to expect).
 
 ## [3.3.0] - 2026-07-21
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ from scpi_control.report_generator.generators.markdown_generator import Markdown
 from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator
 from scpi_control.report_generator.models.report_data import ReportMetadata, TestReport, TestSection, WaveformData
 
+# time_data / voltage_data: your captured numpy arrays (e.g. from scope.get_waveform)
 waveform = WaveformData(channel="CH1", time=time_data, voltage=voltage_data, sample_rate=1e6, record_length=len(voltage_data))
 
 metadata = ReportMetadata(title="Probe Calibration Test Report", technician="Lab Technician", test_date=datetime.now(), equipment_model="SDS824X HD")

--- a/README.md
+++ b/README.md
@@ -27,18 +27,20 @@ A universal Python library for controlling SCPI-compatible test equipment via Et
 ### Core Features
 
 - **Programmatic API**: Control your oscilloscope from Python scripts
+- **Multi-Vendor Oscilloscope Support**: Siglent (legacy SDS1000X-E/SDS2000X Plus and modern SDS800X HD/SDS5000X dialects), Tektronix, and LeCroy, auto-detected from `*IDN?`
+- **Power Supply & DAQ Support**: drive Siglent SPD-series power supplies and SCPI data-acquisition/data-logger units alongside the scope
 - **Automation & Data Collection**: High-level API for batch capture, continuous monitoring, and analysis
 - **GUI Application**: Modern PyQt6-based graphical interface
-- **Waveform Acquisition**: Capture and download waveform data in multiple formats (NPZ, CSV, MAT, HDF5)
+- **Waveform Acquisition**: Capture and download waveform data in multiple formats (.npz, .csv, .mat, .h5)
 - **Acquisition Provenance**: every saved waveform records the instrument, settings, and timestamp that produced it; extract raw data from any saved file with load_waveform() or the scpi-extract CLI
-- **Synthetic Signals & Realistic Mock**: generate parameterized test waveforms (sine/square/triangle/ramp/DC/noise) with SignalSpec/make_waveform, and develop without hardware against a mock scope that synthesizes state-coupled, trigger-aligned waveforms by default
+- **Synthetic Signals & Realistic Mock**: generate parameterized test waveforms (sine/square/triangle/ramp/DC/noise) with `SignalSpec`/`make_waveform`, or `synthesize()`/`stream()` for one-shot arrays and phase-continuous, optionally real-time-paced chunks; develop without hardware against a mock scope that synthesizes state-coupled, trigger-aligned waveforms by default
 - **Channel Configuration**: Control voltage scale, coupling, offset, bandwidth
 - **Trigger Settings**: Configure trigger modes, levels, edge detection
 - **Advanced Analysis**: Built-in FFT, SNR, THD, and statistical analysis tools
 
 ### GUI Features (New!)
 
-- **High-Performance Live View**: Real-time waveform display at 1000+ fps using PyQtGraph
+- **High-Performance Live View**: Real-time waveform display (5-20 fps, configurable) using PyQtGraph
 - **Interactive Visual Measurements**: Click-and-drag measurement markers directly on waveforms
   - 15+ measurement types: Frequency, Vpp, Rise Time, Duty Cycle, etc.
   - Visual gates and markers with real-time calculation
@@ -58,39 +60,30 @@ A universal Python library for controlling SCPI-compatible test equipment via Et
 # Install report generator dependencies
 # pip install "SCPI-Instrument-Control[report-generator]"
 
-from scpi_control.report_generator import ReportGenerator, PDFGenerator, MarkdownGenerator
+from datetime import datetime
 from pathlib import Path
 
-# Create a report generator
-report = ReportGenerator(
-    title="Probe Calibration Test Report",
-    test_id="CAL-2024-001",
-    operator="Lab Technician"
-)
+from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
+from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator
+from scpi_control.report_generator.models.report_data import ReportMetadata, TestReport, TestSection, WaveformData
 
-# Add waveform captures
-waveform = scope.get_waveform(channel=1)
-report.add_waveform(waveform, channel_number=1, name="Calibration Signal")
+waveform = WaveformData(channel="CH1", time=time_data, voltage=voltage_data, sample_rate=1e6, record_length=len(voltage_data))
 
-# Automatic signal analysis
-waveform.analyze()  # Auto-detects signal type, calculates 25+ statistics
+metadata = ReportMetadata(title="Probe Calibration Test Report", technician="Lab Technician", test_date=datetime.now(), equipment_model="SDS824X HD")
+report = TestReport(metadata=metadata)
+report.add_section(TestSection(title="Waveform Captures", waveforms=[waveform], order=1))
+report.overall_result = report.calculate_overall_result()
 
-# Optional: Add AI insights (requires Ollama)
-report.set_ai_model("llama3.2")  # Local LLM analysis
-
-# Generate reports in multiple formats
-pdf_gen = PDFGenerator(report_data=report.data)
-pdf_gen.generate(Path("calibration_report.pdf"))
-
-markdown_gen = MarkdownGenerator(report_data=report.data)
-markdown_gen.generate(Path("calibration_report.md"))
+MarkdownReportGenerator().generate(report, Path("calibration_report.md"))
+PDFReportGenerator().generate(report, Path("calibration_report.pdf"))
 ```
 
 **Key Features:**
 
 - ✅ **Automatic Signal Detection** - FFT-based classification (sine, square, triangle, pulse, etc.)
 - ✅ **Comprehensive Statistics** - 25+ parameters including Vpp, RMS, frequency, SNR, THD, jitter, overshoot
-- ✅ **AI-Powered Analysis** - Optional LLM integration via Ollama for intelligent waveform insights
+- ✅ **Template Presets** - Ready-made report templates such as `ReportTemplate.create_probe_calibration_template()`, manageable from the GUI's Template Manager
+- ✅ **Local-LLM Analysis** - Optional AI insights and Q&A tool-calling via Ollama running on your own machine (no cloud providers, no API keys)
 - ✅ **Region Extraction** - Zoom into plateaus, edges, and transients with calibration guidance
 - ✅ **Multiple Formats** - Generate PDF and Markdown reports with embedded plots
 - ✅ **Professional Layout** - Publication-ready reports with metadata, statistics tables, and visualizations
@@ -162,11 +155,26 @@ pip install "SCPI-Instrument-Control[report-generator]"
 # Vector graphics and XY mode (draw shapes on scope!)
 pip install "SCPI-Instrument-Control[fun]"
 
+# Browser-based lab gateway (scpi-web)
+pip install "SCPI-Instrument-Control[web]"
+
+# USB/GPIB/serial instruments via PyVISA
+pip install "SCPI-Instrument-Control[usb]"
+
 # Everything
 pip install "SCPI-Instrument-Control[all]"
 ```
 
 **Note**: The `siglent-gui` command includes automatic dependency checking. If you try to run the GUI without the required packages, you'll receive a clear error message with installation instructions. Missing optional dependencies (like PyQtGraph for high-performance live view) will trigger warnings but allow the GUI to launch.
+
+### Command-line tools
+
+| Command | Description |
+| --- | --- |
+| `siglent-gui` | Launch the PyQt6 GUI application |
+| `siglent-report-generator` | Launch the standalone report-generator app |
+| `scpi-web` | Serve the browser-based lab gateway (REST + WebSocket API, optional web UI) |
+| `scpi-extract` | Inspect or export a saved waveform file from the command line |
 
 ### From source
 
@@ -353,11 +361,13 @@ Install with `[gui]` extra to add:
 - **Report Generator**: Install with `[report-generator]` to add PyQt6, Pillow, requests, ReportLab, Ollama (PDF/Markdown reports with AI)
 - **HDF5 support**: Install with `[hdf5]` to add h5py >= 3.8.0
 - **Vector Graphics**: Install with `[fun]` to add shapely, Pillow, svgpathtools (XY mode drawing)
+- **Web Gateway**: Install with `[web]` to add FastAPI, Uvicorn, Pillow (browser-based lab gateway, `scpi-web`)
+- **USB/GPIB/Serial**: Install with `[usb]` to add PyVISA + pyvisa-py (USB-TMC, GPIB, and serial instrument connections)
 - **All features**: Install with `[all]` for complete functionality
 
 ## Connection
 
-The oscilloscope must be connected to your network. The default SCPI port is 5024.
+The oscilloscope must be connected to your network. The default SCPI port is 5025.
 
 To find your oscilloscope's IP address:
 
@@ -368,8 +378,6 @@ To find your oscilloscope's IP address:
 ## GUI Application Overview
 
 The SCPI Instrument Control GUI provides a comprehensive interface for controlling your oscilloscope, capturing waveforms, and performing measurements.
-
-> **Note**: Screenshots can be captured following the guide in [`docs/SCREENSHOT_GUIDE.md`](docs/SCREENSHOT_GUIDE.md). This provides visual documentation of all GUI features.
 
 ### Main Window
 
@@ -384,15 +392,13 @@ The main interface consists of:
 
 ### Getting Connected
 
-![Connection Dialog](docs/images/connection_dialog.png)
-
 To connect to your oscilloscope:
 
 1. Launch the GUI: `siglent-gui`
 2. Enter your oscilloscope's IP address
 3. Click **Connect**
 
-The oscilloscope must be connected to your network (default SCPI port: 5024).
+The oscilloscope must be connected to your network (default SCPI port: 5025).
 
 **Finding your oscilloscope's IP address**:
 
@@ -418,8 +424,6 @@ The **Channels** tab provides complete control over all input channels:
 ## GUI Application Guide
 
 ### Live View
-
-![Live View](docs/images/live_view.png)
 
 The GUI features **high-performance real-time waveform viewing** powered by PyQtGraph:
 
@@ -571,6 +575,20 @@ See `examples/vector_graphics_xy_mode.py` for programmatic usage and animation e
 
 ### Other GUI Features
 
+**Power Supply:**
+
+- Dedicated **Power Supply** tab (`Connect to Power Supply...` menu action) for Siglent SPD-series and generic SCPI-99 power supplies
+- Per-channel voltage/current setpoints, output enable, and readback
+
+**Data Logger:**
+
+- Dedicated **Data Logger** tab (`Connect to Data Logger...` menu action) for SCPI DAQ/data-acquisition units
+- Channel scan configuration and readings display
+
+**Terminal:**
+
+- Built-in **Terminal** tab for sending raw SCPI commands directly to the connected instrument
+
 **Reference Waveforms:**
 
 - Save waveforms as references
@@ -646,7 +664,7 @@ open a shared session on — plus manual IP and a hardware-free mock.
 from scpi_control import Oscilloscope
 
 # Connect
-scope = Oscilloscope('192.168.1.100', port=5024, timeout=5.0)
+scope = Oscilloscope('192.168.1.100', port=5025, timeout=5.0)
 scope.connect()
 
 # Device information
@@ -737,7 +755,7 @@ with DataCollector('192.168.1.100') as collector:
     stats = collector.analyze_waveform(data[1])
     print(f"Vpp: {stats['vpp']:.3f}V, Freq: {stats['frequency']/1e3:.2f}kHz")
 
-    # Save to file (supports NPZ, CSV, MAT, HDF5)
+    # Save to file - format is auto-detected from the extension (.npz/.csv/.mat/.h5)
     collector.save_data(data, 'measurement.npz')
 ```
 
@@ -799,15 +817,42 @@ See `examples/` directory for complete automation examples including:
 - Trigger-based capture (`trigger_based_capture.py`)
 - Advanced analysis with visualization (`advanced_analysis.py`)
 
+### Reading Saved Waveforms Back (`load_waveform` / `scpi-extract`)
+
+Any file saved by the library (.npz/.csv/.mat/.h5) can be read back with
+`load_waveform()`, which normalizes format differences and reattaches
+acquisition provenance when present:
+
+```python
+from scpi_control.waveform_io import load_waveform
+
+loaded = load_waveform("measurement.npz")
+print(loaded.time, loaded.voltage)          # numpy arrays
+print(loaded.provenance)                    # instrument/settings snapshot, or None
+df = loaded.to_dataframe()                  # pandas DataFrame, provenance in df.attrs
+```
+
+The same data is available from the command line via `scpi-extract`:
+
+```bash
+scpi-extract measurement.npz --info          # provenance + metadata summary
+scpi-extract measurement.npz --csv out.csv   # dump raw time,voltage rows
+scpi-extract measurement.npz --json          # machine-readable metadata
+```
+
 ## Examples
 
-See the `examples/` directory for complete working examples:
+This project ships 27 runnable example scripts, each documented with its
+requirements in [`examples/README.md`](examples/README.md) — see it for the
+full list. A few highlights:
 
 - **basic_usage.py** - Connection and basic operations
 - **waveform_capture.py** - Capture and save waveforms
 - **measurements.py** - Automated measurements
 - **live_plot.py** - Real-time plotting
 - **probe_calibration_analysis.py** - Automated report generation with region extraction and AI analysis
+- **synthetic_signals.py** - Generating parameterized test waveforms and streaming state-coupled mock captures (no hardware)
+- **waveform_provenance_and_extract.py** - Capturing with provenance, saving, and reading back with `load_waveform()` (no hardware)
 
 ## Supported Models
 
@@ -832,6 +877,22 @@ All Tektronix MSO models (2/4/5/6 Series) share one command variant and
 support automated measurements — see the [SCPI Dialects guide](https://little-did-I-know.github.io/SCPI-Instrument-Control/user-guide/scpi-dialects/) for the full per-vendor gap list.
 
 Command tables were verified command-by-command against the vendor programmer manuals (Tektronix TBS1000C, 2 Series MSO, and 4/5/6 Series MSO/6 Series LPD manuals; the Teledyne LeCroy MAUI Remote Control and Automation Manual) and exercised against a dialect-aware mock; not yet run against real Tektronix or LeCroy hardware.
+
+### Function Generators
+
+- **Siglent SDG1000X Series**: SDG1032X, SDG1025, SDG1020
+- **Siglent SDG2000X Series**: SDG2122X, SDG2082X, SDG2042X
+
+### Power Supplies
+
+- **Siglent SPD3303X Series**: SPD3303X, SPD3303X-E (triple output)
+- **Siglent SPD1000X Series**: SPD1305X, SPD1168X (single output)
+
+### Data Acquisition (DAQ)
+
+- **Keysight/Agilent 34970A Series**: 34970A, 34972A
+- **Keysight DAQ970A Series**: DAQ970A, DAQ973A
+- Generic SCPI-99 data loggers via the DAQ capability registry
 
 ### Compatibility
 
@@ -868,7 +929,9 @@ make format
 make check
 ```
 
-See our [Code of Conduct](CODE_OF_CONDUCT.md) and [Security Policy](SECURITY.md) for more information.
+During development, `python -m pytest --testmon` runs only the tests affected by your changes for fast feedback; the full suite is still required before opening a PR.
+
+See our [Code of Conduct](CONTRIBUTING.md#code-of-conduct) and [Security Policy](SECURITY.md) for more information.
 
 ## Community and Support
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,143 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-07-21
+
+### Added
+
+- `signal_synth.stream()`: an infinite or duration-bounded generator of phase-continuous voltage chunks for live-signal simulation — optional wall-clock pacing (`realtime=True`), correct seeded-noise semantics (seed advances per chunk, so seeded streams are reproducible without repeating noise blocks), and eager parameter validation.
+- Dev tooling: `pytest-testmon` in the `dev` extra for impact-based local test selection (`python -m pytest --testmon`); CI and pre-merge checks still run the full suite.
+
+## [3.2.0] - 2026-07-21
+
+### Added
+
+- Synthetic signals: a public generator API — `SignalSpec` plus `synthesize()`/`make_waveform()` in `scpi_control.signal_synth` — producing sine, square (with duty cycle), triangle, ramp, DC, and Gaussian-noise waveforms as numpy arrays or ready-to-analyze `WaveformData`, with seedable reproducibility.
+- Mock scopes now synthesize realistic waveforms by default (all vendor personalities): traces are computed from the mock's live timebase, V/div, offset, and trigger state at every acquisition — over-range clips at 8-bit full scale, the trigger level/slope aligns the edge at the window center, and unseeded captures animate with fresh noise. Pass `signals={ch: SignalSpec(...)}` to choose the signal, or `waveform_payloads` bytes for the old fixed-payload behavior (unchanged). Web-gateway mock sessions stream synthesized signals out of the box.
+
+### Changed
+
+- MockConnection's default (no `waveform_payloads` given) no longer serves a fixed 4-byte payload — channels synthesize state-coupled signals instead.
+
+## [3.1.0] - 2026-07-21
+
+### Added
+
+- Report generator: a built-in **probe-calibration template preset** (`ReportTemplate.create_probe_calibration_template()`, seedable from the Template Manager via "Create Probe Cal Template") — probe_calibration test type, a compensation procedure, and overshoot/undershoot/ringing/flatness pass/fail limits.
+- Examples: four new runnable, no-hardware examples — `report_ai_qa.py` (local-LLM tool-calling Q&A over a report), `network_discovery.py` (scan the network for SCPI instruments), `report_branding.py` (apply company branding/colours to a report), and `report_computed_analysis.py` (deterministic, LLM-free report analysis).
+- Examples: a `tests/test_examples_smoke.py` guard that executes the no-hardware examples, compile-checks the rest, and blocks known-stale tokens from reappearing.
+- Docs: a real screen capture and a real 1&nbsp;kHz calibration-square-wave plot from a Siglent SDS824X HD (in `docs/images/`), plus the raw capture committed as a test fixture (`tests/fixtures/cal_square_sds824x.npz`) that exercises the analyzer against genuine hardware data.
+- Acquisition provenance: waveforms captured with `acquire()`/`get_waveform()` now record the instrument identity, per-channel settings, trigger configuration, timebase, and UTC timestamp, embedded in every save format (new keys only — existing files and keys are unchanged; pass `provenance=False` to skip the snapshot on high-rate paths).
+- `scpi_control.waveform_io.load_waveform()`: public parser that reads all five waveform file formats (old and new files) into numpy arrays plus normalized metadata/provenance, with an optional `to_dataframe()` pandas helper.
+- `scpi-extract` CLI: inspect provenance (`--info`), dump raw data (`--csv`), or emit machine-readable metadata (`--json`) from any saved waveform file.
+- Waveform savers now persist the previously dropped `timebase`, `voltage_scale`, and `voltage_offset` fields; plain CSV gains a `#`-commented provenance header (channel, sample rate, scales, instrument, timestamp) (suppress with `save_waveform(..., bare=True)`).
+
+### Changed
+
+- Report generator AI: every oscilloscope system prompt now carries one shared grounding rule (claim only what the report data or a tool actually returned; say so plainly when a value is missing rather than inventing it).
+- Report generator AI: key-findings and recommendations are parsed more tolerantly — multi-digit numbering, markdown-bold list markers, and a leading preamble line no longer corrupt the extracted list.
+- Report generator (internal): the oscilloscope and DAQ LLM prompt layers now share one grounding constant and the prompt-lookup / chat-prompt assembly via `llm/_prompt_helpers.py`, removing duplicated boilerplate.
+
+### Fixed
+
+- Report generator analysis: `WaveformAnalyzer`'s noise check no longer computes an O(n²) full autocorrelation — it now reads only the two autocorrelation lags it uses, so analysing large captures (e.g. 1,000,000-sample records) completes in milliseconds instead of hanging. Also removes a divide-by-zero `RuntimeWarning` on constant signals.
+- Examples: repaired broken examples — `simple_capture.py` and `advanced_analysis.py` referenced a non-existent `waveform.time_interval` (now the sample period `1.0 / sample_rate`), and the interactive tutorial saved with an invalid `format="NPZ"` (now `"NPY"`). The report-generation and branding examples now degrade cleanly when reportlab is absent instead of crashing.
+- Examples: updated the stale `Siglent-Oscilloscope` package name (and dead repo links) to `SCPI-Instrument-Control`, and corrected the README's hardware/no-hardware annotations.
+- Screen capture on modern-dialect scopes (SDS800X HD): `ScreenCapture` now selects the correct SCDP command per dialect and reads the raw BMP sized by its own header, instead of over-reading a fixed 10&nbsp;MB — which timed out and dropped the connection. `scope.screen_capture.get_screenshot_pil()` now works on the modern scopes.
+- Report generator analysis: `WaveformAnalyzer.detect_signal_type` no longer misclassifies clean periodic signals (e.g. a square wave captured over many periods) as noise. The noise check now measures spectral concentration — whether one frequency bin dominates — instead of testing autocorrelation at an arbitrary fixed lag.
+- Report generator analysis: `WaveformAnalyzer.detect_signal_type` now classifies pulse/PWM signals (non-50%-duty square waves) as pulse instead of sawtooth. Two-level (flat-topped) signals are separated from ramps before the harmonic scorers run.
+- Report generator DAQ AI: the data-logger analysis prompts now carry the same grounding rule as the oscilloscope prompts (claim only what the data shows; say so when a value is missing), and the session-summary prompt no longer invites a "Here is the summary" preamble.
+- Report generator PDF: characters outside the built-in font's range (⚠, ✓/✗, σ, Ω, …) no longer render as blank boxes — they are normalized to readable text, with a catch-all so any unexpected glyph can never box out.
+
+## [3.0.0] - 2026-07-17
+
+### ⚠️ Breaking Changes
+
+- **The report generator's `WaveformData` fields are renamed, and `channel`
+  moved from the first constructor argument to the third.** `channel_name`,
+  `time_data`, and `voltage_data` are now `channel`, `time`, and `voltage`,
+  matching the base class's field order (`time`, `voltage`, `channel`, ...).
+  Because the position changed along with the name, positional construction
+  such as `WaveformData("CH1", t, v, ...)` does **not** fail with a
+  recognizable rename error — it silently assigns `"CH1"` to `time` and
+  blows up later with `AttributeError: 'str' object has no attribute
+  'shape'`. Construct with keywords (`channel=`, `time=`, `voltage=`) to
+  migrate safely. This is a documented public API — see
+  [`docs/report-generator/api-reference.md`](../report-generator/api-reference.md).
+- **`WaveformData.source` and `WaveformData.description` are removed**, on
+  both the library and report waveform types. `WaveformData(..., source="x")`
+  now raises `TypeError` instead of silently accepting the keyword.
+- **`WaveformData.timebase` and `WaveformData.voltage_scale` are `None`
+  unless an instrument actually reported them**, instead of being derived by
+  assuming a 14-division horizontal grid and an 8-division vertical one —
+  Siglent's geometry, previously applied to Tektronix and LeCroy captures too
+  — with a flat trace given a bare 1.0 V/div. Real acquisitions are
+  unaffected: all three vendor backends pass genuine scope values. Code that
+  does arithmetic on `timebase`/`voltage_scale` from a *synthetic* waveform
+  (a math channel, or hand-built test data) — e.g. `wf.timebase * 1e6` — now
+  raises `TypeError` on `None` instead of silently using an invented number.
+  Guard with a `None` check, or supply real values.
+
+### Added
+
+- Tektronix and LeCroy oscilloscope support (core control, waveform
+  acquisition, measurements): two more wire dialects (`tektronix`, `lecroy`)
+  alongside the existing Siglent legacy/modern pair, auto-detected from
+  `*IDN?` via a manufacturer-first routing step. Covers the Tektronix
+  TBS1000C Series and 2 Series MSO, and the LeCroy WaveSurfer 3000z and
+  WaveRunner 8000 series. See the
+  [SCPI Dialects guide](../user-guide/scpi-dialects.md) for the full
+  per-vendor command tables and known gaps (e.g. LeCroy
+  statistics/cursors/holdoff, Tek 16-bit waveform transfer).
+- Tektronix MSO 4/5/6 Series support (MSO44, MSO46, MSO54, MSO56, MSO58,
+  MSO58LP, MSO64), including 6- and 8-channel models.
+- Badge-based measurements for the modern Tektronix MSO families, which also
+  enables `measure()` on the MSO 2-Series.
+- **Report generator — local-LLM analysis and richer PDFs**
+  (`pip install "SCPI-Instrument-Control[report-generator]"`). Everything here
+  is local-only — no cloud providers, no API keys.
+  - Local-LLM (Ollama) tool calling: the model can call read-only report tools
+    to ground its answers, behind a capability gate that no-ops when the local
+    model cannot do tool calls.
+  - Waveform analysis tools for the model — `analyze_plateaus`, `list_edges`,
+    and `analyze_spectrum` — plus `WaveformAnalyzer.calculate_spectrum`.
+  - Deterministic no-LLM analysis: a `ComputedAnalyzer` populates per-waveform
+    statistics and regions on every report, and composes a summary, findings,
+    and recommendations when no LLM wrote them. Reports now attribute their
+    summary by source (manual / AI / computed) rather than a bare AI flag.
+  - Vector PDF plots: waveform, FFT, and region plots render as scalable vector
+    graphics instead of rasterized images.
+  - Page framework: a running header/footer and page numbers on every page,
+    with section headings kept from stranding at the bottom of a page.
+  - Template branding: a template's logo, company name, header/footer text, and
+    four brand colours apply to the generated PDF, and a built-in starter
+    template can be seeded from the Template Manager.
+
+### Changed
+
+- On the Siglent modern dialect, `trigger.holdoff`, measurement statistics,
+  cursors, and `channel.unit` now raise `FeatureNotSupportedError` immediately
+  instead of writing an unsupported command and timing out
+  (`SiglentTimeoutError`). Code that caught the timeout to detect these
+  unsupported operations must now catch `FeatureNotSupportedError` instead.
+- Probe-ratio wire format on the legacy and modern dialects now serializes
+  floats compactly (`10.0` is sent as `10`), matching how real scopes echo the
+  value back.
+- `add_measurement` now validates and case-normalizes its measurement type
+  (unknown types raise instead of being sent verbatim to the instrument).
+- Channel numbers are validated against the connected model's channel count
+  instead of a fixed 1-4 range. Scopes with fewer than four channels now raise
+  `InvalidParameterError` for a channel they do not have, where they
+  previously queried it.
+- The report generator's `WaveformData` is now a subclass of
+  `scpi_control.waveform.WaveformData` (see Breaking Changes above for the
+  field rename and reorder this involved). Report waveforms now inherit the
+  library's array-shape validation, and `channel` is now guaranteed to be a
+  `str` by the type itself. The loader's explicit `str()` calls at each
+  construction site are unchanged and now redundant, not removed — they stay
+  as a defensive measure against `np.str_`/`bytes` values handed back at the
+  MAT/HDF5 boundary.
+
 ## [2.0.0] - 2026-07-15
 
 ### ⚠️ Breaking Changes
@@ -241,7 +378,7 @@ Users have until v2.0.0 to migrate their imports.
   - Integrated with existing `make docs-generate` automation
 - Updated PyPI documentation URL
   - Changed from README-only link to proper documentation site
-  - PyPI now links to https://little-did-I-know.github.io/Siglent-Oscilloscope/
+  - PyPI now links to https://little-did-I-know.github.io/SCPI-Instrument-Control/
   - Users can access complete API documentation and guides from PyPI
 
 **MkDocs Build System**
@@ -1240,4 +1377,4 @@ pip install "Siglent-Oscilloscope[power-supply-beta,usb]==0.4.0-beta.1"
 - Context manager support for oscilloscope connections
 - Comprehensive error handling with custom exceptions
 
-[0.1.0]: https://github.com/siglent-control/siglent/releases/tag/v0.1.0
+[0.1.0]: https://github.com/little-did-I-know/SCPI-Instrument-Control/releases

--- a/docs/api/provenance.md
+++ b/docs/api/provenance.md
@@ -1,0 +1,21 @@
+# Provenance
+
+Acquisition provenance: which instrument produced a waveform, configured how
+
+::: scpi_control.provenance
+    options:
+      show_root_heading: false
+      show_source: true
+      heading_level: 2
+      members_order: source
+      group_by_category: true
+      show_signature_annotations: true
+      separate_signature: true
+      merge_init_into_class: true
+      filters:
+        - "!^_"  # Exclude private members
+
+## See Also
+
+- [Waveform](waveform.md) - Waveform acquisition and data handling
+- [Waveform I/O](waveform_io.md) - Read saved waveform files back, including their provenance

--- a/docs/api/scpi_extract.md
+++ b/docs/api/scpi_extract.md
@@ -1,0 +1,21 @@
+# SCPI Extract (CLI)
+
+Command-line tool for inspecting and exporting saved waveform files
+
+::: scpi_control.scpi_extract
+    options:
+      show_root_heading: false
+      show_source: true
+      heading_level: 2
+      members_order: source
+      group_by_category: true
+      show_signature_annotations: true
+      separate_signature: true
+      merge_init_into_class: true
+      filters:
+        - "!^_"  # Exclude private members
+
+## See Also
+
+- [Waveform I/O](waveform_io.md) - `load_waveform()`, the function backing this CLI
+- [Provenance](provenance.md) - Acquisition provenance this tool prints and exports

--- a/docs/api/signal_synth.md
+++ b/docs/api/signal_synth.md
@@ -1,0 +1,21 @@
+# Signal Synthesis
+
+Parameterized synthetic waveforms as numpy arrays or WaveformData
+
+::: scpi_control.signal_synth
+    options:
+      show_root_heading: false
+      show_source: true
+      heading_level: 2
+      members_order: source
+      group_by_category: true
+      show_signature_annotations: true
+      separate_signature: true
+      merge_init_into_class: true
+      filters:
+        - "!^_"  # Exclude private members
+
+## See Also
+
+- [Waveform](waveform.md) - Waveform acquisition and data handling
+- [Analysis](analysis.md) - Signal analysis (FFT, THD, SNR)

--- a/docs/api/waveform_io.md
+++ b/docs/api/waveform_io.md
@@ -1,0 +1,21 @@
+# Waveform I/O
+
+Read saved waveform files back into arrays and normalized metadata
+
+::: scpi_control.waveform_io
+    options:
+      show_root_heading: false
+      show_source: true
+      heading_level: 2
+      members_order: source
+      group_by_category: true
+      show_signature_annotations: true
+      separate_signature: true
+      merge_init_into_class: true
+      filters:
+        - "!^_"  # Exclude private members
+
+## See Also
+
+- [Waveform](waveform.md) - Waveform acquisition and data handling
+- [Provenance](provenance.md) - Acquisition provenance attached to saved waveforms

--- a/docs/development/BUILDING_EXECUTABLES.md
+++ b/docs/development/BUILDING_EXECUTABLES.md
@@ -508,7 +508,7 @@ For professional distribution:
 ## Additional Resources
 
 - [PyInstaller Documentation](https://pyinstaller.org/en/stable/)
-- [PyQt6 Deployment Guide](https://www.riverbankcomputing.com/static/Docs/PyQt6/deployment.html)
+- [PyQt6 Deployment Guide](https://www.riverbankcomputing.com/static/Docs/PyQt6/)
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
 
 ## Getting Help

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -1106,4 +1106,4 @@ pip freeze > requirements.txt
 - [Project Structure](structure.md) - Understand the codebase organization
 - [Testing Guide](testing.md) - Learn about the test suite
 - [Contributing Guidelines](contributing.md) - How to contribute
-- [Code of Conduct](../CODE_OF_CONDUCT.md) - Community guidelines
+- [Code of Conduct](contributing.md#code-of-conduct) - Community guidelines

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -353,8 +353,6 @@ Full traceback here
 **Additional context**
 Any other relevant information
 
-````
-
 ## Suggesting Features
 
 ### Feature Request Template

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -422,7 +422,7 @@ scope.connect()
 # Inspect what the code under test actually sent
 waveform = scope.get_waveform(1)
 assert mock.waveform_requests == [1]
-assert any("TDIV" in cmd for cmd in mock.writes)
+assert any("TIMebase" in q or "TDIV" in q for q in mock.queries)
 ```
 
 Key constructor keyword arguments (all optional, keyword-only after `host`,

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -397,62 +397,78 @@ pytest -m "not hardware and not gui and not slow"
 
 ### MockConnection
 
-The project provides a MockConnection for testing without hardware:
+The project provides `MockConnection` (`scpi_control/connection/mock/base.py`) for
+testing without hardware. There is no `add_response()`/`sent_commands` API — state
+is configured via constructor keyword arguments and inspected via public
+attributes:
 
 ```python
 from scpi_control.connection import MockConnection
+from scpi_control.oscilloscope import Oscilloscope
 
-# Create mock connection
-mock = MockConnection()
+# Create a mock connection with initial state
+mock = MockConnection(
+    "mock",
+    idn="Siglent Technologies,SDS824X HD,MOCK0001,3.8.12",
+    channel_states={1: True, 2: False},
+    voltage_scales={1: 0.5},
+    sample_rate=1_000_000.0,
+    timebase=1e-3,
+)
 
-# Configure responses
-mock.add_response("*IDN?", "SIGLENT TECHNOLOGIES,SDS2104X Plus,...")
-mock.add_response("C1:TRA?", "C1:TRA ON")
+scope = Oscilloscope("mock", connection=mock)
+scope.connect()
 
-# Use with Oscilloscope
-scope = Oscilloscope(connection=mock)
-
-# Verify sent commands
-assert "C1:TRA ON" in mock.sent_commands
+# Inspect what the code under test actually sent
+waveform = scope.get_waveform(1)
+assert mock.waveform_requests == [1]
+assert any("TDIV" in cmd for cmd in mock.writes)
 ```
 
-### Mock Responses
+Key constructor keyword arguments (all optional, keyword-only after `host`,
+`port`, `timeout`):
 
-**File: `tests/fixtures/mock_responses.json`**
+- `idn` - the `*IDN?` response string; drives dialect/vendor auto-detection
+- `channel_states`, `voltage_scales`, `voltage_offsets` - per-channel dicts,
+  e.g. `{1: True}`, `{1: 0.5}`
+- `waveform_payloads` - `{channel: bytes}` to serve a fixed captured payload
+  instead of synthesis
+- `signals` - `{channel: SignalSpec(...)}` to choose what a channel
+  synthesizes (see [Synthetic Signals](../user-guide/synthetic-signals.md));
+  channels without an explicit `SignalSpec` still synthesize a state-coupled
+  default waveform - there is no "no signal" option
+- `sample_rate`, `timebase` - initial acquisition settings
+- `trigger_status` - a list of trigger-state tokens the mock returns
+- `custom_responses` - `{command: response}` (or `{command: [responses, ...]}`
+  to pop successive values on repeated queries) for exact-match query
+  overrides, checked before any built-in handling
+- `psu_mode`, `awg_mode`, `daq_mode` (with matching `psu_idn`/`psu_outputs`,
+  `awg_idn`/`awg_channels`, `daq_idn`/`daq_readings`) - switch the mock to a
+  power supply, function generator, or data logger personality instead of an
+  oscilloscope
 
-```json
-{
-  "*IDN?": "SIGLENT TECHNOLOGIES,SDS2104X Plus,SERIAL123,1.0.0",
-  "C1:TRA?": "C1:TRA ON",
-  "C1:VDIV?": "C1:VDIV 1V",
-  "C1:OFST?": "C1:OFST 0V",
-  "TRIG_MODE?": "TRIG_MODE AUTO",
-  "C1:WF? DAT2": "<waveform binary data>"
-}
-```
+Instrumentation attributes recorded automatically, for assertions:
 
-**Load in tests:**
+- `mock.writes` - every command passed to `write()`, in order
+- `mock.queries` - every command passed to `query()`, in order
+- `mock.waveform_requests` - channel numbers requested via `C{n}:WF?`, in order
+- `mock.timebase_updates` - timebase values as they're changed
+- `mock.scale_updates` - `{channel: [values, ...]}` as voltage scale changes,
+  per channel
+
+### Overriding Specific Responses
+
+Use `custom_responses` for exact-match overrides that don't fit synthesis:
 
 ```python
-import json
-from pathlib import Path
+mock = MockConnection(custom_responses={"C1:VDIV?": "C1:VDIV 2.00E+00V"})
+```
 
-@pytest.fixture
-def mock_responses():
-    """Load mock responses from JSON."""
-    path = Path(__file__).parent / "fixtures" / "mock_responses.json"
-    with open(path) as f:
-        return json.load(f)
+Pass a list to return successive values across repeated queries of the same
+command:
 
-
-def test_with_mock_responses(mock_responses):
-    """Test using mock responses."""
-    mock = MockConnection()
-    for cmd, response in mock_responses.items():
-        mock.add_response(cmd, response)
-
-    scope = Oscilloscope(connection=mock)
-    assert scope.model == "SDS2104X Plus"
+```python
+mock = MockConnection(custom_responses={"SAST?": ["Stop", "Run", "Stop"]})
 ```
 
 ### Mocking External Dependencies

--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -9,7 +9,7 @@ Advanced examples demonstrating signal analysis, FFT processing, and specialized
 | [Advanced waveform analysis and visualization](#advanced-waveform-analysis-and-visualization) | Advanced waveform analysis and visualization. |
 | [Probe Calibration Analysis Example](#probe-calibration-analysis-example) | Probe Calibration Analysis Example |
 | [Test the power supply GUI with a mock connection](#test-the-power-supply-gui-with-a-mock-connection) | Test the power supply GUI with a mock connection. |
-| [Example: Generating Professional Test Reports](#example:-generating-professional-test-reports) | Example: Generating Professional Test Reports |
+| [Example: Generating Professional Test Reports](#example-generating-professional-test-reports) | Example: Generating Professional Test Reports |
 | [Vector Graphics on Oscilloscope using XY Mode](#vector-graphics-on-oscilloscope-using-xy-mode) | Vector Graphics on Oscilloscope using XY Mode |
 
 ---
@@ -1128,6 +1128,42 @@ if __name__ == "__main__":
     main()
 ```
 
+### Related Report Generator Examples
+
+These companion scripts each build a synthetic report in-memory (no hardware,
+no saved waveform files needed) and exercise one report-generator feature in
+isolation:
+
+- **`examples/report_computed_analysis.py`** - Deterministic, LLM-free report
+  analysis: runs `ComputedAnalyzer` over a report to fill in the executive
+  summary, key findings, and recommendations straight from the waveform
+  statistics, with `summary_source` set to `"computed"`. No local model or
+  network needed.
+
+  ```bash
+  python examples/report_computed_analysis.py
+  ```
+
+- **`examples/report_branding.py`** - Applies a `BrandingTemplate` (company
+  name, header/footer text, brand colours) to a generated report, producing a
+  branded Markdown report and a colour-branded PDF (skipped with a message if
+  `reportlab` is not installed).
+
+  ```bash
+  python examples/report_branding.py
+  ```
+
+- **`examples/report_ai_qa.py`** - Local-LLM tool-calling Q&A over a report:
+  when a tool-capable Ollama model is available, `ReportAnalyzer` answers
+  questions by calling the report's analysis tools (`list_waveforms`,
+  `analyze_waveform`, ...) instead of guessing from a summary. Prints a clear
+  message and exits cleanly if no local model is available, so it is safe to
+  run anywhere.
+
+  ```bash
+  python examples/report_ai_qa.py
+  ```
+
 ---
 
 ## Vector Graphics on Oscilloscope using XY Mode
@@ -1158,7 +1194,7 @@ This example demonstrates how to use the oscilloscope as a vector display
 by generating waveforms for XY mode.
 
 REQUIREMENTS:
-    - Install fun extras: pip install "Siglent-Oscilloscope[fun]"
+    - Install fun extras: pip install "SCPI-Instrument-Control[fun]"
     - External AWG/DAC to feed signals into scope channels
       OR use scope's built-in AWG if available
     - Oscilloscope channels connected to AWG outputs
@@ -1375,7 +1411,7 @@ if __name__ == "__main__":
             print("Vector graphics features require additional packages.")
             print()
             print("Install with:")
-            print('  pip install "Siglent-Oscilloscope[fun]"')
+            print('  pip install "SCPI-Instrument-Control[fun]"')
             print()
             print("This will install:")
             print("  - shapely (geometric operations)")

--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -266,11 +266,11 @@ Probe Calibration Analysis Example
 ### Requirements
 
 - scpi_control - Core library
-- Oscilloscope connected to network
+- No hardware required
 
 ### Configuration
 
-Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+No hardware required.
 
 ### Usage
 
@@ -616,11 +616,11 @@ Test the power supply GUI with a mock connection.
 ### Requirements
 
 - PyQt6 - For GUI
-- Oscilloscope connected to network
+- No hardware required
 
 ### Configuration
 
-Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+No hardware required.
 
 ### Usage
 
@@ -787,11 +787,11 @@ Ask a local LLM questions about a report, using tool-calling.
 ### Requirements
 
 - scpi_control - Core library
-- Oscilloscope connected to network
+- No hardware required
 
 ### Configuration
 
-Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+No hardware required.
 
 ### Usage
 
@@ -886,11 +886,11 @@ Apply company branding to a generated report.
 ### Requirements
 
 - scpi_control - Core library
-- Oscilloscope connected to network
+- No hardware required
 
 ### Configuration
 
-Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+No hardware required.
 
 ### Usage
 
@@ -997,11 +997,11 @@ Deterministic (LLM-free) report analysis.
 ### Requirements
 
 - scpi_control - Core library
-- Oscilloscope connected to network
+- No hardware required
 
 ### Configuration
 
-Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+No hardware required.
 
 ### Usage
 
@@ -1101,11 +1101,11 @@ Example: Generating Professional Test Reports
 ### Requirements
 
 - scpi_control - Core library
-- Oscilloscope connected to network
+- No hardware required
 
 ### Configuration
 
-Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+No hardware required.
 
 ### Usage
 

--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -9,6 +9,9 @@ Advanced examples demonstrating signal analysis, FFT processing, and specialized
 | [Advanced waveform analysis and visualization](#advanced-waveform-analysis-and-visualization) | Advanced waveform analysis and visualization. |
 | [Probe Calibration Analysis Example](#probe-calibration-analysis-example) | Probe Calibration Analysis Example |
 | [Test the power supply GUI with a mock connection](#test-the-power-supply-gui-with-a-mock-connection) | Test the power supply GUI with a mock connection. |
+| [Ask a local LLM questions about a report, using tool-calling](#ask-a-local-llm-questions-about-a-report-using-tool-calling) | Ask a local LLM questions about a report, using tool-calling. |
+| [Apply company branding to a generated report](#apply-company-branding-to-a-generated-report) | Apply company branding to a generated report. |
+| [Deterministic (LLM-free) report analysis](#deterministic-llm-free-report-analysis) | Deterministic (LLM-free) report analysis. |
 | [Example: Generating Professional Test Reports](#example-generating-professional-test-reports) | Example: Generating Professional Test Reports |
 | [Vector Graphics on Oscilloscope using XY Mode](#vector-graphics-on-oscilloscope-using-xy-mode) | Vector Graphics on Oscilloscope using XY Mode |
 
@@ -41,6 +44,14 @@ python examples/advanced_analysis.py
 This example demonstrates how to perform advanced analysis on captured
 waveforms, including FFT analysis, statistical analysis, and visualization
 using matplotlib.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address. matplotlib is a core dependency, no extra install
+needed.
+
+Expected output: basic and signal-quality stats printed to the console,
+three plot windows (time domain, FFT, histogram), and 'analyzed_waveform.npz'
+plus 'analysis_report.txt' saved to the current directory.
 """
 
 import matplotlib.pyplot as plt
@@ -54,7 +65,7 @@ SCOPE_IP = "192.168.1.100"
 
 def plot_waveform(waveform, channel_num, title="Waveform"):
     """Plot time-domain waveform."""
-    time = np.arange(len(waveform.voltage)) * waveform.time_interval
+    time = np.arange(len(waveform.voltage)) * (1.0 / waveform.sample_rate)
     time_ms = time * 1000  # Convert to milliseconds
 
     plt.figure(figsize=(12, 4))
@@ -70,7 +81,7 @@ def plot_fft(waveform, channel_num):
     """Plot frequency spectrum using FFT."""
     # Perform FFT
     fft_result = np.fft.fft(waveform.voltage)
-    fft_freq = np.fft.fftfreq(len(waveform.voltage), waveform.time_interval)
+    fft_freq = np.fft.fftfreq(len(waveform.voltage), 1.0 / waveform.sample_rate)
 
     # Take only positive frequencies
     positive_freq_idx = fft_freq > 0
@@ -167,7 +178,7 @@ def main():
         print(f"Min:        {basic_stats['min']:.4f} V")
         if basic_stats["frequency"] > 0:
             print(f"Frequency:  {basic_stats['frequency'] / 1e3:.2f} kHz")
-            print(f"Period:     {basic_stats['period'] * 1e6:.2f} µs")
+            print(f"Period:     {basic_stats['period'] * 1e6:.2f} us")
 
         # Advanced signal quality analysis
         print("\n" + "=" * 60)
@@ -274,21 +285,20 @@ python examples/probe_calibration_analysis.py
 """
 Probe Calibration Analysis Example
 
-Demonstrates the new waveform region extraction features for analyzing
-probe compensation using oscilloscope calibration signals.
+Demonstrates waveform region extraction for probe compensation analysis:
+plateau detection, slope analysis, calibration guidance, and zoomed region
+plots in reports.
 
-This example shows:
-1. Automatic plateau detection in square waves
-2. Plateau slope analysis for probe compensation assessment
-3. Calibration guidance generation
-4. Zoomed region plots in PDF reports
-5. Manual region addition and analysis
+By default this example is fully synthetic/no-hardware: it generates its
+own 1kHz square waves with numpy for properly-, under-, and over-compensated
+plateaus. Optionally, for a real-world check, capture a 1kHz square wave
+from your oscilloscope's probe compensation output instead.
 
-For best results, capture a 1kHz square wave from your oscilloscope's
-probe compensation output with different probe compensation settings:
-- Properly compensated (flat plateaus)
-- Undercompensated (rising plateaus)
-- Overcompensated (falling plateaus)
+Requirements: `SCPI-Instrument-Control[report-generator]` -- no hardware
+needed.
+
+Expected output: 'probe_calibration_analysis.pdf', 'probe_calibration_analysis.md',
+and a 'plots/' directory, all saved to the current directory.
 """
 
 from datetime import datetime
@@ -311,7 +321,7 @@ def generate_test_square_wave(slope: float = 0, noise: float = 0.01):
         noise: Noise level to add (RMS voltage)
 
     Returns:
-        Tuple of (time_data, voltage_data)
+        Tuple of (time, voltage)
     """
     # 1kHz square wave, 10ms duration, 100kS/s
     sample_rate = 100000
@@ -531,9 +541,9 @@ trimmer capacitor requires adjustment.
     pdf_success = pdf_generator.generate(report, pdf_path)
 
     if pdf_success:
-        print(f"  ✓ PDF generated successfully ({pdf_path.stat().st_size:,} bytes)")
+        print(f"  [OK] PDF generated successfully ({pdf_path.stat().st_size:,} bytes)")
     else:
-        print(f"  ✗ PDF generation failed")
+        print(f"  [FAILED] PDF generation failed")
 
     # Generate Markdown
     md_path = Path("probe_calibration_analysis.md")
@@ -542,9 +552,9 @@ trimmer capacitor requires adjustment.
     md_success = md_generator.generate(report, md_path)
 
     if md_success:
-        print(f"  ✓ Markdown generated successfully ({md_path.stat().st_size:,} bytes)")
+        print(f"  [OK] Markdown generated successfully ({md_path.stat().st_size:,} bytes)")
     else:
-        print(f"  ✗ Markdown generation failed")
+        print(f"  [FAILED] Markdown generation failed")
 
     # ========================================================================
     # Summary
@@ -552,7 +562,7 @@ trimmer capacitor requires adjustment.
     print("\n" + "=" * 70)
     print("Feature Demonstration Summary")
     print("=" * 70)
-    print("\n✓ Features Demonstrated:")
+    print("\n[OK] Features Demonstrated:")
     print("  1. Automatic plateau detection in square waves")
     print("  2. Plateau slope analysis for probe compensation")
     print("  3. Automatic calibration guidance generation")
@@ -562,7 +572,7 @@ trimmer capacitor requires adjustment.
     print("  7. Color-coded calibration recommendations")
     print("  8. Both PDF and Markdown report generation")
 
-    print("\n✓ Report Contents:")
+    print("\n[OK] Report Contents:")
     print(f"  - {len(report.sections)} test sections")
     total_waveforms = sum(len(s.waveforms) for s in report.sections)
     total_regions = sum(len(w.regions) for w in [wf for s in report.sections for wf in s.waveforms])
@@ -571,7 +581,7 @@ trimmer capacitor requires adjustment.
     print(f"  - {len(report.key_findings)} key findings")
     print(f"  - {len(report.recommendations)} recommendations")
 
-    print("\n✓ Files Generated:")
+    print("\n[OK] Files Generated:")
     if pdf_success:
         print(f"  - {pdf_path}")
     if md_success:
@@ -580,12 +590,12 @@ trimmer capacitor requires adjustment.
 
     print("\n" + "=" * 70)
     print("Review the generated PDF to see:")
-    print("  • Full waveform plots")
-    print("  • Automatic plateau detection")
-    print("  • Zoomed region subsections")
-    print("  • Slope analysis tables")
-    print("  • Color-coded calibration guidance")
-    print("  • Detailed region-specific measurements")
+    print("  - Full waveform plots")
+    print("  - Automatic plateau detection")
+    print("  - Zoomed region subsections")
+    print("  - Slope analysis tables")
+    print("  - Color-coded calibration guidance")
+    print("  - Detailed region-specific measurements")
     print("=" * 70)
 
     return 0
@@ -625,6 +635,11 @@ python examples/psu_gui_test.py
 
 This script demonstrates the PSU control GUI using a mock connection,
 allowing you to test the interface without physical hardware.
+
+Requirements: `SCPI-Instrument-Control[gui]` -- no instrument needed, but it
+opens an interactive PyQt6 window against a mock PSU and requires a display
+and user interaction (choosing a PSU, clicking through the GUI). That is why
+this example is compile-checked only, not auto-executed in the smoke suite.
 """
 
 import sys
@@ -765,6 +780,320 @@ if __name__ == "__main__":
 
 ---
 
+## Ask a local LLM questions about a report, using tool-calling
+
+Ask a local LLM questions about a report, using tool-calling.
+
+### Requirements
+
+- scpi_control - Core library
+- Oscilloscope connected to network
+
+### Configuration
+
+Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+
+### Usage
+
+```bash
+python examples/report_ai_qa.py
+```
+
+### Source Code
+
+```python
+"""Ask a local LLM questions about a report, using tool-calling.
+
+Builds a synthetic report and asks a local Ollama model questions about it. When
+the model supports tools, it answers by CALLING the report's analysis tools
+(list_waveforms, analyze_waveform, ...) rather than guessing from a summary.
+
+This needs a local Ollama running with a tool-capable model (e.g. `ollama run
+llama3.2`). With none available it prints that and exits cleanly -- so the
+example is safe to run anywhere.
+
+Requirements: SCPI-Instrument-Control[report-generator]; optional local Ollama
+for the live Q&A. No hardware.
+"""
+
+from datetime import datetime
+
+import numpy as np
+
+from scpi_control.report_generator.llm.analyzer import ReportAnalyzer
+from scpi_control.report_generator.llm.client import LLMClient, LLMConfig
+from scpi_control.report_generator.models.report_data import ReportMetadata, TestReport, TestSection, WaveformData
+
+
+def build_report() -> TestReport:
+    sample_rate = 1e6
+    t = np.arange(2000) / sample_rate
+    np.random.seed(0)
+    v = 3.3 * np.sin(2 * np.pi * 1000 * t) + 0.02 * np.random.randn(t.size)
+    waveform = WaveformData(channel="C1", time=t, voltage=v, sample_rate=sample_rate, record_length=t.size, label="1 kHz reference")
+    return TestReport(
+        metadata=ReportMetadata(title="AI Q&A Demo", technician="Lab Tech", test_date=datetime.now()),
+        sections=[TestSection(title="Captures", waveforms=[waveform], order=1)],
+    )
+
+
+def main():
+    print("=" * 60)
+    print("Local-LLM tool-calling Q&A over a report")
+    print("=" * 60)
+
+    report = build_report()
+
+    client = LLMClient(LLMConfig.create_ollama_config(model="llama3.2"))
+
+    if not client.supports_tools():
+        print("No tool-capable local model available.")
+        print("Start Ollama with a tool-capable model (e.g. `ollama run llama3.2`) to try the live Q&A.")
+        print("=" * 60)
+        print("Done (skipped live Q&A).")
+        print("=" * 60)
+        return
+
+    analyzer = ReportAnalyzer(client)
+    questions = [
+        "What channels are in this report?",
+        "What kind of signal is on C1, and what is its frequency?",
+    ]
+    for question in questions:
+        print(f"\nQ: {question}")
+        try:
+            answer = analyzer.answer_question(report, question)
+        except Exception as exc:  # never let a model hiccup crash the example
+            print(f"A: (the model call failed: {exc})")
+            continue
+        print(f"A: {answer if answer is not None else '(no answer)'}")
+
+    print("\n" + "=" * 60)
+    print("Done.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+## Apply company branding to a generated report
+
+Apply company branding to a generated report.
+
+### Requirements
+
+- scpi_control - Core library
+- Oscilloscope connected to network
+
+### Configuration
+
+Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+
+### Usage
+
+```bash
+python examples/report_branding.py
+```
+
+### Source Code
+
+```python
+"""Apply company branding to a generated report.
+
+Builds a synthetic report, applies a BrandingTemplate (company name, header and
+footer text, and a brand colour scheme), then renders a branded Markdown report
+plus a colour-branded PDF. Text (company/header/footer) rides on the report
+metadata; the brand colours reach the PDF via PDFReportGenerator(branding=...).
+
+Requirements: SCPI-Instrument-Control[report-generator] (no hardware). The PDF
+step is skipped with a message if reportlab is not installed.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+
+from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
+from scpi_control.report_generator.models.report_data import MeasurementResult, ReportMetadata, TestReport, TestSection, WaveformData
+from scpi_control.report_generator.models.template import BrandingTemplate
+
+try:
+    from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator
+
+    PDF_AVAILABLE = True
+except ImportError:
+    PDF_AVAILABLE = False
+
+
+def build_report() -> TestReport:
+    sample_rate = 1e6
+    t = np.arange(2000) / sample_rate
+    v = 3.3 * np.sin(2 * np.pi * 1000 * t)
+    waveform = WaveformData(channel="C1", time=t, voltage=v, sample_rate=sample_rate, record_length=t.size, label="Output")
+    measurement = MeasurementResult(name="Peak-to-Peak", value=6.6, unit="V", channel="C1", passed=True, criteria_min=6.0, criteria_max=7.0)
+    report = TestReport(
+        metadata=ReportMetadata(title="Branded Report Demo", technician="Lab Tech", test_date=datetime.now()),
+        sections=[TestSection(title="Captures", waveforms=[waveform], measurements=[measurement], order=1)],
+    )
+    report.overall_result = report.calculate_overall_result()
+    return report
+
+
+def main():
+    print("=" * 60)
+    print("Report branding demo")
+    print("=" * 60)
+
+    report = build_report()
+
+    # Text (company/header/footer) goes onto the metadata; colours go to the PDF.
+    branding = BrandingTemplate(
+        company_name="Acme Test Labs",
+        header_text="Acme Test Labs - Confidential",
+        footer_text="(c) 2026 Acme Test Labs",
+        primary_color="#0b5394",
+        secondary_color="#674ea7",
+        success_color="#38761d",
+        failure_color="#cc0000",
+    )
+    # To add a logo, set company_logo_path=Path("logo.png") on the branding above.
+    branding.apply_to_metadata(report.metadata)
+
+    output_dir = Path("branded_reports")
+    output_dir.mkdir(exist_ok=True)
+
+    print("Rendering branded Markdown...")
+    md_path = output_dir / "branded_report.md"
+    if MarkdownReportGenerator(include_plots=False).generate(report, md_path):
+        print(f"  [OK] {md_path}")
+
+    print("Rendering colour-branded PDF...")
+    try:
+        pdf_path = output_dir / "branded_report.pdf"
+        if PDFReportGenerator(branding=branding, include_plots=False).generate(report, pdf_path):
+            print(f"  [OK] {pdf_path}")
+    except ImportError:
+        print("  PDF skipped (reportlab not installed).")
+
+    print("=" * 60)
+    print("Done.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+## Deterministic (LLM-free) report analysis
+
+Deterministic (LLM-free) report analysis.
+
+### Requirements
+
+- scpi_control - Core library
+- Oscilloscope connected to network
+
+### Configuration
+
+Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+
+### Usage
+
+```bash
+python examples/report_computed_analysis.py
+```
+
+### Source Code
+
+```python
+"""Deterministic (LLM-free) report analysis.
+
+Builds a synthetic test report and runs ComputedAnalyzer over it. Unlike the AI
+path, this needs no local model and no network: it fills the executive summary,
+key findings, and recommendations straight from the waveform analysis and sets
+summary_source to "computed".
+
+Requirements: SCPI-Instrument-Control[report-generator] (no hardware, no network)
+"""
+
+from datetime import datetime
+
+import numpy as np
+
+from scpi_control.report_generator.analysis.computed_analyzer import ComputedAnalyzer
+from scpi_control.report_generator.models.report_data import (
+    SUMMARY_SOURCE_COMPUTED,
+    MeasurementResult,
+    ReportMetadata,
+    TestReport,
+    TestSection,
+    WaveformData,
+)
+
+
+def build_report() -> TestReport:
+    """A one-channel synthetic report: a 1 kHz sine with light noise."""
+    sample_rate = 1e6
+    t = np.arange(2000) / sample_rate
+    np.random.seed(0)
+    v = 3.3 * np.sin(2 * np.pi * 1000 * t) + 0.02 * np.random.randn(t.size)
+    waveform = WaveformData(
+        channel="C1",
+        time=t,
+        voltage=v,
+        sample_rate=sample_rate,
+        record_length=t.size,
+        label="1 kHz reference",
+    )
+    measurements = [
+        MeasurementResult(name="Frequency", value=1000.0, unit="Hz", channel="C1", passed=True, criteria_min=990, criteria_max=1010),
+        MeasurementResult(name="Peak-to-Peak", value=6.6, unit="V", channel="C1", passed=True, criteria_min=6.0, criteria_max=7.0),
+    ]
+    report = TestReport(
+        metadata=ReportMetadata(title="Computed Analysis Demo", technician="Lab Tech", test_date=datetime.now()),
+        sections=[TestSection(title="Captures", waveforms=[waveform], measurements=measurements, order=1)],
+    )
+    report.overall_result = report.calculate_overall_result()
+    return report
+
+
+def main():
+    print("=" * 60)
+    print("Deterministic (LLM-free) report analysis")
+    print("=" * 60)
+
+    report = build_report()
+
+    print("Running ComputedAnalyzer (no model, no network)...")
+    ComputedAnalyzer().analyze_report(report)
+
+    print(f"\nsummary_source: {report.summary_source!r}  (expected {SUMMARY_SOURCE_COMPUTED!r})")
+    print("\nExecutive summary:")
+    print(f"  {report.executive_summary}")
+    print("\nKey findings:")
+    for finding in report.key_findings:
+        print(f"  - {finding}")
+    print("\nRecommendations:")
+    for recommendation in report.recommendations:
+        print(f"  - {recommendation}")
+
+    print("\n" + "=" * 60)
+    print("Done.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
 ## Example: Generating Professional Test Reports
 
 Example: Generating Professional Test Reports
@@ -790,15 +1119,16 @@ python examples/report_generation_example.py
 """
 Example: Generating Professional Test Reports
 
-This example demonstrates how to use the Report Generator to create
-professional PDF and Markdown reports from oscilloscope data.
+Demonstrates the Report Generator: synthesizing waveform data with numpy
+(no oscilloscope or input file needed), creating report metadata, adding
+measurements with pass/fail criteria, optional AI analysis, and generating
+PDF and Markdown reports.
 
-Features demonstrated:
-- Loading waveform data from files
-- Creating report metadata
-- Adding measurements with pass/fail criteria
-- Using AI for report analysis (optional)
-- Generating PDF and Markdown reports
+Requirements: `SCPI-Instrument-Control[report-generator]` -- no hardware
+needed.
+
+Expected output: 'example_reports/example_report.md' and, if reportlab is
+installed, 'example_reports/example_report.pdf'.
 """
 
 from datetime import datetime
@@ -808,7 +1138,7 @@ import numpy as np
 
 from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
 from scpi_control.report_generator.models.criteria import ComparisonType, CriteriaSet, MeasurementCriteria
-from scpi_control.report_generator.models.report_data import MeasurementResult, ReportMetadata, TestReport, TestSection, WaveformData
+from scpi_control.report_generator.models.report_data import SUMMARY_SOURCE_AI, MeasurementResult, ReportMetadata, TestReport, TestSection, WaveformData
 
 # Import PDF generator if available
 try:
@@ -828,7 +1158,7 @@ from scpi_control.report_generator.llm.client import LLMClient, LLMConfig
 def create_sample_waveform() -> WaveformData:
     """Create a sample waveform for demonstration."""
     # Generate a simple sine wave with some noise
-    sample_rate = 1e9  # 1 GS/s
+    sample_rate = 1e6  # 1 MS/s
     duration = 1e-3  # 1 ms
     frequency = 1e3  # 1 kHz
 
@@ -966,7 +1296,7 @@ def create_report_with_ai(report: TestReport) -> TestReport:
 
         print("Generating AI-powered executive summary...")
         report.executive_summary = analyzer.generate_executive_summary(report)
-        report.summary_source = "ai"  # attributes the summary as AI-generated
+        report.summary_source = SUMMARY_SOURCE_AI
 
         print("Generating AI key findings...")
         report.key_findings = analyzer.generate_key_findings(report, max_findings=3) or []
@@ -1104,8 +1434,8 @@ def main():
         print(f"    [FAILED] Failed to generate Markdown report")
 
     # Generate PDF report (if available)
-    if PDF_AVAILABLE:
-        print("  - Generating PDF report...")
+    print("  - Generating PDF report...")
+    try:
         pdf_path = output_dir / "example_report.pdf"
         pdf_generator = PDFReportGenerator()
 
@@ -1113,7 +1443,7 @@ def main():
             print(f"    [OK] PDF report saved: {pdf_path}")
         else:
             print(f"    [FAILED] Failed to generate PDF report")
-    else:
+    except ImportError:
         print("  - PDF generation skipped (reportlab not installed)")
 
     # Done!
@@ -1127,42 +1457,6 @@ def main():
 if __name__ == "__main__":
     main()
 ```
-
-### Related Report Generator Examples
-
-These companion scripts each build a synthetic report in-memory (no hardware,
-no saved waveform files needed) and exercise one report-generator feature in
-isolation:
-
-- **`examples/report_computed_analysis.py`** - Deterministic, LLM-free report
-  analysis: runs `ComputedAnalyzer` over a report to fill in the executive
-  summary, key findings, and recommendations straight from the waveform
-  statistics, with `summary_source` set to `"computed"`. No local model or
-  network needed.
-
-  ```bash
-  python examples/report_computed_analysis.py
-  ```
-
-- **`examples/report_branding.py`** - Applies a `BrandingTemplate` (company
-  name, header/footer text, brand colours) to a generated report, producing a
-  branded Markdown report and a colour-branded PDF (skipped with a message if
-  `reportlab` is not installed).
-
-  ```bash
-  python examples/report_branding.py
-  ```
-
-- **`examples/report_ai_qa.py`** - Local-LLM tool-calling Q&A over a report:
-  when a tool-capable Ollama model is available, `ReportAnalyzer` answers
-  questions by calling the report's analysis tools (`list_waveforms`,
-  `analyze_waveform`, ...) instead of guessing from a summary. Prints a clear
-  message and exits cleanly if no local model is available, so it is safe to
-  run anywhere.
-
-  ```bash
-  python examples/report_ai_qa.py
-  ```
 
 ---
 
@@ -1247,7 +1541,7 @@ def main():
     print("Initializing vector display (CH1=X, CH2=Y)...")
     display = scope.vector_display
     display.enable_xy_mode(voltage_scale=1.0)
-    print("✓ XY mode configured")
+    print("[OK] XY mode configured")
     print()
 
     # Create output directory
@@ -1288,7 +1582,7 @@ def main():
     )
     display.save_waveforms(triangle, f"{OUTPUT_DIR}/04_triangle", sample_rate=SAMPLE_RATE, duration=DURATION)
 
-    print("✓ Basic shapes generated\n")
+    print("[OK] Basic shapes generated\n")
 
     # ==========================================
     # Demo 2: Lissajous Figures
@@ -1307,7 +1601,7 @@ def main():
         lissajous = Shape.lissajous(a=a, b=b, delta=delta, points=2000)
         display.save_waveforms(lissajous, f"{OUTPUT_DIR}/lissajous_{name}", sample_rate=SAMPLE_RATE, duration=DURATION)
 
-    print("✓ Lissajous figures generated\n")
+    print("[OK] Lissajous figures generated\n")
 
     # ==========================================
     # Demo 3: Text
@@ -1319,9 +1613,9 @@ def main():
     try:
         text = Shape.text("HELLO", font_size=0.6)
         display.save_waveforms(text, f"{OUTPUT_DIR}/text_hello", sample_rate=SAMPLE_RATE, duration=DURATION)
-        print("✓ Text generated")
+        print("[OK] Text generated")
     except Exception as e:
-        print(f"  ⚠ Text generation skipped: {e}")
+        print(f"  WARNING: Text generation skipped: {e}")
 
     print()
 
@@ -1341,9 +1635,9 @@ def main():
             sample_rate=SAMPLE_RATE,
             duration=DURATION / 10,
         )  # Faster frames
-        print(f"  Frame {i+1}/24 (angle={angle}°)")
+        print(f"  Frame {i+1}/24 (angle={angle}deg)")
 
-    print("✓ Animation frames generated\n")
+    print("[OK] Animation frames generated\n")
 
     # ==========================================
     # Demo 5: Composite Shapes
@@ -1368,7 +1662,7 @@ def main():
     # Combine all parts
     smiley = face_outer.combine(eye_left).combine(eye_right).combine(mouth)
     display.save_waveforms(smiley, f"{OUTPUT_DIR}/composite_smiley", sample_rate=SAMPLE_RATE, duration=DURATION)
-    print("✓ Smiley face generated\n")
+    print("[OK] Smiley face generated\n")
 
     # ==========================================
     # Summary
@@ -1381,8 +1675,8 @@ def main():
     print()
     print("Next Steps:")
     print("  1. Load the .csv files into your AWG")
-    print("     - Load *_x.csv → AWG Channel 1")
-    print("     - Load *_y.csv → AWG Channel 2")
+    print("     - Load *_x.csv -> AWG Channel 1")
+    print("     - Load *_y.csv -> AWG Channel 2")
     print("  2. Enable XY mode on the oscilloscope")
     print("  3. Start the AWG output")
     print("  4. Adjust timebase and voltage scales to see the pattern")

--- a/docs/examples/beginner.md
+++ b/docs/examples/beginner.md
@@ -317,11 +317,11 @@ SCPI dialect auto-detection and manual override.
 ### Requirements
 
 - scpi_control - Core library
-- Oscilloscope connected to network
+- No hardware required
 
 ### Configuration
 
-Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+No hardware required.
 
 ### Usage
 
@@ -687,11 +687,11 @@ Discover SCPI instruments on the local network.
 ### Requirements
 
 - scpi_control - Core library
-- Oscilloscope connected to network
+- No hardware required
 
 ### Configuration
 
-Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+No hardware required.
 
 ### Usage
 

--- a/docs/examples/beginner.md
+++ b/docs/examples/beginner.md
@@ -7,9 +7,9 @@ Complete examples for getting started with the Siglent Oscilloscope library. The
 | Example | Description |
 |---------|-------------|
 | [Basic usage example for Siglent oscilloscope control](#basic-usage-example-for-siglent-oscilloscope-control) | Basic usage example for Siglent oscilloscope control. |
-| [Basic Data Logger / DAQ example](#basic-data-logger-/-daq-example) | Basic Data Logger / DAQ example. |
+| [Basic Data Logger / DAQ example](#basic-data-logger-daq-example) | Basic Data Logger / DAQ example. |
 | [SCPI dialect auto-detection and manual override](#scpi-dialect-auto-detection-and-manual-override) | SCPI dialect auto-detection and manual override. |
-| [Basic Function Generator / AWG Usage Example](#basic-function-generator-/-awg-usage-example) | Basic Function Generator / AWG Usage Example. |
+| [Basic Function Generator / AWG Usage Example](#basic-function-generator-awg-usage-example) | Basic Function Generator / AWG Usage Example. |
 | [Measurement example for Siglent oscilloscope](#measurement-example-for-siglent-oscilloscope) | Measurement example for Siglent oscilloscope. |
 | [Basic power supply control example](#basic-power-supply-control-example) | Basic power supply control example. |
 | [Simple single capture example](#simple-single-capture-example) | Simple single capture example. |
@@ -697,7 +697,7 @@ Connection Methods:
     - USB: See psu_usb_connection.py
 
 For USB support:
-    pip install "Siglent-Oscilloscope[usb]"
+    pip install "SCPI-Instrument-Control[usb]"
 """
 
 from scpi_control import PowerSupply

--- a/docs/examples/beginner.md
+++ b/docs/examples/beginner.md
@@ -11,6 +11,7 @@ Complete examples for getting started with the Siglent Oscilloscope library. The
 | [SCPI dialect auto-detection and manual override](#scpi-dialect-auto-detection-and-manual-override) | SCPI dialect auto-detection and manual override. |
 | [Basic Function Generator / AWG Usage Example](#basic-function-generator-awg-usage-example) | Basic Function Generator / AWG Usage Example. |
 | [Measurement example for Siglent oscilloscope](#measurement-example-for-siglent-oscilloscope) | Measurement example for Siglent oscilloscope. |
+| [Discover SCPI instruments on the local network](#discover-scpi-instruments-on-the-local-network) | Discover SCPI instruments on the local network. |
 | [Basic power supply control example](#basic-power-supply-control-example) | Basic power supply control example. |
 | [Simple single capture example](#simple-single-capture-example) | Simple single capture example. |
 | [Waveform capture example for Siglent oscilloscope](#waveform-capture-example-for-siglent-oscilloscope) | Waveform capture example for Siglent oscilloscope. |
@@ -43,6 +44,13 @@ python examples/basic_usage.py
 
 This script demonstrates how to connect to an oscilloscope,
 configure channels and trigger, and perform basic operations.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address.
+
+Expected output: connection/device info, channel and trigger configuration
+echoed to the console, frequency/Vpp measurements on Channel 1, and a summary
+of each enabled channel's configuration. No files are written.
 """
 
 from scpi_control import Oscilloscope
@@ -562,6 +570,13 @@ python examples/measurements.py
 
 This script demonstrates how to perform automated measurements
 on oscilloscope channels.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address.
+
+Expected output: individual measurements (frequency, period, Vpp, amplitude,
+max/min, RMS, mean) on Channel 1 printed to the console, followed by the
+combined result of measure_all(). No files are written.
 """
 
 import time
@@ -601,7 +616,7 @@ def main():
 
         try:
             period = scope.measurement.measure_period(1)
-            print(f"Period:       {period*1e6:.6f} µs")
+            print(f"Period:       {period*1e6:.6f} us")
         except Exception as e:
             print(f"Period:       Error - {e}")
 
@@ -650,13 +665,78 @@ def main():
                 if "freq" in name.lower():
                     print(f"{name:12s}: {value/1e6:.6f} MHz")
                 elif "period" in name.lower():
-                    print(f"{name:12s}: {value*1e6:.6f} µs")
+                    print(f"{name:12s}: {value*1e6:.6f} us")
                 else:
                     print(f"{name:12s}: {value:.6f} V")
             else:
                 print(f"{name:12s}: N/A")
 
         print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+## Discover SCPI instruments on the local network
+
+Discover SCPI instruments on the local network.
+
+### Requirements
+
+- scpi_control - Core library
+- Oscilloscope connected to network
+
+### Configuration
+
+Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+
+### Usage
+
+```bash
+python examples/network_discovery.py
+```
+
+### Source Code
+
+```python
+"""Discover SCPI instruments on the local network.
+
+Scans a range of addresses, probes each for a SCPI *IDN? response, and prints
+what it finds. This example scans a documentation-only TEST-NET range so it
+returns quickly with no results in most environments; change `cidr` (or pass
+cidr=None to auto-scan your local /24) to find real instruments.
+
+Requirements: SCPI-Instrument-Control (core install, no hardware)
+"""
+
+from scpi_control.server.discovery import discover
+
+
+def main():
+    print("=" * 60)
+    print("Network instrument discovery")
+    print("=" * 60)
+
+    # A small TEST-NET-1 range (RFC 5737): fast and hostless, for a safe demo.
+    # For real use: discover(cidr=None) auto-scans your local subnet, or pass a
+    # CIDR like discover(cidr="192.168.1.0/24").
+    cidr = "192.0.2.0/30"
+    print(f"Scanning {cidr} ...")
+    found = discover(cidr=cidr, connect_timeout=0.3, probe_timeout=0.5)
+
+    if not found:
+        print("No instruments found in this range.")
+    else:
+        print(f"Found {len(found)} instrument(s):")
+        for entry in found:
+            print(f"  {entry}")
+
+    print("=" * 60)
+    print("Done.")
+    print("=" * 60)
 
 
 if __name__ == "__main__":
@@ -702,10 +782,13 @@ For USB support:
 
 from scpi_control import PowerSupply
 
+# Replace with your power supply's IP address
+PSU_IP = "192.168.1.200"
+
 
 def main():
     # Connect to power supply (use your PSU's IP address)
-    psu = PowerSupply("192.168.1.200")
+    psu = PowerSupply(PSU_IP)
 
     print("Connecting to power supply...")
     psu.connect()
@@ -764,7 +847,7 @@ def main():
 def multi_output_example():
     """Example for multi-output power supplies (e.g., SPD3303X)."""
 
-    psu = PowerSupply("192.168.1.200")
+    psu = PowerSupply(PSU_IP)
     psu.connect()
 
     if psu.model_capability.num_outputs < 3:
@@ -806,7 +889,7 @@ def context_manager_example():
     """Example using context manager for automatic connection management."""
 
     # Using 'with' ensures proper connection/disconnection
-    with PowerSupply("192.168.1.200") as psu:
+    with PowerSupply(PSU_IP) as psu:
         print(f"Connected to {psu.model_capability.model_name}")
 
         psu.output1.voltage = 3.3
@@ -869,6 +952,13 @@ python examples/simple_capture.py
 
 This example shows how to capture a single waveform from one or more channels
 and save it to a file.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address.
+
+Expected output: per-channel capture stats and basic analysis (Vpp, mean,
+RMS, frequency) printed to the console, and 'simple_capture.npz' saved to
+the current directory.
 """
 
 from scpi_control.automation import DataCollector
@@ -892,7 +982,7 @@ def main():
             print(f"\nChannel {ch}:")
             print(f"  Samples: {len(waveform.voltage)}")
             print(f"  Sample rate: {waveform.sample_rate / 1e6:.2f} MSa/s")
-            print(f"  Time interval: {waveform.time_interval * 1e9:.2f} ns")
+            print(f"  Time interval: {(1.0 / waveform.sample_rate) * 1e9:.2f} ns")
             print(f"  Voltage range: {waveform.voltage.min():.3f}V to {waveform.voltage.max():.3f}V")
 
         # Analyze waveforms
@@ -946,6 +1036,13 @@ python examples/waveform_capture.py
 
 This script demonstrates how to capture waveform data from
 the oscilloscope and save it to a file.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address. matplotlib is a core dependency, no extra install
+needed.
+
+Expected output: captures Channel 1, saves 'waveform.csv' and 'waveform.png'
+to the current directory, and opens a plot window.
 """
 
 import matplotlib.pyplot as plt
@@ -982,7 +1079,7 @@ def main():
 
         print(f"Captured {len(waveform)} samples")
         print(f"Sample rate: {waveform.sample_rate/1e9:.3f} GSa/s")
-        print(f"Timebase: {waveform.timebase*1e6:.3f} µs/div")
+        print(f"Timebase: {waveform.timebase*1e6:.3f} us/div")
 
         # Save waveform to CSV
         print("\nSaving waveform data to 'waveform.csv'...")

--- a/docs/examples/intermediate.md
+++ b/docs/examples/intermediate.md
@@ -12,10 +12,11 @@ Intermediate examples showing automation patterns, real-time data capture, and b
 | [Live plotting example for Siglent oscilloscope](#live-plotting-example-for-siglent-oscilloscope) | Live plotting example for Siglent oscilloscope. |
 | [Advanced PSU features demonstration](#advanced-psu-features-demonstration) | Advanced PSU features demonstration. |
 | [Power supply control via USB connection](#power-supply-control-via-usb-connection) | Power supply control via USB connection. |
+| [Synthetic signal generation: parameterized test waveforms, and the mock](#synthetic-signal-generation-parameterized-test-waveforms-and-the-mock) | Synthetic signal generation: parameterized test waveforms, and the mock
+oscilloscope's state-coupled synthesis. |
 | [Record measurement trends in-process and export them as CSV](#record-measurement-trends-in-process-and-export-them-as-csv) | Record measurement trends in-process and export them as CSV. |
 | [Trigger-based event capture](#trigger-based-event-capture) | Trigger-based event capture. |
-| [Synthetic Signal Generation](#synthetic-signal-generation) | Parameterized synthetic waveforms and the mock's state-coupled synthesis. |
-| [Waveform Provenance and scpi-extract](#waveform-provenance-and-scpi-extract) | Read back a waveform's recorded instrument state with `load_waveform()` and `scpi-extract`. |
+| [Acquisition provenance and the load_waveform() / scpi-extract workflow](#acquisition-provenance-and-the-load_waveform-scpi-extract-workflow) | Acquisition provenance and the load_waveform() / scpi-extract workflow. |
 
 ---
 
@@ -46,6 +47,13 @@ python examples/batch_capture.py
 This example demonstrates how to capture multiple waveforms with different
 timebase and voltage scale settings. This is useful for characterizing
 signals at different time scales or for automated testing.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address.
+
+Expected output: progress lines for each capture, a summary of the first
+five results, and the batch saved to a 'batch_output/' directory (waveform
+files plus metadata.txt) in the current directory.
 """
 
 from scpi_control.automation import DataCollector
@@ -133,6 +141,13 @@ python examples/continuous_capture.py
 This example demonstrates how to collect waveforms continuously over a
 period of time. This is useful for monitoring signals, collecting statistics,
 or capturing time-varying phenomena.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address.
+
+Expected output: a 10-second in-memory capture run with Vpp statistics
+printed to the console, followed by a 30-second run that saves waveform
+files to a 'continuous_data/' directory in the current directory.
 """
 
 from scpi_control.automation import DataCollector
@@ -294,18 +309,6 @@ if __name__ == "__main__":
     main()
 ```
 
-### Related Example: LAN Instrument Discovery
-
-**`examples/network_discovery.py`** - Scans a CIDR range for SCPI instruments
-by probing each address for an `*IDN?` response, printing whatever it finds.
-The example scans a safe, hostless TEST-NET-1 range by default so it returns
-quickly with no results; pass a real subnet (or `cidr=None` to auto-scan your
-local `/24`) to find real instruments. No hardware required to run it as-is.
-
-```bash
-python examples/network_discovery.py
-```
-
 ---
 
 ## Live plotting example for Siglent oscilloscope
@@ -334,6 +337,14 @@ python examples/live_plot.py
 
 This script demonstrates real-time waveform acquisition and plotting
 using matplotlib animation.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address. matplotlib is a core dependency, no extra install
+needed.
+
+Expected output: an interactive plot window that updates every 200ms with
+the live Channel 1 waveform, until the window is closed. No files are
+written.
 """
 
 import time
@@ -502,6 +513,13 @@ Demonstrates:
 - Timer functionality
 - Waveform generation
 - OVP/OCP protection
+
+Requirements: SCPI-Instrument-Control (core install) -- runs entirely against
+a mock connection, no hardware needed.
+
+Expected output: console narration of each demo, plus CSV logs
+('psu_manual_log.csv', 'psu_timed_log.csv', 'psu_output1_log.csv',
+'characterization_log.csv') saved to the current directory.
 """
 
 import time
@@ -1067,7 +1085,7 @@ def main():
     devices = discover_devices()
 
     if not devices:
-        print("\n⚠️  No Siglent devices found")
+        print("\nWARNING: No Siglent devices found")
         print("\nMake sure:")
         print("  1. Device is connected via USB")
         print("  2. USB drivers are installed")
@@ -1078,7 +1096,7 @@ def main():
 
     # Step 2: Use the first discovered device
     resource_string, idn = devices[0]
-    print(f"\n✓ Using device: {resource_string}")
+    print(f"\n[OK] Using device: {resource_string}")
 
     # Run USB example
     usb_connection_example(resource_string)
@@ -1110,6 +1128,147 @@ if __name__ == "__main__":
         print("  - pyvisa: VISA library interface")
         print("  - pyvisa-py: Pure Python backend (no NI-VISA needed)")
         print("\nAfter installation, run this example again.")
+```
+
+---
+
+## Synthetic signal generation: parameterized test waveforms, and the mock
+
+Synthetic signal generation: parameterized test waveforms, and the mock
+oscilloscope's state-coupled synthesis.
+
+### Requirements
+
+- scpi_control - Core library
+- Oscilloscope connected to network
+
+### Configuration
+
+Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+
+### Usage
+
+```bash
+python examples/synthetic_signals.py
+```
+
+### Source Code
+
+```python
+"""Synthetic signal generation: parameterized test waveforms, and the mock
+oscilloscope's state-coupled synthesis.
+
+scpi_control.signal_synth.SignalSpec describes a waveform (kind, frequency,
+amplitude, offset, phase, duty, additive noise, and an optional seed for
+reproducibility); synthesize()/make_waveform() turn a spec into a numpy array
+or a full WaveformData ready for analysis, saving, or the report generator.
+The same engine powers MockConnection: channels without an explicit
+waveform_payloads entry synthesize live from the mock's current state, so
+SCPI commands that change the timebase or voltage scale visibly change the
+next capture -- exactly like a real scope.
+
+This example (1) generates a few signal kinds directly and prints basic
+stats, (2) opens a mock oscilloscope session, acquires, then changes TDIV and
+VDIV over SCPI to show the capture's length and clipping respond, and (3)
+saves one synthesized capture and reloads it with load_waveform() to show the
+chain composes.
+
+Requirements: SCPI-Instrument-Control (core install) -- runs entirely against
+a mock connection, no instrument needed.
+"""
+
+from pathlib import Path
+
+from scpi_control.connection import MockConnection
+from scpi_control.oscilloscope import Oscilloscope
+from scpi_control.signal_synth import SignalSpec, make_waveform
+from scpi_control.waveform_io import load_waveform
+
+OUTPUT_DIR = Path.cwd()
+NPZ_PATH = OUTPUT_DIR / "synthetic_demo.npz"
+
+# 8-bit code path constants the mock synthesizer uses internally
+# (scpi_control/connection/mock/synth.py) -- reused here only to predict the
+# voltage ceiling a given V/div setting clips at.
+CODES_PER_DIV = 25
+CODE_LIMIT = 127
+
+
+def _print_stats(label: str, voltage) -> None:
+    vpp = float(voltage.max() - voltage.min())
+    print(f"{label:12s}: Vpp={vpp:.4f} V  mean={voltage.mean():.4f} V  std={voltage.std():.4f} V  n={len(voltage)}")
+
+
+def demo_make_waveform() -> None:
+    """Generate a few signal kinds directly and print basic stats."""
+    print("=== Part 1: make_waveform() -- basic stats per kind ===")
+    kinds = [
+        ("square", SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, duty=0.5)),
+        ("sine", SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0)),
+        ("noisy sine", SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.05, seed=7)),
+    ]
+    for label, spec in kinds:
+        waveform = make_waveform(spec, sample_rate=100_000.0, n_points=1_000)
+        _print_stats(label, waveform.voltage)
+
+
+def demo_mock_session() -> None:
+    """Open a mock scope session and show SCPI writes change the next capture."""
+    print()
+    print("=== Part 2: mock oscilloscope session -- state-coupled synthesis ===")
+    conn = MockConnection(
+        "mock",
+        idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0",
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=1_000_000.0,
+        timebase=1e-3,
+        signals={1: SignalSpec(kind="sine", frequency=2_000.0, amplitude=0.8, noise_rms=0.02, seed=42)},
+    )
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    try:
+        waveform = scope.get_waveform(1, provenance=False)
+        print(f"Initial capture (TDIV=1e-3, C1:VDIV=1.0): {len(waveform.voltage)} points, " f"Vpp={float(waveform.voltage.max() - waveform.voltage.min()):.3f} V")
+
+        # Shrinking the timebase shrinks the acquisition window (14 divisions
+        # x timebase), so fewer points come back at the same sample rate.
+        scope.write("TDIV 1e-4")
+        shorter = scope.get_waveform(1, provenance=False)
+        print(f"After TDIV 1e-4: {len(shorter.voltage)} points (window shrank from 14 ms to 1.4 ms)")
+
+        # Tightening the voltage scale below the signal's amplitude clips the
+        # capture, just like an 8-bit scope's ADC would over-range.
+        scope.write("C1:VDIV 0.1")
+        clipped = scope.get_waveform(1, provenance=False)
+        clip_ceiling = CODE_LIMIT * 0.1 / CODES_PER_DIV
+        peak = float(max(abs(clipped.voltage.max()), abs(clipped.voltage.min())))
+        print(f"After C1:VDIV 0.1: peak |V| = {peak:.3f} V (signal amplitude is 0.8 V, " f"but the 8-bit code path ceilings at ~{clip_ceiling:.3f} V for this V/div)")
+
+        print()
+        print("=== Part 3: save + load_waveform() -- the chain composes ===")
+        final = scope.get_waveform(1, provenance=True)
+        scope.waveform.save_waveform(final, str(NPZ_PATH))
+        print(f"Saved {NPZ_PATH.name} ({len(final.voltage)} points)")
+    finally:
+        scope.disconnect()
+
+
+def demo_reload() -> None:
+    """Reload the saved capture and show the raw data survives the round trip."""
+    loaded = load_waveform(NPZ_PATH)
+    print(f"Reloaded {NPZ_PATH.name} ({loaded.source_format}): {len(loaded.voltage)} points, " f"channel {loaded.channel}, sample_rate {loaded.sample_rate}")
+    print(f"First 5 samples (V): {loaded.voltage[:5].tolist()}")
+
+
+def main() -> None:
+    demo_make_waveform()
+    demo_mock_session()
+    demo_reload()
+
+
+if __name__ == "__main__":
+    main()
 ```
 
 ---
@@ -1219,6 +1378,13 @@ python examples/trigger_based_capture.py
 This example demonstrates how to wait for specific trigger conditions
 and capture waveforms when they occur. This is useful for capturing
 sporadic events or signals that meet specific criteria.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address.
+
+Expected output: a single trigger wait (up to 30s) that saves to
+'trigger_captures/' if it fires, followed by up to 10 polled trigger events
+saved to 'multi_trigger_captures/' in the current directory.
 """
 
 from scpi_control.automation import DataCollector, TriggerWaitCollector
@@ -1308,81 +1474,114 @@ if __name__ == "__main__":
 
 ---
 
-## Synthetic Signal Generation
+## Acquisition provenance and the load_waveform() / scpi-extract workflow
 
-`SignalSpec` describes a waveform (kind, frequency, amplitude, offset, phase,
-duty, additive noise, and an optional seed for reproducibility);
-`synthesize()`/`make_waveform()` turn a spec into a numpy array or a full
-`WaveformData` ready for analysis, saving, or the report generator. The same
-engine powers `MockConnection`: a channel without an explicit
-`waveform_payloads` entry synthesizes live from the mock's current state, so
-SCPI commands that change the timebase or voltage scale visibly change the
-next capture, exactly like a real scope. This example generates a few signal
-kinds directly, opens a mock oscilloscope session and changes `TDIV`/`VDIV`
-over SCPI to show the capture respond, then saves a synthesized capture and
-reloads it with `load_waveform()` to show the pieces compose.
+Acquisition provenance and the load_waveform() / scpi-extract workflow.
 
 ### Requirements
 
-- scpi_control - Core library (no hardware — runs entirely against a mock connection)
+- scpi_control - Core library
+- Oscilloscope connected to network
 
-### Usage
+### Configuration
 
-```bash
-python examples/synthetic_signals.py
-```
-
-### Key Snippet
-
-```python
-from scpi_control.signal_synth import SignalSpec, make_waveform
-
-spec = SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.05, seed=7)
-waveform = make_waveform(spec, sample_rate=100_000.0, n_points=1_000)
-```
-
-See also: [Synthetic Signals](../user-guide/synthetic-signals.md) (user guide),
-[Signal Synthesis API](../api/signal_synth.md).
-
----
-
-## Waveform Provenance and scpi-extract
-
-Every waveform saved by the library now embeds a snapshot of the instrument
-state that produced it: instrument IDN, per-channel settings (scale,
-coupling, probe ratio), trigger configuration, timebase, sample rate, and a
-UTC timestamp. This example acquires from a mock oscilloscope (no hardware
-required), saves NPZ and CSV, then reads both back with
-`scpi_control.waveform_io.load_waveform()` and prints the instrument model,
-channel scale, and first few samples — exactly what the `scpi-extract`
-command-line tool does.
-
-### Requirements
-
-- scpi_control - Core library (no hardware — runs entirely against a mock connection)
+Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
 
 ### Usage
 
 ```bash
 python examples/waveform_provenance_and_extract.py
-
-# Inspect the saved files directly from the command line:
-scpi-extract provenance_demo.npz
-scpi-extract provenance_demo.csv --json
 ```
 
-### Key Snippet
+### Source Code
 
 ```python
+"""Acquisition provenance and the load_waveform() / scpi-extract workflow.
+
+Every saved waveform now embeds a snapshot of the instrument state that
+produced it: instrument IDN, per-channel settings (scale, coupling, probe
+ratio), trigger configuration, timebase, sample rate, and a UTC timestamp.
+This example acquires from a mock oscilloscope (no hardware required), saves
+NPZ and CSV, then reads both back with scpi_control.waveform_io.load_waveform()
+and prints the instrument model, channel scale, and first few samples --
+exactly what scpi-extract does from the command line.
+
+To inspect the saved files yourself:
+    scpi-extract provenance_demo.npz
+    scpi-extract provenance_demo.csv --json
+
+Requirements: SCPI-Instrument-Control (core install) -- runs entirely against
+a mock connection, no instrument needed.
+"""
+
+from pathlib import Path
+
+from scpi_control.connection import MockConnection
+from scpi_control.oscilloscope import Oscilloscope
 from scpi_control.waveform_io import load_waveform
 
-loaded = load_waveform("provenance_demo.npz")
-print(loaded.provenance.instrument.model, loaded.channel, loaded.voltage[:5])
-```
+OUTPUT_DIR = Path.cwd()
+NPZ_PATH = OUTPUT_DIR / "provenance_demo.npz"
+CSV_PATH = OUTPUT_DIR / "provenance_demo.csv"
 
-See also: [Data Provenance](../user-guide/data-provenance.md) (user guide),
-[Waveform I/O API](../api/waveform_io.md), [Provenance API](../api/provenance.md),
-[SCPI Extract CLI API](../api/scpi_extract.md).
+
+def acquire_and_save() -> None:
+    """Connect to a mock scope, acquire channel 1 with provenance, and save it."""
+    conn = MockConnection(
+        "mock",
+        idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0",
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=1_000.0,
+        timebase=1e-3,
+        waveform_payloads={1: bytes(range(256))},
+        # The base mock doesn't answer every legacy-dialect query (e.g. probe
+        # ratio); fill in the ones the provenance snapshot reads so channel 1
+        # comes back fully populated instead of silently falling back to None.
+        custom_responses={"C1:ATTN?": "10", "C1:BWL?": "OFF", "C1:UNIT?": "V"},
+    )
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    try:
+        # provenance=True is the default; shown here for clarity.
+        waveform = scope.get_waveform(1, provenance=True)
+        scope.waveform.save_waveform(waveform, str(NPZ_PATH), format="NPY")
+        scope.waveform.save_waveform(waveform, str(CSV_PATH), format="CSV")
+        print(f"Saved {NPZ_PATH.name} and {CSV_PATH.name}")
+    finally:
+        scope.disconnect()
+
+
+def inspect(path: Path) -> None:
+    """Reload a saved waveform and print what its provenance records."""
+    loaded = load_waveform(path)
+    print(f"\n--- {path.name} ({loaded.source_format}) ---")
+
+    prov = loaded.provenance
+    if prov is None:
+        print("No provenance recorded (file predates this feature).")
+        return
+
+    if prov.instrument is not None:
+        print(f"Instrument model: {prov.instrument.model}")
+
+    channel_settings = prov.channels.get(loaded.channel) or prov.channels.get(1)
+    if channel_settings is not None:
+        print(f"Channel {channel_settings.channel} scale: {channel_settings.voltage_scale} V/div (probe {channel_settings.probe_ratio}x)")
+
+    print(f"Acquired (UTC): {prov.acquired_at}")
+    print(f"First 5 samples (V): {loaded.voltage[:5].tolist()}")
+
+
+def main() -> None:
+    acquire_and_save()
+    inspect(NPZ_PATH)
+    inspect(CSV_PATH)
+
+
+if __name__ == "__main__":
+    main()
+```
 
 ---
 

--- a/docs/examples/intermediate.md
+++ b/docs/examples/intermediate.md
@@ -221,11 +221,11 @@ Drive the web gateway's REST API from Python — no browser needed.
 ### Requirements
 
 - scpi_control - Core library
-- Oscilloscope connected to network
+- No hardware required
 
 ### Configuration
 
-Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+No hardware required.
 
 ### Usage
 
@@ -490,11 +490,11 @@ Advanced PSU features demonstration.
 ### Requirements
 
 - scpi_control - Core library
-- Oscilloscope connected to network
+- No hardware required
 
 ### Configuration
 
-Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+No hardware required.
 
 ### Usage
 
@@ -1140,11 +1140,11 @@ oscilloscope's state-coupled synthesis.
 ### Requirements
 
 - scpi_control - Core library
-- Oscilloscope connected to network
+- No hardware required
 
 ### Configuration
 
-Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+No hardware required.
 
 ### Usage
 
@@ -1481,11 +1481,11 @@ Acquisition provenance and the load_waveform() / scpi-extract workflow.
 ### Requirements
 
 - scpi_control - Core library
-- Oscilloscope connected to network
+- No hardware required
 
 ### Configuration
 
-Update `SCOPE_IP` to match your oscilloscope's IP address (default: `192.168.1.100`).
+No hardware required.
 
 ### Usage
 

--- a/docs/examples/intermediate.md
+++ b/docs/examples/intermediate.md
@@ -8,12 +8,14 @@ Intermediate examples showing automation patterns, real-time data capture, and b
 |---------|-------------|
 | [Batch capture with different configurations](#batch-capture-with-different-configurations) | Batch capture with different configurations. |
 | [Continuous time-series data collection](#continuous-time-series-data-collection) | Continuous time-series data collection. |
-| [Drive the web gateway's REST API from Python — no browser needed](#drive-the-web-gateway's-rest-api-from-python-—-no-browser-needed) | Drive the web gateway's REST API from Python — no browser needed. |
+| [Drive the web gateway's REST API from Python — no browser needed](#drive-the-web-gateways-rest-api-from-python-no-browser-needed) | Drive the web gateway's REST API from Python — no browser needed. |
 | [Live plotting example for Siglent oscilloscope](#live-plotting-example-for-siglent-oscilloscope) | Live plotting example for Siglent oscilloscope. |
 | [Advanced PSU features demonstration](#advanced-psu-features-demonstration) | Advanced PSU features demonstration. |
 | [Power supply control via USB connection](#power-supply-control-via-usb-connection) | Power supply control via USB connection. |
 | [Record measurement trends in-process and export them as CSV](#record-measurement-trends-in-process-and-export-them-as-csv) | Record measurement trends in-process and export them as CSV. |
 | [Trigger-based event capture](#trigger-based-event-capture) | Trigger-based event capture. |
+| [Synthetic Signal Generation](#synthetic-signal-generation) | Parameterized synthetic waveforms and the mock's state-coupled synthesis. |
+| [Waveform Provenance and scpi-extract](#waveform-provenance-and-scpi-extract) | Read back a waveform's recorded instrument state with `load_waveform()` and `scpi-extract`. |
 
 ---
 
@@ -290,6 +292,18 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+```
+
+### Related Example: LAN Instrument Discovery
+
+**`examples/network_discovery.py`** - Scans a CIDR range for SCPI instruments
+by probing each address for an `*IDN?` response, printing whatever it finds.
+The example scans a safe, hostless TEST-NET-1 range by default so it returns
+quickly with no results; pass a real subnet (or `cidr=None` to auto-scan your
+local `/24`) to find real instruments. No hardware required to run it as-is.
+
+```bash
+python examples/network_discovery.py
 ```
 
 ---
@@ -835,7 +849,7 @@ This example demonstrates how to connect to a Siglent power supply via USB
 using the VISAConnection class.
 
 Requirements:
-    pip install "Siglent-Oscilloscope[usb]"
+    pip install "SCPI-Instrument-Control[usb]"
 
 Supports:
     - USB (USB-TMC protocol)
@@ -870,7 +884,7 @@ def discover_devices():
     except ImportError as e:
         print(f"  Error: {e}")
         print("\nInstall USB support with:")
-        print("  pip install 'Siglent-Oscilloscope[usb]'")
+        print("  pip install 'SCPI-Instrument-Control[usb]'")
         return None
 
     # Find Siglent devices specifically
@@ -1057,7 +1071,7 @@ def main():
         print("\nMake sure:")
         print("  1. Device is connected via USB")
         print("  2. USB drivers are installed")
-        print("  3. PyVISA is installed: pip install 'Siglent-Oscilloscope[usb]'")
+        print("  3. PyVISA is installed: pip install 'SCPI-Instrument-Control[usb]'")
         print("\nFor testing without hardware:")
         print("  - See examples below (commented out)")
         return
@@ -1091,7 +1105,7 @@ if __name__ == "__main__":
         print("=" * 60)
         print("\nUSB support requires PyVISA.")
         print("\nInstall with:")
-        print("  pip install 'Siglent-Oscilloscope[usb]'")
+        print("  pip install 'SCPI-Instrument-Control[usb]'")
         print("\nThis includes:")
         print("  - pyvisa: VISA library interface")
         print("  - pyvisa-py: Pure Python backend (no NI-VISA needed)")
@@ -1291,6 +1305,84 @@ def main():
 if __name__ == "__main__":
     main()
 ```
+
+---
+
+## Synthetic Signal Generation
+
+`SignalSpec` describes a waveform (kind, frequency, amplitude, offset, phase,
+duty, additive noise, and an optional seed for reproducibility);
+`synthesize()`/`make_waveform()` turn a spec into a numpy array or a full
+`WaveformData` ready for analysis, saving, or the report generator. The same
+engine powers `MockConnection`: a channel without an explicit
+`waveform_payloads` entry synthesizes live from the mock's current state, so
+SCPI commands that change the timebase or voltage scale visibly change the
+next capture, exactly like a real scope. This example generates a few signal
+kinds directly, opens a mock oscilloscope session and changes `TDIV`/`VDIV`
+over SCPI to show the capture respond, then saves a synthesized capture and
+reloads it with `load_waveform()` to show the pieces compose.
+
+### Requirements
+
+- scpi_control - Core library (no hardware — runs entirely against a mock connection)
+
+### Usage
+
+```bash
+python examples/synthetic_signals.py
+```
+
+### Key Snippet
+
+```python
+from scpi_control.signal_synth import SignalSpec, make_waveform
+
+spec = SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.05, seed=7)
+waveform = make_waveform(spec, sample_rate=100_000.0, n_points=1_000)
+```
+
+See also: [Synthetic Signals](../user-guide/synthetic-signals.md) (user guide),
+[Signal Synthesis API](../api/signal_synth.md).
+
+---
+
+## Waveform Provenance and scpi-extract
+
+Every waveform saved by the library now embeds a snapshot of the instrument
+state that produced it: instrument IDN, per-channel settings (scale,
+coupling, probe ratio), trigger configuration, timebase, sample rate, and a
+UTC timestamp. This example acquires from a mock oscilloscope (no hardware
+required), saves NPZ and CSV, then reads both back with
+`scpi_control.waveform_io.load_waveform()` and prints the instrument model,
+channel scale, and first few samples — exactly what the `scpi-extract`
+command-line tool does.
+
+### Requirements
+
+- scpi_control - Core library (no hardware — runs entirely against a mock connection)
+
+### Usage
+
+```bash
+python examples/waveform_provenance_and_extract.py
+
+# Inspect the saved files directly from the command line:
+scpi-extract provenance_demo.npz
+scpi-extract provenance_demo.csv --json
+```
+
+### Key Snippet
+
+```python
+from scpi_control.waveform_io import load_waveform
+
+loaded = load_waveform("provenance_demo.npz")
+print(loaded.provenance.instrument.model, loaded.channel, loaded.voltage[:5])
+```
+
+See also: [Data Provenance](../user-guide/data-provenance.md) (user guide),
+[Waveform I/O API](../api/waveform_io.md), [Provenance API](../api/provenance.md),
+[SCPI Extract CLI API](../api/scpi_extract.md).
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -162,7 +162,7 @@ scope.disconnect()
 Expected output:
 
 ```
-2.0.0
+3.3.0
 Siglent Technologies,SDS824X HD,SDSMMDD1XXXXX,8.2.5.1.37R9
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -181,7 +181,7 @@ with DataCollector('192.168.1.100') as collector:
 
 ## Next Steps
 
-!!! tip "Learn More" - [Connection Setup](connection.md) - Configure network and connection settings - [Basic Usage](../user-guide/basic-usage.md) - Detailed usage guide - [Waveform Capture](../user-guide/waveform-capture.md) - Advanced capture techniques - [Measurements](../user-guide/measurements.md) - All measurement types - [GUI Guide](../gui/overview.md) - GUI application features - [Web Gateway](../gateway/index.md) - Browser-based lab gateway
+!!! tip "Learn More" - [Connection Setup](connection.md) - Configure network and connection settings - [Basic Usage](../user-guide/basic-usage.md) - Detailed usage guide - [Waveform Capture](../user-guide/waveform-capture.md) - Advanced capture techniques - [Data Provenance](../user-guide/data-provenance.md) - What gets recorded with every capture - [Synthetic Signals](../user-guide/synthetic-signals.md) - Generate test waveforms without hardware - [Measurements](../user-guide/measurements.md) - All measurement types - [GUI Guide](../gui/overview.md) - GUI application features - [Web Gateway](../gateway/index.md) - Browser-based lab gateway
 
 !!! example "Examples"
 Check out the [examples directory](https://github.com/little-did-I-know/SCPI-Instrument-Control/tree/main/examples) for more code samples:

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,8 @@ This library provides comprehensive control for SCPI test equipment — oscillos
     - **FFT Analysis** - Frequency domain analysis of captured waveforms
     - **Protocol Decoding** - Decode I2C, SPI, and UART protocols
     - **Automation** - High-level automation classes for data collection
+    - **Data Provenance** - Every capture records the instrument, settings, and timestamp that produced it; read it back with `load_waveform()` or the `scpi-extract` CLI
+    - **Synthetic Signals** - Generate parameterized waveforms (sine, square, triangle, ramp, DC, noise) with no instrument required; mock scopes synthesize state-coupled captures by default
 
 === "GUI Application"
 
@@ -84,7 +86,7 @@ This library provides comprehensive control for SCPI test equipment — oscillos
     - **Multi-channel** - Simultaneous capture from all channels
     - **Thread-safe** - Background data acquisition without blocking
     - **Type hints** - Full type annotation for IDE support
-    - **Extensive tests** - 660+ automated tests
+    - **Extensive tests** - 1,100+ automated tests
     - **Documentation** - Comprehensive docstrings and guides
 
 ## Installation

--- a/docs/report-generator/getting-started.md
+++ b/docs/report-generator/getting-started.md
@@ -15,18 +15,16 @@ If you have the source code:
 
 ```bash
 # Navigate to the project directory
-cd Siglent
+cd SCPI-Instrument-Control
 
 # Install with report generator dependencies
 pip install -e ".[report-generator]"
 ```
 
-### Option 2: Install from PyPI (Future)
-
-Once published to PyPI:
+### Option 2: Install from PyPI
 
 ```bash
-pip install siglent-oscilloscope[report-generator]
+pip install "SCPI-Instrument-Control[report-generator]"
 ```
 
 ### Verify Installation

--- a/docs/report-generator/index.md
+++ b/docs/report-generator/index.md
@@ -2,8 +2,6 @@
 
 The **Siglent Report Generator** is a powerful standalone application for creating professional test reports from oscilloscope waveform data. Generate beautiful PDF and Markdown reports with AI-powered insights, all running completely offline.
 
-![Report Generator Overview](../images/report-generator-main.png)
-
 ## Key Features
 
 ### 📊 Professional Reports
@@ -85,9 +83,9 @@ python -m scpi_control.report_generator.app
 ### Advanced Usage
 
 - [**Template System**](templates.md) - Save and reuse report configurations
-- [**Pass/Fail Criteria**](templates.md#pass-fail-criteria) - Define test criteria
+- [**Pass/Fail Criteria**](templates.md#passfail-criteria) - Define test criteria
 - [**Programmatic API**](api-reference.md) - Use Python API for automation
-- [**Building Executables**](building-executables.md) - Create standalone apps
+- [**Building Executables**](../development/BUILDING_EXECUTABLES.md) - Create standalone apps
 
 ## Example Use Cases
 

--- a/docs/user-guide/advanced-features.md
+++ b/docs/user-guide/advanced-features.md
@@ -731,6 +731,8 @@ with DataCollector(SCOPE_IP) as collector:
 
 You've completed the User Guide! Here are some resources for further learning:
 
+- [Data Provenance](data-provenance.md) - What gets recorded with every capture
+- [Synthetic Signals](synthetic-signals.md) - Generate test waveforms without hardware
 - [API Reference](../api/oscilloscope.md) - Detailed API documentation
 - [Examples](../examples/beginner.md) - Real-world usage examples
 - [GUI Guide](../gui/overview.md) - Learn about the GUI application

--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -472,7 +472,10 @@ with Oscilloscope(SCOPE_IP) as scope:
 
 ## Next Steps
 
+- [SCPI Dialects](scpi-dialects.md) - Command differences across vendors and models
 - [Waveform Capture](waveform-capture.md) - Advanced capture techniques and data formats
+- [Data Provenance](data-provenance.md) - What gets recorded with every capture
+- [Synthetic Signals](synthetic-signals.md) - Generate test waveforms without hardware
 - [Measurements](measurements.md) - Automated measurements and statistics
 - [Trigger Control](trigger-control.md) - Advanced trigger modes and conditions
 - [Advanced Features](advanced-features.md) - FFT, math channels, and automation

--- a/docs/user-guide/waveform-capture.md
+++ b/docs/user-guide/waveform-capture.md
@@ -587,6 +587,7 @@ with Oscilloscope(SCOPE_IP) as scope:
 
 ## Next Steps
 
+- [Data Provenance](data-provenance.md) - What gets recorded with every capture
 - [Measurements](measurements.md) - Automated measurements and statistics
 - [Trigger Control](trigger-control.md) - Advanced trigger configuration
 - [Advanced Features](advanced-features.md) - FFT analysis and math channels

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,14 +24,14 @@ pip install "SCPI-Instrument-Control"
 | File | What it shows | Requirements |
 | --- | --- | --- |
 | `basic_usage.py` | Connecting to an oscilloscope, configuring channels and trigger, and performing basic operations. | Oscilloscope on the network |
-| `waveform_capture.py` | Capturing waveform data from the oscilloscope and saving it to a file. | Oscilloscope on the network, matplotlib |
+| `waveform_capture.py` | Capturing waveform data from the oscilloscope and saving it to a file. | Oscilloscope on the network (matplotlib is a core dependency) |
 | `measurements.py` | Automated measurements (frequency, Vpp, RMS, period, etc.) on oscilloscope channels. | Oscilloscope on the network |
-| `live_plot.py` | Real-time waveform acquisition and plotting using matplotlib animation. | Oscilloscope on the network, matplotlib |
+| `live_plot.py` | Real-time waveform acquisition and plotting using matplotlib animation. | Oscilloscope on the network (matplotlib is a core dependency) |
 | `simple_capture.py` | Single waveform capture with analysis via the automation API (Vpp, RMS, frequency) and saving to NumPy format. | Oscilloscope on the network |
 | `batch_capture.py` | Capturing multiple waveforms with different timebase and voltage-scale settings, for characterizing signals at different scales. | Oscilloscope on the network |
 | `continuous_capture.py` | Collecting waveforms continuously over a period of time, for monitoring, statistics, or time-varying phenomena. | Oscilloscope on the network |
 | `trigger_based_capture.py` | Waiting for specific trigger conditions and capturing waveforms when they occur, for sporadic events. | Oscilloscope on the network |
-| `advanced_analysis.py` | Advanced waveform analysis and visualization: FFT analysis, statistical analysis, and matplotlib plots. | Oscilloscope on the network, matplotlib |
+| `advanced_analysis.py` | Advanced waveform analysis and visualization: FFT analysis, statistical analysis, and matplotlib plots. | Oscilloscope on the network (matplotlib is a core dependency) |
 | `probe_calibration_analysis.py` | Waveform region extraction for probe compensation analysis: plateau detection, slope analysis, calibration guidance, and zoomed PDF report plots. | `SCPI-Instrument-Control[report-generator]` (no hardware — fully synthetic) |
 | `dialect_override_example.py` | SCPI dialect auto-detection from `*IDN?` and the `dialect=` override for forcing a command set; runs entirely on mock connections. | Core install only (no hardware) |
 | `waveform_provenance_and_extract.py` | Acquisition provenance: capturing a waveform with the instrument/settings snapshot attached, saving NPZ and CSV, and reading them back with `load_waveform()`; runs entirely against a mock connection -- no instrument needed. | Core install only (no hardware) |
@@ -71,7 +71,7 @@ pip install "SCPI-Instrument-Control"
 
 | File | What it shows | Requirements |
 | --- | --- | --- |
-| `report_generation_example.py` | Generating professional PDF/Markdown test reports: loading waveform data, adding measurements with pass/fail criteria, optional AI analysis, and rendering the report. | `SCPI-Instrument-Control[report-generator]` |
+| `report_generation_example.py` | Generating professional PDF/Markdown test reports: synthesizing waveform data with numpy, adding measurements with pass/fail criteria, optional AI analysis, and rendering the report. | `SCPI-Instrument-Control[report-generator]` (no hardware - fully synthetic) |
 | `report_computed_analysis.py` | Deterministic, LLM-free report analysis: `ComputedAnalyzer` fills the executive summary, key findings, and recommendations from the waveform data with no model or network. | `SCPI-Instrument-Control[report-generator]` (no hardware) |
 | `report_branding.py` | Applying a `BrandingTemplate` to a report: company name, header/footer text, and a brand colour scheme, rendered to a branded Markdown report and a colour-branded PDF. | `SCPI-Instrument-Control[report-generator]` (no hardware) |
 | `report_ai_qa.py` | Interactive Q&A over a report with a local LLM using tool-calling: the model calls the report's analysis tools to answer, and the example degrades cleanly when no tool-capable Ollama model is running. | `SCPI-Instrument-Control[report-generator]`; optional local Ollama (no hardware) |
@@ -80,7 +80,7 @@ pip install "SCPI-Instrument-Control"
 
 | File | What it shows | Requirements |
 | --- | --- | --- |
-| `interactive_tutorial.ipynb` | End-to-end Jupyter walkthrough: connect, configure channels/trigger, capture and plot a waveform, run automated measurements, FFT analysis, multi-channel capture, and export — narrated step by step. | Jupyter, oscilloscope on the network, matplotlib, scipy |
+| `interactive_tutorial.ipynb` | End-to-end Jupyter walkthrough: connect, configure channels/trigger, capture and plot a waveform, run automated measurements, FFT analysis, multi-channel capture, and export — narrated step by step. | Jupyter, oscilloscope on the network (matplotlib and scipy are core dependencies) |
 
 ## Configuration
 
@@ -91,14 +91,16 @@ LAN address: **Utility → I/O → LAN** on the instrument's front panel.
 The scripts marked "no hardware" above (`dialect_override_example.py`,
 `waveform_provenance_and_extract.py`, `synthetic_signals.py`, `trend_logging_walkthrough.py`, `psu_gui_test.py`,
 `probe_calibration_analysis.py`, `psu_advanced_features.py`, `network_discovery.py`,
-`report_computed_analysis.py`, `report_branding.py`, `report_ai_qa.py`) use mock
-connections and run as-is.
+`report_computed_analysis.py`, `report_branding.py`, `report_ai_qa.py`,
+`report_generation_example.py`) use mock connections or synthetic data and run as-is.
 
 ## Running an example
 
 ```bash
 python examples/basic_usage.py
 ```
+
+On Windows terminals with a legacy codepage, set `PYTHONIOENCODING=utf-8` first if a script prints Unicode symbols.
 
 For `gateway_rest_client.py`, start the gateway first, in another terminal:
 

--- a/examples/advanced_analysis.py
+++ b/examples/advanced_analysis.py
@@ -3,6 +3,14 @@
 This example demonstrates how to perform advanced analysis on captured
 waveforms, including FFT analysis, statistical analysis, and visualization
 using matplotlib.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address. matplotlib is a core dependency, no extra install
+needed.
+
+Expected output: basic and signal-quality stats printed to the console,
+three plot windows (time domain, FFT, histogram), and 'analyzed_waveform.npz'
+plus 'analysis_report.txt' saved to the current directory.
 """
 
 import matplotlib.pyplot as plt
@@ -129,7 +137,7 @@ def main():
         print(f"Min:        {basic_stats['min']:.4f} V")
         if basic_stats["frequency"] > 0:
             print(f"Frequency:  {basic_stats['frequency'] / 1e3:.2f} kHz")
-            print(f"Period:     {basic_stats['period'] * 1e6:.2f} µs")
+            print(f"Period:     {basic_stats['period'] * 1e6:.2f} us")
 
         # Advanced signal quality analysis
         print("\n" + "=" * 60)

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -2,6 +2,13 @@
 
 This script demonstrates how to connect to an oscilloscope,
 configure channels and trigger, and perform basic operations.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address.
+
+Expected output: connection/device info, channel and trigger configuration
+echoed to the console, frequency/Vpp measurements on Channel 1, and a summary
+of each enabled channel's configuration. No files are written.
 """
 
 from scpi_control import Oscilloscope

--- a/examples/batch_capture.py
+++ b/examples/batch_capture.py
@@ -3,6 +3,13 @@
 This example demonstrates how to capture multiple waveforms with different
 timebase and voltage scale settings. This is useful for characterizing
 signals at different time scales or for automated testing.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address.
+
+Expected output: progress lines for each capture, a summary of the first
+five results, and the batch saved to a 'batch_output/' directory (waveform
+files plus metadata.txt) in the current directory.
 """
 
 from scpi_control.automation import DataCollector

--- a/examples/continuous_capture.py
+++ b/examples/continuous_capture.py
@@ -3,6 +3,13 @@
 This example demonstrates how to collect waveforms continuously over a
 period of time. This is useful for monitoring signals, collecting statistics,
 or capturing time-varying phenomena.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address.
+
+Expected output: a 10-second in-memory capture run with Vpp statistics
+printed to the console, followed by a 30-second run that saves waveform
+files to a 'continuous_data/' directory in the current directory.
 """
 
 from scpi_control.automation import DataCollector

--- a/examples/live_plot.py
+++ b/examples/live_plot.py
@@ -2,6 +2,14 @@
 
 This script demonstrates real-time waveform acquisition and plotting
 using matplotlib animation.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address. matplotlib is a core dependency, no extra install
+needed.
+
+Expected output: an interactive plot window that updates every 200ms with
+the live Channel 1 waveform, until the window is closed. No files are
+written.
 """
 
 import time

--- a/examples/measurements.py
+++ b/examples/measurements.py
@@ -2,6 +2,13 @@
 
 This script demonstrates how to perform automated measurements
 on oscilloscope channels.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address.
+
+Expected output: individual measurements (frequency, period, Vpp, amplitude,
+max/min, RMS, mean) on Channel 1 printed to the console, followed by the
+combined result of measure_all(). No files are written.
 """
 
 import time
@@ -41,7 +48,7 @@ def main():
 
         try:
             period = scope.measurement.measure_period(1)
-            print(f"Period:       {period*1e6:.6f} µs")
+            print(f"Period:       {period*1e6:.6f} us")
         except Exception as e:
             print(f"Period:       Error - {e}")
 
@@ -90,7 +97,7 @@ def main():
                 if "freq" in name.lower():
                     print(f"{name:12s}: {value/1e6:.6f} MHz")
                 elif "period" in name.lower():
-                    print(f"{name:12s}: {value*1e6:.6f} µs")
+                    print(f"{name:12s}: {value*1e6:.6f} us")
                 else:
                     print(f"{name:12s}: {value:.6f} V")
             else:

--- a/examples/probe_calibration_analysis.py
+++ b/examples/probe_calibration_analysis.py
@@ -2,21 +2,20 @@
 """
 Probe Calibration Analysis Example
 
-Demonstrates the new waveform region extraction features for analyzing
-probe compensation using oscilloscope calibration signals.
+Demonstrates waveform region extraction for probe compensation analysis:
+plateau detection, slope analysis, calibration guidance, and zoomed region
+plots in reports.
 
-This example shows:
-1. Automatic plateau detection in square waves
-2. Plateau slope analysis for probe compensation assessment
-3. Calibration guidance generation
-4. Zoomed region plots in PDF reports
-5. Manual region addition and analysis
+By default this example is fully synthetic/no-hardware: it generates its
+own 1kHz square waves with numpy for properly-, under-, and over-compensated
+plateaus. Optionally, for a real-world check, capture a 1kHz square wave
+from your oscilloscope's probe compensation output instead.
 
-For best results, capture a 1kHz square wave from your oscilloscope's
-probe compensation output with different probe compensation settings:
-- Properly compensated (flat plateaus)
-- Undercompensated (rising plateaus)
-- Overcompensated (falling plateaus)
+Requirements: `SCPI-Instrument-Control[report-generator]` -- no hardware
+needed.
+
+Expected output: 'probe_calibration_analysis.pdf', 'probe_calibration_analysis.md',
+and a 'plots/' directory, all saved to the current directory.
 """
 
 from datetime import datetime
@@ -259,9 +258,9 @@ trimmer capacitor requires adjustment.
     pdf_success = pdf_generator.generate(report, pdf_path)
 
     if pdf_success:
-        print(f"  ✓ PDF generated successfully ({pdf_path.stat().st_size:,} bytes)")
+        print(f"  [OK] PDF generated successfully ({pdf_path.stat().st_size:,} bytes)")
     else:
-        print(f"  ✗ PDF generation failed")
+        print(f"  [FAILED] PDF generation failed")
 
     # Generate Markdown
     md_path = Path("probe_calibration_analysis.md")
@@ -270,9 +269,9 @@ trimmer capacitor requires adjustment.
     md_success = md_generator.generate(report, md_path)
 
     if md_success:
-        print(f"  ✓ Markdown generated successfully ({md_path.stat().st_size:,} bytes)")
+        print(f"  [OK] Markdown generated successfully ({md_path.stat().st_size:,} bytes)")
     else:
-        print(f"  ✗ Markdown generation failed")
+        print(f"  [FAILED] Markdown generation failed")
 
     # ========================================================================
     # Summary
@@ -280,7 +279,7 @@ trimmer capacitor requires adjustment.
     print("\n" + "=" * 70)
     print("Feature Demonstration Summary")
     print("=" * 70)
-    print("\n✓ Features Demonstrated:")
+    print("\n[OK] Features Demonstrated:")
     print("  1. Automatic plateau detection in square waves")
     print("  2. Plateau slope analysis for probe compensation")
     print("  3. Automatic calibration guidance generation")
@@ -290,7 +289,7 @@ trimmer capacitor requires adjustment.
     print("  7. Color-coded calibration recommendations")
     print("  8. Both PDF and Markdown report generation")
 
-    print("\n✓ Report Contents:")
+    print("\n[OK] Report Contents:")
     print(f"  - {len(report.sections)} test sections")
     total_waveforms = sum(len(s.waveforms) for s in report.sections)
     total_regions = sum(len(w.regions) for w in [wf for s in report.sections for wf in s.waveforms])
@@ -299,7 +298,7 @@ trimmer capacitor requires adjustment.
     print(f"  - {len(report.key_findings)} key findings")
     print(f"  - {len(report.recommendations)} recommendations")
 
-    print("\n✓ Files Generated:")
+    print("\n[OK] Files Generated:")
     if pdf_success:
         print(f"  - {pdf_path}")
     if md_success:
@@ -308,12 +307,12 @@ trimmer capacitor requires adjustment.
 
     print("\n" + "=" * 70)
     print("Review the generated PDF to see:")
-    print("  • Full waveform plots")
-    print("  • Automatic plateau detection")
-    print("  • Zoomed region subsections")
-    print("  • Slope analysis tables")
-    print("  • Color-coded calibration guidance")
-    print("  • Detailed region-specific measurements")
+    print("  - Full waveform plots")
+    print("  - Automatic plateau detection")
+    print("  - Zoomed region subsections")
+    print("  - Slope analysis tables")
+    print("  - Color-coded calibration guidance")
+    print("  - Detailed region-specific measurements")
     print("=" * 70)
 
     return 0

--- a/examples/psu_advanced_features.py
+++ b/examples/psu_advanced_features.py
@@ -6,6 +6,13 @@ Demonstrates:
 - Timer functionality
 - Waveform generation
 - OVP/OCP protection
+
+Requirements: SCPI-Instrument-Control (core install) -- runs entirely against
+a mock connection, no hardware needed.
+
+Expected output: console narration of each demo, plus CSV logs
+('psu_manual_log.csv', 'psu_timed_log.csv', 'psu_output1_log.csv',
+'characterization_log.csv') saved to the current directory.
 """
 
 import time

--- a/examples/psu_basic_control.py
+++ b/examples/psu_basic_control.py
@@ -13,10 +13,13 @@ For USB support:
 
 from scpi_control import PowerSupply
 
+# Replace with your power supply's IP address
+PSU_IP = "192.168.1.200"
+
 
 def main():
     # Connect to power supply (use your PSU's IP address)
-    psu = PowerSupply("192.168.1.200")
+    psu = PowerSupply(PSU_IP)
 
     print("Connecting to power supply...")
     psu.connect()
@@ -75,7 +78,7 @@ def main():
 def multi_output_example():
     """Example for multi-output power supplies (e.g., SPD3303X)."""
 
-    psu = PowerSupply("192.168.1.200")
+    psu = PowerSupply(PSU_IP)
     psu.connect()
 
     if psu.model_capability.num_outputs < 3:
@@ -117,7 +120,7 @@ def context_manager_example():
     """Example using context manager for automatic connection management."""
 
     # Using 'with' ensures proper connection/disconnection
-    with PowerSupply("192.168.1.200") as psu:
+    with PowerSupply(PSU_IP) as psu:
         print(f"Connected to {psu.model_capability.model_name}")
 
         psu.output1.voltage = 3.3

--- a/examples/psu_gui_test.py
+++ b/examples/psu_gui_test.py
@@ -2,6 +2,11 @@
 
 This script demonstrates the PSU control GUI using a mock connection,
 allowing you to test the interface without physical hardware.
+
+Requirements: `SCPI-Instrument-Control[gui]` -- no instrument needed, but it
+opens an interactive PyQt6 window against a mock PSU and requires a display
+and user interaction (choosing a PSU, clicking through the GUI). That is why
+this example is compile-checked only, not auto-executed in the smoke suite.
 """
 
 import sys

--- a/examples/psu_usb_connection.py
+++ b/examples/psu_usb_connection.py
@@ -222,7 +222,7 @@ def main():
     devices = discover_devices()
 
     if not devices:
-        print("\n⚠️  No Siglent devices found")
+        print("\nWARNING: No Siglent devices found")
         print("\nMake sure:")
         print("  1. Device is connected via USB")
         print("  2. USB drivers are installed")
@@ -233,7 +233,7 @@ def main():
 
     # Step 2: Use the first discovered device
     resource_string, idn = devices[0]
-    print(f"\n✓ Using device: {resource_string}")
+    print(f"\n[OK] Using device: {resource_string}")
 
     # Run USB example
     usb_connection_example(resource_string)

--- a/examples/report_generation_example.py
+++ b/examples/report_generation_example.py
@@ -1,15 +1,16 @@
 """
 Example: Generating Professional Test Reports
 
-This example demonstrates how to use the Report Generator to create
-professional PDF and Markdown reports from oscilloscope data.
+Demonstrates the Report Generator: synthesizing waveform data with numpy
+(no oscilloscope or input file needed), creating report metadata, adding
+measurements with pass/fail criteria, optional AI analysis, and generating
+PDF and Markdown reports.
 
-Features demonstrated:
-- Loading waveform data from files
-- Creating report metadata
-- Adding measurements with pass/fail criteria
-- Using AI for report analysis (optional)
-- Generating PDF and Markdown reports
+Requirements: `SCPI-Instrument-Control[report-generator]` -- no hardware
+needed.
+
+Expected output: 'example_reports/example_report.md' and, if reportlab is
+installed, 'example_reports/example_report.pdf'.
 """
 
 from datetime import datetime

--- a/examples/simple_capture.py
+++ b/examples/simple_capture.py
@@ -2,6 +2,13 @@
 
 This example shows how to capture a single waveform from one or more channels
 and save it to a file.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address.
+
+Expected output: per-channel capture stats and basic analysis (Vpp, mean,
+RMS, frequency) printed to the console, and 'simple_capture.npz' saved to
+the current directory.
 """
 
 from scpi_control.automation import DataCollector

--- a/examples/trigger_based_capture.py
+++ b/examples/trigger_based_capture.py
@@ -3,6 +3,13 @@
 This example demonstrates how to wait for specific trigger conditions
 and capture waveforms when they occur. This is useful for capturing
 sporadic events or signals that meet specific criteria.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address.
+
+Expected output: a single trigger wait (up to 30s) that saves to
+'trigger_captures/' if it fires, followed by up to 10 polled trigger events
+saved to 'multi_trigger_captures/' in the current directory.
 """
 
 from scpi_control.automation import DataCollector, TriggerWaitCollector

--- a/examples/vector_graphics_xy_mode.py
+++ b/examples/vector_graphics_xy_mode.py
@@ -57,7 +57,7 @@ def main():
     print("Initializing vector display (CH1=X, CH2=Y)...")
     display = scope.vector_display
     display.enable_xy_mode(voltage_scale=1.0)
-    print("✓ XY mode configured")
+    print("[OK] XY mode configured")
     print()
 
     # Create output directory
@@ -98,7 +98,7 @@ def main():
     )
     display.save_waveforms(triangle, f"{OUTPUT_DIR}/04_triangle", sample_rate=SAMPLE_RATE, duration=DURATION)
 
-    print("✓ Basic shapes generated\n")
+    print("[OK] Basic shapes generated\n")
 
     # ==========================================
     # Demo 2: Lissajous Figures
@@ -117,7 +117,7 @@ def main():
         lissajous = Shape.lissajous(a=a, b=b, delta=delta, points=2000)
         display.save_waveforms(lissajous, f"{OUTPUT_DIR}/lissajous_{name}", sample_rate=SAMPLE_RATE, duration=DURATION)
 
-    print("✓ Lissajous figures generated\n")
+    print("[OK] Lissajous figures generated\n")
 
     # ==========================================
     # Demo 3: Text
@@ -129,9 +129,9 @@ def main():
     try:
         text = Shape.text("HELLO", font_size=0.6)
         display.save_waveforms(text, f"{OUTPUT_DIR}/text_hello", sample_rate=SAMPLE_RATE, duration=DURATION)
-        print("✓ Text generated")
+        print("[OK] Text generated")
     except Exception as e:
-        print(f"  ⚠ Text generation skipped: {e}")
+        print(f"  WARNING: Text generation skipped: {e}")
 
     print()
 
@@ -151,9 +151,9 @@ def main():
             sample_rate=SAMPLE_RATE,
             duration=DURATION / 10,
         )  # Faster frames
-        print(f"  Frame {i+1}/24 (angle={angle}°)")
+        print(f"  Frame {i+1}/24 (angle={angle}deg)")
 
-    print("✓ Animation frames generated\n")
+    print("[OK] Animation frames generated\n")
 
     # ==========================================
     # Demo 5: Composite Shapes
@@ -178,7 +178,7 @@ def main():
     # Combine all parts
     smiley = face_outer.combine(eye_left).combine(eye_right).combine(mouth)
     display.save_waveforms(smiley, f"{OUTPUT_DIR}/composite_smiley", sample_rate=SAMPLE_RATE, duration=DURATION)
-    print("✓ Smiley face generated\n")
+    print("[OK] Smiley face generated\n")
 
     # ==========================================
     # Summary
@@ -191,8 +191,8 @@ def main():
     print()
     print("Next Steps:")
     print("  1. Load the .csv files into your AWG")
-    print("     - Load *_x.csv → AWG Channel 1")
-    print("     - Load *_y.csv → AWG Channel 2")
+    print("     - Load *_x.csv -> AWG Channel 1")
+    print("     - Load *_y.csv -> AWG Channel 2")
     print("  2. Enable XY mode on the oscilloscope")
     print("  3. Start the AWG output")
     print("  4. Adjust timebase and voltage scales to see the pattern")

--- a/examples/waveform_capture.py
+++ b/examples/waveform_capture.py
@@ -2,6 +2,13 @@
 
 This script demonstrates how to capture waveform data from
 the oscilloscope and save it to a file.
+
+Requirements: an oscilloscope reachable on the network -- edit SCOPE_IP below
+to match its LAN address. matplotlib is a core dependency, no extra install
+needed.
+
+Expected output: captures Channel 1, saves 'waveform.csv' and 'waveform.png'
+to the current directory, and opens a plot window.
 """
 
 import matplotlib.pyplot as plt
@@ -38,7 +45,7 @@ def main():
 
         print(f"Captured {len(waveform)} samples")
         print(f"Sample rate: {waveform.sample_rate/1e9:.3f} GSa/s")
-        print(f"Timebase: {waveform.timebase*1e6:.3f} µs/div")
+        print(f"Timebase: {waveform.timebase*1e6:.3f} us/div")
 
         # Save waveform to CSV
         print("\nSaving waveform data to 'waveform.csv'...")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,6 @@
 site_name: SCPI Instrument Control
+exclude_docs: |
+  superpowers/
 site_description: Universal Python library for controlling SCPI-compatible test equipment (oscilloscopes, function generators, power supplies) via Ethernet/LAN
 site_author: Robin Mumm
 site_url: https://little-did-I-know.github.io/SCPI-Instrument-Control/
@@ -145,6 +147,10 @@ nav:
       - Channel: api/channel.md
       - Trigger: api/trigger.md
       - Waveform: api/waveform.md
+      - Signal Synthesis: api/signal_synth.md
+      - Waveform I/O: api/waveform_io.md
+      - Provenance: api/provenance.md
+      - SCPI Extract (CLI): api/scpi_extract.md
       - Measurement: api/measurement.md
       - Analysis: api/analysis.md
       - Automation: api/automation.md

--- a/scpi_control/automation.py
+++ b/scpi_control/automation.py
@@ -343,31 +343,35 @@ class DataCollector:
         logger.info(f"Continuous capture complete: {capture_count} captures over {duration}s")
         return results
 
-    def save_data(self, waveforms: Dict[int, WaveformData], filename: str, format: str = "npz") -> None:
+    def save_data(self, waveforms: Dict[int, WaveformData], filename: str, format: Optional[str] = None) -> None:
         """Save captured waveform data to file.
 
         Args:
             waveforms: Dictionary mapping channel number to WaveformData
             filename: Output filename
-            format: File format ('npz', 'csv', 'mat', 'h5')
+            format: File format - one of 'CSV', 'CSV_ENHANCED', 'NPY', 'MAT', 'HDF5'.
+                If None (default), the format is auto-detected from each generated
+                per-channel filename's extension.
 
         Example:
             >>> data = collector.capture_single([1, 2])
             >>> collector.save_data(data, 'measurement.npz')
         """
         for ch, waveform in waveforms.items():
-            base, ext = filename.rsplit(".", 1) if "." in filename else (filename, format)
+            base, ext = filename.rsplit(".", 1) if "." in filename else (filename, format or "npz")
             ch_filename = f"{base}_ch{ch}.{ext}"
             self.scope.waveform.save_waveform(waveform, ch_filename, format=format)
             logger.info(f"Saved channel {ch} to {ch_filename}")
 
-    def save_batch(self, batch_results: List[Dict[str, Any]], output_dir: str, format: str = "npz") -> None:
+    def save_batch(self, batch_results: List[Dict[str, Any]], output_dir: str, format: Optional[str] = None) -> None:
         """Save batch capture results to directory.
 
         Args:
             batch_results: List of batch capture results
             output_dir: Output directory path
-            format: File format ('npz', 'csv', 'mat', 'h5')
+            format: File format - one of 'CSV', 'CSV_ENHANCED', 'NPY', 'MAT', 'HDF5'.
+                If None (default), the format is auto-detected from each generated
+                filename's extension.
 
         Example:
             >>> results = collector.batch_capture(...)
@@ -398,8 +402,9 @@ class DataCollector:
             config_str = "_".join([f"{k}={v}" for k, v in result["config"].items()]).replace("/", "-")
             trigger_num = result["trigger_num"]
 
+            ext = format or "npz"
             for ch, waveform in result["waveforms"].items():
-                filename = f"capture_{i:04d}_ch{ch}_{config_str}_trig{trigger_num}.{format}"
+                filename = f"capture_{i:04d}_ch{ch}_{config_str}_trig{trigger_num}.{ext}"
                 filepath = output_path / filename
                 self.scope.waveform.save_waveform(waveform, str(filepath), format=format)
 

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -1204,36 +1204,36 @@ class WaveformAnalyzer:
         abs_slope = abs(slope)
 
         if abs_slope < SLOPE_THRESHOLD_GOOD:
-            return "✓ Probe compensation is good. Plateau is flat and stable."
+            return "[OK] Probe compensation is good. Plateau is flat and stable."
 
         elif abs_slope < SLOPE_THRESHOLD_MODERATE:
             # Determine direction based on slope sign
             if slope > 0:
                 # Positive slope (rising plateau) indicates undercompensation
-                return "⚠ Probe is slightly undercompensated. " "Turn trimmer capacitor clockwise 10-15° and retest. " f"(Measured slope: {slope:.0f} V/s)"
+                return "[WARNING] Probe is slightly undercompensated. " "Turn trimmer capacitor clockwise 10-15 degrees and retest. " f"(Measured slope: {slope:.0f} V/s)"
             else:
                 # Negative slope (falling plateau) indicates overcompensation
-                return "⚠ Probe is slightly overcompensated. " "Turn trimmer capacitor counter-clockwise 10-15° and retest. " f"(Measured slope: {slope:.0f} V/s)"
+                return "[WARNING] Probe is slightly overcompensated. " "Turn trimmer capacitor counter-clockwise 10-15 degrees and retest. " f"(Measured slope: {slope:.0f} V/s)"
 
         elif abs_slope < SLOPE_THRESHOLD_POOR:
             if slope > 0:
-                return "⚠⚠ Probe is undercompensated. " "Turn trimmer capacitor clockwise 30-45° and retest. " f"(Measured slope: {slope:.0f} V/s)"
+                return "[WARNING] Probe is undercompensated. " "Turn trimmer capacitor clockwise 30-45 degrees and retest. " f"(Measured slope: {slope:.0f} V/s)"
             else:
-                return "⚠⚠ Probe is overcompensated. " "Turn trimmer capacitor counter-clockwise 30-45° and retest. " f"(Measured slope: {slope:.0f} V/s)"
+                return "[WARNING] Probe is overcompensated. " "Turn trimmer capacitor counter-clockwise 30-45 degrees and retest. " f"(Measured slope: {slope:.0f} V/s)"
 
         else:
             # Severe compensation issue
             if slope > 0:
                 return (
-                    "⚠⚠⚠ Probe is severely undercompensated! "
-                    "Turn trimmer capacitor clockwise 60-90° and retest. "
+                    "[WARNING] Probe is severely undercompensated! "
+                    "Turn trimmer capacitor clockwise 60-90 degrees and retest. "
                     "If problem persists, check probe connection and cable. "
                     f"(Measured slope: {slope:.0f} V/s)"
                 )
             else:
                 return (
-                    "⚠⚠⚠ Probe is severely overcompensated! "
-                    "Turn trimmer capacitor counter-clockwise 60-90° and retest. "
+                    "[WARNING] Probe is severely overcompensated! "
+                    "Turn trimmer capacitor counter-clockwise 60-90 degrees and retest. "
                     "If problem persists, check probe connection and cable. "
                     f"(Measured slope: {slope:.0f} V/s)"
                 )

--- a/scripts/docs/docs_config.yaml
+++ b/scripts/docs/docs_config.yaml
@@ -17,6 +17,7 @@ examples:
       - "psu_basic_control.py"
       - "function_generator_basic.py"
       - "data_logger_basic.py"
+      - "network_discovery.py"
 
     intermediate:
       - "live_plot.py"
@@ -27,6 +28,8 @@ examples:
       - "trend_logging_walkthrough.py"
       - "psu_advanced_features.py"
       - "psu_usb_connection.py"
+      - "synthetic_signals.py"
+      - "waveform_provenance_and_extract.py"
 
     advanced:
       - "advanced_analysis.py"
@@ -34,6 +37,9 @@ examples:
       - "probe_calibration_analysis.py"
       - "report_generation_example.py"
       - "psu_gui_test.py"
+      - "report_branding.py"
+      - "report_computed_analysis.py"
+      - "report_ai_qa.py"
 
   # Files to exclude from documentation
   exclude_files:

--- a/scripts/docs/generate_examples_docs.py
+++ b/scripts/docs/generate_examples_docs.py
@@ -37,6 +37,30 @@ class ExampleMetadata:
     scope_ip: str
     category: str
     requirements: List[str]
+    no_hardware: bool
+
+
+# Phrases examples actually use in their docstrings to say they need no real
+# instrument (mock-only, synthetic data, etc.). Matched case-insensitively
+# against the module docstring so examples that document themselves as
+# hardware-free don't get an oscilloscope requirement or SCOPE_IP
+# configuration block stamped on them.
+NO_HARDWARE_PATTERN = re.compile(
+    r"no hardware|mock connection|fully synthetic|without hardware|hardware-free|no instrument needed",
+    re.IGNORECASE,
+)
+
+
+def is_no_hardware_example(docstring: str) -> bool:
+    """Detect whether an example's docstring declares it needs no real hardware.
+
+    Args:
+        docstring: Module docstring.
+
+    Returns:
+        True if the docstring indicates the example runs without hardware.
+    """
+    return bool(NO_HARDWARE_PATTERN.search(docstring))
 
 
 def load_config(config_path: Path = None) -> dict:
@@ -130,7 +154,10 @@ def extract_requirements(filepath: Path, docstring: str) -> List[str]:
     if not requirements:
         requirements = ["scpi_control - Core library"]
 
-    requirements.append("Oscilloscope connected to network")
+    if is_no_hardware_example(docstring):
+        requirements.append("No hardware required")
+    else:
+        requirements.append("Oscilloscope connected to network")
 
     return requirements
 
@@ -230,6 +257,7 @@ def parse_example_file(filepath: Path, config: dict) -> ExampleMetadata:
         scope_ip=scope_ip,
         category=category,
         requirements=requirements,
+        no_hardware=is_no_hardware_example(docstring),
     )
 
 
@@ -264,7 +292,10 @@ def generate_example_section(example: ExampleMetadata) -> str:
     # Configuration
     lines.append("### Configuration")
     lines.append("")
-    lines.append(f"Update `SCOPE_IP` to match your oscilloscope's IP address (default: `{example.scope_ip}`).")
+    if example.no_hardware:
+        lines.append("No hardware required.")
+    else:
+        lines.append(f"Update `SCOPE_IP` to match your oscilloscope's IP address (default: `{example.scope_ip}`).")
     lines.append("")
 
     # Usage

--- a/scripts/docs/generate_examples_docs.py
+++ b/scripts/docs/generate_examples_docs.py
@@ -16,6 +16,7 @@ Output:
 
 import ast
 import re
+import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -153,6 +154,30 @@ def get_example_title(filename: str, docstring: str) -> str:
     # Generate from filename
     name = filename.replace(".py", "").replace("_", " ").title()
     return name
+
+
+def slugify_heading(title: str) -> str:
+    """Slugify a heading the same way Python-Markdown's ``toc`` extension does.
+
+    MkDocs (via Python-Markdown's ``toc`` extension, as configured with
+    ``permalink: true`` and no custom slugify function) generates heading
+    anchors with ``markdown.extensions.toc.slugify(value, '-')``. That
+    function: NFKD-normalizes and drops non-ASCII characters, strips
+    everything that isn't a word character, whitespace, or hyphen, lowercases
+    the result, then collapses runs of whitespace into a single separator.
+    Reimplemented here (rather than importing ``markdown``) so the TOC links
+    generated in this script always match the anchors MkDocs actually emits.
+
+    Args:
+        title: Heading text (e.g. an example's title).
+
+    Returns:
+        URL anchor fragment (without the leading '#').
+    """
+    value = unicodedata.normalize("NFKD", title)
+    value = value.encode("ascii", "ignore").decode("ascii")
+    value = re.sub(r"[^\w\s-]", "", value).strip().lower()
+    return re.sub(r"[-\s]+", "-", value)
 
 
 def categorize_example(filename: str, config: dict) -> str:
@@ -299,7 +324,7 @@ def generate_category_page(category: str, examples: List[ExampleMetadata], confi
     lines.append("| Example | Description |")
     lines.append("|---------|-------------|")
     for example in examples:
-        anchor = example.title.lower().replace(" ", "-")
+        anchor = slugify_heading(example.title)
         lines.append(f"| [{example.title}](#{anchor}) | {example.description} |")
     lines.append("")
 

--- a/tests/test_automation_save.py
+++ b/tests/test_automation_save.py
@@ -1,0 +1,128 @@
+"""Regression tests for DataCollector.save_data / save_batch default format.
+
+Bug: both methods defaulted to format="npz" and passed it straight through to
+Waveform.save_waveform, which upper-cases the format string and only accepts
+CSV, CSV_ENHANCED, NPY, MAT, HDF5 -- "NPZ" is not among them, so the default
+(documented) call path raised InvalidParameterError. The fix changes the
+default to None so save_waveform's extension-based auto-detect applies.
+"""
+
+import numpy as np
+import pytest
+
+from scpi_control.automation import DataCollector
+from scpi_control.connection.mock import MockConnection
+from scpi_control.exceptions import InvalidParameterError
+from scpi_control.waveform import WaveformData
+
+
+@pytest.fixture
+def collector():
+    mock_connection = MockConnection(
+        channel_states={1: True, 2: True},
+        sample_rate=1_000.0,
+        timebase=1e-3,
+    )
+    return DataCollector("mock", connection=mock_connection)
+
+
+def _make_waveform(channel: int) -> WaveformData:
+    time = np.linspace(0, 1e-3, 100)
+    voltage = np.sin(2 * np.pi * 1000 * time)
+    return WaveformData(
+        time=time,
+        voltage=voltage,
+        channel=channel,
+        sample_rate=1_000.0,
+        timebase=1e-3,
+        voltage_scale=1.0,
+    )
+
+
+def test_save_data_default_format_writes_npz_loadable_by_numpy(tmp_path):
+    """Regression test: default save_data(...) call must not raise.
+
+    This mirrors the README example: collector.save_data(data, 'measurement.npz').
+    """
+    mock_connection = MockConnection(channel_states={1: True}, sample_rate=1_000.0, timebase=1e-3)
+    collector = DataCollector("mock", connection=mock_connection)
+    waveforms = {1: _make_waveform(1)}
+    filename = str(tmp_path / "measurement.npz")
+
+    collector.save_data(waveforms, filename)
+
+    saved_path = tmp_path / "measurement_ch1.npz"
+    assert saved_path.exists()
+
+    with np.load(saved_path, allow_pickle=True) as npz:
+        assert "time" in npz
+        assert "voltage" in npz
+        assert len(npz["time"]) == 100
+        assert len(npz["voltage"]) == 100
+
+
+def test_save_data_explicit_npy_format_works(tmp_path):
+    # Filename intentionally ends in .npz: numpy's np.savez() appends a .npz
+    # suffix itself whenever the target name doesn't already end in .npz, so a
+    # ".npy" filename here would land on disk as "..._ch1.npy.npz" -- a quirk
+    # of numpy, not something this fix changes. Using ".npz" keeps the test
+    # focused on the explicit-format contract this fix is pinning.
+    mock_connection = MockConnection(channel_states={1: True}, sample_rate=1_000.0, timebase=1e-3)
+    collector = DataCollector("mock", connection=mock_connection)
+    waveforms = {1: _make_waveform(1)}
+    filename = str(tmp_path / "measurement.npz")
+
+    collector.save_data(waveforms, filename, format="NPY")
+
+    saved_path = tmp_path / "measurement_ch1.npz"
+    assert saved_path.exists()
+
+    with np.load(saved_path, allow_pickle=True) as npz:
+        assert "time" in npz
+        assert "voltage" in npz
+
+
+def test_save_data_explicit_lowercase_npz_still_raises(tmp_path):
+    """Pin the contract: save_waveform only accepts the exact tokens it upper-cases
+    to CSV/CSV_ENHANCED/NPY/MAT/HDF5. An explicit format="npz" is not one of them
+    and must still raise -- only the *default* (None) auto-detects."""
+    mock_connection = MockConnection(channel_states={1: True}, sample_rate=1_000.0, timebase=1e-3)
+    collector = DataCollector("mock", connection=mock_connection)
+    waveforms = {1: _make_waveform(1)}
+    filename = str(tmp_path / "measurement.npz")
+
+    with pytest.raises(InvalidParameterError):
+        collector.save_data(waveforms, filename, format="npz")
+
+
+def test_save_batch_default_format_smoke(tmp_path):
+    mock_connection = MockConnection(channel_states={1: True, 2: True}, sample_rate=1_000.0, timebase=1e-3)
+    collector = DataCollector("mock", connection=mock_connection)
+
+    batch_results = [
+        {
+            "timestamp": "2026-07-21T00:00:00",
+            "config": {"timebase": "1e-3"},
+            "waveforms": {1: _make_waveform(1), 2: _make_waveform(2)},
+            "trigger_num": 0,
+        },
+        {
+            "timestamp": "2026-07-21T00:00:01",
+            "config": {"timebase": "1e-3"},
+            "waveforms": {1: _make_waveform(1), 2: _make_waveform(2)},
+            "trigger_num": 1,
+        },
+    ]
+
+    output_dir = tmp_path / "batch_out"
+    collector.save_batch(batch_results, str(output_dir))
+
+    saved_files = sorted(output_dir.glob("capture_*.npz"))
+    assert len(saved_files) == 4  # 2 captures * 2 channels
+
+    for saved_file in saved_files:
+        with np.load(saved_file, allow_pickle=True) as npz:
+            assert "time" in npz
+            assert "voltage" in npz
+
+    assert (output_dir / "metadata.txt").exists()


### PR DESCRIPTION
## Summary

Audit-driven documentation sweep: three parallel audits (README, examples, docs site) plus a mechanical link check of every markdown file, then fixes for everything found. One real code bug surfaced and is fixed here too.

**Code fixes**
- `DataCollector.save_data()` / `save_batch()` no longer raise `InvalidParameterError` on their default format — it now auto-detects from the filename extension (the README's own quick-start snippet used to crash). New regression tests in `tests/test_automation_save.py`.
- Report-analyzer calibration guidance strings are ASCII-safe (no more `UnicodeEncodeError` on legacy Windows consoles).
- `scripts/docs/generate_examples_docs.py`: anchors now match mkdocs' real slugification (the old naive slugs produced broken TOC links on every regeneration), and no-hardware examples no longer get "Oscilloscope connected to network" boilerplate stamped on them.

**README**
- Replaced the report-generator quick-start (it used a fabricated API — `ReportGenerator`/`PDFGenerator` don't exist) with a real, executed sample; fixed the default SCPI port (5024 → 5025, three places) and the GUI frame-rate claim.
- Documented what was missing: multi-vendor scopes, DAQ, PSU/AWG supported models, `web` and `usb` extras, all four CLI tools, `load_waveform()` + `scpi-extract` usage, the GUI's Power Supply / Data Logger / Terminal tabs, `--testmon`.
- Removed three dead links (two nonexistent screenshots, a nonexistent guide) and repointed the Code of Conduct link.

**Examples** — every script now has a fully spelled-out docstring (what it demonstrates, what it needs, what to expect); requirements labels corrected (matplotlib/scipy are core deps; `report_generation_example.py` is no-hardware); non-ASCII prints replaced across six scripts; `psu_basic_control.py` gets a proper `PSU_IP` constant.

**Docs site**
- `docs/superpowers/` (61 internal planning files) is now excluded from the built site.
- Four new API reference pages: `signal_synth`, `waveform_io`, `provenance`, `scpi_extract`.
- Changelog page synced through 3.3.0; stale `MockConnection` testing guide rewritten against the real API (example executed to verify); old package-name install commands corrected; all 3 broken links and 6 broken anchors fixed; "Next Steps" cross-links added for the provenance/synthetic-signals guides; examples pages regenerated with the new examples included.
- External links verified across all 83 markdown files (two genuinely dead URLs fixed; remaining flags are bot-blocking/placeholder false positives).

## Test plan

- [x] Full suite: 1116 passed / 19 skipped (baseline 1112; +4 regression tests)
- [x] `mkdocs build` exit 0 — zero link/anchor warnings, no superpowers/ files in the built site
- [x] Examples-docs regeneration idempotent (`git status` clean after rerun)
- [x] Both new doc code samples executed verbatim (README report-generator sample; testing.md MockConnection example)
- [x] `black --check --line-length 200` and `flake8 --select=E9,F63,F7,F82` clean; changed markdown BOM-free
