### PR TITLE
chore: add pytest-xdist for parallel local test runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Dev tooling: `pytest-xdist` in the `dev` extra for parallel local test runs (`python -m pytest -n auto`); complements `--testmon` (use one or the other per invocation).
+
 ## [3.3.1] - 2026-07-21
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,24 @@ python -m pytest tests/
 
 CI and pre-merge checks always run the full suite.
 
+### Parallel Local Runs with xdist
+
+`pytest-xdist` (installed with the `dev` extra) spreads the suite across
+multiple worker processes:
+
+```bash
+python -m pytest -n auto
+```
+
+`-n auto` spawns one worker per CPU core; on a multi-core machine this cuts
+full-suite wall time substantially. Prefer `--testmon` for tight edit loops
+where only a handful of tests need to rerun, and `-n auto` when you want the
+whole suite fast (e.g. before committing) — run one or the other per
+invocation rather than combining them. (In local testing with pytest-testmon
+2.2.0 and pytest-xdist 3.8.0, `--testmon -n auto` together did not error and
+testmon's change detection still worked correctly across workers, but this
+combination isn't a primary supported workflow, so keep them separate.)
+
 ### Writing Tests
 
 - Place tests in the `tests/` directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0.0",
     "pytest-testmon>=2.0",
+    "pytest-xdist>=3.5",
     "codecov>=2.1.0",
     "black>=26.5,<27; python_version >= '3.10'",
     "flake8>=6.0",


### PR DESCRIPTION
## Summary

Adds pytest-xdist to the dev extra for parallel local test runs, verified parallel-safe before wiring in:

- Two full `-n auto` runs: 1116 passed / 19 skipped each, no reordering flakiness, zero shared-state conflicts (no test changes or xdist_group markers needed)
- Wall time: 111 s serial -> 41 s parallel (16 workers, ~2.7x) on a 32-logical-core machine
- CONTRIBUTING documents when to use `-n auto` vs `--testmon` (one per invocation), including the empirically-tested note that the combination happens to work but is not a primary supported workflow
- Changelog entry under [Unreleased]

## Test plan

- [x] Two parallel full-suite runs green; final serial run 1116 / 19 unchanged
- [x] flake8 gate clean; CHANGELOG byte-clean (no BOM)
