### PR TITLE
Comparison & batch reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Dev tooling: `pytest-xdist` in the `dev` extra for parallel local test runs (`python -m pytest -n auto`); complements `--testmon` (use one or the other per invocation).
+- Report generator: before/after comparison and multi-DUT batch reports — load multiple capture-file runs, overlay their waveforms, and get delta tables (comparison) or per-DUT summary with aggregates and yield (batch). Available from the Python API and the GUI's new Report → Comparison / Batch Report dialog.
+- Report generator: optional raw-data appendix (source-file manifest with SHA-256 checksums, capture timestamps, and instrument identity from provenance) and a configurable sign-off block (template-defined roles with signature/date lines). Both also work on ordinary single-run reports.
+
+### Fixed
+
+- Report generator: the waveform loader no longer drops acquisition provenance when loading capture files.
 
 ## [3.3.1] - 2026-07-21
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ PDFReportGenerator().generate(report, Path("calibration_report.pdf"))
 - ✅ **Region Extraction** - Zoom into plateaus, edges, and transients with calibration guidance
 - ✅ **Multiple Formats** - Generate PDF and Markdown reports with embedded plots
 - ✅ **Professional Layout** - Publication-ready reports with metadata, statistics tables, and visualizations
+- ✅ **Comparison & Batch Reports** - Compare before/after captures or aggregate multi-DUT batches with delta/yield tables, a sign-off block, and a SHA-256 raw-data manifest; available via `Report → Comparison / Batch Report…` in the GUI
 
 **Report Sections Include:**
 

--- a/docs/api/comparison.md
+++ b/docs/api/comparison.md
@@ -1,0 +1,49 @@
+# Comparison & Batch Reports
+
+Multi-run comparison (before/after deltas) and batch (cross-DUT yield) analysis and report building
+
+::: scpi_control.report_generator.models.comparison
+    options:
+      show_root_heading: false
+      show_source: true
+      heading_level: 2
+      members_order: source
+      group_by_category: true
+      show_signature_annotations: true
+      separate_signature: true
+      merge_init_into_class: true
+      filters:
+        - "!^_"  # Exclude private members
+
+::: scpi_control.report_generator.analysis.comparison_analyzer
+    options:
+      show_root_heading: false
+      show_source: true
+      heading_level: 2
+      members_order: source
+      group_by_category: true
+      show_signature_annotations: true
+      separate_signature: true
+      merge_init_into_class: true
+      filters:
+        - "!^_"  # Exclude private members
+
+::: scpi_control.report_generator.comparison_report_builder
+    options:
+      show_root_heading: false
+      show_source: true
+      heading_level: 2
+      members_order: source
+      group_by_category: true
+      show_signature_annotations: true
+      separate_signature: true
+      merge_init_into_class: true
+      filters:
+        - "!^_"  # Exclude private members
+
+## See Also
+
+- [Waveform](waveform.md) - Waveform acquisition and data handling
+- [Analysis](analysis.md) - Signal analysis (FFT, THD, SNR)
+- [Signal Synthesis](signal_synth.md) - Parameterized synthetic waveforms for hardware-free examples
+- [Report Generator: API Reference](../report-generator/api-reference.md) - Single-run report building blocks (ReportMetadata, TestReport, generators)

--- a/docs/examples/intermediate.md
+++ b/docs/examples/intermediate.md
@@ -7,6 +7,8 @@ Intermediate examples showing automation patterns, real-time data capture, and b
 | Example | Description |
 |---------|-------------|
 | [Batch capture with different configurations](#batch-capture-with-different-configurations) | Batch capture with different configurations. |
+| [Batch report across five synthesized DUTs, one of them an outlier](#batch-report-across-five-synthesized-duts-one-of-them-an-outlier) | Batch report across five synthesized DUTs, one of them an outlier. |
+| [Before/after comparison report: two synthetic captures, one comparison report](#beforeafter-comparison-report-two-synthetic-captures-one-comparison-report) | Before/after comparison report: two synthetic captures, one comparison report. |
 | [Continuous time-series data collection](#continuous-time-series-data-collection) | Continuous time-series data collection. |
 | [Drive the web gateway's REST API from Python — no browser needed](#drive-the-web-gateways-rest-api-from-python-no-browser-needed) | Drive the web gateway's REST API from Python — no browser needed. |
 | [Live plotting example for Siglent oscilloscope](#live-plotting-example-for-siglent-oscilloscope) | Live plotting example for Siglent oscilloscope. |
@@ -106,6 +108,278 @@ def main():
         print("\nSaving batch results to 'batch_output' directory...")
         collector.save_batch(results, "batch_output", format="npz")
         print("Done! Results saved to 'batch_output/' with metadata.txt")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+## Batch report across five synthesized DUTs, one of them an outlier
+
+Batch report across five synthesized DUTs, one of them an outlier.
+
+### Requirements
+
+- scpi_control - Core library
+- No hardware required
+
+### Configuration
+
+No hardware required.
+
+### Usage
+
+```bash
+python examples/batch_report.py
+```
+
+### Source Code
+
+```python
+"""Batch report across five synthesized DUTs, one of them an outlier.
+
+Synthesizes five "DUT" captures (four within spec, one with a high outlier
+amplitude), runs them through the comparison pipeline in batch mode
+(MODE_BATCH), and builds a report showing per-DUT pass/fail, cross-run
+aggregate statistics (mean/std/min/max), and a yield figure that lands in the
+executive summary -- e.g. "Yield: 4/5 passed (80%)".
+
+No real oscilloscope required -- every DUT capture is fully synthetic.
+
+Requirements: SCPI-Instrument-Control[report-generator] -- no hardware needed.
+
+Expected output: 'batch_report_output/batch_report.md' (plus a 'plots'
+subdirectory with the overlay image).
+"""
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import Mock
+
+from scpi_control.provenance import AcquisitionProvenance, InstrumentInfo
+from scpi_control.report_generator.analysis.comparison_analyzer import ComparisonAnalyzer
+from scpi_control.report_generator.comparison_report_builder import build_comparison_report
+from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
+from scpi_control.report_generator.models.comparison import MODE_BATCH, Run, RunMetadata, RunSet
+from scpi_control.report_generator.models.criteria import ComparisonType, CriteriaSet, MeasurementCriteria
+from scpi_control.report_generator.models.report_data import ReportMetadata
+from scpi_control.signal_synth import SignalSpec, make_waveform
+from scpi_control.waveform import Waveform
+
+OUTPUT_DIR = Path("batch_report_output")
+
+# Nominal amplitude is 1.0 V (Vpp ~2.0 V); DUT-04 is a deliberate outlier.
+DUT_AMPLITUDES = [1.0, 1.02, 0.98, 1.35, 1.01]
+
+
+def _save_capture(name: str, amplitude: float, seed: int) -> Path:
+    """Synthesize one sine capture and save it as CSV, provenance attached.
+
+    save_waveform() only writes the channel header line on plain CSV when
+    waveform.provenance is set -- see scpi_control/waveform.py.
+    """
+    waveform = make_waveform(SignalSpec(kind="sine", frequency=1_000.0, amplitude=amplitude, noise_rms=0.02, seed=seed), sample_rate=100_000.0, n_points=2_000)
+    waveform.provenance = AcquisitionProvenance(instrument=InstrumentInfo(manufacturer="Siglent", model="SDS1104X-E"))
+    path = OUTPUT_DIR / name
+    Waveform(Mock()).save_waveform(waveform, str(path), format="CSV")
+    return path
+
+
+def build_runset() -> RunSet:
+    """Five DUT runs, one with an out-of-spec amplitude."""
+    runs = []
+    for i, amplitude in enumerate(DUT_AMPLITUDES, start=1):
+        dut_id = f"DUT-{i:02d}"
+        capture_file = _save_capture(f"{dut_id.lower()}.csv", amplitude=amplitude, seed=100 + i)
+        runs.append(Run(label=dut_id, files=[capture_file], metadata=RunMetadata(dut_id=dut_id)))
+
+    # Vpp must land within 1.8-2.2 V; DUT-04's higher amplitude (Vpp ~2.7 V) fails.
+    criteria = CriteriaSet(name="Vpp acceptance", description="Output amplitude acceptance window")
+    criteria.add_criteria(MeasurementCriteria(measurement_name="vpp", comparison_type=ComparisonType.RANGE, min_value=1.8, max_value=2.2, description="Peak-to-peak within spec", severity="critical"))
+
+    return RunSet(runs=runs, mode=MODE_BATCH, criteria_set=criteria)
+
+
+def main() -> None:
+    print("=" * 60)
+    print("Batch report demo")
+    print("=" * 60)
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+
+    runset = build_runset()
+    result = ComparisonAnalyzer.analyze(runset)
+
+    print(f"Yield: {result.yield_passed}/{result.yield_total} DUTs passed")
+
+    metadata = ReportMetadata(
+        title="Production Batch Test",
+        technician="Lab Tech",
+        test_date=datetime.now(),
+        equipment_model="SDS1104X-E",
+    )
+    # build_comparison_report() includes the raw-data appendix (SHA-256
+    # manifest) and a sign-off block by default -- pass include_appendix=False
+    # / include_signoff=False, or a ReportTemplate, to change that.
+    report = build_comparison_report(result, metadata)
+
+    print(f"Overall result: {report.overall_result}")
+    print(f"Executive summary: {report.executive_summary}")
+
+    md_path = OUTPUT_DIR / "batch_report.md"
+    if MarkdownReportGenerator().generate(report, md_path):
+        print(f"  [OK] {md_path}")
+    else:
+        print("  [FAILED] Markdown report generation failed")
+
+    # For a PDF instead (or in addition), install the optional dependency and swap in
+    # PDFReportGenerator: pip install "SCPI-Instrument-Control[report-generator]"
+    #   from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator
+    #   PDFReportGenerator().generate(report, OUTPUT_DIR / "batch_report.pdf")
+
+    print("=" * 60)
+    print("Done.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+## Before/after comparison report: two synthetic captures, one comparison report
+
+Before/after comparison report: two synthetic captures, one comparison report.
+
+### Requirements
+
+- scpi_control - Core library
+- No hardware required
+
+### Configuration
+
+No hardware required.
+
+### Usage
+
+```bash
+python examples/comparison_report.py
+```
+
+### Source Code
+
+```python
+"""Before/after comparison report: two synthetic captures, one comparison report.
+
+Synthesizes a "before" and an "after" capture with make_waveform() (the "after"
+capture has higher amplitude and more noise), saves each as CSV, then runs the
+new comparison pipeline: RunSet -> ComparisonAnalyzer -> build_comparison_report().
+A vpp CriteriaSet marks the amplitude regression as a failure, and the rendered
+Markdown report includes the overlay plot, a Delta/Delta% table vs baseline, a
+SHA-256 raw-data manifest, and a sign-off block (both on by default for
+comparison reports).
+
+No real oscilloscope required -- both captures are fully synthetic.
+
+Requirements: SCPI-Instrument-Control[report-generator] -- no hardware needed.
+
+Expected output: 'comparison_report_output/comparison_report.md' (plus a
+'plots' subdirectory with the overlay image).
+"""
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import Mock
+
+from scpi_control.provenance import AcquisitionProvenance, InstrumentInfo
+from scpi_control.report_generator.analysis.comparison_analyzer import ComparisonAnalyzer
+from scpi_control.report_generator.comparison_report_builder import build_comparison_report
+from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
+from scpi_control.report_generator.models.comparison import Run, RunMetadata, RunSet
+from scpi_control.report_generator.models.criteria import ComparisonType, CriteriaSet, MeasurementCriteria
+from scpi_control.report_generator.models.report_data import ReportMetadata
+from scpi_control.signal_synth import SignalSpec, make_waveform
+from scpi_control.waveform import Waveform
+
+OUTPUT_DIR = Path("comparison_report_output")
+
+
+def _save_capture(name: str, amplitude: float, noise_rms: float) -> Path:
+    """Synthesize one sine capture and save it as CSV, provenance attached.
+
+    save_waveform() only writes the channel header line on plain CSV when
+    waveform.provenance is set -- without it every plain CSV round-trips as
+    channel "1" regardless of the synthesized channel, which is harmless here
+    (a single channel per run) but matches the convention used elsewhere.
+    """
+    waveform = make_waveform(SignalSpec(kind="sine", frequency=1_000.0, amplitude=amplitude, noise_rms=noise_rms, seed=42), sample_rate=100_000.0, n_points=2_000)
+    waveform.provenance = AcquisitionProvenance(instrument=InstrumentInfo(manufacturer="Siglent", model="SDS1104X-E"))
+    path = OUTPUT_DIR / name
+    Waveform(Mock()).save_waveform(waveform, str(path), format="CSV")
+    return path
+
+
+def build_runset() -> RunSet:
+    """Two runs: a clean 'before' capture and a noisier, higher-amplitude 'after'."""
+    before_file = _save_capture("before.csv", amplitude=1.0, noise_rms=0.02)
+    after_file = _save_capture("after.csv", amplitude=1.3, noise_rms=0.06)
+
+    # Vpp is expected to stay within 1.8-2.2 V; the "after" run's higher
+    # amplitude (Vpp ~2.6 V) will fail this and show up as a delta and a FAIL.
+    criteria = CriteriaSet(name="Vpp stability", description="Output amplitude must not drift")
+    criteria.add_criteria(MeasurementCriteria(measurement_name="vpp", comparison_type=ComparisonType.RANGE, min_value=1.8, max_value=2.2, description="Peak-to-peak within spec", severity="critical"))
+
+    return RunSet(
+        runs=[
+            Run(label="before", files=[before_file], metadata=RunMetadata(condition="Before firmware update")),
+            Run(label="after", files=[after_file], metadata=RunMetadata(condition="After firmware update")),
+        ],
+        criteria_set=criteria,
+        # mode defaults to MODE_COMPARISON; baseline_index defaults to 0 ("before").
+    )
+
+
+def main() -> None:
+    print("=" * 60)
+    print("Comparison report demo")
+    print("=" * 60)
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+
+    runset = build_runset()
+    result = ComparisonAnalyzer.analyze(runset)
+
+    metadata = ReportMetadata(
+        title="Firmware Update Regression Check",
+        technician="Lab Tech",
+        test_date=datetime.now(),
+        equipment_model="SDS1104X-E",
+    )
+    # build_comparison_report() includes the raw-data appendix (SHA-256
+    # manifest) and a sign-off block by default -- pass include_appendix=False
+    # / include_signoff=False, or a ReportTemplate, to change that.
+    report = build_comparison_report(result, metadata)
+
+    print(f"Overall result: {report.overall_result}")
+    print(f"Executive summary: {report.executive_summary}")
+
+    md_path = OUTPUT_DIR / "comparison_report.md"
+    if MarkdownReportGenerator().generate(report, md_path):
+        print(f"  [OK] {md_path}")
+    else:
+        print("  [FAILED] Markdown report generation failed")
+
+    # For a PDF instead (or in addition), install the optional dependency and swap in
+    # PDFReportGenerator: pip install "SCPI-Instrument-Control[report-generator]"
+    #   from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator
+    #   PDFReportGenerator().generate(report, OUTPUT_DIR / "comparison_report.pdf")
+
+    print("=" * 60)
+    print("Done.")
+    print("=" * 60)
 
 
 if __name__ == "__main__":

--- a/examples/batch_report.py
+++ b/examples/batch_report.py
@@ -1,0 +1,108 @@
+"""Batch report across five synthesized DUTs, one of them an outlier.
+
+Synthesizes five "DUT" captures (four within spec, one with a high outlier
+amplitude), runs them through the comparison pipeline in batch mode
+(MODE_BATCH), and builds a report showing per-DUT pass/fail, cross-run
+aggregate statistics (mean/std/min/max), and a yield figure that lands in the
+executive summary -- e.g. "Yield: 4/5 passed (80%)".
+
+No real oscilloscope required -- every DUT capture is fully synthetic.
+
+Requirements: SCPI-Instrument-Control[report-generator] -- no hardware needed.
+
+Expected output: 'batch_report_output/batch_report.md' (plus a 'plots'
+subdirectory with the overlay image).
+"""
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import Mock
+
+from scpi_control.provenance import AcquisitionProvenance, InstrumentInfo
+from scpi_control.report_generator.analysis.comparison_analyzer import ComparisonAnalyzer
+from scpi_control.report_generator.comparison_report_builder import build_comparison_report
+from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
+from scpi_control.report_generator.models.comparison import MODE_BATCH, Run, RunMetadata, RunSet
+from scpi_control.report_generator.models.criteria import ComparisonType, CriteriaSet, MeasurementCriteria
+from scpi_control.report_generator.models.report_data import ReportMetadata
+from scpi_control.signal_synth import SignalSpec, make_waveform
+from scpi_control.waveform import Waveform
+
+OUTPUT_DIR = Path("batch_report_output")
+
+# Nominal amplitude is 1.0 V (Vpp ~2.0 V); DUT-04 is a deliberate outlier.
+DUT_AMPLITUDES = [1.0, 1.02, 0.98, 1.35, 1.01]
+
+
+def _save_capture(name: str, amplitude: float, seed: int) -> Path:
+    """Synthesize one sine capture and save it as CSV, provenance attached.
+
+    save_waveform() only writes the channel header line on plain CSV when
+    waveform.provenance is set -- see scpi_control/waveform.py.
+    """
+    waveform = make_waveform(SignalSpec(kind="sine", frequency=1_000.0, amplitude=amplitude, noise_rms=0.02, seed=seed), sample_rate=100_000.0, n_points=2_000)
+    waveform.provenance = AcquisitionProvenance(instrument=InstrumentInfo(manufacturer="Siglent", model="SDS1104X-E"))
+    path = OUTPUT_DIR / name
+    Waveform(Mock()).save_waveform(waveform, str(path), format="CSV")
+    return path
+
+
+def build_runset() -> RunSet:
+    """Five DUT runs, one with an out-of-spec amplitude."""
+    runs = []
+    for i, amplitude in enumerate(DUT_AMPLITUDES, start=1):
+        dut_id = f"DUT-{i:02d}"
+        capture_file = _save_capture(f"{dut_id.lower()}.csv", amplitude=amplitude, seed=100 + i)
+        runs.append(Run(label=dut_id, files=[capture_file], metadata=RunMetadata(dut_id=dut_id)))
+
+    # Vpp must land within 1.8-2.2 V; DUT-04's higher amplitude (Vpp ~2.7 V) fails.
+    criteria = CriteriaSet(name="Vpp acceptance", description="Output amplitude acceptance window")
+    criteria.add_criteria(MeasurementCriteria(measurement_name="vpp", comparison_type=ComparisonType.RANGE, min_value=1.8, max_value=2.2, description="Peak-to-peak within spec", severity="critical"))
+
+    return RunSet(runs=runs, mode=MODE_BATCH, criteria_set=criteria)
+
+
+def main() -> None:
+    print("=" * 60)
+    print("Batch report demo")
+    print("=" * 60)
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+
+    runset = build_runset()
+    result = ComparisonAnalyzer.analyze(runset)
+
+    print(f"Yield: {result.yield_passed}/{result.yield_total} DUTs passed")
+
+    metadata = ReportMetadata(
+        title="Production Batch Test",
+        technician="Lab Tech",
+        test_date=datetime.now(),
+        equipment_model="SDS1104X-E",
+    )
+    # build_comparison_report() includes the raw-data appendix (SHA-256
+    # manifest) and a sign-off block by default -- pass include_appendix=False
+    # / include_signoff=False, or a ReportTemplate, to change that.
+    report = build_comparison_report(result, metadata)
+
+    print(f"Overall result: {report.overall_result}")
+    print(f"Executive summary: {report.executive_summary}")
+
+    md_path = OUTPUT_DIR / "batch_report.md"
+    if MarkdownReportGenerator().generate(report, md_path):
+        print(f"  [OK] {md_path}")
+    else:
+        print("  [FAILED] Markdown report generation failed")
+
+    # For a PDF instead (or in addition), install the optional dependency and swap in
+    # PDFReportGenerator: pip install "SCPI-Instrument-Control[report-generator]"
+    #   from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator
+    #   PDFReportGenerator().generate(report, OUTPUT_DIR / "batch_report.pdf")
+
+    print("=" * 60)
+    print("Done.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/comparison_report.py
+++ b/examples/comparison_report.py
@@ -1,0 +1,112 @@
+"""Before/after comparison report: two synthetic captures, one comparison report.
+
+Synthesizes a "before" and an "after" capture with make_waveform() (the "after"
+capture has higher amplitude and more noise), saves each as CSV, then runs the
+new comparison pipeline: RunSet -> ComparisonAnalyzer -> build_comparison_report().
+A vpp CriteriaSet marks the amplitude regression as a failure, and the rendered
+Markdown report includes the overlay plot, a Delta/Delta% table vs baseline, a
+SHA-256 raw-data manifest, and a sign-off block (both on by default for
+comparison reports).
+
+No real oscilloscope required -- both captures are fully synthetic.
+
+Requirements: SCPI-Instrument-Control[report-generator] -- no hardware needed.
+
+Expected output: 'comparison_report_output/comparison_report.md' (plus a
+'plots' subdirectory with the overlay image).
+"""
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import Mock
+
+from scpi_control.provenance import AcquisitionProvenance, InstrumentInfo
+from scpi_control.report_generator.analysis.comparison_analyzer import ComparisonAnalyzer
+from scpi_control.report_generator.comparison_report_builder import build_comparison_report
+from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
+from scpi_control.report_generator.models.comparison import Run, RunMetadata, RunSet
+from scpi_control.report_generator.models.criteria import ComparisonType, CriteriaSet, MeasurementCriteria
+from scpi_control.report_generator.models.report_data import ReportMetadata
+from scpi_control.signal_synth import SignalSpec, make_waveform
+from scpi_control.waveform import Waveform
+
+OUTPUT_DIR = Path("comparison_report_output")
+
+
+def _save_capture(name: str, amplitude: float, noise_rms: float) -> Path:
+    """Synthesize one sine capture and save it as CSV, provenance attached.
+
+    save_waveform() only writes the channel header line on plain CSV when
+    waveform.provenance is set -- without it every plain CSV round-trips as
+    channel "1" regardless of the synthesized channel, which is harmless here
+    (a single channel per run) but matches the convention used elsewhere.
+    """
+    waveform = make_waveform(SignalSpec(kind="sine", frequency=1_000.0, amplitude=amplitude, noise_rms=noise_rms, seed=42), sample_rate=100_000.0, n_points=2_000)
+    waveform.provenance = AcquisitionProvenance(instrument=InstrumentInfo(manufacturer="Siglent", model="SDS1104X-E"))
+    path = OUTPUT_DIR / name
+    Waveform(Mock()).save_waveform(waveform, str(path), format="CSV")
+    return path
+
+
+def build_runset() -> RunSet:
+    """Two runs: a clean 'before' capture and a noisier, higher-amplitude 'after'."""
+    before_file = _save_capture("before.csv", amplitude=1.0, noise_rms=0.02)
+    after_file = _save_capture("after.csv", amplitude=1.3, noise_rms=0.06)
+
+    # Vpp is expected to stay within 1.8-2.2 V; the "after" run's higher
+    # amplitude (Vpp ~2.6 V) will fail this and show up as a delta and a FAIL.
+    criteria = CriteriaSet(name="Vpp stability", description="Output amplitude must not drift")
+    criteria.add_criteria(MeasurementCriteria(measurement_name="vpp", comparison_type=ComparisonType.RANGE, min_value=1.8, max_value=2.2, description="Peak-to-peak within spec", severity="critical"))
+
+    return RunSet(
+        runs=[
+            Run(label="before", files=[before_file], metadata=RunMetadata(condition="Before firmware update")),
+            Run(label="after", files=[after_file], metadata=RunMetadata(condition="After firmware update")),
+        ],
+        criteria_set=criteria,
+        # mode defaults to MODE_COMPARISON; baseline_index defaults to 0 ("before").
+    )
+
+
+def main() -> None:
+    print("=" * 60)
+    print("Comparison report demo")
+    print("=" * 60)
+
+    OUTPUT_DIR.mkdir(exist_ok=True)
+
+    runset = build_runset()
+    result = ComparisonAnalyzer.analyze(runset)
+
+    metadata = ReportMetadata(
+        title="Firmware Update Regression Check",
+        technician="Lab Tech",
+        test_date=datetime.now(),
+        equipment_model="SDS1104X-E",
+    )
+    # build_comparison_report() includes the raw-data appendix (SHA-256
+    # manifest) and a sign-off block by default -- pass include_appendix=False
+    # / include_signoff=False, or a ReportTemplate, to change that.
+    report = build_comparison_report(result, metadata)
+
+    print(f"Overall result: {report.overall_result}")
+    print(f"Executive summary: {report.executive_summary}")
+
+    md_path = OUTPUT_DIR / "comparison_report.md"
+    if MarkdownReportGenerator().generate(report, md_path):
+        print(f"  [OK] {md_path}")
+    else:
+        print("  [FAILED] Markdown report generation failed")
+
+    # For a PDF instead (or in addition), install the optional dependency and swap in
+    # PDFReportGenerator: pip install "SCPI-Instrument-Control[report-generator]"
+    #   from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator
+    #   PDFReportGenerator().generate(report, OUTPUT_DIR / "comparison_report.pdf")
+
+    print("=" * 60)
+    print("Done.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
       - Waveform: api/waveform.md
       - Signal Synthesis: api/signal_synth.md
       - Waveform I/O: api/waveform_io.md
+      - Comparison & Batch Reports: api/comparison.md
       - Provenance: api/provenance.md
       - SCPI Extract (CLI): api/scpi_extract.md
       - Measurement: api/measurement.md

--- a/scpi_control/report_generator/analysis/__init__.py
+++ b/scpi_control/report_generator/analysis/__init__.py
@@ -1,1 +1,9 @@
 """Deterministic, LLM-free report analysis."""
+
+from scpi_control.report_generator.analysis.comparison_analyzer import STAT_UNITS, ComparisonAnalysisError, ComparisonAnalyzer
+
+__all__ = [
+    "STAT_UNITS",
+    "ComparisonAnalysisError",
+    "ComparisonAnalyzer",
+]

--- a/scpi_control/report_generator/analysis/comparison_analyzer.py
+++ b/scpi_control/report_generator/analysis/comparison_analyzer.py
@@ -1,0 +1,220 @@
+# scpi_control/report_generator/analysis/comparison_analyzer.py
+"""Loads and analyzes a RunSet into a ComparisonResult.
+
+Strict by default: a bad file fails the whole analysis with the run and file
+named. skip_bad_runs=True demotes that to a warning and drops the run, except
+when fewer than two runs survive or the comparison baseline itself is lost.
+"""
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from scpi_control.report_generator.models.comparison import (
+    MODE_COMPARISON,
+    AggregateStats,
+    ComparisonResult,
+    DeltaEntry,
+    Run,
+    RunSet,
+)
+from scpi_control.report_generator.models.criteria import CriteriaSet
+from scpi_control.report_generator.models.report_data import MeasurementResult
+from scpi_control.report_generator.utils.waveform_loader import WaveformLoader
+
+logger = logging.getLogger(__name__)
+
+# Units for MeasurementResult rows, keyed by WaveformAnalyzer statistic name.
+STAT_UNITS: Dict[str, str] = {
+    "vmax": "V",
+    "vmin": "V",
+    "vpp": "V",
+    "vmean": "V",
+    "vrms": "V",
+    "vamp": "V",
+    "dc_offset": "V",
+    "noise_level": "V",
+    "frequency": "Hz",
+    "period": "s",
+    "rise_time": "s",
+    "fall_time": "s",
+    "pulse_width": "s",
+    "jitter": "s",
+    "duty_cycle": "%",
+    "overshoot": "%",
+    "undershoot": "%",
+    "thd": "%",
+    "snr": "dB",
+}
+
+
+class ComparisonAnalysisError(Exception):
+    """Analysis could not produce a usable result."""
+
+
+class ComparisonAnalyzer:
+    """Turns a RunSet into a fully computed ComparisonResult."""
+
+    @staticmethod
+    def analyze(runset: RunSet, *, skip_bad_runs: bool = False) -> ComparisonResult:
+        runset.validate()
+        warnings: List[str] = []
+        baseline_label = runset.baseline.label
+
+        surviving: List[Run] = []
+        for run in runset.runs:
+            error = ComparisonAnalyzer._load_run(run)
+            if error is not None:
+                if not skip_bad_runs:
+                    raise ComparisonAnalysisError(error)
+                run.load_errors.append(error)
+                warnings.append(f"Run '{run.label}' skipped: {error}")
+                continue
+            surviving.append(run)
+
+        if len(surviving) < 2:
+            raise ComparisonAnalysisError(f"Need at least 2 usable runs, got {len(surviving)}")
+        if runset.mode == MODE_COMPARISON and all(run.label != baseline_label for run in surviving):
+            raise ComparisonAnalysisError(f"Baseline run '{baseline_label}' could not be loaded")
+
+        runset.runs = surviving
+        runset.baseline_index = next(i for i, run in enumerate(surviving) if run.label == baseline_label) if runset.mode == MODE_COMPARISON else 0
+
+        for run in runset.runs:
+            for wf in run.waveforms:
+                wf.analyze()
+            ComparisonAnalyzer._apply_criteria(run, runset.criteria_set)
+
+        matched, match_warnings = ComparisonAnalyzer._match_channels(runset.runs)
+        warnings.extend(match_warnings)
+
+        result = ComparisonResult(runset=runset, matched_channels=matched, warnings=warnings)
+        ComparisonAnalyzer._compute(result)
+        return result
+
+    @staticmethod
+    def _load_run(run: Run) -> Optional[str]:
+        """Load all files for a run; return an error message or None."""
+        waveforms = []
+        for filepath in run.files:
+            try:
+                waveforms.extend(WaveformLoader.load(Path(filepath)))
+            except (FileNotFoundError, ValueError, OSError) as e:
+                return f"Run '{run.label}': {filepath}: {e}"
+        run.waveforms = waveforms
+        return None
+
+    @staticmethod
+    def _apply_criteria(run: Run, criteria_set: Optional[CriteriaSet]) -> None:
+        """Build run.measurements from criteria (matched by statistic key) and set run.passed."""
+        run.measurements = []
+        if criteria_set is None:
+            run.passed = None
+            return
+        evaluated: List[bool] = []
+        for wf in run.waveforms:
+            stats = wf.statistics or {}
+            for criteria in criteria_set.criteria_list:
+                if criteria.channel is not None and criteria.channel != wf.label:
+                    continue
+                value = stats.get(criteria.measurement_name)
+                if value is None:
+                    continue
+                outcome = criteria.validate(float(value))
+                run.measurements.append(
+                    MeasurementResult(
+                        name=criteria.measurement_name,
+                        value=float(value),
+                        unit=STAT_UNITS.get(criteria.measurement_name, ""),
+                        channel=wf.label,
+                        passed=outcome.passed,
+                        criteria_min=criteria.min_value,
+                        criteria_max=criteria.max_value,
+                    )
+                )
+                evaluated.append(outcome.passed)
+        run.passed = all(evaluated) if evaluated else None
+
+    @staticmethod
+    def _match_channels(runs: List[Run]):
+        """Channels (by waveform label) present in every run, insertion-ordered.
+
+        Duplicate labels within a run: first occurrence wins, with a warning.
+        Labels missing from any run are unmatched, with a warning."""
+        warnings: List[str] = []
+        per_run: List[Dict[str, object]] = []
+        for run in runs:
+            seen: Dict[str, object] = {}
+            for wf in run.waveforms:
+                if wf.label in seen:
+                    warnings.append(f"Run '{run.label}': duplicate channel label '{wf.label}'; using the first")
+                    continue
+                seen[wf.label] = wf
+            per_run.append(seen)
+
+        first = per_run[0]
+        matched = [label for label in first if all(label in seen for seen in per_run)]
+        all_labels = []
+        for seen in per_run:
+            for label in seen:
+                if label not in all_labels:
+                    all_labels.append(label)
+        for label in all_labels:
+            if label not in matched:
+                missing = [runs[i].label for i, seen in enumerate(per_run) if label not in seen]
+                warnings.append(f"Channel '{label}' missing from runs {missing}; excluded from comparison")
+        return matched, warnings
+
+    @staticmethod
+    def _waveform_for(run: Run, label: str):
+        for wf in run.waveforms:
+            if wf.label == label:
+                return wf
+        return None
+
+    @staticmethod
+    def _compute(result: ComparisonResult) -> None:
+        """Fill deltas (comparison), aggregates (batch), and yield."""
+        runset = result.runset
+        for label in result.matched_channels:
+            stats_per_run = []
+            for run in runset.runs:
+                wf = ComparisonAnalyzer._waveform_for(run, label)
+                stats_per_run.append({k: v for k, v in (wf.statistics or {}).items() if isinstance(v, (int, float)) and not isinstance(v, bool)})
+            shared = set(stats_per_run[0])
+            for stats in stats_per_run[1:]:
+                shared &= set(stats)
+            shared_ordered = [k for k in stats_per_run[0] if k in shared]
+
+            if runset.mode == MODE_COMPARISON:
+                baseline_stats = stats_per_run[runset.baseline_index]
+                result.deltas[label] = {}
+                for stat in shared_ordered:
+                    base = float(baseline_stats[stat])
+                    entries = []
+                    for i, run in enumerate(runset.runs):
+                        if i == runset.baseline_index:
+                            continue
+                        value = float(stats_per_run[i][stat])
+                        delta = value - base
+                        pct = (100.0 * delta / base) if base != 0 else None
+                        entries.append(DeltaEntry(run_label=run.label, value=value, delta=delta, pct=pct))
+                    result.deltas[label][stat] = entries
+            else:
+                result.aggregates[label] = {}
+                for stat in shared_ordered:
+                    values = np.array([float(stats[stat]) for stats in stats_per_run], dtype=float)
+                    result.aggregates[label][stat] = AggregateStats(
+                        mean=float(values.mean()),
+                        std=float(values.std(ddof=1)) if len(values) > 1 else None,
+                        min=float(values.min()),
+                        max=float(values.max()),
+                        n=len(values),
+                    )
+
+        evaluated = [run for run in runset.runs if run.passed is not None]
+        if evaluated:
+            result.yield_passed = sum(1 for run in evaluated if run.passed)
+            result.yield_total = len(evaluated)

--- a/scpi_control/report_generator/analysis/comparison_analyzer.py
+++ b/scpi_control/report_generator/analysis/comparison_analyzer.py
@@ -120,7 +120,7 @@ class ComparisonAnalyzer:
                 if criteria.channel is not None and criteria.channel != wf.label:
                     continue
                 value = stats.get(criteria.measurement_name)
-                if value is None:
+                if value is None or not isinstance(value, (int, float)) or isinstance(value, bool):
                     continue
                 outcome = criteria.validate(float(value))
                 run.measurements.append(

--- a/scpi_control/report_generator/comparison_dialog.py
+++ b/scpi_control/report_generator/comparison_dialog.py
@@ -278,7 +278,8 @@ if QT_AVAILABLE:
 
             mode = MODE_COMPARISON if self.comparison_radio.isChecked() else MODE_BATCH
             baseline_index = max(self.baseline_combo.currentIndex(), 0)
-            return self.model.to_runset(mode, baseline_index=baseline_index)
+            template = self._selected_template()
+            return self.model.to_runset(mode, baseline_index=baseline_index, criteria_set=template.criteria_set if template else None)
 
         def _selected_template(self) -> Optional[ReportTemplate]:
             name = self.template_combo.currentText()

--- a/scpi_control/report_generator/comparison_dialog.py
+++ b/scpi_control/report_generator/comparison_dialog.py
@@ -1,0 +1,407 @@
+"""Dialog for building comparison/batch reports from saved capture files.
+
+ComparisonRunTableModel is deliberately Qt-free so validation and run
+assembly are unit-testable headless; the QDialog is a thin shell around it.
+"""
+
+import logging
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from scpi_control.report_generator.analysis.comparison_analyzer import ComparisonAnalysisError, ComparisonAnalyzer
+from scpi_control.report_generator.comparison_report_builder import build_comparison_report
+from scpi_control.report_generator.models.comparison import MODE_BATCH, MODE_COMPARISON, Run, RunMetadata, RunSet
+from scpi_control.report_generator.models.report_data import ReportMetadata
+from scpi_control.report_generator.models.template import ReportTemplate
+
+logger = logging.getLogger(__name__)
+
+try:  # Qt only needed for the dialog, not the model
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtWidgets import (
+        QAbstractItemView,
+        QApplication,
+        QCheckBox,
+        QComboBox,
+        QDialog,
+        QFileDialog,
+        QGroupBox,
+        QHBoxLayout,
+        QHeaderView,
+        QLabel,
+        QLineEdit,
+        QMessageBox,
+        QProgressDialog,
+        QPushButton,
+        QRadioButton,
+        QTableWidget,
+        QTableWidgetItem,
+        QVBoxLayout,
+    )
+
+    QT_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only when PyQt6 is absent
+    QT_AVAILABLE = False
+
+
+class ComparisonRunTableModel:
+    """Backing store for the dialog's run table."""
+
+    def __init__(self):
+        self._runs: List[Run] = []
+
+    def add_run(self, label: str, files: List[Path], dut_id: Optional[str] = None) -> None:
+        self._runs.append(Run(label=label, files=list(files), metadata=RunMetadata(dut_id=dut_id)))
+
+    def remove_run(self, index: int) -> None:
+        del self._runs[index]
+
+    def runs(self) -> List[Run]:
+        return list(self._runs)
+
+    def validate(self) -> List[str]:
+        errors: List[str] = []
+        if len(self._runs) < 2:
+            errors.append("Add at least 2 runs")
+        labels = [r.label.strip() for r in self._runs]
+        if any(not label for label in labels):
+            errors.append("Every run needs a non-empty label")
+        if len(set(labels)) != len(labels):
+            errors.append("Run labels must be unique")
+        for run in self._runs:
+            if not run.files:
+                errors.append(f"Run '{run.label}' has no files")
+        return errors
+
+    def to_runset(self, mode: str, baseline_index: int = 0, criteria_set=None) -> RunSet:
+        return RunSet(runs=self.runs(), mode=mode, baseline_index=baseline_index, criteria_set=criteria_set)
+
+
+if QT_AVAILABLE:
+
+    class ComparisonReportDialog(QDialog):
+        """Assemble a RunSet from saved capture files and generate a comparison/batch report."""
+
+        # Same filter string as MainWindow._import_waveforms (main_window.py:277)
+        WAVEFORM_FILE_FILTER = "Waveform Files (*.npz *.csv *.mat *.h5 *.hdf5);;All Files (*)"
+
+        def __init__(self, parent=None):
+            super().__init__(parent)
+            self.parent_window = parent
+            self.model = ComparisonRunTableModel()
+
+            self.setWindowTitle("Comparison / Batch Report")
+            self.setModal(True)
+            self.resize(800, 600)
+
+            self._setup_ui()
+            self._refresh_table()
+            self._refresh_baseline_combo()
+
+        def _setup_ui(self):
+            layout = QVBoxLayout()
+
+            # Run table
+            table_group = QGroupBox("Runs")
+            table_layout = QVBoxLayout()
+
+            self.run_table = QTableWidget(0, 4)
+            self.run_table.setHorizontalHeaderLabels(["Label", "DUT ID", "Files", "Remove"])
+            self.run_table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+            self.run_table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+            table_layout.addWidget(self.run_table)
+
+            add_run_btn = QPushButton("Add Run...")
+            add_run_btn.clicked.connect(self._add_run)
+            table_layout.addWidget(add_run_btn)
+
+            table_group.setLayout(table_layout)
+            layout.addWidget(table_group)
+
+            # Mode selection
+            mode_group = QGroupBox("Mode")
+            mode_layout = QHBoxLayout()
+            self.comparison_radio = QRadioButton("Comparison")
+            self.comparison_radio.setChecked(True)
+            self.comparison_radio.toggled.connect(self._on_mode_changed)
+            self.batch_radio = QRadioButton("Batch")
+            mode_layout.addWidget(self.comparison_radio)
+            mode_layout.addWidget(self.batch_radio)
+            mode_group.setLayout(mode_layout)
+            layout.addWidget(mode_group)
+
+            # Baseline selection (comparison mode only)
+            baseline_layout = QHBoxLayout()
+            self.baseline_label = QLabel("Baseline run:")
+            baseline_layout.addWidget(self.baseline_label)
+            self.baseline_combo = QComboBox()
+            baseline_layout.addWidget(self.baseline_combo)
+            layout.addLayout(baseline_layout)
+
+            # Template selection
+            template_layout = QHBoxLayout()
+            template_layout.addWidget(QLabel("Template:"))
+            self.template_combo = QComboBox()
+            self.template_combo.addItem("(none)")
+            for name in ReportTemplate.list_templates():
+                self.template_combo.addItem(name)
+            self.template_combo.currentIndexChanged.connect(self._on_template_selected)
+            template_layout.addWidget(self.template_combo)
+            layout.addLayout(template_layout)
+
+            # Report metadata
+            metadata_layout = QHBoxLayout()
+            metadata_layout.addWidget(QLabel("Title:"))
+            self.title_edit = QLineEdit("Comparison Report")
+            metadata_layout.addWidget(self.title_edit)
+            metadata_layout.addWidget(QLabel("Technician:"))
+            self.technician_edit = QLineEdit()
+            metadata_layout.addWidget(self.technician_edit)
+            layout.addLayout(metadata_layout)
+
+            # Options
+            options_layout = QHBoxLayout()
+            self.include_appendix_check = QCheckBox("Include raw-data appendix")
+            self.include_appendix_check.setChecked(True)
+            options_layout.addWidget(self.include_appendix_check)
+            self.include_signoff_check = QCheckBox("Include sign-off block")
+            self.include_signoff_check.setChecked(True)
+            options_layout.addWidget(self.include_signoff_check)
+            layout.addLayout(options_layout)
+
+            # Generate buttons
+            generate_layout = QHBoxLayout()
+            self.generate_pdf_btn = QPushButton("Generate PDF")
+            self.generate_pdf_btn.clicked.connect(self._generate_pdf)
+            generate_layout.addWidget(self.generate_pdf_btn)
+
+            self.generate_md_btn = QPushButton("Generate Markdown")
+            self.generate_md_btn.clicked.connect(self._generate_markdown)
+            generate_layout.addWidget(self.generate_md_btn)
+
+            close_btn = QPushButton("Close")
+            close_btn.clicked.connect(self.reject)
+            generate_layout.addWidget(close_btn)
+
+            layout.addLayout(generate_layout)
+
+            self.setLayout(layout)
+            self._on_mode_changed()
+
+        def _on_mode_changed(self):
+            is_comparison = self.comparison_radio.isChecked()
+            self.baseline_label.setVisible(is_comparison)
+            self.baseline_combo.setVisible(is_comparison)
+
+        def _on_template_selected(self):
+            name = self.template_combo.currentText()
+            if name == "(none)":
+                return
+            try:
+                template = ReportTemplate.load_from_library(name)
+            except Exception as e:
+                QMessageBox.warning(self, "Template Error", f"Failed to load template '{name}':\n{str(e)}")
+                return
+            self.include_appendix_check.setChecked(template.include_raw_data_appendix)
+            self.include_signoff_check.setChecked(template.include_signoff)
+
+        def _add_run(self):
+            file_paths, _ = QFileDialog.getOpenFileNames(
+                self,
+                "Add Run Files",
+                "",
+                self.WAVEFORM_FILE_FILTER,
+            )
+            if not file_paths:
+                return
+
+            label = f"Run {len(self.model.runs()) + 1}"
+            self.model.add_run(label, [Path(p) for p in file_paths])
+            self._refresh_table()
+            self._refresh_baseline_combo()
+
+        def _remove_run(self, index: int):
+            self.model.remove_run(index)
+            self._refresh_table()
+            self._refresh_baseline_combo()
+
+        def _refresh_table(self):
+            runs = self.model.runs()
+            self.run_table.setRowCount(len(runs))
+            for row, run in enumerate(runs):
+                label_item = QTableWidgetItem(run.label)
+                self.run_table.setItem(row, 0, label_item)
+
+                dut_item = QTableWidgetItem(run.metadata.dut_id or "")
+                self.run_table.setItem(row, 1, dut_item)
+
+                files_item = QTableWidgetItem(str(len(run.files)))
+                files_item.setFlags(files_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+                self.run_table.setItem(row, 2, files_item)
+
+                remove_btn = QPushButton("Remove")
+                remove_btn.clicked.connect(lambda _checked=False, i=row: self._remove_run(i))
+                self.run_table.setCellWidget(row, 3, remove_btn)
+
+            self._sync_model_from_table()
+
+        def _sync_model_from_table(self):
+            """Pull edited labels/DUT IDs from the table back into the model."""
+            runs = self.model.runs()
+            for row, run in enumerate(runs):
+                label_item = self.run_table.item(row, 0)
+                dut_item = self.run_table.item(row, 1)
+                if label_item is not None:
+                    run.label = label_item.text()
+                if dut_item is not None:
+                    run.metadata.dut_id = dut_item.text() or None
+
+        def _refresh_baseline_combo(self):
+            self._sync_model_from_table()
+            current = self.baseline_combo.currentIndex()
+            self.baseline_combo.blockSignals(True)
+            self.baseline_combo.clear()
+            for run in self.model.runs():
+                self.baseline_combo.addItem(run.label)
+            if 0 <= current < self.baseline_combo.count():
+                self.baseline_combo.setCurrentIndex(current)
+            self.baseline_combo.blockSignals(False)
+
+        def _build_runset(self) -> Optional[RunSet]:
+            self._sync_model_from_table()
+            errors = self.model.validate()
+            if errors:
+                QMessageBox.warning(self, "Cannot Generate Report", "\n".join(errors))
+                return None
+
+            mode = MODE_COMPARISON if self.comparison_radio.isChecked() else MODE_BATCH
+            baseline_index = max(self.baseline_combo.currentIndex(), 0)
+            return self.model.to_runset(mode, baseline_index=baseline_index)
+
+        def _selected_template(self) -> Optional[ReportTemplate]:
+            name = self.template_combo.currentText()
+            if name == "(none)":
+                return None
+            try:
+                return ReportTemplate.load_from_library(name)
+            except Exception:
+                return None
+
+        def _build_report(self):
+            """Validate, analyze, and build a TestReport, or None on error (dialog shown)."""
+            runset = self._build_runset()
+            if runset is None:
+                return None
+
+            try:
+                result = ComparisonAnalyzer.analyze(runset)
+            except ComparisonAnalysisError as e:
+                QMessageBox.critical(self, "Analysis Error", str(e))
+                return None
+
+            template = self._selected_template()
+            metadata = ReportMetadata(
+                title=self.title_edit.text() or "Comparison Report",
+                technician=self.technician_edit.text(),
+                test_date=datetime.now(),
+            )
+            report = build_comparison_report(
+                result,
+                metadata,
+                template,
+                include_appendix=self.include_appendix_check.isChecked(),
+                include_signoff=self.include_signoff_check.isChecked(),
+            )
+            return report
+
+        def _generate_pdf(self):
+            if self.parent_window is None:
+                QMessageBox.warning(self, "Cannot Generate", "No parent window available to save the report.")
+                return
+
+            report = self._build_report()
+            if report is None:
+                return
+
+            try:
+                from reportlab.lib.pagesizes import A4, letter
+
+                from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator
+            except ImportError:
+                QMessageBox.warning(self, "PDF Unavailable", "reportlab package not installed.")
+                return
+
+            page_size = A4 if self.parent_window.current_options.page_size == "a4" else letter
+
+            temp_pdf_fd, temp_pdf_path = tempfile.mkstemp(suffix=".pdf")
+            import os
+
+            os.close(temp_pdf_fd)
+            temp_pdf_path = Path(temp_pdf_path)
+
+            progress = QProgressDialog("Generating PDF report...", None, 0, 100, self)
+            progress.setWindowModality(Qt.WindowModality.WindowModal)
+            progress.setMinimumDuration(0)
+            progress.setAutoClose(True)
+            progress.setAutoReset(False)
+            progress.show()
+            QApplication.processEvents()
+
+            def update_progress(percent: int, message: str):
+                progress.setValue(percent)
+                progress.setLabelText(f"Generating PDF... {percent}%\n{message}" if message else f"Generating PDF... {percent}%")
+                QApplication.processEvents()
+
+            try:
+                generator = PDFReportGenerator(
+                    page_size=page_size,
+                    report_options=self.parent_window.current_options,
+                    progress_callback=update_progress,
+                )
+                success = generator.generate(report, temp_pdf_path)
+                progress.close()
+
+                if not success or not temp_pdf_path.exists() or temp_pdf_path.stat().st_size == 0:
+                    QMessageBox.warning(self, "Generation Failed", "Failed to generate PDF report.")
+                    self.parent_window._safe_delete_temp_file(temp_pdf_path)
+                    return
+
+                target_path, _ = QFileDialog.getSaveFileName(
+                    self,
+                    "Save PDF Report",
+                    f"comparison_report_{datetime.now().strftime('%Y%m%d_%H%M%S')}.pdf",
+                    "PDF Files (*.pdf)",
+                )
+                if target_path:
+                    self.parent_window._save_final_pdf(temp_pdf_path, Path(target_path))
+                self.parent_window._safe_delete_temp_file(temp_pdf_path)
+
+            except Exception as e:
+                progress.close()
+                self.parent_window._safe_delete_temp_file(temp_pdf_path)
+                logger.exception("Comparison PDF generation error")
+                QMessageBox.critical(self, "Generation Error", f"Error generating PDF:\n{str(e)}")
+
+        def _generate_markdown(self):
+            if self.parent_window is None:
+                QMessageBox.warning(self, "Cannot Generate", "No parent window available to save the report.")
+                return
+
+            report = self._build_report()
+            if report is None:
+                return
+
+            target_path, _ = QFileDialog.getSaveFileName(
+                self,
+                "Save Markdown Report",
+                f"comparison_report_{datetime.now().strftime('%Y%m%d_%H%M%S')}.md",
+                "Markdown Files (*.md)",
+            )
+            if not target_path:
+                return
+
+            from scpi_control.report_generator.models.plot_style import PlotStyle
+
+            self.parent_window._save_as_markdown(report, Path(target_path), PlotStyle())

--- a/scpi_control/report_generator/comparison_report_builder.py
+++ b/scpi_control/report_generator/comparison_report_builder.py
@@ -7,8 +7,23 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from scpi_control.report_generator.models.comparison import Run
-from scpi_control.report_generator.models.report_elements import DataManifest, ManifestEntry, SignoffBlock, SignoffRole
+from scpi_control.report_generator.analysis.comparison_analyzer import STAT_UNITS
+from scpi_control.report_generator.models.comparison import MODE_COMPARISON, ComparisonResult, Run, RunSet
+from scpi_control.report_generator.models.report_data import SUMMARY_SOURCE_COMPUTED, ReportMetadata, TestReport, TestSection
+from scpi_control.report_generator.models.report_elements import (
+    STATUS_FAIL,
+    STATUS_PASS,
+    ComparisonTable,
+    DataManifest,
+    ManifestEntry,
+    OverlayPlotSpec,
+    OverlayTrace,
+    SignoffBlock,
+    SignoffRole,
+    TableCell,
+)
+from scpi_control.report_generator.models.template import ReportTemplate
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
 
 logger = logging.getLogger(__name__)
 
@@ -73,3 +88,245 @@ def build_manifest(runs: List[Run]) -> DataManifest:
 def build_signoff(roles: List[str], names: Optional[Dict[str, str]] = None) -> SignoffBlock:
     names = names or {}
     return SignoffBlock(roles=[SignoffRole(title=title, name=names.get(title)) for title in roles])
+
+
+_RUN_COLORS = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f"]
+
+# Shown when no criteria constrain the batch table (filtered to computed stats).
+_DEFAULT_KEY_STATS = ["vpp", "vmean", "frequency"]
+
+
+def _fmt(stat: str, value: Optional[float]) -> str:
+    return WaveformAnalyzer.format_stat_value(stat, value) if value is not None else "—"
+
+
+def _run_color(index: int) -> str:
+    return _RUN_COLORS[index % len(_RUN_COLORS)]
+
+
+def _status(passed: Optional[bool]) -> Optional[str]:
+    if passed is None:
+        return None
+    return STATUS_PASS if passed else STATUS_FAIL
+
+
+def _overview_section(result: ComparisonResult) -> TestSection:
+    runset = result.runset
+    section = TestSection(title="Overview", order=0)
+    headers = ["Run", "DUT ID", "Condition", "Files", "Result"]
+    rows = []
+    for i, run in enumerate(runset.runs):
+        label = run.label + (" (baseline)" if runset.mode == MODE_COMPARISON and i == runset.baseline_index else "")
+        verdict = "PASS" if run.passed else "FAIL" if run.passed is False else "—"
+        rows.append([TableCell(label), TableCell(run.metadata.dut_id or "—"), TableCell(run.metadata.condition or "—"), TableCell(str(len(run.files))), TableCell(verdict, status=_status(run.passed))])
+    section.comparison_table = ComparisonTable(title="Runs", headers=headers, rows=rows)
+    if result.warnings:
+        section.content = "Warnings:\n" + "\n".join(f"- {w}" for w in result.warnings)
+    return section
+
+
+def _overlay_section(result: ComparisonResult) -> TestSection:
+    section = TestSection(title="Waveform Overlays", order=1)
+    for label in result.matched_channels:
+        traces = []
+        for i, run in enumerate(result.runset.runs):
+            for wf in run.waveforms:
+                if wf.label == label:
+                    traces.append(OverlayTrace(run_label=run.label, waveform=wf, color=_run_color(i)))
+                    break
+        section.overlay_plots.append(OverlayPlotSpec(channel_label=label, traces=traces))
+    return section
+
+
+def _comparison_section(result: ComparisonResult) -> TestSection:
+    """Rows = 'stat (channel)'; columns = baseline value then value/Δ/Δ% per other run."""
+    runset = result.runset
+    baseline = runset.baseline
+    section = TestSection(title="Comparison Results", order=2)
+    others = [run for i, run in enumerate(runset.runs) if i != runset.baseline_index]
+    headers = ["Measurement", f"{baseline.label} (baseline)"]
+    for run in others:
+        headers.extend([run.label, f"Δ vs {baseline.label}", "Δ%"])
+    rows = []
+    for channel in result.matched_channels:
+        baseline_wf = next(wf for wf in baseline.waveforms if wf.label == channel)
+        for stat, entries in result.deltas.get(channel, {}).items():
+            name = f"{stat} ({channel})" if len(result.matched_channels) > 1 else stat
+            row = [TableCell(name), TableCell(_fmt(stat, (baseline_wf.statistics or {}).get(stat)))]
+            by_label = {e.run_label: e for e in entries}
+            for run in others:
+                entry = by_label.get(run.label)
+                if entry is None:
+                    row.extend([TableCell("—"), TableCell("—"), TableCell("—")])
+                    continue
+                sign = "+" if (entry.delta or 0) >= 0 else ""
+                row.append(TableCell(_fmt(stat, entry.value)))
+                row.append(TableCell(f"{sign}{_fmt(stat, entry.delta)}" if entry.delta is not None else "—"))
+                row.append(TableCell(f"{sign}{entry.pct:.1f}%" if entry.pct is not None else "—"))
+            rows.append(row)
+    section.comparison_table = ComparisonTable(title="Measurements vs baseline", headers=headers, rows=rows)
+    return section
+
+
+def _key_stats(runset: RunSet, result: ComparisonResult) -> List[str]:
+    if runset.criteria_set is not None and runset.criteria_set.criteria_list:
+        return [c.measurement_name for c in runset.criteria_set.criteria_list]
+    computed = set()
+    for channel_stats in result.aggregates.values():
+        computed.update(channel_stats)
+    return [s for s in _DEFAULT_KEY_STATS if s in computed]
+
+
+def _batch_section(result: ComparisonResult) -> TestSection:
+    runset = result.runset
+    section = TestSection(title="Batch Summary", order=2)
+    stats = _key_stats(runset, result)
+    channels = result.matched_channels
+
+    def col_name(stat, channel):
+        return f"{stat} ({channel})" if len(channels) > 1 else stat
+
+    headers = ["Run", "DUT ID", "Result"] + [col_name(s, c) for c in channels for s in stats]
+    rows = []
+    for run in runset.runs:
+        verdict = "PASS" if run.passed else "FAIL" if run.passed is False else "—"
+        row = [TableCell(run.label), TableCell(run.metadata.dut_id or "—"), TableCell(verdict, status=_status(run.passed))]
+        for channel in channels:
+            wf = next((w for w in run.waveforms if w.label == channel), None)
+            for stat in stats:
+                value = (wf.statistics or {}).get(stat) if wf is not None else None
+                row.append(TableCell(_fmt(stat, value)))
+        rows.append(row)
+    section.comparison_table = ComparisonTable(title="Per-DUT results", headers=headers, rows=rows)
+
+    agg_headers = ["Measurement", "Mean", "Std", "Min", "Max", "n"]
+    agg_rows = []
+    for channel in channels:
+        for stat, agg in result.aggregates.get(channel, {}).items():
+            if stat not in stats:
+                continue
+            agg_rows.append(
+                [
+                    TableCell(col_name(stat, channel)),
+                    TableCell(_fmt(stat, agg.mean)),
+                    TableCell(_fmt(stat, agg.std) if agg.std is not None else "—"),
+                    TableCell(_fmt(stat, agg.min)),
+                    TableCell(_fmt(stat, agg.max)),
+                    TableCell(str(agg.n)),
+                ]
+            )
+    aggregates_section = TestSection(title="Batch Aggregates", order=3)
+    aggregates_section.comparison_table = ComparisonTable(title="Across-run statistics", headers=agg_headers, rows=agg_rows)
+    return section, aggregates_section
+
+
+def _full_stats_table(result: ComparisonResult) -> ComparisonTable:
+    """Appendix: every shared numeric statistic, per matched channel, per run."""
+    runset = result.runset
+    headers = ["Measurement"] + [run.label for run in runset.runs]
+    rows = []
+    for channel in result.matched_channels:
+        stat_source = result.deltas.get(channel) or result.aggregates.get(channel) or {}
+        for stat in stat_source:
+            name = f"{stat} ({channel})" if len(result.matched_channels) > 1 else stat
+            row = [TableCell(name)]
+            for run in runset.runs:
+                wf = next((w for w in run.waveforms if w.label == channel), None)
+                row.append(TableCell(_fmt(stat, (wf.statistics or {}).get(stat) if wf is not None else None)))
+            rows.append(row)
+    return ComparisonTable(title="Per-run statistics", headers=headers, rows=rows)
+
+
+def _executive_summary(result: ComparisonResult) -> str:
+    runset = result.runset
+    if runset.mode == MODE_COMPARISON:
+        parts = [f"Compared {len(runset.runs)} runs against baseline '{runset.baseline.label}'."]
+        largest = None
+        for channel, stats in result.deltas.items():
+            for stat, entries in stats.items():
+                for e in entries:
+                    if e.pct is not None and (largest is None or abs(e.pct) > abs(largest[3])):
+                        largest = (channel, stat, e.run_label, e.pct)
+        if largest is not None:
+            channel, stat, run_label, pct = largest
+            parts.append(f"Largest relative change: {stat} on channel {channel}, {pct:+.1f}% in '{run_label}'.")
+    else:
+        parts = [f"Batch of {len(runset.runs)} runs."]
+        if result.yield_total:
+            parts.append(f"Yield: {result.yield_passed}/{result.yield_total} passed ({100.0 * result.yield_passed / result.yield_total:.0f}%).")
+    if result.warnings:
+        parts.append(f"{len(result.warnings)} warning(s) — see Overview.")
+    return " ".join(parts)
+
+
+def build_comparison_report(
+    result: ComparisonResult,
+    metadata: ReportMetadata,
+    template: Optional[ReportTemplate] = None,
+    *,
+    include_appendix: Optional[bool] = None,
+    include_signoff: Optional[bool] = None,
+) -> TestReport:
+    """Assemble a standard TestReport from an analyzed RunSet.
+
+    Explicit kwargs win; otherwise template settings; with neither, both the
+    appendix and sign-off are included (comparison reports exist for
+    traceability)."""
+    runset = result.runset
+    if include_appendix is None:
+        include_appendix = template.include_raw_data_appendix if template is not None else True
+    if include_signoff is None:
+        include_signoff = template.include_signoff if template is not None else True
+
+    report = TestReport(metadata=metadata)
+    report.add_section(_overview_section(result))
+    report.add_section(_overlay_section(result))
+    if runset.mode == MODE_COMPARISON:
+        report.add_section(_comparison_section(result))
+    else:
+        batch, aggregates = _batch_section(result)
+        report.add_section(batch)
+        report.add_section(aggregates)
+
+    next_order = len(report.sections)
+    if include_appendix:
+        appendix = TestSection(title="Raw Data Appendix", order=next_order)
+        appendix.manifest = build_manifest(runset.runs)
+        appendix.comparison_table = _full_stats_table(result)
+        for run in runset.runs:
+            appendix.measurements.extend(run.measurements)
+        report.add_section(appendix)
+        next_order += 1
+    if include_signoff:
+        roles = template.signoff_roles if template is not None else list(DEFAULT_SIGNOFF_ROLES)
+        names = template.signoff_names if template is not None else None
+        signoff_section = TestSection(title="Sign-Off", order=next_order)
+        signoff_section.signoff = build_signoff(roles, names)
+        report.add_section(signoff_section)
+
+    report.executive_summary = _executive_summary(result)
+    report.summary_source = SUMMARY_SOURCE_COMPUTED
+    evaluated = [run.passed for run in runset.runs if run.passed is not None]
+    report.overall_result = "FAIL" if False in evaluated else ("PASS" if evaluated else "INCONCLUSIVE")
+    return report
+
+
+def append_signoff_and_appendix(report: TestReport, template: ReportTemplate) -> None:
+    """Single-run path: honor the template's appendix/sign-off flags on an
+    already-built report. Manifest is derived from section waveforms."""
+    next_order = max((s.order for s in report.sections), default=-1) + 1
+    if template.include_raw_data_appendix:
+        pseudo = Run(label=report.metadata.title, files=[])
+        for section in report.sections:
+            for wf in section.waveforms:
+                if wf.source_file is not None:
+                    pseudo.files.append(Path(wf.source_file))
+                    pseudo.waveforms.append(wf)
+        appendix = TestSection(title="Raw Data Appendix", order=next_order)
+        appendix.manifest = build_manifest([pseudo])
+        report.add_section(appendix)
+        next_order += 1
+    if template.include_signoff:
+        signoff_section = TestSection(title="Sign-Off", order=next_order)
+        signoff_section.signoff = build_signoff(template.signoff_roles, template.signoff_names)
+        report.add_section(signoff_section)

--- a/scpi_control/report_generator/comparison_report_builder.py
+++ b/scpi_control/report_generator/comparison_report_builder.py
@@ -1,0 +1,75 @@
+"""Builds TestReports from analyzed RunSets, plus the manifest/sign-off helpers
+shared with the single-run report path."""
+
+import hashlib
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from scpi_control.report_generator.models.comparison import Run
+from scpi_control.report_generator.models.report_elements import DataManifest, ManifestEntry, SignoffBlock, SignoffRole
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SIGNOFF_ROLES = ["Tested by", "Reviewed by", "Approved by"]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _instrument_string(provenance) -> Optional[str]:
+    """'Manufacturer Model (Serial)' from an AcquisitionProvenance, or None."""
+    if provenance is None or provenance.instrument is None:
+        return None
+    info = provenance.instrument
+    parts = [p for p in (info.manufacturer, info.model) if p]
+    if not parts and not info.serial:
+        return None
+    text = " ".join(parts) if parts else "Unknown instrument"
+    if info.serial:
+        text += f" ({info.serial})"
+    return text
+
+
+def build_manifest(runs: List[Run]) -> DataManifest:
+    """One entry per source file per run. Timestamp: provenance acquired_at,
+    else waveform capture_timestamp, else file mtime (ISO, UTC)."""
+    entries: List[ManifestEntry] = []
+    for run in runs:
+        by_source: Dict[str, object] = {}
+        for wf in run.waveforms:
+            if wf.source_file is not None:
+                by_source.setdefault(str(wf.source_file), wf)
+        for filepath in run.files:
+            path = Path(filepath)
+            wf = by_source.get(str(path))
+            provenance = getattr(wf, "provenance", None) if wf is not None else None
+            timestamp = None
+            if provenance is not None and provenance.acquired_at:
+                timestamp = provenance.acquired_at
+            elif wf is not None and getattr(wf, "capture_timestamp", None):
+                timestamp = wf.capture_timestamp.isoformat()
+            elif path.exists():
+                timestamp = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat()
+            entries.append(
+                ManifestEntry(
+                    run_label=run.label,
+                    file_path=str(path),
+                    size_bytes=path.stat().st_size if path.exists() else 0,
+                    sha256=_sha256(path) if path.exists() else "",
+                    capture_timestamp=timestamp,
+                    instrument=_instrument_string(provenance),
+                )
+            )
+    return DataManifest(entries=entries)
+
+
+def build_signoff(roles: List[str], names: Optional[Dict[str, str]] = None) -> SignoffBlock:
+    names = names or {}
+    return SignoffBlock(roles=[SignoffRole(title=title, name=names.get(title)) for title in roles])

--- a/scpi_control/report_generator/comparison_report_builder.py
+++ b/scpi_control/report_generator/comparison_report_builder.py
@@ -3,11 +3,11 @@ shared with the single-run report path."""
 
 import hashlib
 import logging
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
-from scpi_control.report_generator.analysis.comparison_analyzer import STAT_UNITS
 from scpi_control.report_generator.models.comparison import MODE_COMPARISON, ComparisonResult, Run, RunSet
 from scpi_control.report_generator.models.report_data import SUMMARY_SOURCE_COMPUTED, ReportMetadata, TestReport, TestSection
 from scpi_control.report_generator.models.report_elements import (
@@ -177,7 +177,7 @@ def _key_stats(runset: RunSet, result: ComparisonResult) -> List[str]:
     return [s for s in _DEFAULT_KEY_STATS if s in computed]
 
 
-def _batch_section(result: ComparisonResult) -> TestSection:
+def _batch_section(result: ComparisonResult) -> Tuple[TestSection, TestSection]:
     runset = result.runset
     section = TestSection(title="Batch Summary", order=2)
     stats = _key_stats(runset, result)
@@ -221,14 +221,34 @@ def _batch_section(result: ComparisonResult) -> TestSection:
 
 
 def _full_stats_table(result: ComparisonResult) -> ComparisonTable:
-    """Appendix: every shared numeric statistic, per matched channel, per run."""
+    """Appendix: every numeric statistic, per channel present in any run, per run.
+
+    Unlike the matched-channels comparison table, this covers channels that
+    only appear in some runs (they render "—" for runs lacking them) so the
+    appendix stays a complete raw-data record."""
     runset = result.runset
     headers = ["Measurement"] + [run.label for run in runset.runs]
+
+    all_channels: List[str] = []
+    for run in runset.runs:
+        for wf in run.waveforms:
+            if wf.label not in all_channels:
+                all_channels.append(wf.label)
+
     rows = []
-    for channel in result.matched_channels:
-        stat_source = result.deltas.get(channel) or result.aggregates.get(channel) or {}
-        for stat in stat_source:
-            name = f"{stat} ({channel})" if len(result.matched_channels) > 1 else stat
+    for channel in all_channels:
+        stats: List[str] = []
+        for run in runset.runs:
+            wf = next((w for w in run.waveforms if w.label == channel), None)
+            if wf is None:
+                continue
+            for stat, value in (wf.statistics or {}).items():
+                if not isinstance(value, (int, float)) or isinstance(value, bool):
+                    continue
+                if stat not in stats:
+                    stats.append(stat)
+        for stat in stats:
+            name = f"{stat} ({channel})" if len(all_channels) > 1 else stat
             row = [TableCell(name)]
             for run in runset.runs:
                 wf = next((w for w in run.waveforms if w.label == channel), None)
@@ -294,7 +314,9 @@ def build_comparison_report(
         appendix.manifest = build_manifest(runset.runs)
         appendix.comparison_table = _full_stats_table(result)
         for run in runset.runs:
-            appendix.measurements.extend(run.measurements)
+            for m in run.measurements:
+                channel = f"{run.label} · {m.channel}" if m.channel else run.label
+                appendix.measurements.append(replace(m, channel=channel))
         report.add_section(appendix)
         next_order += 1
     if include_signoff:
@@ -317,9 +339,11 @@ def append_signoff_and_appendix(report: TestReport, template: ReportTemplate) ->
     next_order = max((s.order for s in report.sections), default=-1) + 1
     if template.include_raw_data_appendix:
         pseudo = Run(label=report.metadata.title, files=[])
+        seen_sources = set()
         for section in report.sections:
             for wf in section.waveforms:
-                if wf.source_file is not None:
+                if wf.source_file is not None and str(wf.source_file) not in seen_sources:
+                    seen_sources.add(str(wf.source_file))
                     pseudo.files.append(Path(wf.source_file))
                     pseudo.waveforms.append(wf)
         appendix = TestSection(title="Raw Data Appendix", order=next_order)

--- a/scpi_control/report_generator/generators/markdown_generator.py
+++ b/scpi_control/report_generator/generators/markdown_generator.py
@@ -185,6 +185,19 @@ class MarkdownReportGenerator(BaseReportGenerator):
             lines.append(section.ai_insights)
             lines.append("")
 
+        # Overlay plots (comparison/batch)
+        if section.overlay_plots and self.include_plots:
+            for spec in section.overlay_plots:
+                plot_path = self._generate_overlay_plot(spec, base_path, f"{section.title}_overlay_{spec.channel_label}")
+                if plot_path:
+                    lines.append(f"![Overlay: {spec.channel_label}]({plot_path})")
+                    lines.append("")
+
+        # Comparison table
+        if section.comparison_table:
+            lines.append(self._generate_comparison_table(section.comparison_table))
+            lines.append("")
+
         # Waveforms
         if section.waveforms:
             lines.append("### Waveforms")
@@ -216,6 +229,16 @@ class MarkdownReportGenerator(BaseReportGenerator):
             for img_path in section.images:
                 lines.append(f"![Image]({img_path})")
                 lines.append("")
+
+        # Raw-data manifest
+        if section.manifest:
+            lines.append(self._generate_manifest(section.manifest))
+            lines.append("")
+
+        # Sign-off block
+        if section.signoff:
+            lines.append(self._generate_signoff(section.signoff))
+            lines.append("")
 
         return "\n".join(lines)
 
@@ -548,3 +571,63 @@ class MarkdownReportGenerator(BaseReportGenerator):
         plt.close(fig)
 
         return f"{self.plots_dir}/{filename}"
+
+    def _generate_comparison_table(self, table) -> str:
+        lines = [f"### {table.title}", ""]
+        lines.append("| " + " | ".join(table.headers) + " |")
+        lines.append("|" + "|".join("---" for _ in table.headers) + "|")
+        for row in table.rows:
+            cells = []
+            for cell in row:
+                text = cell.text
+                if cell.status == "pass":
+                    text += " ✅"
+                elif cell.status == "fail":
+                    text += " ❌"
+                cells.append(text)
+            lines.append("| " + " | ".join(cells) + " |")
+        return "\n".join(lines)
+
+    def _generate_manifest(self, manifest) -> str:
+        lines = ["### Source Data Manifest", ""]
+        lines.append("| Run | File | Size (bytes) | SHA-256 | Captured | Instrument |")
+        lines.append("|---|---|---|---|---|---|")
+        for entry in manifest.entries:
+            lines.append(f"| {entry.run_label} | {entry.file_path} | {entry.size_bytes} | `{entry.sha256}` | {entry.capture_timestamp or '—'} | {entry.instrument or '—'} |")
+        return "\n".join(lines)
+
+    def _generate_signoff(self, signoff) -> str:
+        lines = []
+        for role in signoff.roles:
+            name = f" {role.name}" if role.name else ""
+            lines.append(f"**{role.title}:**{name}")
+            lines.append("")
+            lines.append("Signature: ________________________    Date: ____________")
+            lines.append("")
+        return "\n".join(lines)
+
+    def _generate_overlay_plot(self, spec, base_path: Path, name: str) -> Optional[str]:
+        try:
+            plots_path = base_path / self.plots_dir
+            plots_path.mkdir(parents=True, exist_ok=True)
+            filename = f"{name.replace(' ', '_')}.png"
+            filepath = plots_path / filename
+
+            if self.plot_style.matplotlib_style != "default":
+                plt.style.use(self.plot_style.matplotlib_style)
+            fig, ax = plt.subplots(figsize=(10, 4))
+            for trace in spec.traces:
+                wf = trace.waveform
+                ax.plot(wf.time * 1e6, wf.voltage, color=trace.color, linewidth=self.plot_style.waveform_linewidth, label=trace.run_label)
+            self.plot_style.apply_to_axes(ax)
+            ax.set_xlabel("Time (µs)", fontsize=self.plot_style.label_fontsize)
+            ax.set_ylabel("Voltage (V)", fontsize=self.plot_style.label_fontsize)
+            ax.set_title(f"Channel {spec.channel_label} — all runs", fontsize=self.plot_style.title_fontsize)
+            ax.legend()
+            plt.tight_layout()
+            plt.savefig(filepath, dpi=150, bbox_inches="tight")
+            plt.close(fig)
+            return f"{self.plots_dir}/{filename}"
+        except Exception as e:
+            logger.exception(f"Error generating overlay plot: {e}")
+            return None

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -641,6 +641,20 @@ class PDFReportGenerator(BaseReportGenerator):
             story.append(Paragraph(insights_text, self.styles["Normal"]))
             story.append(Spacer(1, 0.1 * inch))
 
+        # Overlay plots (comparison/batch)
+        if section.overlay_plots and self.include_plots:
+            for spec in section.overlay_plots:
+                drawing = self._generate_overlay_plot(spec)
+                if drawing is not None:
+                    story.append(KeepTogether([Paragraph(f"Channel {spec.channel_label} — all runs", self.styles["SubsectionHeading"]), drawing]))
+                    story.append(Spacer(1, 0.1 * inch))
+
+        # Comparison table
+        if section.comparison_table:
+            story.append(Paragraph(section.comparison_table.title, self.styles["SubsectionHeading"]))
+            story.append(self._generate_comparison_table_element(section.comparison_table))
+            story.append(Spacer(1, 0.1 * inch))
+
         # Waveforms
         if section.waveforms:
             story.append(Paragraph("Waveforms", self.styles["SubsectionHeading"]))
@@ -681,6 +695,16 @@ class PDFReportGenerator(BaseReportGenerator):
                         story.append(Spacer(1, 0.1 * inch))
                     except Exception:
                         pass
+
+        # Raw-data manifest
+        if section.manifest:
+            story.append(Paragraph("Source Data Manifest", self.styles["SubsectionHeading"]))
+            story.append(self._generate_manifest_table(section.manifest))
+            story.append(Spacer(1, 0.1 * inch))
+
+        # Sign-off block
+        if section.signoff:
+            story.append(self._generate_signoff_block(section.signoff))
 
         story.append(Spacer(1, 0.2 * inch))
 
@@ -1178,6 +1202,83 @@ class PDFReportGenerator(BaseReportGenerator):
         except Exception as e:
             logger.exception(f"Failed to generate waveform plot: {e}")
             return None
+
+    def _generate_overlay_plot(self, spec) -> Optional[Drawing]:
+        """Generate a multi-run overlay plot (one axes, one trace per run) as a scaled vector Drawing."""
+        try:
+            style = self.plot_style.matplotlib_style or "default"
+            buf = io.BytesIO()
+            with plt.style.context(style):
+                fig, ax = plt.subplots(figsize=(self.plot_width / inch, self.plot_height / inch))
+                for trace in spec.traces:
+                    wf = trace.waveform
+                    ax.plot(wf.time * 1e6, wf.voltage, color=trace.color, linewidth=self.plot_style.waveform_linewidth, label=trace.run_label)
+                self.plot_style.apply_to_axes(ax)
+                ax.set_xlabel("Time (µs)", fontsize=self.plot_style.label_fontsize)
+                ax.set_ylabel("Voltage (V)", fontsize=self.plot_style.label_fontsize)
+                ax.legend(fontsize=self.plot_style.label_fontsize)
+                fig.tight_layout()
+                fig.savefig(buf, format="svg")
+                plt.close(fig)
+            buf.seek(0)
+            return _svg_to_drawing(buf, self.plot_width, self.plot_height)
+        except Exception as e:
+            logger.exception(f"Failed to generate overlay plot: {e}")
+            return None
+
+    def _generate_comparison_table_element(self, table) -> Table:
+        """Render a ComparisonTable with brand-colored pass/fail cell text."""
+        data = [list(table.headers)] + [[cell.text for cell in row] for row in table.rows]
+        element = Table(data, repeatRows=1)
+        style_commands = [
+            ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor(self.branding.primary_color)),
+            ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("FONTSIZE", (0, 0), (-1, -1), 8),
+            ("GRID", (0, 0), (-1, -1), 0.5, colors.black),
+            ("BACKGROUND", (0, 1), (-1, -1), colors.beige),
+            ("BOTTOMPADDING", (0, 0), (-1, 0), 6),
+        ]
+        for r, row in enumerate(table.rows, start=1):
+            for c, cell in enumerate(row):
+                if cell.status == "pass":
+                    style_commands.append(("TEXTCOLOR", (c, r), (c, r), colors.HexColor(self.branding.success_color)))
+                elif cell.status == "fail":
+                    style_commands.append(("TEXTCOLOR", (c, r), (c, r), colors.HexColor(self.branding.failure_color)))
+        element.setStyle(TableStyle(style_commands))
+        return element
+
+    def _generate_manifest_table(self, manifest) -> Table:
+        """Render the raw-data manifest (one row per source file, hash truncated for width)."""
+        data = [["Run", "File", "Size", "SHA-256", "Captured", "Instrument"]]
+        for entry in manifest.entries:
+            sha_short = entry.sha256[:16] + "…" if entry.sha256 else "—"
+            data.append([entry.run_label, Path(entry.file_path).name, str(entry.size_bytes), sha_short, entry.capture_timestamp or "—", entry.instrument or "—"])
+        element = Table(data, repeatRows=1)
+        element.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor(self.branding.primary_color)),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 7),
+                    ("GRID", (0, 0), (-1, -1), 0.5, colors.black),
+                    ("BACKGROUND", (0, 1), (-1, -1), colors.beige),
+                ]
+            )
+        )
+        return element
+
+    def _generate_signoff_block(self, signoff) -> KeepTogether:
+        """Render the sign-off block (role/name plus blank signature+date lines), kept on one page."""
+        elements = [Paragraph("Sign-Off", self.styles["SectionHeading"])]
+        for role in signoff.roles:
+            name = f" {role.name}" if role.name else ""
+            elements.append(Spacer(1, 0.25 * inch))
+            elements.append(Paragraph(f"<b>{role.title}:</b>{name}", self.styles["Normal"]))
+            elements.append(Spacer(1, 0.05 * inch))
+            elements.append(Paragraph("Signature: ________________________&nbsp;&nbsp;&nbsp;&nbsp;Date: ____________", self.styles["Normal"]))
+        return KeepTogether(elements)
 
     def _generate_fft_plot(self, frequency: np.ndarray, magnitude: np.ndarray) -> Optional[Drawing]:
         """Generate an FFT plot as a scaled vector Drawing."""

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -646,7 +646,8 @@ class PDFReportGenerator(BaseReportGenerator):
             for spec in section.overlay_plots:
                 drawing = self._generate_overlay_plot(spec)
                 if drawing is not None:
-                    story.append(KeepTogether([Paragraph(f"Channel {spec.channel_label} — all runs", self.styles["SubsectionHeading"]), drawing]))
+                    channel_label = self._markdown_to_reportlab(spec.channel_label)
+                    story.append(KeepTogether([Paragraph(f"Channel {channel_label} — all runs", self.styles["SubsectionHeading"]), drawing]))
                     story.append(Spacer(1, 0.1 * inch))
 
         # Comparison table
@@ -1249,11 +1250,26 @@ class PDFReportGenerator(BaseReportGenerator):
         return element
 
     def _generate_manifest_table(self, manifest) -> Table:
-        """Render the raw-data manifest (one row per source file, hash truncated for width)."""
+        """Render the raw-data manifest (one row per source file). The file path
+        and SHA-256 are rendered in full via small, wrapping Paragraph cells so
+        provenance stays verifiable rather than truncated for width."""
+        small_style = ParagraphStyle("ManifestSmall", parent=self.styles["Normal"], fontSize=6.5, leading=8)
+
+        def _cell(text: str) -> Paragraph:
+            return Paragraph(self._markdown_to_reportlab(text) if text else "—", small_style)
+
         data = [["Run", "File", "Size", "SHA-256", "Captured", "Instrument"]]
         for entry in manifest.entries:
-            sha_short = entry.sha256[:16] + "…" if entry.sha256 else "—"
-            data.append([entry.run_label, Path(entry.file_path).name, str(entry.size_bytes), sha_short, entry.capture_timestamp or "—", entry.instrument or "—"])
+            data.append(
+                [
+                    entry.run_label,
+                    _cell(entry.file_path),
+                    str(entry.size_bytes),
+                    _cell(entry.sha256),
+                    entry.capture_timestamp or "—",
+                    entry.instrument or "—",
+                ]
+            )
         element = Table(data, repeatRows=1)
         element.setStyle(
             TableStyle(
@@ -1271,11 +1287,12 @@ class PDFReportGenerator(BaseReportGenerator):
 
     def _generate_signoff_block(self, signoff) -> KeepTogether:
         """Render the sign-off block (role/name plus blank signature+date lines), kept on one page."""
-        elements = [Paragraph("Sign-Off", self.styles["SectionHeading"])]
+        elements = []
         for role in signoff.roles:
-            name = f" {role.name}" if role.name else ""
+            title = self._markdown_to_reportlab(role.title)
+            name = f" {self._markdown_to_reportlab(role.name)}" if role.name else ""
             elements.append(Spacer(1, 0.25 * inch))
-            elements.append(Paragraph(f"<b>{role.title}:</b>{name}", self.styles["Normal"]))
+            elements.append(Paragraph(f"<b>{title}:</b>{name}", self.styles["Normal"]))
             elements.append(Spacer(1, 0.05 * inch))
             elements.append(Paragraph("Signature: ________________________&nbsp;&nbsp;&nbsp;&nbsp;Date: ____________", self.styles["Normal"]))
         return KeepTogether(elements)

--- a/scpi_control/report_generator/main_window.py
+++ b/scpi_control/report_generator/main_window.py
@@ -651,11 +651,15 @@ class MainWindow(QMainWindow):
         ComputedAnalyzer().analyze_report(report)
 
         # Sign-off / raw-data appendix (template-driven, overridden by the
-        # left-panel checkboxes)
-        if self.current_template is not None:
-            self.current_template.include_signoff = self.include_signoff_check.isChecked()
-            self.current_template.include_raw_data_appendix = self.include_appendix_check.isChecked()
-            append_signoff_and_appendix(report, self.current_template)
+        # left-panel checkboxes). Without a loaded template, fall back to an
+        # ad hoc one so the checkboxes still take effect on their own.
+        template = self.current_template
+        if template is None and (self.include_signoff_check.isChecked() or self.include_appendix_check.isChecked()):
+            template = ReportTemplate(name="Ad hoc")
+        if template is not None:
+            template.include_signoff = self.include_signoff_check.isChecked()
+            template.include_raw_data_appendix = self.include_appendix_check.isChecked()
+            append_signoff_and_appendix(report, template)
 
         # Update chat sidebar and AI panel with report
         self.current_report = report

--- a/scpi_control/report_generator/main_window.py
+++ b/scpi_control/report_generator/main_window.py
@@ -18,6 +18,7 @@ from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QAction
 from PyQt6.QtWidgets import (
     QApplication,
+    QCheckBox,
     QFileDialog,
     QGroupBox,
     QHBoxLayout,
@@ -36,6 +37,7 @@ from PyQt6.QtWidgets import (
 )
 
 from scpi_control.report_generator.analysis.computed_analyzer import ComputedAnalyzer
+from scpi_control.report_generator.comparison_report_builder import append_signoff_and_appendix
 from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
 from scpi_control.report_generator.models.app_settings import AppSettings
 from scpi_control.report_generator.models.plot_style import PlotStyle
@@ -94,6 +96,12 @@ class MainWindow(QMainWindow):
 
         self._setup_ui()
         self._setup_menu()
+
+        # Re-default the sign-off/appendix checkboxes if a template was restored
+        # from the previous session.
+        if self.current_template is not None:
+            self.include_signoff_check.setChecked(self.current_template.include_signoff)
+            self.include_appendix_check.setChecked(self.current_template.include_raw_data_appendix)
 
     def _safe_delete_temp_file(self, temp_path: Path, max_retries: int = 10):
         """
@@ -205,6 +213,14 @@ class MainWindow(QMainWindow):
         layout.addWidget(QLabel("Report Metadata:"))
         layout.addWidget(metadata_scroll)
 
+        # Sign-off / appendix options (overriding a loaded template's defaults)
+        signoff_layout = QHBoxLayout()
+        self.include_signoff_check = QCheckBox("Include sign-off block")
+        signoff_layout.addWidget(self.include_signoff_check)
+        self.include_appendix_check = QCheckBox("Include raw-data appendix")
+        signoff_layout.addWidget(self.include_appendix_check)
+        layout.addLayout(signoff_layout)
+
         # Report generation buttons
         generate_layout = QHBoxLayout()
 
@@ -266,6 +282,12 @@ class MainWindow(QMainWindow):
         llm_action = QAction("&LLM Configuration...", self)
         llm_action.triggered.connect(self._configure_llm)
         settings_menu.addAction(llm_action)
+
+        # Report menu
+        report_menu = menubar.addMenu("&Report")
+        comparison_action = QAction("&Comparison / Batch Report...", self)
+        comparison_action.triggered.connect(self._open_comparison_dialog)
+        report_menu.addAction(comparison_action)
 
         # Help menu
         help_menu = menubar.addMenu("&Help")
@@ -628,6 +650,13 @@ class MainWindow(QMainWindow):
         # report-level summary/findings/recommendations only if the LLM did not.
         ComputedAnalyzer().analyze_report(report)
 
+        # Sign-off / raw-data appendix (template-driven, overridden by the
+        # left-panel checkboxes)
+        if self.current_template is not None:
+            self.current_template.include_signoff = self.include_signoff_check.isChecked()
+            self.current_template.include_raw_data_appendix = self.include_appendix_check.isChecked()
+            append_signoff_and_appendix(report, self.current_template)
+
         # Update chat sidebar and AI panel with report
         self.current_report = report
         self.chat_sidebar.set_report(report)
@@ -748,6 +777,10 @@ class MainWindow(QMainWindow):
         self.current_options.plot_height_inches = template.plot_height_inches
         self.current_options.plot_dpi = template.plot_dpi
 
+        # Re-default the sign-off/appendix checkboxes from the loaded template
+        self.include_signoff_check.setChecked(template.include_signoff)
+        self.include_appendix_check.setChecked(template.include_raw_data_appendix)
+
         # Apply the template's branding (logo/company/header/footer + colors)
         metadata = self.metadata_panel.get_metadata()
         template.branding.apply_to_metadata(metadata)
@@ -841,6 +874,13 @@ class MainWindow(QMainWindow):
         """Open template management dialog."""
         dialog = TemplateManagerDialog(self)
         dialog.template_selected.connect(self._on_template_loaded)
+        dialog.exec()
+
+    def _open_comparison_dialog(self):
+        """Open the comparison/batch report dialog."""
+        from scpi_control.report_generator.comparison_dialog import ComparisonReportDialog
+
+        dialog = ComparisonReportDialog(self)
         dialog.exec()
 
     def closeEvent(self, event):

--- a/scpi_control/report_generator/models/__init__.py
+++ b/scpi_control/report_generator/models/__init__.py
@@ -2,6 +2,7 @@
 
 from scpi_control.report_generator.models.criteria import CriteriaResult, MeasurementCriteria
 from scpi_control.report_generator.models.report_data import MeasurementResult, ReportMetadata, TestReport, TestSection, WaveformData
+from scpi_control.report_generator.models.report_elements import ComparisonTable, DataManifest, ManifestEntry, OverlayPlotSpec, OverlayTrace, SignoffBlock, SignoffRole, TableCell
 from scpi_control.report_generator.models.template import ReportTemplate
 
 __all__ = [
@@ -13,4 +14,12 @@ __all__ = [
     "ReportTemplate",
     "MeasurementCriteria",
     "CriteriaResult",
+    "ComparisonTable",
+    "DataManifest",
+    "ManifestEntry",
+    "OverlayPlotSpec",
+    "OverlayTrace",
+    "SignoffBlock",
+    "SignoffRole",
+    "TableCell",
 ]

--- a/scpi_control/report_generator/models/__init__.py
+++ b/scpi_control/report_generator/models/__init__.py
@@ -1,5 +1,15 @@
 """Data models for report generation."""
 
+from scpi_control.report_generator.models.comparison import (
+    MODE_BATCH,
+    MODE_COMPARISON,
+    AggregateStats,
+    ComparisonResult,
+    DeltaEntry,
+    Run,
+    RunMetadata,
+    RunSet,
+)
 from scpi_control.report_generator.models.criteria import CriteriaResult, MeasurementCriteria
 from scpi_control.report_generator.models.report_data import MeasurementResult, ReportMetadata, TestReport, TestSection, WaveformData
 from scpi_control.report_generator.models.report_elements import ComparisonTable, DataManifest, ManifestEntry, OverlayPlotSpec, OverlayTrace, SignoffBlock, SignoffRole, TableCell
@@ -22,4 +32,12 @@ __all__ = [
     "SignoffBlock",
     "SignoffRole",
     "TableCell",
+    "MODE_BATCH",
+    "MODE_COMPARISON",
+    "AggregateStats",
+    "ComparisonResult",
+    "DeltaEntry",
+    "Run",
+    "RunMetadata",
+    "RunSet",
 ]

--- a/scpi_control/report_generator/models/comparison.py
+++ b/scpi_control/report_generator/models/comparison.py
@@ -1,0 +1,105 @@
+"""Multi-run input model for comparison and batch reports.
+
+A Run is a set of capture files plus per-run metadata; a RunSet is the ordered
+collection the ComparisonAnalyzer consumes. Comparison mode measures deltas
+against a baseline run; batch mode aggregates across runs (DUTs).
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from scpi_control.report_generator.models.criteria import CriteriaSet
+from scpi_control.report_generator.models.report_data import MeasurementResult, WaveformData
+
+MODE_COMPARISON = "comparison"  # deltas vs a baseline run (before/after = 2 runs)
+MODE_BATCH = "batch"  # cross-DUT aggregates + yield
+
+
+@dataclass
+class RunMetadata:
+    """Descriptive, optional context for one run."""
+
+    dut_id: Optional[str] = None
+    condition: Optional[str] = None
+    operator: Optional[str] = None
+    timestamp: Optional[datetime] = None
+    notes: Optional[str] = None
+
+
+@dataclass
+class Run:
+    """One test run: capture files in, analyzed waveforms/measurements out."""
+
+    label: str
+    files: List[Path]
+    metadata: RunMetadata = field(default_factory=RunMetadata)
+
+    # Populated by ComparisonAnalyzer.analyze:
+    waveforms: List[WaveformData] = field(default_factory=list)
+    measurements: List[MeasurementResult] = field(default_factory=list)
+    passed: Optional[bool] = None  # None when no criteria applied
+    load_errors: List[str] = field(default_factory=list)
+
+
+@dataclass
+class RunSet:
+    """The full input to a comparison or batch analysis."""
+
+    runs: List[Run]
+    mode: str = MODE_COMPARISON
+    baseline_index: int = 0  # comparison mode only
+    criteria_set: Optional[CriteriaSet] = None
+
+    def validate(self) -> None:
+        """Raise ValueError on structural problems (before any file I/O)."""
+        if len(self.runs) < 2:
+            raise ValueError(f"A RunSet needs at least 2 runs, got {len(self.runs)}")
+        labels = [run.label for run in self.runs]
+        if len(set(labels)) != len(labels):
+            raise ValueError(f"Run labels must be unique, got {labels}")
+        if self.mode not in (MODE_COMPARISON, MODE_BATCH):
+            raise ValueError(f"Unknown mode {self.mode!r}; use {MODE_COMPARISON!r} or {MODE_BATCH!r}")
+        if not (0 <= self.baseline_index < len(self.runs)):
+            raise ValueError(f"baseline_index {self.baseline_index} out of range for {len(self.runs)} runs")
+
+    @property
+    def baseline(self) -> Run:
+        return self.runs[self.baseline_index]
+
+
+@dataclass
+class DeltaEntry:
+    """One non-baseline run's value for one statistic, relative to baseline."""
+
+    run_label: str
+    value: Optional[float]
+    delta: Optional[float]  # value - baseline_value
+    pct: Optional[float]  # None when baseline value is 0 or a value is missing
+
+
+@dataclass
+class AggregateStats:
+    """Cross-run aggregate of one statistic (batch mode)."""
+
+    mean: float
+    std: Optional[float]  # ddof=1; None for n < 2
+    min: float
+    max: float
+    n: int
+
+
+@dataclass
+class ComparisonResult:
+    """Everything the report builder needs, fully computed."""
+
+    runset: RunSet
+    matched_channels: List[str]
+    # channel label -> stat name -> per-run delta entries (comparison mode)
+    deltas: Dict[str, Dict[str, List[DeltaEntry]]] = field(default_factory=dict)
+    # channel label -> stat name -> aggregate (batch mode)
+    aggregates: Dict[str, Dict[str, AggregateStats]] = field(default_factory=dict)
+    yield_passed: Optional[int] = None
+    yield_total: Optional[int] = None
+    warnings: List[str] = field(default_factory=list)

--- a/scpi_control/report_generator/models/report_data.py
+++ b/scpi_control/report_generator/models/report_data.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 
 from scpi_control.waveform import WaveformData as CaptureWaveform
+from scpi_control.report_generator.models.report_elements import ComparisonTable, DataManifest, OverlayPlotSpec, SignoffBlock
 
 SUMMARY_SOURCE_MANUAL = "manual"
 SUMMARY_SOURCE_AI = "ai"
@@ -460,6 +461,12 @@ class TestSection:
     ai_summary: Optional[str] = None
     ai_insights: Optional[str] = None
 
+    # Comparison/batch elements (rendered by both generators when set)
+    comparison_table: Optional[ComparisonTable] = None
+    overlay_plots: List[OverlayPlotSpec] = field(default_factory=list)
+    manifest: Optional[DataManifest] = None
+    signoff: Optional[SignoffBlock] = None
+
     order: int = 0  # For sorting sections
 
     def to_dict(self) -> Dict[str, Any]:
@@ -480,6 +487,15 @@ class TestSection:
             data["ai_summary"] = self.ai_summary
         if self.ai_insights:
             data["ai_insights"] = self.ai_insights
+
+        if self.comparison_table:
+            data["comparison_table"] = self.comparison_table.to_dict()
+        if self.overlay_plots:
+            data["overlay_plots"] = [p.to_dict() for p in self.overlay_plots]
+        if self.manifest:
+            data["manifest"] = self.manifest.to_dict()
+        if self.signoff:
+            data["signoff"] = self.signoff.to_dict()
 
         return data
 

--- a/scpi_control/report_generator/models/report_elements.py
+++ b/scpi_control/report_generator/models/report_elements.py
@@ -1,0 +1,124 @@
+"""Renderable section elements for comparison/batch reports.
+
+These are presentation-layer values a TestSection can carry and both
+generators know how to render: a status-aware table, multi-run overlay plot
+specs, a raw-data manifest, and a sign-off block. They hold no analysis
+logic — the comparison analyzer and report builder fill them in.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+STATUS_PASS = "pass"
+STATUS_FAIL = "fail"
+
+
+@dataclass
+class TableCell:
+    """One cell: display text plus an optional pass/fail status for styling."""
+
+    text: str
+    status: Optional[str] = None  # STATUS_PASS, STATUS_FAIL, or None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {"text": self.text}
+        if self.status is not None:
+            data["status"] = self.status
+        return data
+
+
+@dataclass
+class ComparisonTable:
+    """A generic status-aware table (comparison columns, batch summary, aggregates)."""
+
+    title: str
+    headers: List[str]
+    rows: List[List[TableCell]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "title": self.title,
+            "headers": list(self.headers),
+            "rows": [[cell.to_dict() for cell in row] for row in self.rows],
+        }
+
+
+@dataclass
+class OverlayTrace:
+    """One run's waveform in an overlay plot. `waveform` is a report
+    WaveformData; typed Any to avoid a circular import with report_data."""
+
+    run_label: str
+    waveform: Any
+    color: Optional[str] = None
+
+
+@dataclass
+class OverlayPlotSpec:
+    """All runs' traces for one matched channel, drawn on a single axes."""
+
+    channel_label: str
+    traces: List[OverlayTrace] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        # Waveform arrays are not serializable; record what was plotted.
+        return {"channel_label": self.channel_label, "runs": [t.run_label for t in self.traces]}
+
+
+@dataclass
+class ManifestEntry:
+    """Provenance line for one source file of one run."""
+
+    run_label: str
+    file_path: str
+    size_bytes: int
+    sha256: str
+    capture_timestamp: Optional[str] = None  # ISO string
+    instrument: Optional[str] = None  # human-readable identity
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "run_label": self.run_label,
+            "file_path": self.file_path,
+            "size_bytes": self.size_bytes,
+            "sha256": self.sha256,
+        }
+        if self.capture_timestamp is not None:
+            data["capture_timestamp"] = self.capture_timestamp
+        if self.instrument is not None:
+            data["instrument"] = self.instrument
+        return data
+
+
+@dataclass
+class DataManifest:
+    """Raw-data appendix: every source file with checksum and identity."""
+
+    entries: List[ManifestEntry] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"entries": [e.to_dict() for e in self.entries]}
+
+
+@dataclass
+class SignoffRole:
+    """One approval line: role title plus an optional pre-filled name."""
+
+    title: str
+    name: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {"title": self.title}
+        if self.name is not None:
+            data["name"] = self.name
+        return data
+
+
+@dataclass
+class SignoffBlock:
+    """Printable approval block rendered at the end of a report."""
+
+    roles: List[SignoffRole] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"roles": [r.to_dict() for r in self.roles]}

--- a/scpi_control/report_generator/models/template.py
+++ b/scpi_control/report_generator/models/template.py
@@ -149,6 +149,12 @@ class ReportTemplate:
     include_waveform_plots: bool = True
     include_fft_analysis: bool = True
 
+    # Sign-off & raw-data appendix (applies to single-run and comparison reports)
+    include_signoff: bool = False
+    signoff_roles: List[str] = field(default_factory=lambda: ["Tested by", "Reviewed by", "Approved by"])
+    signoff_names: Dict[str, str] = field(default_factory=dict)
+    include_raw_data_appendix: bool = False
+
     # AI/LLM settings
     llm_provider: Optional[str] = None  # "ollama", "lm_studio", "openai", "custom"
     llm_endpoint: Optional[str] = None
@@ -238,6 +244,10 @@ class ReportTemplate:
             "include_recommendations": self.include_recommendations,
             "include_waveform_plots": self.include_waveform_plots,
             "include_fft_analysis": self.include_fft_analysis,
+            "include_signoff": self.include_signoff,
+            "signoff_roles": list(self.signoff_roles),
+            "signoff_names": dict(self.signoff_names),
+            "include_raw_data_appendix": self.include_raw_data_appendix,
             # AI/LLM settings
             "auto_generate_summary": self.auto_generate_summary,
             "auto_generate_findings": self.auto_generate_findings,
@@ -331,6 +341,10 @@ class ReportTemplate:
             "include_recommendations",
             "include_waveform_plots",
             "include_fft_analysis",
+            "include_signoff",
+            "signoff_roles",
+            "signoff_names",
+            "include_raw_data_appendix",
             "llm_provider",
             "llm_endpoint",
             "llm_model",

--- a/scpi_control/report_generator/utils/waveform_loader.py
+++ b/scpi_control/report_generator/utils/waveform_loader.py
@@ -5,7 +5,6 @@ Supports loading waveform data from NPZ, CSV, MAT, and HDF5 files
 created by scpi_control.
 """
 
-import json
 import logging
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
@@ -13,9 +12,8 @@ from typing import Dict, Iterable, List, Optional
 import numpy as np
 
 from scpi_control import waveform_schema as ws
-from scpi_control.provenance import AcquisitionProvenance
 from scpi_control.report_generator.models.report_data import WaveformData
-from scpi_control.waveform_io import load_waveform as _load_native
+from scpi_control.waveform_io import load_waveform as _load_native, _parse_provenance
 
 logger = logging.getLogger(__name__)
 
@@ -190,12 +188,7 @@ class WaveformLoader:
         derived_rate = WaveformLoader._rate_from_time(time_data)
 
         # Reconstruct provenance from header if present
-        provenance = None
-        if ws.CSV_HEADER_PROVENANCE in header:
-            try:
-                provenance = AcquisitionProvenance.from_json(header[ws.CSV_HEADER_PROVENANCE])
-            except Exception as e:
-                logger.warning(f"Failed to parse provenance from {filepath}: {e}")
+        provenance = _parse_provenance(header.get(ws.CSV_HEADER_PROVENANCE))
 
         waveforms = []
         for i in range(1, data.shape[1]):

--- a/scpi_control/report_generator/utils/waveform_loader.py
+++ b/scpi_control/report_generator/utils/waveform_loader.py
@@ -5,6 +5,7 @@ Supports loading waveform data from NPZ, CSV, MAT, and HDF5 files
 created by scpi_control.
 """
 
+import json
 import logging
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
@@ -12,6 +13,7 @@ from typing import Dict, Iterable, List, Optional
 import numpy as np
 
 from scpi_control import waveform_schema as ws
+from scpi_control.provenance import AcquisitionProvenance
 from scpi_control.report_generator.models.report_data import WaveformData
 from scpi_control.waveform_io import load_waveform as _load_native
 
@@ -186,6 +188,15 @@ class WaveformLoader:
 
         time_data = data[:, 0]
         derived_rate = WaveformLoader._rate_from_time(time_data)
+
+        # Reconstruct provenance from header if present
+        provenance = None
+        if ws.CSV_HEADER_PROVENANCE in header:
+            try:
+                provenance = AcquisitionProvenance.from_json(header[ws.CSV_HEADER_PROVENANCE])
+            except Exception as e:
+                logger.warning(f"Failed to parse provenance from {filepath}: {e}")
+
         waveforms = []
         for i in range(1, data.shape[1]):
             voltage = data[:, i]
@@ -203,6 +214,7 @@ class WaveformLoader:
                     sample_rate=WaveformLoader._rate_from_header(header, derived_rate),
                     record_length=len(voltage),
                     source_file=filepath,
+                    provenance=provenance,
                 )
             )
         return waveforms

--- a/scpi_control/report_generator/utils/waveform_loader.py
+++ b/scpi_control/report_generator/utils/waveform_loader.py
@@ -60,6 +60,7 @@ def _from_loaded(loaded) -> WaveformData:
         sample_rate=sample_rate,
         record_length=len(voltage),
         source_file=loaded.source_path,
+        provenance=loaded.provenance,
     )
 
 

--- a/scripts/docs/docs_config.yaml
+++ b/scripts/docs/docs_config.yaml
@@ -30,6 +30,8 @@ examples:
       - "psu_usb_connection.py"
       - "synthetic_signals.py"
       - "waveform_provenance_and_extract.py"
+      - "comparison_report.py"
+      - "batch_report.py"
 
     advanced:
       - "advanced_analysis.py"

--- a/tests/test_comparison_analyzer.py
+++ b/tests/test_comparison_analyzer.py
@@ -61,11 +61,14 @@ def _two_run_set(tmp_path, mode=MODE_COMPARISON, criteria=None, amp2=1.5):
 
 
 def test_analyze_loads_and_analyzes_each_run(tmp_path):
+    # amplitude 1.0 ("before") -> vpp ~2.0; amplitude 1.5 ("after") -> vpp ~3.0
     result = ComparisonAnalyzer.analyze(_two_run_set(tmp_path))
+    by_label = {run.label: run for run in result.runset.runs}
     for run in result.runset.runs:
         assert len(run.waveforms) == 1
         assert run.waveforms[0].statistics is not None
-        assert run.waveforms[0].statistics["vpp"] == pytest.approx(2.0, rel=0.3) or run.label == "after"
+    assert by_label["before"].waveforms[0].statistics["vpp"] == pytest.approx(2.0, rel=0.3)
+    assert by_label["after"].waveforms[0].statistics["vpp"] == pytest.approx(3.0, rel=0.3)
 
 
 def test_matched_channels_found_by_label(tmp_path):
@@ -174,3 +177,14 @@ def test_batch_aggregates_and_yield(tmp_path):
 def test_yield_none_without_criteria(tmp_path):
     result = ComparisonAnalyzer.analyze(_two_run_set(tmp_path, mode=MODE_BATCH))
     assert result.yield_passed is None and result.yield_total is None
+
+
+def test_non_numeric_criteria_value_is_skipped_not_raised(tmp_path):
+    # signal_type is a string statistic; criteria naming it must not raise on
+    # float(value) and must simply evaluate nothing for it.
+    cs = CriteriaSet(name="bad")
+    cs.add_criteria(MeasurementCriteria(measurement_name="signal_type", comparison_type=ComparisonType.RANGE, min_value=0.0, max_value=1.0))
+    result = ComparisonAnalyzer.analyze(_two_run_set(tmp_path, criteria=cs))
+    for run in result.runset.runs:
+        assert run.measurements == []
+        assert run.passed is None

--- a/tests/test_comparison_analyzer.py
+++ b/tests/test_comparison_analyzer.py
@@ -1,0 +1,119 @@
+"""ComparisonAnalyzer: loading, per-run analysis, matching, deltas, aggregates."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from scpi_control.provenance import AcquisitionProvenance, InstrumentInfo
+from scpi_control.report_generator.analysis.comparison_analyzer import ComparisonAnalysisError, ComparisonAnalyzer
+from scpi_control.report_generator.models.comparison import MODE_BATCH, MODE_COMPARISON, Run, RunSet
+from scpi_control.report_generator.models.criteria import ComparisonType, CriteriaSet, MeasurementCriteria
+from scpi_control.signal_synth import SignalSpec, make_waveform
+from scpi_control.waveform import Waveform
+
+
+def _capture(tmp_path, name, amplitude=1.0, frequency=1_000.0, channel=1):
+    """Write one synthetic sine capture and return its path.
+
+    Provenance is attached so the plain-CSV writer emits the channel header
+    line (`save_waveform` only writes it when `waveform.provenance` is set --
+    see `scpi_control/waveform.py`); without it every plain CSV round-trips as
+    channel "CH1" regardless of the `channel` argument, which collapses the
+    channel-matching tests below.
+    """
+    wf = make_waveform(SignalSpec(kind="sine", frequency=frequency, amplitude=amplitude, seed=42), 100_000.0, 2_000, channel=channel)
+    wf.provenance = AcquisitionProvenance(instrument=InstrumentInfo(model="Mock"))
+    path = tmp_path / name
+    Waveform(Mock()).save_waveform(wf, str(path), format="CSV")
+    return path
+
+
+def _vpp_criteria(vmin, vmax):
+    cs = CriteriaSet(name="limits")
+    cs.add_criteria(MeasurementCriteria(measurement_name="vpp", comparison_type=ComparisonType.RANGE, min_value=vmin, max_value=vmax))
+    return cs
+
+
+def _two_run_set(tmp_path, mode=MODE_COMPARISON, criteria=None, amp2=1.5):
+    return RunSet(
+        runs=[
+            Run(label="before", files=[_capture(tmp_path, "before.csv", amplitude=1.0)]),
+            Run(label="after", files=[_capture(tmp_path, "after.csv", amplitude=amp2)]),
+        ],
+        mode=mode,
+        criteria_set=criteria,
+    )
+
+
+def test_analyze_loads_and_analyzes_each_run(tmp_path):
+    result = ComparisonAnalyzer.analyze(_two_run_set(tmp_path))
+    for run in result.runset.runs:
+        assert len(run.waveforms) == 1
+        assert run.waveforms[0].statistics is not None
+        assert run.waveforms[0].statistics["vpp"] == pytest.approx(2.0, rel=0.3) or run.label == "after"
+
+
+def test_matched_channels_found_by_label(tmp_path):
+    result = ComparisonAnalyzer.analyze(_two_run_set(tmp_path))
+    assert result.matched_channels == ["1"]
+
+
+def test_unmatched_channel_warns_but_does_not_fail(tmp_path):
+    runset = _two_run_set(tmp_path)
+    runset.runs[1].files.append(_capture(tmp_path, "extra.csv", channel=2))
+    result = ComparisonAnalyzer.analyze(runset)
+    assert result.matched_channels == ["1"]
+    assert any("2" in w for w in result.warnings)
+
+
+def test_criteria_set_pass_fail_per_run(tmp_path):
+    # vpp ~2.0 for amplitude=1.0 (pass), ~3.0 for amplitude=1.5 (fail)
+    result = ComparisonAnalyzer.analyze(_two_run_set(tmp_path, criteria=_vpp_criteria(1.5, 2.5)))
+    before, after = result.runset.runs
+    assert before.passed is True
+    assert after.passed is False
+    assert before.measurements[0].name == "vpp" and before.measurements[0].unit == "V"
+
+
+def test_no_criteria_means_passed_is_none(tmp_path):
+    result = ComparisonAnalyzer.analyze(_two_run_set(tmp_path))
+    assert all(run.passed is None for run in result.runset.runs)
+
+
+def test_missing_file_strict_raises_naming_run_and_file(tmp_path):
+    runset = _two_run_set(tmp_path)
+    runset.runs[1].files = [tmp_path / "missing.csv"]
+    with pytest.raises(ComparisonAnalysisError, match="after") as exc:
+        ComparisonAnalyzer.analyze(runset)
+    assert "missing.csv" in str(exc.value)
+
+
+def test_skip_bad_runs_drops_run_with_warning(tmp_path):
+    runset = RunSet(
+        runs=[
+            Run(label="a", files=[_capture(tmp_path, "a.csv")]),
+            Run(label="b", files=[tmp_path / "missing.csv"]),
+            Run(label="c", files=[_capture(tmp_path, "c.csv")]),
+        ],
+        mode=MODE_BATCH,
+    )
+    result = ComparisonAnalyzer.analyze(runset, skip_bad_runs=True)
+    assert [run.label for run in result.runset.runs] == ["a", "c"]
+    assert any("b" in w for w in result.warnings)
+
+
+def test_skip_bad_runs_still_errors_below_two_survivors(tmp_path):
+    runset = _two_run_set(tmp_path)
+    runset.runs[0].files = [tmp_path / "gone1.csv"]
+    runset.runs[1].files = [tmp_path / "gone2.csv"]
+    with pytest.raises(ComparisonAnalysisError, match="at least 2"):
+        ComparisonAnalyzer.analyze(runset, skip_bad_runs=True)
+
+
+def test_dropping_baseline_in_comparison_mode_errors(tmp_path):
+    runset = _two_run_set(tmp_path)
+    runset.runs[0].files = [tmp_path / "gone.csv"]  # baseline_index == 0
+    runset.runs.append(Run(label="third", files=[_capture(tmp_path, "third.csv")]))
+    with pytest.raises(ComparisonAnalysisError, match="[Bb]aseline"):
+        ComparisonAnalyzer.analyze(runset, skip_bad_runs=True)

--- a/tests/test_comparison_analyzer.py
+++ b/tests/test_comparison_analyzer.py
@@ -29,6 +29,20 @@ def _capture(tmp_path, name, amplitude=1.0, frequency=1_000.0, channel=1):
     return path
 
 
+def _dc_capture(tmp_path, name, level, channel=1):
+    """Write one synthetic DC capture and return its path.
+
+    Provenance is attached so the plain-CSV writer emits the channel header
+    line; without it every plain CSV round-trips as channel "CH1" regardless
+    of the `channel` argument.
+    """
+    wf = make_waveform(SignalSpec(kind="dc", offset=level, seed=42), 100_000.0, 2_000, channel=channel)
+    wf.provenance = AcquisitionProvenance(instrument=InstrumentInfo(model="Mock"))
+    path = tmp_path / name
+    Waveform(Mock()).save_waveform(wf, str(path), format="CSV")
+    return path
+
+
 def _vpp_criteria(vmin, vmax):
     cs = CriteriaSet(name="limits")
     cs.add_criteria(MeasurementCriteria(measurement_name="vpp", comparison_type=ComparisonType.RANGE, min_value=vmin, max_value=vmax))
@@ -117,3 +131,46 @@ def test_dropping_baseline_in_comparison_mode_errors(tmp_path):
     runset.runs.append(Run(label="third", files=[_capture(tmp_path, "third.csv")]))
     with pytest.raises(ComparisonAnalysisError, match="[Bb]aseline"):
         ComparisonAnalyzer.analyze(runset, skip_bad_runs=True)
+
+
+def test_comparison_deltas_vs_baseline(tmp_path):
+    # amplitude 1.0 -> vpp ~2.0; amplitude 1.5 -> vpp ~3.0; delta ~= +1.0, pct ~= +50%
+    result = ComparisonAnalyzer.analyze(_two_run_set(tmp_path, amp2=1.5))
+    entries = result.deltas["1"]["vpp"]
+    assert len(entries) == 1 and entries[0].run_label == "after"
+    assert entries[0].delta == pytest.approx(1.0, rel=0.1)
+    assert entries[0].pct == pytest.approx(50.0, rel=0.1)
+
+
+def test_zero_baseline_gives_none_pct(tmp_path):
+    # vmean of an offset-free sine is ~0 but not exactly 0; use a dc waveform at 0 V.
+    runset = RunSet(
+        runs=[
+            Run(label="base", files=[_dc_capture(tmp_path, "b.csv", level=0.0)]),
+            Run(label="other", files=[_dc_capture(tmp_path, "o.csv", level=1.0)]),
+        ],
+        mode=MODE_COMPARISON,
+    )
+    result = ComparisonAnalyzer.analyze(runset)
+    vmean_entries = result.deltas["1"]["vmean"]
+    assert vmean_entries[0].delta == pytest.approx(1.0, abs=1e-6)
+    assert vmean_entries[0].pct is None
+
+
+def test_batch_aggregates_and_yield(tmp_path):
+    runset = RunSet(
+        runs=[Run(label=f"dut{i}", files=[_capture(tmp_path, f"d{i}.csv", amplitude=a)]) for i, a in enumerate([1.0, 1.0, 1.5])],
+        mode=MODE_BATCH,
+        criteria_set=_vpp_criteria(1.5, 2.5),
+    )
+    result = ComparisonAnalyzer.analyze(runset)
+    agg = result.aggregates["1"]["vpp"]
+    assert agg.n == 3
+    assert agg.min == pytest.approx(2.0, rel=0.1) and agg.max == pytest.approx(3.0, rel=0.1)
+    assert agg.std is not None and agg.std > 0
+    assert (result.yield_passed, result.yield_total) == (2, 3)
+
+
+def test_yield_none_without_criteria(tmp_path):
+    result = ComparisonAnalyzer.analyze(_two_run_set(tmp_path, mode=MODE_BATCH))
+    assert result.yield_passed is None and result.yield_total is None

--- a/tests/test_comparison_builder.py
+++ b/tests/test_comparison_builder.py
@@ -7,8 +7,12 @@ from unittest.mock import Mock
 import pytest
 
 from scpi_control.provenance import AcquisitionProvenance, InstrumentInfo
-from scpi_control.report_generator.comparison_report_builder import build_manifest, build_signoff
-from scpi_control.report_generator.models.comparison import Run
+from scpi_control.report_generator.analysis.comparison_analyzer import ComparisonAnalyzer
+from scpi_control.report_generator.comparison_report_builder import append_signoff_and_appendix, build_comparison_report, build_manifest, build_signoff
+from scpi_control.report_generator.models.comparison import MODE_BATCH, MODE_COMPARISON, Run, RunSet
+from scpi_control.report_generator.models.criteria import ComparisonType, CriteriaSet, MeasurementCriteria
+from scpi_control.report_generator.models.report_data import SUMMARY_SOURCE_COMPUTED, ReportMetadata, TestReport, TestSection
+from scpi_control.report_generator.models.template import ReportTemplate
 from scpi_control.report_generator.utils.waveform_loader import WaveformLoader
 from scpi_control.signal_synth import SignalSpec, make_waveform
 from scpi_control.waveform import Waveform
@@ -52,3 +56,84 @@ def test_signoff_roles_with_prefilled_names():
     block = build_signoff(["Tested by", "Approved by"], names={"Tested by": "Robin"})
     assert [r.title for r in block.roles] == ["Tested by", "Approved by"]
     assert block.roles[0].name == "Robin" and block.roles[1].name is None
+
+
+def _metadata():
+    return ReportMetadata(title="Comparison", technician="Robin", test_date=datetime(2026, 7, 22, 12, 0, 0))
+
+
+def _analyzed(tmp_path, mode=MODE_COMPARISON, criteria=None, n=2, amps=(1.0, 1.5, 1.0)):
+    runs = [Run(label=f"run{i}", files=[_capture_file(tmp_path, f"r{i}.csv", amps[i])]) for i in range(n)]
+    return ComparisonAnalyzer.analyze(RunSet(runs=runs, mode=mode, criteria_set=criteria))
+
+
+def _capture_file(tmp_path, name, amplitude):
+    """Write one synthetic sine capture and return its path.
+
+    Provenance is attached so the plain-CSV writer emits the channel header
+    line -- see `_capture` in tests/test_comparison_analyzer.py for the same
+    adaptation and its rationale.
+    """
+    wf = make_waveform(SignalSpec(kind="sine", frequency=1_000.0, amplitude=amplitude, seed=7), 100_000.0, 2_000)
+    wf.provenance = AcquisitionProvenance(instrument=InstrumentInfo(model="Mock"))
+    path = tmp_path / name
+    Waveform(Mock()).save_waveform(wf, str(path), format="CSV")
+    return path
+
+
+def test_comparison_report_sections_in_order(tmp_path):
+    report = build_comparison_report(_analyzed(tmp_path), _metadata())
+    titles = [s.title for s in report.sections]
+    assert titles == ["Overview", "Waveform Overlays", "Comparison Results", "Raw Data Appendix", "Sign-Off"]
+    assert report.summary_source == SUMMARY_SOURCE_COMPUTED
+    assert report.executive_summary
+
+
+def test_batch_report_has_batch_summary_and_yield(tmp_path):
+    cs = CriteriaSet(name="limits")
+    cs.add_criteria(MeasurementCriteria(measurement_name="vpp", comparison_type=ComparisonType.RANGE, min_value=1.5, max_value=2.5))
+    report = build_comparison_report(_analyzed(tmp_path, mode=MODE_BATCH, criteria=cs, n=3), _metadata())
+    titles = [s.title for s in report.sections]
+    assert "Batch Summary" in titles and "Comparison Results" not in titles
+    assert "2/3" in report.executive_summary
+    assert report.overall_result == "FAIL"
+
+
+def test_overlay_specs_carry_all_runs(tmp_path):
+    report = build_comparison_report(_analyzed(tmp_path), _metadata())
+    overlays = report.sections[1].overlay_plots
+    assert len(overlays) == 1
+    assert [t.run_label for t in overlays[0].traces] == ["run0", "run1"]
+
+
+def test_comparison_table_has_delta_columns(tmp_path):
+    report = build_comparison_report(_analyzed(tmp_path), _metadata())
+    table = report.sections[2].comparison_table
+    assert table.headers[0] == "Measurement"
+    assert any("Δ" in h for h in table.headers)
+    assert any(cell.text.startswith("vpp") for row in table.rows for cell in row[:1])
+
+
+def test_signoff_and_appendix_can_be_disabled(tmp_path):
+    report = build_comparison_report(_analyzed(tmp_path), _metadata(), include_appendix=False, include_signoff=False)
+    titles = [s.title for s in report.sections]
+    assert "Raw Data Appendix" not in titles and "Sign-Off" not in titles
+
+
+def test_template_signoff_roles_flow_through(tmp_path):
+    template = ReportTemplate(name="t", include_signoff=True, include_raw_data_appendix=True, signoff_roles=["QA"], signoff_names={"QA": "Robin"})
+    report = build_comparison_report(_analyzed(tmp_path), _metadata(), template=template)
+    signoff = report.sections[-1].signoff
+    assert signoff.roles[0].title == "QA" and signoff.roles[0].name == "Robin"
+
+
+def test_append_signoff_and_appendix_on_single_run_report(tmp_path):
+    path = _capture_file(tmp_path, "single.csv", 1.0)
+    section = TestSection(title="Waveforms")
+    section.waveforms = WaveformLoader.load(path)
+    report = TestReport(metadata=_metadata(), sections=[section])
+    template = ReportTemplate(name="t", include_signoff=True, include_raw_data_appendix=True)
+    append_signoff_and_appendix(report, template)
+    titles = [s.title for s in report.sections]
+    assert titles[-2:] == ["Raw Data Appendix", "Sign-Off"]
+    assert report.sections[-2].manifest.entries[0].file_path == str(path)

--- a/tests/test_comparison_builder.py
+++ b/tests/test_comparison_builder.py
@@ -67,14 +67,14 @@ def _analyzed(tmp_path, mode=MODE_COMPARISON, criteria=None, n=2, amps=(1.0, 1.5
     return ComparisonAnalyzer.analyze(RunSet(runs=runs, mode=mode, criteria_set=criteria))
 
 
-def _capture_file(tmp_path, name, amplitude):
+def _capture_file(tmp_path, name, amplitude, channel=1):
     """Write one synthetic sine capture and return its path.
 
     Provenance is attached so the plain-CSV writer emits the channel header
     line -- see `_capture` in tests/test_comparison_analyzer.py for the same
     adaptation and its rationale.
     """
-    wf = make_waveform(SignalSpec(kind="sine", frequency=1_000.0, amplitude=amplitude, seed=7), 100_000.0, 2_000)
+    wf = make_waveform(SignalSpec(kind="sine", frequency=1_000.0, amplitude=amplitude, seed=7), 100_000.0, 2_000, channel=channel)
     wf.provenance = AcquisitionProvenance(instrument=InstrumentInfo(model="Mock"))
     path = tmp_path / name
     Waveform(Mock()).save_waveform(wf, str(path), format="CSV")
@@ -137,3 +137,64 @@ def test_append_signoff_and_appendix_on_single_run_report(tmp_path):
     titles = [s.title for s in report.sections]
     assert titles[-2:] == ["Raw Data Appendix", "Sign-Off"]
     assert report.sections[-2].manifest.entries[0].file_path == str(path)
+
+
+def test_append_signoff_and_appendix_dedupes_one_source_multiple_channels(tmp_path):
+    """A single multi-channel file loaded as several waveforms must still
+    produce exactly one manifest entry (one representative waveform per
+    source file, for provenance -- not one row per channel)."""
+    pytest.importorskip("scipy")
+    import numpy as np
+    from scipy.io import savemat
+
+    path = tmp_path / "multi.mat"
+    savemat(str(path), {"time": np.arange(200) / 1e5, "ch1": np.ones(200), "ch2": np.ones(200) * 2.0})
+    section = TestSection(title="Waveforms")
+    section.waveforms = WaveformLoader.load(path)
+    assert len(section.waveforms) == 2  # sanity: two channels from one file
+    report = TestReport(metadata=_metadata(), sections=[section])
+    template = ReportTemplate(name="t", include_signoff=True, include_raw_data_appendix=True)
+    append_signoff_and_appendix(report, template)
+    manifest = report.sections[-2].manifest
+    assert len(manifest.entries) == 1
+    assert manifest.entries[0].file_path == str(path)
+
+
+def test_appendix_includes_unmatched_channel_with_dash_for_missing_run(tmp_path):
+    """The appendix must cover channels present in only some runs (not just
+    result.matched_channels), with "—" for runs lacking that channel."""
+    run_a = Run(label="dut_a", files=[_capture_file(tmp_path, "a1.csv", 1.0, channel=1)])
+    run_b = Run(
+        label="dut_b",
+        files=[_capture_file(tmp_path, "b1.csv", 1.0, channel=1), _capture_file(tmp_path, "b2.csv", 1.0, channel=2)],
+    )
+    result = ComparisonAnalyzer.analyze(RunSet(runs=[run_a, run_b], mode=MODE_BATCH))
+    assert result.matched_channels == ["1"]  # channel "2" is unmatched
+
+    report = build_comparison_report(result, _metadata())
+    appendix = next(s for s in report.sections if s.title == "Raw Data Appendix")
+    table = appendix.comparison_table
+    assert table.headers == ["Measurement", "dut_a", "dut_b"]
+
+    channel_2_rows = [row for row in table.rows if row[0].text.endswith("(2)")]
+    assert channel_2_rows, "channel '2' rows must appear in the appendix even though it's unmatched"
+    for row in channel_2_rows:
+        assert row[1].text == "—"  # dut_a has no channel 2
+        assert row[2].text != "—"  # dut_b does
+
+
+def test_appendix_measurements_carry_run_label_in_channel(tmp_path):
+    cs = CriteriaSet(name="limits")
+    cs.add_criteria(MeasurementCriteria(measurement_name="vpp", comparison_type=ComparisonType.RANGE, min_value=0.0, max_value=10.0))
+    result = _analyzed(tmp_path, criteria=cs)
+    report = build_comparison_report(result, _metadata())
+    appendix = next(s for s in report.sections if s.title == "Raw Data Appendix")
+    assert appendix.measurements
+    for m in appendix.measurements:
+        assert " · " in m.channel
+        run_label = m.channel.split(" · ")[0]
+        assert run_label in ("run0", "run1")
+    # the source runs' own measurements must be untouched (no mutation)
+    for run in result.runset.runs:
+        for m in run.measurements:
+            assert " · " not in (m.channel or "")

--- a/tests/test_comparison_builder.py
+++ b/tests/test_comparison_builder.py
@@ -1,0 +1,54 @@
+"""Manifest, sign-off, and report assembly for comparison/batch reports."""
+
+import hashlib
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from scpi_control.provenance import AcquisitionProvenance, InstrumentInfo
+from scpi_control.report_generator.comparison_report_builder import build_manifest, build_signoff
+from scpi_control.report_generator.models.comparison import Run
+from scpi_control.report_generator.utils.waveform_loader import WaveformLoader
+from scpi_control.signal_synth import SignalSpec, make_waveform
+from scpi_control.waveform import Waveform
+
+
+def _run_with_file(tmp_path, label="before", name="a.csv"):
+    wf = make_waveform(SignalSpec(kind="sine", seed=1), 100_000.0, 500)
+    wf.provenance = AcquisitionProvenance(instrument=InstrumentInfo(manufacturer="Siglent", model="SDS824X HD", serial="SN1"), acquired_at="2026-07-22T10:00:00+00:00")
+    path = tmp_path / name
+    Waveform(Mock()).save_waveform(wf, str(path), format="CSV")
+    run = Run(label=label, files=[path])
+    run.waveforms = WaveformLoader.load(path)
+    return run, path
+
+
+def test_manifest_entry_has_size_hash_identity(tmp_path):
+    run, path = _run_with_file(tmp_path)
+    manifest = build_manifest([run])
+    entry = manifest.entries[0]
+    assert entry.run_label == "before"
+    assert entry.file_path == str(path)
+    assert entry.size_bytes == path.stat().st_size
+    assert entry.sha256 == hashlib.sha256(path.read_bytes()).hexdigest()
+    assert entry.instrument == "Siglent SDS824X HD (SN1)"
+    assert entry.capture_timestamp == "2026-07-22T10:00:00+00:00"
+
+
+def test_manifest_without_provenance_uses_mtime_and_dash_free_fields(tmp_path):
+    wf = make_waveform(SignalSpec(kind="sine", seed=1), 100_000.0, 500)
+    path = tmp_path / "bare.csv"
+    Waveform(Mock()).save_waveform(wf, str(path), format="CSV", bare=True)
+    run = Run(label="r", files=[path])
+    run.waveforms = WaveformLoader.load(path)
+    entry = build_manifest([run]).entries[0]
+    assert entry.instrument is None
+    # mtime fallback still yields a parseable ISO timestamp
+    datetime.fromisoformat(entry.capture_timestamp)
+
+
+def test_signoff_roles_with_prefilled_names():
+    block = build_signoff(["Tested by", "Approved by"], names={"Tested by": "Robin"})
+    assert [r.title for r in block.roles] == ["Tested by", "Approved by"]
+    assert block.roles[0].name == "Robin" and block.roles[1].name is None

--- a/tests/test_comparison_dialog.py
+++ b/tests/test_comparison_dialog.py
@@ -1,11 +1,11 @@
 """Run-table model logic (headless) + dialog construction smoke test."""
 
-import sys
 from pathlib import Path
 
 import pytest
 
 from scpi_control.report_generator.comparison_dialog import ComparisonRunTableModel
+from scpi_control.report_generator.models.criteria import CriteriaSet
 
 
 def test_add_and_remove_runs():
@@ -36,21 +36,26 @@ def test_valid_model_has_no_errors():
     assert model.validate() == []
 
 
-pytest.importorskip("PyQt6")
-from PyQt6.QtWidgets import QApplication
+def test_to_runset_carries_criteria_set():
+    model = ComparisonRunTableModel()
+    model.add_run("a", [Path("a.csv")])
+    model.add_run("b", [Path("b.csv")])
+    criteria_set = CriteriaSet(name="limits")
+    runset = model.to_runset("comparison", baseline_index=0, criteria_set=criteria_set)
+    assert runset.criteria_set is criteria_set
 
 
-@pytest.fixture(scope="module")
-def qapp():
-    """Create QApplication instance for tests."""
+def test_comparison_dialog_construction():
+    """ComparisonReportDialog can be constructed without a parent MainWindow crash."""
+    import sys
+
+    pytest.importorskip("PyQt6")
+    from PyQt6.QtWidgets import QApplication
+
     app = QApplication.instance()
     if app is None:
         app = QApplication(sys.argv)
-    yield app
 
-
-def test_comparison_dialog_construction(qapp):
-    """ComparisonReportDialog can be constructed without a parent MainWindow crash."""
     from scpi_control.report_generator.comparison_dialog import ComparisonReportDialog
 
     dialog = ComparisonReportDialog()

--- a/tests/test_comparison_dialog.py
+++ b/tests/test_comparison_dialog.py
@@ -1,0 +1,59 @@
+"""Run-table model logic (headless) + dialog construction smoke test."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from scpi_control.report_generator.comparison_dialog import ComparisonRunTableModel
+
+
+def test_add_and_remove_runs():
+    model = ComparisonRunTableModel()
+    model.add_run("before", [Path("a.csv")], dut_id="DUT-1")
+    model.add_run("after", [Path("b.csv")])
+    assert [r.label for r in model.runs()] == ["before", "after"]
+    assert model.runs()[0].metadata.dut_id == "DUT-1"
+    model.remove_run(0)
+    assert [r.label for r in model.runs()] == ["after"]
+
+
+def test_validate_flags_problems():
+    model = ComparisonRunTableModel()
+    assert any("2 runs" in e for e in model.validate())
+    model.add_run("a", [Path("a.csv")])
+    model.add_run("a", [Path("b.csv")])
+    assert any("unique" in e for e in model.validate())
+    model.remove_run(1)
+    model.add_run("b", [])
+    assert any("file" in e.lower() for e in model.validate())
+
+
+def test_valid_model_has_no_errors():
+    model = ComparisonRunTableModel()
+    model.add_run("a", [Path("a.csv")])
+    model.add_run("b", [Path("b.csv")])
+    assert model.validate() == []
+
+
+pytest.importorskip("PyQt6")
+from PyQt6.QtWidgets import QApplication
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Create QApplication instance for tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication(sys.argv)
+    yield app
+
+
+def test_comparison_dialog_construction(qapp):
+    """ComparisonReportDialog can be constructed without a parent MainWindow crash."""
+    from scpi_control.report_generator.comparison_dialog import ComparisonReportDialog
+
+    dialog = ComparisonReportDialog()
+    assert dialog is not None
+    assert hasattr(dialog, "model")
+    dialog.close()

--- a/tests/test_comparison_models.py
+++ b/tests/test_comparison_models.py
@@ -1,0 +1,51 @@
+"""RunSet validation rules for comparison/batch reports."""
+
+from pathlib import Path
+
+import pytest
+
+from scpi_control.report_generator.models.comparison import (
+    MODE_BATCH,
+    MODE_COMPARISON,
+    Run,
+    RunMetadata,
+    RunSet,
+)
+
+
+def _runs(n=2):
+    return [Run(label=f"run{i}", files=[Path(f"r{i}.csv")]) for i in range(n)]
+
+
+def test_valid_runset_passes_validation():
+    RunSet(runs=_runs(2), mode=MODE_COMPARISON).validate()
+    RunSet(runs=_runs(3), mode=MODE_BATCH).validate()
+
+
+def test_fewer_than_two_runs_rejected():
+    with pytest.raises(ValueError, match="at least 2 runs"):
+        RunSet(runs=_runs(1)).validate()
+
+
+def test_duplicate_labels_rejected():
+    runs = _runs(2)
+    runs[1].label = "run0"
+    with pytest.raises(ValueError, match="unique"):
+        RunSet(runs=runs).validate()
+
+
+def test_baseline_index_out_of_range_rejected():
+    with pytest.raises(ValueError, match="baseline_index"):
+        RunSet(runs=_runs(2), baseline_index=2).validate()
+
+
+def test_unknown_mode_rejected():
+    with pytest.raises(ValueError, match="mode"):
+        RunSet(runs=_runs(2), mode="diff").validate()
+
+
+def test_run_metadata_defaults_are_empty():
+    run = Run(label="a", files=[])
+    assert isinstance(run.metadata, RunMetadata)
+    assert run.metadata.dut_id is None
+    assert run.waveforms == [] and run.measurements == [] and run.passed is None

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -42,6 +42,8 @@ EXECUTE = [
     ("report_ai_qa.py", "requests"),
     ("waveform_provenance_and_extract.py", None),
     ("synthetic_signals.py", None),
+    ("comparison_report.py", None),
+    ("batch_report.py", None),
 ]
 
 _TIMEOUTS = {"report_ai_qa.py": 240}

--- a/tests/test_markdown_comparison_elements.py
+++ b/tests/test_markdown_comparison_elements.py
@@ -41,12 +41,51 @@ def test_comparison_table_rendered_with_status_marks(tmp_path):
 
 
 def test_manifest_rendered(tmp_path):
+    """Test that manifest renders with exact header, full-hash rows, and proper null handling."""
+    # Test case 1: Full entry with all fields populated
     section = TestSection(title="Raw Data Appendix")
-    section.manifest = DataManifest(entries=[ManifestEntry(run_label="before", file_path="a.csv", size_bytes=1234, sha256="ab" * 32, capture_timestamp="2026-07-22T10:00:00+00:00", instrument="Siglent SDS824X HD (SN1)")])
+    full_hash = "ab" * 32  # 64-char SHA-256 hash
+    entry = ManifestEntry(
+        run_label="before",
+        file_path="a.csv",
+        size_bytes=1234,
+        sha256=full_hash,
+        capture_timestamp="2026-07-22T10:00:00+00:00",
+        instrument="Siglent SDS824X HD (SN1)",
+    )
+    section.manifest = DataManifest(entries=[entry])
     text = _generate(tmp_path, section)
-    assert "SHA-256" in text
-    assert ("ab" * 32)[:16] in text  # hash shown (possibly truncated to >=16 chars)
-    assert "Siglent SDS824X HD (SN1)" in text
+
+    # Assert exact header line
+    expected_header = "| Run | File | Size (bytes) | SHA-256 | Captured | Instrument |"
+    assert expected_header in text, f"Expected header not found. Got:\n{text}"
+
+    # Assert exact data row with backtick-wrapped full hash
+    expected_row = f"| before | a.csv | 1234 | `{full_hash}` | 2026-07-22T10:00:00+00:00 | Siglent SDS824X HD (SN1) |"
+    assert expected_row in text, f"Expected data row not found. Got:\n{text}"
+
+
+def test_manifest_rendered_with_null_fields(tmp_path):
+    """Test that manifest renders null fields as em-dashes."""
+    section = TestSection(title="Raw Data Appendix")
+    entry = ManifestEntry(
+        run_label="after",
+        file_path="b.csv",
+        size_bytes=5678,
+        sha256="cd" * 32,
+        capture_timestamp=None,
+        instrument=None,
+    )
+    section.manifest = DataManifest(entries=[entry])
+    text = _generate(tmp_path, section)
+
+    # Assert exact header line (should be same as other test)
+    expected_header = "| Run | File | Size (bytes) | SHA-256 | Captured | Instrument |"
+    assert expected_header in text, f"Expected header not found. Got:\n{text}"
+
+    # Assert data row with em-dashes for null fields
+    expected_row = f"| after | b.csv | 5678 | `{'cd' * 32}` | — | — |"
+    assert expected_row in text, f"Expected data row with null fields not found. Got:\n{text}"
 
 
 def test_signoff_rendered_with_lines(tmp_path):

--- a/tests/test_markdown_comparison_elements.py
+++ b/tests/test_markdown_comparison_elements.py
@@ -1,0 +1,74 @@
+"""Markdown generator renders comparison tables, overlays, manifest, sign-off."""
+
+from datetime import datetime
+
+from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
+from scpi_control.report_generator.models.report_data import ReportMetadata, TestReport, TestSection
+from scpi_control.report_generator.models.report_elements import (
+    STATUS_FAIL,
+    STATUS_PASS,
+    ComparisonTable,
+    DataManifest,
+    ManifestEntry,
+    OverlayPlotSpec,
+    OverlayTrace,
+    SignoffBlock,
+    SignoffRole,
+    TableCell,
+)
+
+
+def _report(section):
+    return TestReport(metadata=ReportMetadata(title="T", technician="R", test_date=datetime(2026, 7, 22)), sections=[section])
+
+
+def _generate(tmp_path, section, include_plots=False):
+    out = tmp_path / "report.md"
+    assert MarkdownReportGenerator(include_plots=include_plots).generate(_report(section), out)
+    return out.read_text(encoding="utf-8")
+
+
+def test_comparison_table_rendered_with_status_marks(tmp_path):
+    section = TestSection(title="Comparison Results")
+    section.comparison_table = ComparisonTable(
+        title="Vs baseline",
+        headers=["Measurement", "before", "after"],
+        rows=[[TableCell("vpp"), TableCell("2.0 V", status=STATUS_PASS), TableCell("3.0 V", status=STATUS_FAIL)]],
+    )
+    text = _generate(tmp_path, section)
+    assert "| Measurement | before | after |" in text
+    assert "| vpp | 2.0 V ✅ | 3.0 V ❌ |" in text
+
+
+def test_manifest_rendered(tmp_path):
+    section = TestSection(title="Raw Data Appendix")
+    section.manifest = DataManifest(entries=[ManifestEntry(run_label="before", file_path="a.csv", size_bytes=1234, sha256="ab" * 32, capture_timestamp="2026-07-22T10:00:00+00:00", instrument="Siglent SDS824X HD (SN1)")])
+    text = _generate(tmp_path, section)
+    assert "SHA-256" in text
+    assert ("ab" * 32)[:16] in text  # hash shown (possibly truncated to >=16 chars)
+    assert "Siglent SDS824X HD (SN1)" in text
+
+
+def test_signoff_rendered_with_lines(tmp_path):
+    section = TestSection(title="Sign-Off")
+    section.signoff = SignoffBlock(roles=[SignoffRole(title="Tested by", name="Robin"), SignoffRole(title="Approved by")])
+    text = _generate(tmp_path, section)
+    assert "**Tested by:** Robin" in text
+    assert "**Approved by:**" in text
+    assert text.count("Signature: ") == 2 and text.count("Date: ") == 2
+
+
+def test_overlay_plot_written_and_referenced(tmp_path):
+    import numpy as np
+
+    from scpi_control.report_generator.models.report_data import WaveformData
+
+    def wf(label):
+        t = np.linspace(0, 1e-3, 100)
+        return WaveformData(channel=label, time=t, voltage=np.sin(2 * np.pi * 1000 * t), sample_rate=100_000.0, record_length=100)
+
+    section = TestSection(title="Waveform Overlays")
+    section.overlay_plots = [OverlayPlotSpec(channel_label="1", traces=[OverlayTrace("before", wf("1"), "#1f77b4"), OverlayTrace("after", wf("1"), "#ff7f0e")])]
+    text = _generate(tmp_path, section, include_plots=True)
+    assert "![Overlay: 1](plots/" in text
+    assert (tmp_path / "plots").exists() and any((tmp_path / "plots").iterdir())

--- a/tests/test_pdf_comparison_elements.py
+++ b/tests/test_pdf_comparison_elements.py
@@ -1,0 +1,59 @@
+"""PDF generator renders the comparison/batch elements without error."""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+reportlab = pytest.importorskip("reportlab")
+
+from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator
+from scpi_control.report_generator.models.report_data import ReportMetadata, TestReport, TestSection, WaveformData
+from scpi_control.report_generator.models.report_elements import (
+    STATUS_FAIL,
+    STATUS_PASS,
+    ComparisonTable,
+    DataManifest,
+    ManifestEntry,
+    OverlayPlotSpec,
+    OverlayTrace,
+    SignoffBlock,
+    SignoffRole,
+    TableCell,
+)
+
+
+def _wf(label):
+    t = np.linspace(0, 1e-3, 200)
+    return WaveformData(channel=label, time=t, voltage=np.sin(2 * np.pi * 1000 * t), sample_rate=200_000.0, record_length=200)
+
+
+def _full_section():
+    section = TestSection(title="Everything")
+    section.comparison_table = ComparisonTable(title="T", headers=["M", "a", "b"], rows=[[TableCell("vpp"), TableCell("2 V", status=STATUS_PASS), TableCell("3 V", status=STATUS_FAIL)]])
+    section.overlay_plots = [OverlayPlotSpec(channel_label="1", traces=[OverlayTrace("before", _wf("1"), "#1f77b4"), OverlayTrace("after", _wf("1"), "#ff7f0e")])]
+    section.manifest = DataManifest(entries=[ManifestEntry(run_label="r", file_path="a.csv", size_bytes=1, sha256="ab" * 32)])
+    section.signoff = SignoffBlock(roles=[SignoffRole(title="Tested by", name="Robin"), SignoffRole(title="Approved by")])
+    return section
+
+
+def test_pdf_generates_with_all_new_elements(tmp_path):
+    report = TestReport(metadata=ReportMetadata(title="T", technician="R", test_date=datetime(2026, 7, 22)), sections=[_full_section()])
+    out = tmp_path / "report.pdf"
+    assert PDFReportGenerator().generate(report, out)
+    assert out.exists() and out.stat().st_size > 2_000
+
+
+def test_pdf_generates_without_new_elements_unchanged(tmp_path):
+    report = TestReport(metadata=ReportMetadata(title="T", technician="R", test_date=datetime(2026, 7, 22)), sections=[TestSection(title="Plain", content="hello")])
+    out = tmp_path / "plain.pdf"
+    assert PDFReportGenerator().generate(report, out)
+    assert out.exists()
+
+
+def test_comparison_table_element_method_exists_and_returns_table():
+    from reportlab.platypus import Table as RLTable
+
+    gen = PDFReportGenerator()
+    table = gen._generate_comparison_table_element(ComparisonTable(title="T", headers=["M", "v"], rows=[[TableCell("vpp"), TableCell("2 V", status=STATUS_FAIL)]]))
+    assert isinstance(table, RLTable)

--- a/tests/test_pdf_comparison_elements.py
+++ b/tests/test_pdf_comparison_elements.py
@@ -51,6 +51,17 @@ def test_pdf_generates_without_new_elements_unchanged(tmp_path):
     assert out.exists()
 
 
+def test_signoff_role_with_xml_special_chars_generates_successfully(tmp_path):
+    """Sign-off role title/name containing XML-special characters must be
+    escaped, not raw-interpolated into Paragraph markup."""
+    section = TestSection(title="Sign-Off")
+    section.signoff = SignoffBlock(roles=[SignoffRole(title="R&D Approver <QA>", name="A & B")])
+    report = TestReport(metadata=ReportMetadata(title="T", technician="R", test_date=datetime(2026, 7, 22)), sections=[section])
+    out = tmp_path / "signoff.pdf"
+    assert PDFReportGenerator().generate(report, out)
+    assert out.exists() and out.stat().st_size > 0
+
+
 def test_comparison_table_element_method_exists_and_returns_table():
     from reportlab.platypus import Table as RLTable
 

--- a/tests/test_report_elements.py
+++ b/tests/test_report_elements.py
@@ -1,7 +1,5 @@
 """New renderable section elements: tables, overlays, manifest, sign-off."""
 
-from datetime import datetime
-
 from scpi_control.report_generator.models.report_data import ReportMetadata, TestSection
 from scpi_control.report_generator.models.report_elements import (
     STATUS_FAIL,
@@ -9,6 +7,8 @@ from scpi_control.report_generator.models.report_elements import (
     ComparisonTable,
     DataManifest,
     ManifestEntry,
+    OverlayPlotSpec,
+    OverlayTrace,
     SignoffBlock,
     SignoffRole,
     TableCell,
@@ -45,10 +45,12 @@ def test_test_section_serializes_new_elements_only_when_set():
     rich.comparison_table = ComparisonTable(title="t", headers=["h"], rows=[])
     rich.manifest = DataManifest(entries=[])
     rich.signoff = SignoffBlock(roles=[SignoffRole(title="Tested by")])
+    rich.overlay_plots = [OverlayPlotSpec(channel_label="1", traces=[OverlayTrace(run_label="before", waveform=None, color="#1f77b4")])]
     d = rich.to_dict()
     assert d["comparison_table"]["title"] == "t"
     assert d["manifest"] == {"entries": []}
     assert d["signoff"]["roles"][0]["title"] == "Tested by"
+    assert d["overlay_plots"] == [{"channel_label": "1", "runs": ["before"]}]
 
 
 def test_status_constants_are_pass_fail():

--- a/tests/test_report_elements.py
+++ b/tests/test_report_elements.py
@@ -1,0 +1,55 @@
+"""New renderable section elements: tables, overlays, manifest, sign-off."""
+
+from datetime import datetime
+
+from scpi_control.report_generator.models.report_data import ReportMetadata, TestSection
+from scpi_control.report_generator.models.report_elements import (
+    STATUS_FAIL,
+    STATUS_PASS,
+    ComparisonTable,
+    DataManifest,
+    ManifestEntry,
+    SignoffBlock,
+    SignoffRole,
+    TableCell,
+)
+
+
+def test_comparison_table_to_dict_round_trips_cells():
+    table = ComparisonTable(
+        title="Vpp by run",
+        headers=["Measurement", "Baseline", "After", "Δ"],
+        rows=[[TableCell("vpp"), TableCell("1.00 V"), TableCell("1.10 V", status=STATUS_FAIL), TableCell("+0.10 V")]],
+    )
+    d = table.to_dict()
+    assert d["headers"][1] == "Baseline"
+    assert d["rows"][0][2] == {"text": "1.10 V", "status": STATUS_FAIL}
+    assert d["rows"][0][0] == {"text": "vpp"}
+
+
+def test_manifest_and_signoff_to_dict():
+    manifest = DataManifest(entries=[ManifestEntry(run_label="before", file_path="a.csv", size_bytes=123, sha256="ab" * 32, capture_timestamp="2026-07-22T10:00:00+00:00", instrument="Siglent SDS824X HD (SN1)")])
+    assert manifest.to_dict()["entries"][0]["sha256"] == "ab" * 32
+    signoff = SignoffBlock(roles=[SignoffRole(title="Tested by", name="Robin"), SignoffRole(title="Approved by")])
+    d = signoff.to_dict()
+    assert d["roles"][0] == {"title": "Tested by", "name": "Robin"}
+    assert d["roles"][1] == {"title": "Approved by"}
+
+
+def test_test_section_serializes_new_elements_only_when_set():
+    plain = TestSection(title="Plain")
+    d = plain.to_dict()
+    assert "comparison_table" not in d and "manifest" not in d and "signoff" not in d and "overlay_plots" not in d
+
+    rich = TestSection(title="Rich")
+    rich.comparison_table = ComparisonTable(title="t", headers=["h"], rows=[])
+    rich.manifest = DataManifest(entries=[])
+    rich.signoff = SignoffBlock(roles=[SignoffRole(title="Tested by")])
+    d = rich.to_dict()
+    assert d["comparison_table"]["title"] == "t"
+    assert d["manifest"] == {"entries": []}
+    assert d["signoff"]["roles"][0]["title"] == "Tested by"
+
+
+def test_status_constants_are_pass_fail():
+    assert STATUS_PASS == "pass" and STATUS_FAIL == "fail"

--- a/tests/test_report_loader_provenance.py
+++ b/tests/test_report_loader_provenance.py
@@ -35,3 +35,11 @@ def test_loader_reads_provenance_bearing_files(tmp_path, filename, format):
     assert len(loaded[0].voltage) == 80
     assert loaded[0].sample_rate == pytest.approx(80_000.0)
     assert loaded[0].channel == "1"
+
+
+def test_loader_preserves_provenance_object(tmp_path):
+    out = tmp_path / "wf.npz"
+    Waveform(Mock()).save_waveform(_waveform(), str(out))
+    loaded = WaveformLoader.load(out)
+    assert loaded[0].provenance is not None
+    assert loaded[0].provenance.instrument.model == "SDS824X HD"

--- a/tests/test_template_signoff_fields.py
+++ b/tests/test_template_signoff_fields.py
@@ -1,0 +1,35 @@
+"""Template fields for sign-off and raw-data appendix, with backward compat."""
+
+from scpi_control.report_generator.models.template import ReportTemplate
+
+
+def test_defaults():
+    t = ReportTemplate(name="t")
+    assert t.include_signoff is False
+    assert t.signoff_roles == ["Tested by", "Reviewed by", "Approved by"]
+    assert t.signoff_names == {}
+    assert t.include_raw_data_appendix is False
+
+
+def test_round_trip():
+    t = ReportTemplate(name="t", include_signoff=True, signoff_roles=["QA"], signoff_names={"QA": "Robin"}, include_raw_data_appendix=True)
+    t2 = ReportTemplate.from_dict(t.to_dict())
+    assert t2.include_signoff is True
+    assert t2.signoff_roles == ["QA"]
+    assert t2.signoff_names == {"QA": "Robin"}
+    assert t2.include_raw_data_appendix is True
+
+
+def test_old_template_json_without_fields_loads():
+    t = ReportTemplate(name="old")
+    data = t.to_dict()
+    for key in ("include_signoff", "signoff_roles", "signoff_names", "include_raw_data_appendix"):
+        data.pop(key, None)
+    t2 = ReportTemplate.from_dict(data)
+    assert t2.include_signoff is False and t2.signoff_roles == ["Tested by", "Reviewed by", "Approved by"]
+
+
+def test_default_lists_are_not_shared_between_instances():
+    a, b = ReportTemplate(name="a"), ReportTemplate(name="b")
+    a.signoff_roles.append("Extra")
+    assert "Extra" not in b.signoff_roles


### PR DESCRIPTION
Adds multi-run reporting to the report generator: before/after comparison and multi-DUT batch reports, plus a raw-data appendix and sign-off block that also work on ordinary single-run reports.

## What's new

- **Run/RunSet model + ComparisonAnalyzer** (`models/comparison.py`, `analysis/comparison_analyzer.py`): a run is a set of capture files plus metadata (DUT ID, condition, ...). The analyzer loads each run, computes statistics, applies a `CriteriaSet` per run (matched by statistic key, e.g. `vpp`), matches channels across runs, and computes deltas vs a baseline (comparison mode) or cross-run aggregates and yield (batch mode). Strict on bad files by default; `skip_bad_runs=True` demotes to warnings.
- **Report assembly** (`comparison_report_builder.py`): emits a standard `TestReport` — overview with per-run verdicts, multi-run overlay plots per matched channel, delta tables with % change (comparison) or per-DUT summary + aggregates (batch), a deterministic computed executive summary, raw-data appendix, and sign-off block.
- **Four new renderable section elements** (comparison table, overlay plot spec, data manifest, sign-off block) rendered by both the Markdown and PDF generators, with pass/fail coloring from the branding palette. Existing reports render unchanged.
- **Raw-data appendix**: source-file manifest with sizes, SHA-256 checksums, capture timestamps, and instrument identity from acquisition provenance, plus full per-run statistics and run-attributed measurements.
- **Sign-off block**: template-configurable roles (default Tested by / Reviewed by / Approved by) with signature and date lines; names pre-fillable via `signoff_names`.
- **Template fields**: `include_signoff`, `signoff_roles`, `signoff_names`, `include_raw_data_appendix` — old template JSONs keep loading.
- **GUI**: new Report → Comparison / Batch Report… dialog (run table, mode toggle, baseline picker, template selection incl. its criteria set, generate PDF/Markdown via the existing save flow), and include-sign-off / include-appendix checkboxes for single-run reports.
- **Fix**: the report generator's waveform loader no longer drops acquisition provenance (including the CSV Provenance-JSON header).
- Two runnable no-hardware examples (`examples/comparison_report.py`, `examples/batch_report.py`), API docs page, README bullet, changelog entry.

No breaking changes; targets a minor release (v3.4.0).

## Verification

- Full suite: 1176 passed / 19 skipped (`pytest -n auto`); baseline before the branch was 1116 / 19.
- `black --check --line-length 200 scpi_control/ examples/` clean; `flake8 --select=E9,F63,F7,F82` clean; `mkdocs build` clean.
- Both examples run end-to-end without hardware via mock signal synthesis.

## Deferred follow-ups (intentionally out of scope)

- Criteria naming unification: the analyzer matches criteria by statistic key (`vpp`), while the built-in probe-calibration template uses display names (`Overshoot`) — those criteria won't evaluate in comparison reports until unified.
- Comparison dialog PDF output uses default branding/plot style (single-run flow passes the metadata-panel branding); parity pass pending.
- Baseline combo doesn't refresh on in-table label edits (selection is index-based, so output is unaffected).
- A task-oriented user-guide docs page (the API reference page shipped in this PR).
