### PR TITLE
Trustworthy report numbers: stop silent fabrication of scientific metrics (audit theme #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- Power supply and function-generator readback (`measure_voltage`/`measure_current`/`measure_power`,
+  setpoint/OVP/OCP getters, and AWG `frequency`/`amplitude`/`offset`/`phase`) now raise
+  `CommandError` when the instrument returns an unparseable response, instead of silently returning
+  `0.0`. Callers that relied on the silent zero must handle the exception.
+
 ### Added
 
 - Dev tooling: `pytest-xdist` in the `dev` extra for parallel local test runs (`python -m pytest -n auto`); complements `--testmon` (use one or the other per invocation).
@@ -16,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Report generator: the waveform loader no longer drops acquisition provenance when loading capture files.
+- Analysis: corrected THD (each harmonic is read at its own bin, robust to an off-bin fundamental),
+  noise/SNR (estimated from a signal-free residual instead of the whole-signal RMS), `vamp`
+  (Vtop − Vbase amplitude, not the vertical midpoint), overshoot/undershoot (only reported for
+  flat-topped signals), duty cycle (correct when the capture starts on the high level), DC
+  classification (no longer fooled by a large offset over real ripple), FFT peak detection (finds
+  peaks below 0 dB), and SciPy window handling for the power spectrum / spectrogram.
+- Reports and the live webapp spectrum now use a single THD engine, so they report the same number
+  for the same capture. Report-path THD now sums the first 5 harmonics (previously 10).
+- DAQ AI threshold suggestions now bind each extracted number to its label instead of grabbing the
+  first number in the sentence.
 
 ## [3.3.1] - 2026-07-21
 

--- a/scpi_control/analysis.py
+++ b/scpi_control/analysis.py
@@ -353,49 +353,40 @@ class FFTAnalyzer:
 
     @staticmethod
     def calculate_thd(fft_result: FFTResult, fundamental_freq: float, num_harmonics: int = 5) -> Optional[float]:
-        """Calculate Total Harmonic Distortion (THD).
-
-        Args:
-            fft_result: FFT result
-            fundamental_freq: Fundamental frequency (Hz)
-            num_harmonics: Number of harmonics to include
-
-        Returns:
-            THD in percent or None if error
-        """
+        """Calculate Total Harmonic Distortion (THD) as a percentage."""
         try:
-            # Find fundamental frequency bin
             freq_resolution = fft_result.frequency[1] - fft_result.frequency[0]
-            fund_idx = int(round(fundamental_freq / freq_resolution))
-
-            if fund_idx >= len(fft_result.magnitude):
-                logger.error("Fundamental frequency out of range")
+            if freq_resolution <= 0:
                 return None
 
-            # Get fundamental magnitude (linear)
             if fft_result.magnitude_db:
-                fund_mag = 10 ** (fft_result.magnitude[fund_idx] / 20.0)
+                linear = 10 ** (fft_result.magnitude / 20.0)
             else:
-                fund_mag = fft_result.magnitude[fund_idx]
+                linear = np.asarray(fft_result.magnitude, dtype=float)
+            length = len(linear)
 
-            # Calculate harmonic magnitudes
+            def bin_energy(order: int) -> Optional[float]:
+                idx = int(round(order * fundamental_freq / freq_resolution))
+                if idx >= length:
+                    return None
+                lo = max(0, idx - 2)
+                hi = min(length, idx + 3)  # +/- 2 bins, RSS, captures off-bin leakage
+                seg = linear[lo:hi]
+                return float(np.sqrt(np.sum(seg**2)))
+
+            fund_mag = bin_energy(1)
+            if not fund_mag:
+                return None
+
             harmonic_power = 0.0
             for n in range(2, num_harmonics + 2):
-                harmonic_idx = n * fund_idx
-                if harmonic_idx < len(fft_result.magnitude):
-                    if fft_result.magnitude_db:
-                        harm_mag = 10 ** (fft_result.magnitude[harmonic_idx] / 20.0)
-                    else:
-                        harm_mag = fft_result.magnitude[harmonic_idx]
+                harm_mag = bin_energy(n)
+                if harm_mag is not None:
                     harmonic_power += harm_mag**2
 
-            # Calculate THD
             thd = 100.0 * np.sqrt(harmonic_power) / fund_mag
-
             logger.info(f"THD calculated: {thd:.2f}% (fundamental={fundamental_freq:.2f} Hz)")
-
             return thd
-
         except Exception as e:
             logger.error(f"THD calculation error: {e}")
             return None

--- a/scpi_control/analysis.py
+++ b/scpi_control/analysis.py
@@ -9,6 +9,12 @@ from scipy import signal
 
 logger = logging.getLogger(__name__)
 
+# thd_of_waveform's dominant-tone gate: mirrors _NOISE_PEAK_TO_MEDIAN in
+# waveform_analyzer.py's _has_dominant_tone. Without a clearly dominant
+# spectral peak, there is no fundamental to measure harmonics against, so
+# THD is undefined rather than a number computed from noise.
+_THD_MIN_PEAK_TO_MEDIAN = 15.0
+
 
 @dataclass
 class FFTResult:
@@ -422,7 +428,16 @@ class FFTAnalyzer:
         mag = result.magnitude
         if len(mag) < 2:
             return None
-        fund_idx = 1 + int(np.argmax(mag[1:]))  # skip DC bin of the rfft magnitude
+        pos = mag[1:]  # skip DC bin of the rfft magnitude
+        if pos.size == 0:
+            return None
+        mx = float(np.max(pos))
+        if mx == 0.0:
+            return None
+        med = float(np.median(pos))
+        if med > 0.0 and mx / med < _THD_MIN_PEAK_TO_MEDIAN:
+            return None  # no dominant tone -> not a periodic signal, THD is undefined
+        fund_idx = 1 + int(np.argmax(pos))
         fundamental_freq = float(result.frequency[fund_idx])
         if fundamental_freq <= 0:
             return None

--- a/scpi_control/analysis.py
+++ b/scpi_control/analysis.py
@@ -411,3 +411,19 @@ class FFTAnalyzer:
         except Exception as e:
             logger.error(f"THD calculation error: {e}")
             return None
+
+    @staticmethod
+    def thd_of_waveform(waveform, window: str = "hanning", num_harmonics: int = 5) -> Optional[float]:
+        """Canonical THD for a waveform: the single entry both reports and the webapp use."""
+        analyzer = FFTAnalyzer()
+        result = analyzer.compute_fft(waveform, window=window, output_db=False, detrend=True)
+        if result is None:
+            return None
+        mag = result.magnitude
+        if len(mag) < 2:
+            return None
+        fund_idx = 1 + int(np.argmax(mag[1:]))  # skip DC bin of the rfft magnitude
+        fundamental_freq = float(result.frequency[fund_idx])
+        if fundamental_freq <= 0:
+            return None
+        return FFTAnalyzer.calculate_thd(result, fundamental_freq, num_harmonics)

--- a/scpi_control/analysis.py
+++ b/scpi_control/analysis.py
@@ -40,7 +40,7 @@ class FFTResult:
             List of (frequency, magnitude) tuples
         """
         # Find peaks
-        peaks, _ = signal.find_peaks(self.magnitude, height=0)
+        peaks, _ = signal.find_peaks(self.magnitude)
 
         # Sort by magnitude (descending)
         if len(peaks) > 0:

--- a/scpi_control/analysis.py
+++ b/scpi_control/analysis.py
@@ -71,9 +71,30 @@ class FFTAnalyzer:
         "flattop": signal.windows.flattop,
     }
 
+    _SCIPY_WINDOW_NAMES = {
+        "hanning": "hann",
+        "rectangular": "boxcar",
+        "hamming": "hamming",
+        "blackman": "blackman",
+        "bartlett": "bartlett",
+        "flattop": "flattop",
+    }
+
     def __init__(self):
         """Initialize FFT analyzer."""
         logger.info("FFT analyzer initialized")
+
+    @staticmethod
+    def _scipy_window_name(window: str) -> str:
+        """Map public window names to SciPy window names.
+
+        Args:
+            window: Public window name (e.g., 'hanning')
+
+        Returns:
+            SciPy window name (e.g., 'hann')
+        """
+        return FFTAnalyzer._SCIPY_WINDOW_NAMES.get(window.lower(), window)
 
     def compute_fft(self, waveform, window: str = "hanning", output_db: bool = True, detrend: bool = True) -> Optional[FFTResult]:
         """Compute FFT of a waveform.
@@ -173,7 +194,7 @@ class FFTAnalyzer:
                 nperseg = min(256, len(voltage) // 4)
 
             # Compute power spectral density using Welch's method
-            frequencies, psd = signal.welch(voltage, fs=sample_rate, window=window, nperseg=nperseg, scaling="density")
+            frequencies, psd = signal.welch(voltage, fs=sample_rate, window=FFTAnalyzer._scipy_window_name(window), nperseg=nperseg, scaling="density")
 
             logger.info(f"Power spectrum computed using Welch's method")
 
@@ -207,7 +228,7 @@ class FFTAnalyzer:
                 nperseg = min(256, len(voltage) // 4)
 
             # Compute spectrogram
-            frequencies, times, Sxx = signal.spectrogram(voltage, fs=sample_rate, window=window, nperseg=nperseg)
+            frequencies, times, Sxx = signal.spectrogram(voltage, fs=sample_rate, window=FFTAnalyzer._scipy_window_name(window), nperseg=nperseg)
 
             logger.info(f"Spectrogram computed: {len(frequencies)}x{len(times)} matrix")
 

--- a/scpi_control/awg_output.py
+++ b/scpi_control/awg_output.py
@@ -442,9 +442,8 @@ class AWGOutput:
 
         try:
             return float(response)
-        except ValueError:
-            logger.error(f"Failed to parse float from response: {response}")
-            return 0.0
+        except ValueError as exc:
+            raise exceptions.CommandError(f"Unparseable AWG response: {response!r}") from exc
 
     def _parse_string(self, response: str) -> str:
         """Parse string value from SCPI response.

--- a/scpi_control/power_supply_output.py
+++ b/scpi_control/power_supply_output.py
@@ -370,9 +370,8 @@ class PowerSupplyOutput:
 
         try:
             return float(response)
-        except ValueError:
-            logger.error(f"Failed to parse float from response: {response}")
-            return 0.0
+        except ValueError as exc:
+            raise exceptions.CommandError(f"Unparseable PSU response: {response!r}") from exc
 
     def get_configuration(self) -> Dict[str, any]:
         """Get all output configuration parameters.

--- a/scpi_control/report_generator/llm/daq_analyzer.py
+++ b/scpi_control/report_generator/llm/daq_analyzer.py
@@ -281,10 +281,16 @@ class DAQAnalyzer:
 
     @staticmethod
     def _extract_number(text: str) -> Optional[float]:
-        """Extract a number from a line of text."""
+        """Extract the value bound to a label in a line of LLM text.
+
+        Drops a leading list enumerator ("1.", "2)") so the ordinal is not read as
+        the value, and prefers the number after a colon when the label uses one.
+        """
         import re
 
-        # Find numbers (including negative and decimal)
+        text = re.sub(r"^\s*\d+\s*[.)]\s*", "", text)  # strip a leading list ordinal
+        if ":" in text:
+            text = text.split(":", 1)[1]  # value follows the label's colon
         numbers = re.findall(r"-?\d+\.?\d*", text)
         if numbers:
             try:

--- a/scpi_control/report_generator/llm/daq_analyzer.py
+++ b/scpi_control/report_generator/llm/daq_analyzer.py
@@ -288,7 +288,7 @@ class DAQAnalyzer:
         """
         import re
 
-        text = re.sub(r"^\s*\d+\s*[.)]\s*", "", text)  # strip a leading list ordinal
+        text = re.sub(r"^\s*\d+\s*[.)]\s+", "", text)  # strip a leading list ordinal
         if ":" in text:
             text = text.split(":", 1)[1]  # value follows the label's colon
         numbers = re.findall(r"-?\d+\.?\d*", text)

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -10,7 +10,7 @@ from typing import Dict, Optional, Tuple
 
 import numpy as np
 from scipy import signal as scipy_signal
-from scipy.fft import fft, fftfreq, rfft
+from scipy.fft import fft, fftfreq, irfft, rfft
 
 from scpi_control.report_generator.models.report_data import WaveformData, WaveformRegion
 
@@ -21,6 +21,16 @@ logger = logging.getLogger(__name__)
 # is less than this multiple of the median bin. Empirically, real periodic
 # signals sit >=~280x while white noise sits ~4x, so this is not sensitive.
 _NOISE_PEAK_TO_MEDIAN = 15.0
+
+# _estimate_noise's tone-subtraction residual is never exactly zero for a
+# synthetic, perfectly clean signal -- the FFT/IFFT round trip leaves a
+# floating-point residual around ~1e-15..1e-12 relative to the signal. That
+# residual is measurement precision, not real noise, so an SNR computed from
+# it (hundreds of dB) would still be a fabricated number. Gate SNR on the
+# noise floor being at least this fraction of the signal amplitude -- many
+# orders of magnitude above float round-off, comfortably below any real
+# instrument's noise floor.
+_MIN_MEASURABLE_NOISE_RATIO = 1e-9
 
 
 class SignalType:
@@ -296,16 +306,13 @@ class WaveformAnalyzer:
         try:
             v = waveform.voltage
 
-            # Estimate noise level (high-frequency component)
-            # Use standard deviation of detrended signal
-            v_detrended = v - np.mean(v)
-            noise_level = np.std(v_detrended)
+            vmax = float(np.max(v))
+            vmin = float(np.min(v))
+            signal_amplitude = (vmax - vmin) / 2.0
 
-            # Signal to Noise Ratio (SNR)
-            vmax = np.max(v)
-            vmin = np.min(v)
-            signal_amplitude = (vmax - vmin) / 2
-            snr = 20 * np.log10(signal_amplitude / noise_level) if noise_level > 0 else None
+            noise_level = WaveformAnalyzer._estimate_noise(waveform)
+            measurable_noise = noise_level and noise_level > 0 and signal_amplitude > 0 and noise_level > signal_amplitude * _MIN_MEASURABLE_NOISE_RATIO
+            snr = 20 * np.log10(signal_amplitude / noise_level) if measurable_noise else None
 
             # Overshoot/undershoot are meaningful only for flat-topped signals.
             if WaveformAnalyzer._is_two_level(v):
@@ -349,6 +356,40 @@ class WaveformAnalyzer:
                 "undershoot": None,
                 "jitter": None,
             }
+
+    @staticmethod
+    def _estimate_noise(waveform: WaveformData) -> Optional[float]:
+        """Estimate noise RMS from a signal-free residual, or None when not separable."""
+        v = np.asarray(waveform.voltage, dtype=float)
+        n = v.size
+        if n < 8:
+            return None
+        # Two-level signals: use the settled-plateau noise.
+        if WaveformAnalyzer._is_two_level(v):
+            stab = WaveformAnalyzer.calculate_plateau_stability(waveform, SignalType.SQUARE).get("plateau_stability")
+            return None if stab is None else float(stab)
+        # Otherwise require a dominant tone to subtract; without one we cannot
+        # separate signal from noise, so report None rather than guess.
+        if not WaveformAnalyzer._has_dominant_tone(v):
+            return None
+        x = v - np.mean(v)
+        spectrum = rfft(x)
+        mag = np.abs(spectrum)
+        if mag[1:].size == 0:
+            return None
+        fund_bin = 1 + int(np.argmax(mag[1:]))
+        noise_spec = spectrum.copy()
+        noise_spec[0] = 0.0
+        half = 2
+        h = 1
+        while h * fund_bin < len(spectrum):
+            center = h * fund_bin
+            lo = max(1, center - half)
+            hi = min(len(spectrum), center + half + 1)
+            noise_spec[lo:hi] = 0.0
+            h += 1
+        residual = irfft(noise_spec, n=n)
+        return float(np.sqrt(np.mean(residual**2)))
 
     @staticmethod
     def format_stat_value(name: str, value: Optional[float]) -> str:

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -126,7 +126,7 @@ class WaveformAnalyzer:
 
             # Compute FFT
             n = len(v)
-            yf = fft(v)
+            yf = fft(v - np.mean(v))  # remove DC so the fundamental is not masked
             xf = fftfreq(n, 1 / sample_rate)
 
             # Get positive frequencies only
@@ -137,7 +137,7 @@ class WaveformAnalyzer:
             # Find peak frequency (excluding DC component)
             if len(yf_pos) > 1:
                 # Skip first bin (DC)
-                peak_idx = np.argmax(yf_pos[1:]) + 1
+                peak_idx = int(np.argmax(yf_pos))
                 frequency = xf_pos[peak_idx]
                 period = 1 / frequency if frequency > 0 else None
 
@@ -663,7 +663,7 @@ class WaveformAnalyzer:
                 return None
 
             # Find fundamental frequency (peak)
-            peak_idx = np.argmax(yf_pos[1:]) + 1  # Skip DC
+            peak_idx = int(np.argmax(yf_pos))  # DC already removed above
             fundamental_freq = xf_pos[peak_idx]
             fundamental_amp = yf_pos[peak_idx]
 

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -791,35 +791,13 @@ class WaveformAnalyzer:
             return None
 
     @staticmethod
-    def calculate_thd(waveform: WaveformData, num_harmonics: int = 10) -> Optional[float]:
-        """
-        Calculate Total Harmonic Distortion (THD) as a percentage.
+    def calculate_thd(waveform: WaveformData, num_harmonics: int = 5) -> Optional[float]:
+        """Total Harmonic Distortion (%). Delegates to the canonical FFTAnalyzer engine
+        so reports and the live webapp spectrum report the same number."""
+        from scpi_control.analysis import FFTAnalyzer
 
-        THD = sqrt(sum(harmonics[2:]^2)) / fundamental * 100
-
-        Args:
-            waveform: Waveform data
-            num_harmonics: Number of harmonics to include
-
-        Returns:
-            THD percentage, or None if calculation fails
-        """
         try:
-            harmonics = WaveformAnalyzer._get_harmonic_ratios(waveform, num_harmonics)
-
-            if harmonics is None or len(harmonics) < 2:
-                return None
-
-            # THD = sqrt(sum of squares of harmonics) / fundamental
-            fundamental = harmonics[0]
-            if fundamental == 0:
-                return None
-
-            harmonic_power = np.sum(harmonics[1:] ** 2)
-            thd = np.sqrt(harmonic_power) / fundamental * 100
-
-            return thd
-
+            return FFTAnalyzer.thd_of_waveform(waveform, num_harmonics=num_harmonics)
         except Exception as e:
             logger.exception(f"Error calculating THD: {e}")
             return None

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -307,15 +307,19 @@ class WaveformAnalyzer:
             signal_amplitude = (vmax - vmin) / 2
             snr = 20 * np.log10(signal_amplitude / noise_level) if noise_level > 0 else None
 
-            # Overshoot and undershoot (percentage above/below steady-state levels)
-            # This is approximate - we'll use top 10% and bottom 10% as steady state
-            v_sorted = np.sort(v)
-            n = len(v_sorted)
-            v_high_steady = np.mean(v_sorted[int(0.85 * n) : int(0.95 * n)])  # High steady state
-            v_low_steady = np.mean(v_sorted[int(0.05 * n) : int(0.15 * n)])  # Low steady state
-
-            overshoot = ((vmax - v_high_steady) / (v_high_steady - v_low_steady)) * 100 if v_high_steady != v_low_steady else 0
-            undershoot = ((v_low_steady - vmin) / (v_high_steady - v_low_steady)) * 100 if v_high_steady != v_low_steady else 0
+            # Overshoot/undershoot are meaningful only for flat-topped signals.
+            if WaveformAnalyzer._is_two_level(v):
+                vtop, vbase = WaveformAnalyzer._estimate_top_base(v)
+                span = vtop - vbase
+                if span > 0:
+                    overshoot = max(0.0, (float(np.max(v)) - vtop) / span * 100)
+                    undershoot = max(0.0, (vbase - float(np.min(v))) / span * 100)
+                else:
+                    overshoot = None
+                    undershoot = None
+            else:
+                overshoot = None
+                undershoot = None
 
             # Jitter (standard deviation of edge timing)
             # Find all rising edges
@@ -331,8 +335,8 @@ class WaveformAnalyzer:
             return {
                 "noise_level": noise_level,
                 "snr": snr,
-                "overshoot": max(0, overshoot),  # Don't show negative overshoot
-                "undershoot": max(0, undershoot),  # Don't show negative undershoot
+                "overshoot": overshoot,
+                "undershoot": undershoot,
                 "jitter": jitter,
             }
 

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -382,12 +382,25 @@ class WaveformAnalyzer:
         noise_spec[0] = 0.0
         half = 2
         h = 1
+        notched_count = 0
         while h * fund_bin < len(spectrum):
             center = h * fund_bin
             lo = max(1, center - half)
             hi = min(len(spectrum), center + half + 1)
             noise_spec[lo:hi] = 0.0
+            notched_count += hi - lo
             h += 1
+        # A very low fundamental bin (near-1-cycle capture) makes the ±2-bin
+        # harmonic notches overlap and blank out essentially the whole
+        # spectrum, so the residual RMS collapses toward 0 -- a fabricated
+        # "perfectly clean" reading, not a real noise measurement. A normal
+        # multi-cycle capture (e.g. fund_bin=8 over a 4001-bin spectrum)
+        # legitimately notches ~60% of bins and still leaves a representative
+        # noise residual; fund_bin<=5 leaves 2 bins or fewer -- essentially
+        # nothing to estimate noise from. 0.9 sits well above the former and
+        # well below the latter, so only near-total blanking trips this guard.
+        if notched_count > 0.9 * len(spectrum):
+            return None
         residual = irfft(noise_spec, n=n)
         return float(np.sqrt(np.mean(residual**2)))
 

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -136,7 +136,7 @@ class WaveformAnalyzer:
 
             # Find peak frequency (excluding DC component)
             if len(yf_pos) > 1:
-                # Skip first bin (DC)
+                # DC already removed above; first positive bin is a valid fundamental candidate
                 peak_idx = int(np.argmax(yf_pos))
                 frequency = xf_pos[peak_idx]
                 period = 1 / frequency if frequency > 0 else None
@@ -559,7 +559,7 @@ class WaveformAnalyzer:
         """Check if signal is DC (very low variation)."""
         # A real periodic component means the signal is not DC, regardless of how
         # large the DC offset is (the offset is what made the old std/mean test wrong).
-        if WaveformAnalyzer._has_dominant_tone(np.asarray(v, dtype=float)):
+        if WaveformAnalyzer._has_dominant_tone(v):
             return False
         std = np.std(v)
         mean = np.mean(np.abs(v))

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -32,6 +32,11 @@ _NOISE_PEAK_TO_MEDIAN = 15.0
 # instrument's noise floor.
 _MIN_MEASURABLE_NOISE_RATIO = 1e-9
 
+# When the harmonic notches used for noise estimation cover more than this
+# fraction of the spectrum, too little signal-free spectrum remains to estimate
+# noise, so _estimate_noise returns None rather than a fabricated near-zero value.
+_MAX_NOTCHED_FRACTION = 0.9
+
 
 class SignalType:
     """Signal type constants."""
@@ -380,27 +385,19 @@ class WaveformAnalyzer:
         fund_bin = 1 + int(np.argmax(mag[1:]))
         noise_spec = spectrum.copy()
         noise_spec[0] = 0.0
+        notched = np.zeros(len(spectrum), dtype=bool)
+        notched[0] = True  # DC bin zeroed above
         half = 2
         h = 1
-        notched_count = 0
         while h * fund_bin < len(spectrum):
             center = h * fund_bin
             lo = max(1, center - half)
             hi = min(len(spectrum), center + half + 1)
             noise_spec[lo:hi] = 0.0
-            notched_count += hi - lo
+            notched[lo:hi] = True
             h += 1
-        # A very low fundamental bin (near-1-cycle capture) makes the ±2-bin
-        # harmonic notches overlap and blank out essentially the whole
-        # spectrum, so the residual RMS collapses toward 0 -- a fabricated
-        # "perfectly clean" reading, not a real noise measurement. A normal
-        # multi-cycle capture (e.g. fund_bin=8 over a 4001-bin spectrum)
-        # legitimately notches ~60% of bins and still leaves a representative
-        # noise residual; fund_bin<=5 leaves 2 bins or fewer -- essentially
-        # nothing to estimate noise from. 0.9 sits well above the former and
-        # well below the latter, so only near-total blanking trips this guard.
-        if notched_count > 0.9 * len(spectrum):
-            return None
+        if notched.sum() > _MAX_NOTCHED_FRACTION * len(spectrum):
+            return None  # too little signal-free spectrum remains to estimate noise
         residual = irfft(noise_spec, n=n)
         return float(np.sqrt(np.mean(residual**2)))
 

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -94,7 +94,8 @@ class WaveformAnalyzer:
         vpp = vmax - vmin
         vmean = np.mean(v)
         vrms = np.sqrt(np.mean(v**2))
-        vamp = (vmax + vmin) / 2  # Amplitude (middle of range)
+        vtop, vbase = WaveformAnalyzer._estimate_top_base(v)
+        vamp = vtop - vbase  # Amplitude (Vtop - Vbase), offset-independent
 
         return {
             "vmax": vmax,
@@ -503,6 +504,29 @@ class WaveformAnalyzer:
         if mean == 0:
             return std < threshold
         return (std / mean) < threshold
+
+    @staticmethod
+    def _estimate_top_base(v: np.ndarray) -> Tuple[float, float]:
+        """Estimate the settled high (Vtop) and low (Vbase) levels via a histogram.
+
+        For flat-topped signals this returns the modal plateau levels (excluding
+        overshoot spikes); for signals without flat tops it collapses to
+        (vmax, vmin). Offset-independent.
+        """
+        v = np.asarray(v, dtype=float)
+        vmin = float(np.min(v))
+        vmax = float(np.max(v))
+        if vmax <= vmin:
+            return vmax, vmin
+        nbins = max(10, min(256, v.size // 20))
+        hist, edges = np.histogram(v, bins=nbins, range=(vmin, vmax))
+        centers = (edges[:-1] + edges[1:]) / 2.0
+        mid = (vmin + vmax) / 2.0
+        lower = centers < mid
+        upper = ~lower
+        vbase = float(centers[lower][int(np.argmax(hist[lower]))]) if hist[lower].any() else vmin
+        vtop = float(centers[upper][int(np.argmax(hist[upper]))]) if hist[upper].any() else vmax
+        return vtop, vbase
 
     @staticmethod
     def _is_two_level(v: np.ndarray, band: float = 0.15, min_fraction: float = 0.8) -> bool:

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -274,15 +274,15 @@ class WaveformAnalyzer:
 
             # Calculate pulse width and duty cycle
             if len(rising_edges) > 0 and len(falling_edges) > 0:
-                # Pulse width: time from rising edge to next falling edge
-                if falling_edges[0] > rising_edges[0]:
-                    pulse_width = (falling_edges[0] - rising_edges[0]) * dt
-
-                # Duty cycle: ratio of high time to period
-                if len(rising_edges) > 1:
-                    period_samples = rising_edges[1] - rising_edges[0]
-                    high_samples = falling_edges[0] - rising_edges[0] if falling_edges[0] > rising_edges[0] else 0
-                    duty_cycle = (high_samples / period_samples) * 100  # Percentage
+                # First falling edge after the first rising edge (ignore a leading
+                # falling edge when the capture starts on the high plateau).
+                fe_after = falling_edges[falling_edges > rising_edges[0]]
+                if len(fe_after) > 0:
+                    pulse_width = (fe_after[0] - rising_edges[0]) * dt
+                    if len(rising_edges) > 1:
+                        period_samples = rising_edges[1] - rising_edges[0]
+                        high_samples = fe_after[0] - rising_edges[0]
+                        duty_cycle = (high_samples / period_samples) * 100
 
             return {
                 "rise_time": rise_time,

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -503,6 +503,10 @@ class WaveformAnalyzer:
     @staticmethod
     def _is_dc_signal(v: np.ndarray, threshold: float = 0.01) -> bool:
         """Check if signal is DC (very low variation)."""
+        # A real periodic component means the signal is not DC, regardless of how
+        # large the DC offset is (the offset is what made the old std/mean test wrong).
+        if WaveformAnalyzer._has_dominant_tone(np.asarray(v, dtype=float)):
+            return False
         std = np.std(v)
         mean = np.mean(np.abs(v))
         if mean == 0:
@@ -570,6 +574,27 @@ class WaveformAnalyzer:
         if median == 0.0:
             return False  # isolated tones on a zero floor: not noise
         return bool((float(np.max(mag)) / median) < _NOISE_PEAK_TO_MEDIAN)
+
+    @staticmethod
+    def _has_dominant_tone(v: np.ndarray) -> bool:
+        """True if a single spectral bin clearly dominates (a real periodic component).
+
+        Unlike _is_noise, a constant signal (no spectral content) returns False here,
+        so it is still classified DC upstream.
+        """
+        v = np.asarray(v, dtype=float)
+        if v.size < 4:
+            return False
+        mag = np.abs(rfft(v - np.mean(v)))[1:]  # drop DC bin
+        if mag.size == 0:
+            return False
+        mx = float(np.max(mag))
+        if mx == 0.0:
+            return False  # constant / no spectral content
+        median = float(np.median(mag))
+        if median == 0.0:
+            return True  # isolated tone(s) on a zero floor
+        return (mx / median) >= _NOISE_PEAK_TO_MEDIAN
 
     @staticmethod
     def _get_harmonic_ratios(waveform: WaveformData, num_harmonics: int = 5) -> Optional[np.ndarray]:

--- a/scpi_control/server/compute.py
+++ b/scpi_control/server/compute.py
@@ -46,10 +46,8 @@ def spectrum_frame(config: Dict[str, Any], acquired: Dict[str, Any]) -> Optional
     if result is None:
         return None
     peaks = [[float(f), float(m)] for f, m in result.get_peak_frequency(5)]
-    thd = None
-    if peaks:
-        thd_value = FFTAnalyzer.calculate_thd(result, peaks[0][0])
-        thd = float(thd_value) if thd_value is not None else None
+    thd_value = FFTAnalyzer.thd_of_waveform(data)
+    thd = float(thd_value) if thd_value is not None else None
     df = float(result.frequency[1] - result.frequency[0]) if len(result.frequency) > 1 else 1.0
     pooled, pool = _max_pool(result.magnitude, MAX_SPECTRUM_BINS)
     return {

--- a/tests/test_analysis_peaks.py
+++ b/tests/test_analysis_peaks.py
@@ -1,0 +1,14 @@
+"""Peaks below 0 dB (small signals) must still be found in dB mode."""
+
+import numpy as np
+
+from scpi_control.analysis import FFTResult
+
+
+def test_get_peak_frequency_finds_sub_zero_db_peak():
+    freq = np.array([0.0, 10.0, 20.0, 30.0, 40.0, 50.0])
+    mag_db = np.array([-40.0, -30.0, -12.0, -30.0, -35.0, -38.0])  # local max at 20 Hz, below 0 dB
+    result = FFTResult(frequency=freq, magnitude=mag_db, phase=np.zeros(6), window="hann", sample_rate=100.0, magnitude_db=True)
+    peaks = result.get_peak_frequency(1)
+    assert peaks
+    assert abs(peaks[0][0] - 20.0) < 1e-9

--- a/tests/test_analysis_spectra.py
+++ b/tests/test_analysis_spectra.py
@@ -1,0 +1,21 @@
+"""Welch/spectrogram must accept the module's public window names on modern SciPy."""
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from scpi_control.analysis import FFTAnalyzer
+
+
+def _sine():
+    fs, n = 1e6, 10000
+    t = np.arange(n) / fs
+    return SimpleNamespace(voltage=np.sin(2 * np.pi * 50_000 * t), time=t)
+
+
+def test_power_spectrum_returns_result():
+    assert FFTAnalyzer().compute_power_spectrum(_sine()) is not None
+
+
+def test_spectrogram_returns_result():
+    assert FFTAnalyzer().compute_spectrogram(_sine()) is not None

--- a/tests/test_analysis_thd.py
+++ b/tests/test_analysis_thd.py
@@ -1,0 +1,21 @@
+"""THD reads each harmonic at its own rounded bin, robust to an off-bin fundamental."""
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from scpi_control.analysis import FFTAnalyzer
+
+
+def test_thd_off_bin_fundamental():
+    fs, n = 1e6, 10000
+    t = np.arange(n) / fs
+    f0 = 10040.0  # 0.4 bins off-center (df = 100 Hz)
+    v = np.sin(2 * np.pi * f0 * t) + 0.2 * np.sin(2 * np.pi * 3 * f0 * t) + 0.1 * np.sin(2 * np.pi * 5 * f0 * t)
+    wf = SimpleNamespace(voltage=v, time=t)
+    analyzer = FFTAnalyzer()
+    result = analyzer.compute_fft(wf, window="hanning", output_db=False, detrend=True)
+    thd = FFTAnalyzer.calculate_thd(result, f0, num_harmonics=5)
+    # true THD = sqrt(0.2^2 + 0.1^2) = 22.36 %
+    assert thd is not None
+    assert 18.0 < thd < 27.0

--- a/tests/test_analysis_thd.py
+++ b/tests/test_analysis_thd.py
@@ -19,3 +19,13 @@ def test_thd_off_bin_fundamental():
     # true THD = sqrt(0.2^2 + 0.1^2) = 22.36 %
     assert thd is not None
     assert 18.0 < thd < 27.0
+
+
+def test_thd_of_waveform_is_none_for_pure_noise():
+    rng = np.random.default_rng(2)
+    fs, n = 1e6, 4000
+    t = np.arange(n) / fs
+    noise = SimpleNamespace(voltage=rng.standard_normal(n), time=t)
+    assert FFTAnalyzer.thd_of_waveform(noise) is None
+    tone = SimpleNamespace(voltage=np.sin(2 * np.pi * 5000 * t) + 0.2 * np.sin(2 * np.pi * 15000 * t), time=t)
+    assert FFTAnalyzer.thd_of_waveform(tone) is not None

--- a/tests/test_daq_analyzer_extract.py
+++ b/tests/test_daq_analyzer_extract.py
@@ -14,3 +14,10 @@ def test_plain_labelled_value():
 
 def test_no_number_returns_none():
     assert DAQAnalyzer._extract_number("no numbers here") is None
+
+
+def test_bare_leading_decimal_value_not_truncated():
+    # A line that leads with the value itself must not have its integer part
+    # eaten as a list ordinal (regression: "10.5" -> 5.0).
+    assert DAQAnalyzer._extract_number("10.5 is critical high") == 10.5
+    assert DAQAnalyzer._extract_number("5.2 is the warning high threshold") == 5.2

--- a/tests/test_daq_analyzer_extract.py
+++ b/tests/test_daq_analyzer_extract.py
@@ -1,0 +1,16 @@
+"""Threshold extraction must bind the number to its label, not grab the list ordinal."""
+
+from scpi_control.report_generator.llm.daq_analyzer import DAQAnalyzer
+
+
+def test_ignores_leading_list_ordinal():
+    assert DAQAnalyzer._extract_number("1. warning high: 5.2 v") == 5.2
+    assert DAQAnalyzer._extract_number("2. warning low: 4.8 v") == 4.8
+
+
+def test_plain_labelled_value():
+    assert DAQAnalyzer._extract_number("critical high alarm at 10.5") == 10.5
+
+
+def test_no_number_returns_none():
+    assert DAQAnalyzer._extract_number("no numbers here") is None

--- a/tests/test_function_generator.py
+++ b/tests/test_function_generator.py
@@ -2,13 +2,14 @@
 
 import pytest
 
-from scpi_control import FunctionGenerator
+from scpi_control import FunctionGenerator, exceptions
 from scpi_control.awg_models import (
     AWGCapability,
     ChannelSpec,
     create_generic_awg_capability,
     detect_awg_from_idn,
 )
+from scpi_control.awg_output import AWGOutput
 from scpi_control.awg_scpi_commands import AWGSCPICommandSet
 from scpi_control.connection.mock import MockConnection
 
@@ -437,6 +438,17 @@ class TestWaveformTypes:
 
         mock_awg.channel1.ramp_symmetry = 50.0  # Triangle
         assert mock_awg.channel1.ramp_symmetry == 50.0
+
+
+class TestAWGParseFloat:
+    """Test AWGOutput._parse_float method."""
+
+    def test_awg_parse_float_raises_on_garbage(self):
+        """Test that _parse_float raises CommandError on unparseable response."""
+        obj = AWGOutput.__new__(AWGOutput)  # _parse_float uses no instance state
+        assert obj._parse_float("C1:BSWV FRQ,1000HZ") == 1000.0  # driver echo form -> 1000.0
+        with pytest.raises(exceptions.CommandError):
+            obj._parse_float("NONE")
 
 
 if __name__ == "__main__":

--- a/tests/test_power_supply.py
+++ b/tests/test_power_supply.py
@@ -614,8 +614,6 @@ class TestDataLogging:
 
 
 def test_parse_float_raises_on_garbage():
-    import pytest
-
     from scpi_control import exceptions
     from scpi_control.power_supply_output import PowerSupplyOutput
 

--- a/tests/test_power_supply.py
+++ b/tests/test_power_supply.py
@@ -613,5 +613,17 @@ class TestDataLogging:
         assert log_file.exists()
 
 
+def test_parse_float_raises_on_garbage():
+    import pytest
+
+    from scpi_control import exceptions
+    from scpi_control.power_supply_output import PowerSupplyOutput
+
+    obj = PowerSupplyOutput.__new__(PowerSupplyOutput)  # _parse_float uses no instance state
+    assert obj._parse_float("5.000V") == 5.0
+    with pytest.raises(exceptions.CommandError):
+        obj._parse_float("OVERLOAD")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_thd_consistency.py
+++ b/tests/test_thd_consistency.py
@@ -1,0 +1,24 @@
+"""The report THD path and the webapp THD path agree for the same capture."""
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from scpi_control.analysis import FFTAnalyzer
+from scpi_control.report_generator.models.report_data import WaveformData
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+
+def test_report_and_webapp_thd_agree():
+    fs, n = 1e6, 10000
+    t = np.arange(n) / fs
+    f0 = 5000.0
+    v = np.sin(2 * np.pi * f0 * t) + 0.2 * np.sin(2 * np.pi * 3 * f0 * t)  # ~20 % THD
+    report_wf = WaveformData(channel="C1", time=t, voltage=v, sample_rate=fs, record_length=n)
+    webapp_wf = SimpleNamespace(voltage=v, time=t)
+
+    report_thd = WaveformAnalyzer.calculate_thd(report_wf)
+    webapp_thd = FFTAnalyzer.thd_of_waveform(webapp_wf)
+
+    assert report_thd is not None and webapp_thd is not None
+    assert abs(report_thd - webapp_thd) < 1e-6

--- a/tests/test_waveform_analyzer_amplitude.py
+++ b/tests/test_waveform_analyzer_amplitude.py
@@ -1,0 +1,20 @@
+"""vamp is the scope-standard amplitude (Vtop - Vbase), offset-independent."""
+import numpy as np
+
+from scpi_control.report_generator.models.report_data import WaveformData
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+
+def make_waveform(voltage, rate=1e6):
+    n = len(voltage)
+    return WaveformData(channel="C1", time=np.arange(n) / rate, voltage=voltage, sample_rate=rate, record_length=n)
+
+
+def test_vamp_is_offset_independent_amplitude():
+    t = np.arange(4000) / 1e6
+    sine = np.sin(2 * np.pi * 1000 * t)  # 2 Vpp, centered at 0
+    centered = WaveformAnalyzer.calculate_amplitude_stats(make_waveform(sine))
+    offset = WaveformAnalyzer.calculate_amplitude_stats(make_waveform(sine + 2.5))
+    # Both describe the same 2 Vpp signal, so vamp must be the same and ~2.0, not the midpoint.
+    assert abs(centered["vamp"] - offset["vamp"]) < 1e-6
+    assert abs(centered["vamp"] - 2.0) < 0.05

--- a/tests/test_waveform_analyzer_amplitude.py
+++ b/tests/test_waveform_analyzer_amplitude.py
@@ -1,4 +1,5 @@
 """vamp is the scope-standard amplitude (Vtop - Vbase), offset-independent."""
+
 import numpy as np
 
 from scpi_control.report_generator.models.report_data import WaveformData

--- a/tests/test_waveform_analyzer_dc.py
+++ b/tests/test_waveform_analyzer_dc.py
@@ -1,0 +1,24 @@
+"""DC classification must not be fooled by a large offset over real ripple."""
+
+import numpy as np
+
+from scpi_control.report_generator.models.report_data import WaveformData
+from scpi_control.report_generator.utils.waveform_analyzer import SignalType, WaveformAnalyzer
+
+
+def make_waveform(voltage, rate=1e6):
+    n = len(voltage)
+    return WaveformData(channel="C1", time=np.arange(n) / rate, voltage=voltage, sample_rate=rate, record_length=n)
+
+
+def test_rail_with_ripple_is_not_dc():
+    t = np.arange(20000) / 1e6
+    v = 12.0 + 0.05 * np.sin(2 * np.pi * 100_000 * t)  # 12 V rail + 100 mVpp ripple
+    stype, _ = WaveformAnalyzer.detect_signal_type(make_waveform(v))
+    assert stype != SignalType.DC
+
+
+def test_constant_rail_is_dc():
+    v = np.full(2000, 5.0)
+    stype, _ = WaveformAnalyzer.detect_signal_type(make_waveform(v))
+    assert stype == SignalType.DC

--- a/tests/test_waveform_analyzer_frequency.py
+++ b/tests/test_waveform_analyzer_frequency.py
@@ -1,0 +1,30 @@
+"""The fundamental in the first positive FFT bin must not be skipped."""
+
+import numpy as np
+
+from scpi_control.report_generator.models.report_data import WaveformData
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+
+def make_waveform(voltage, rate=1e6):
+    n = len(voltage)
+    return WaveformData(channel="C1", time=np.arange(n) / rate, voltage=voltage, sample_rate=rate, record_length=n)
+
+
+def test_single_period_sine_frequency():
+    n, rate = 1000, 1e6
+    t = np.arange(n) / rate
+    f0 = rate / n  # exactly one period over the record -> fundamental in bin 1
+    v = np.sin(2 * np.pi * f0 * t)
+    stats = WaveformAnalyzer.calculate_frequency_stats(make_waveform(v, rate))
+    assert stats["frequency"] is not None
+    assert abs(stats["frequency"] - f0) < rate / n  # within one bin
+
+
+def test_single_period_sine_harmonics_negligible():
+    n, rate = 1000, 1e6
+    t = np.arange(n) / rate
+    v = np.sin(2 * np.pi * (rate / n) * t)
+    ratios = WaveformAnalyzer._get_harmonic_ratios(make_waveform(v, rate))
+    assert ratios is not None
+    assert ratios[1] < 0.1  # a pure sine has a negligible 2nd harmonic

--- a/tests/test_waveform_analyzer_quality.py
+++ b/tests/test_waveform_analyzer_quality.py
@@ -36,3 +36,21 @@ def test_square_overshoot_is_measured():
     q = WaveformAnalyzer.calculate_quality_stats(make_waveform(_square_with_overshoot(0.05)))
     assert q["overshoot"] is not None
     assert 3.0 < q["overshoot"] < 7.0
+
+
+def test_clean_sine_has_near_zero_noise_and_no_snr():
+    t = np.arange(8000) / 1e6
+    v = np.sin(2 * np.pi * 1000 * t)  # perfectly clean, integer number of periods
+    q = WaveformAnalyzer.calculate_quality_stats(make_waveform(v))
+    assert q["noise_level"] is not None and q["noise_level"] < 1e-3  # ~0, not 0.707
+    assert q["snr"] is None  # no measurable noise -> no fabricated dB
+
+
+def test_noisy_sine_noise_estimate_matches_injected():
+    rng = np.random.default_rng(0)
+    t = np.arange(8000) / 1e6
+    v = np.sin(2 * np.pi * 1000 * t) + 0.01 * rng.standard_normal(t.size)  # 10 mV RMS noise
+    q = WaveformAnalyzer.calculate_quality_stats(make_waveform(v))
+    assert q["noise_level"] is not None
+    assert 0.006 < q["noise_level"] < 0.014  # ~10 mV
+    assert q["snr"] is not None and 30 < q["snr"] < 50  # ~37 dB (0.707 / 0.01)

--- a/tests/test_waveform_analyzer_quality.py
+++ b/tests/test_waveform_analyzer_quality.py
@@ -54,3 +54,12 @@ def test_noisy_sine_noise_estimate_matches_injected():
     assert q["noise_level"] is not None
     assert 0.006 < q["noise_level"] < 0.014  # ~10 mV
     assert q["snr"] is not None and 30 < q["snr"] < 50  # ~37 dB (0.707 / 0.01)
+
+
+def test_single_cycle_capture_noise_is_none_not_zero():
+    rng = np.random.default_rng(1)
+    n, rate = 1000, 1e6
+    t = np.arange(n) / rate
+    v = np.sin(2 * np.pi * (rate / n) * t) + 0.01 * rng.standard_normal(n)  # one period over the record
+    q = WaveformAnalyzer.calculate_quality_stats(make_waveform(v, rate))
+    assert q["noise_level"] is None  # cannot separate noise from a 1-cycle capture; must not fabricate 0.0

--- a/tests/test_waveform_analyzer_quality.py
+++ b/tests/test_waveform_analyzer_quality.py
@@ -63,3 +63,15 @@ def test_single_cycle_capture_noise_is_none_not_zero():
     v = np.sin(2 * np.pi * (rate / n) * t) + 0.01 * rng.standard_normal(n)  # one period over the record
     q = WaveformAnalyzer.calculate_quality_stats(make_waveform(v, rate))
     assert q["noise_level"] is None  # cannot separate noise from a 1-cycle capture; must not fabricate 0.0
+
+
+def test_noise_estimate_boundary_five_vs_six_cycles():
+    rng = np.random.default_rng(3)
+    n, rate = 1000, 1e6
+    t = np.arange(n) / rate
+    # 5 cycles over the record (fund_bin=5): notches blanket ~all of the spectrum -> cannot estimate
+    five = np.sin(2 * np.pi * (5 * rate / n) * t) + 0.01 * rng.standard_normal(n)
+    assert WaveformAnalyzer.calculate_quality_stats(make_waveform(five, rate))["noise_level"] is None
+    # 6 cycles (fund_bin=6): enough signal-free spectrum survives -> a real (non-None) estimate
+    six = np.sin(2 * np.pi * (6 * rate / n) * t) + 0.01 * rng.standard_normal(n)
+    assert WaveformAnalyzer.calculate_quality_stats(make_waveform(six, rate))["noise_level"] is not None

--- a/tests/test_waveform_analyzer_quality.py
+++ b/tests/test_waveform_analyzer_quality.py
@@ -1,4 +1,5 @@
 """Quality metrics: overshoot/undershoot and noise/SNR are honest (no fabrication)."""
+
 import numpy as np
 
 from scpi_control.report_generator.models.report_data import WaveformData
@@ -17,9 +18,9 @@ def _square_with_overshoot(overshoot_frac=0.05):
     rising = np.where((v[:-1] < 0) & (v[1:] >= 0))[0]
     falling = np.where((v[:-1] > 0) & (v[1:] <= 0))[0]
     for idx in rising:
-        v[idx + 1: idx + 4] = 1.0 + spike
+        v[idx + 1 : idx + 4] = 1.0 + spike
     for idx in falling:
-        v[idx + 1: idx + 4] = -1.0 - spike
+        v[idx + 1 : idx + 4] = -1.0 - spike
     return v
 
 

--- a/tests/test_waveform_analyzer_quality.py
+++ b/tests/test_waveform_analyzer_quality.py
@@ -1,0 +1,37 @@
+"""Quality metrics: overshoot/undershoot and noise/SNR are honest (no fabrication)."""
+import numpy as np
+
+from scpi_control.report_generator.models.report_data import WaveformData
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+
+def make_waveform(voltage, rate=1e6):
+    n = len(voltage)
+    return WaveformData(channel="C1", time=np.arange(n) / rate, voltage=voltage, sample_rate=rate, record_length=n)
+
+
+def _square_with_overshoot(overshoot_frac=0.05):
+    t = np.arange(4000) / 1e6
+    v = np.where(np.sin(2 * np.pi * 1000 * t) >= 0, 1.0, -1.0).astype(float)  # -1..+1, amplitude 2.0
+    spike = overshoot_frac * 2.0  # fraction of the peak-to-peak amplitude
+    rising = np.where((v[:-1] < 0) & (v[1:] >= 0))[0]
+    falling = np.where((v[:-1] > 0) & (v[1:] <= 0))[0]
+    for idx in rising:
+        v[idx + 1: idx + 4] = 1.0 + spike
+    for idx in falling:
+        v[idx + 1: idx + 4] = -1.0 - spike
+    return v
+
+
+def test_clean_sine_reports_no_overshoot():
+    t = np.arange(4000) / 1e6
+    v = np.sin(2 * np.pi * 1000 * t)
+    q = WaveformAnalyzer.calculate_quality_stats(make_waveform(v))
+    assert q["overshoot"] is None
+    assert q["undershoot"] is None
+
+
+def test_square_overshoot_is_measured():
+    q = WaveformAnalyzer.calculate_quality_stats(make_waveform(_square_with_overshoot(0.05)))
+    assert q["overshoot"] is not None
+    assert 3.0 < q["overshoot"] < 7.0

--- a/tests/test_waveform_analyzer_timing.py
+++ b/tests/test_waveform_analyzer_timing.py
@@ -1,0 +1,20 @@
+"""Duty cycle must not depend on the trigger phase of the capture."""
+
+import numpy as np
+
+from scpi_control.report_generator.models.report_data import WaveformData
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+
+def make_waveform(voltage, rate=1e6):
+    n = len(voltage)
+    return WaveformData(channel="C1", time=np.arange(n) / rate, voltage=voltage, sample_rate=rate, record_length=n)
+
+
+def test_duty_cycle_when_capture_starts_high():
+    t = np.arange(4000) / 1e6
+    # cosine-phased square: first sample sits on the high plateau
+    v = np.where(np.cos(2 * np.pi * 1000 * t) >= 0, 1.0, -1.0)
+    stats = WaveformAnalyzer.calculate_timing_stats(make_waveform(v))
+    assert stats["duty_cycle"] is not None
+    assert abs(stats["duty_cycle"] - 50.0) < 5.0  # was 0.00 %


### PR DESCRIPTION
## Summary

Sub-project #1 of the 2026-07-22 whole-project audit remediation. Addresses audit **theme #1 — "silent fabrication of scientific numbers"**: the analysis stack was shipping wrong or invented metrics with no error flag, the worst failure mode for a scientist audience putting these numbers in reports. Every fixed metric now either computes a defensible value or returns `None` (rendered "N/A") — never a fabricated stand-in. Stat-dict **keys are unchanged**, so report models, the comparison analyzer, and the generators keep working; only the values change (corrected, or honestly `None`).

## ⚠️ Breaking change

PSU and function-generator readback (`measure_voltage`/`measure_current`/`measure_power`, setpoint/OVP/OCP getters, and AWG `frequency`/`amplitude`/`offset`/`phase`) now **raise `CommandError`** on an unparseable instrument response instead of silently returning `0.0`. Callers that relied on the silent zero must handle the exception. Recorded under `### ⚠️ Breaking Changes` in the changelog → drives a MAJOR version bump at release.

## Fixed (audit findings)

| Finding | Fix |
|---|---|
| **C1** | THD reads each harmonic at its own rounded bin (RSS over ±2 bins), robust to an off-bin fundamental — was ~3× underreported |
| **C2** | noise/SNR estimated from a signal-free residual, not the whole-signal RMS — a clean 1 V sine no longer reports "Noise 707 mV / SNR 3 dB" |
| **M41** | `vamp` = Vtop−Vbase amplitude, not the vertical midpoint (offset-independent) |
| **M42** | overshoot/undershoot only for flat-topped signals — a clean sine no longer reports ~2.8% overshoot |
| **M28** | duty cycle correct when the capture starts on the high level — was 0.00% |
| **M43** | DC classification offset-independent — a 12 V rail + ripple is no longer classified "dc" |
| **M40** | FFT peak detection no longer skips the first positive bin — correct fundamental for ~1-period captures (two sites) |
| **M2** | FFT peak detection finds sub-0-dB peaks (small signals no longer return no peaks) |
| **H1** | SciPy window-name mapping — `compute_power_spectrum`/`compute_spectrogram` no longer always return `None` |
| **M3** | single canonical THD engine — the live spectrum and PDF reports now report the same number (report-path THD now sums 5 harmonics, was 10) |
| **H15 / M6** | PSU/AWG readback raises on garbage (the breaking change above) |
| **M35** | LLM threshold extraction binds numbers to their labels instead of grabbing the first number in the line |

## Also (honesty edges caught in review)

- Live webapp spectrum THD now returns `None` for a pure-noise channel instead of a fabricated value.
- Noise estimate returns `None` (not a fabricated ~0) when too little signal-free spectrum survives — e.g. ~1-cycle captures.

## Testing

Full suite **1176 → 1200 passing / 19 skipped**; `black --check --line-length 200 scpi_control/ examples/` and `flake8 --select=E9,F63,F7,F82` clean. Every fix is TDD'd against an analytically-known input (off-bin THD signal with injected harmonics, clean sine, high-start square, one-period sine, 12 V + ripple, garbage SCPI response, etc.).

## Deferred follow-ups (tracked, not in this PR)

- `daq_analyzer._extract_number` splits on the first colon — a timestamp before the label (`"at 10:30 warning high: 5.2"`) mis-binds; needs a label-anchored parse.
- `get_configuration` reads setpoints outside its measurement `try/except`, so a garbage setpoint echo raises mid config-dump (asymmetric with the wrapped measurements — an intended consequence of the breaking change, but worth a graceful-dump guard).
- The noise estimate is biased low in proportion to the notched fraction (inherent to the notch approach; the new guard only prevents the fabricated-zero extreme).
- `_NOISE_PEAK_TO_MEDIAN` and `_THD_MIN_PEAK_TO_MEDIAN` are two independent `15.0` constants across modules.

Remaining audit themes — mock fidelity, the comparison pass/fail spine, report escaping, server security, blind tests, provenance honesty — are queued as follow-up sub-projects.
