### PR TITLE
Comparison/batch pass-fail spine: make report verdicts trustworthy (audit theme #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dev tooling: `pytest-xdist` in the `dev` extra for parallel local test runs (`python -m pytest -n auto`); complements `--testmon` (use one or the other per invocation).
 - Report generator: before/after comparison and multi-DUT batch reports — load multiple capture-file runs, overlay their waveforms, and get delta tables (comparison) or per-DUT summary with aggregates and yield (batch). Available from the Python API and the GUI's new Report → Comparison / Batch Report dialog.
 - Report generator: optional raw-data appendix (source-file manifest with SHA-256 checksums, capture timestamps, and instrument identity from provenance) and a configurable sign-off block (template-defined roles with signature/date lines). Both also work on ordinary single-run reports.
+- Report generator: `top_flatness` waveform statistic (top-plateau deviation as % of amplitude); the probe-calibration preset now evaluates overshoot/undershoot (pass/fail) and top flatness (warning).
 
 ### Fixed
 
@@ -33,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for the same capture. Report-path THD now sums the first 5 harmonics (previously 10).
 - DAQ AI threshold suggestions now bind each extracted number to its label instead of grabbing the
   first number in the sentence.
+- Comparison/batch reports: pass/fail criteria now match analyzer statistics (case-insensitive plus
+  display-name aliases) — previously the shipped criteria template produced empty verdicts. Criteria
+  that cannot be evaluated are surfaced as warnings (never silently dropped), half-open RANGE criteria
+  are enforced, verdicts are severity-aware (only `critical` criteria gate) with a distinct INCOMPLETE
+  state, and yield reports an incomplete count instead of inflating the pass rate.
 
 ## [3.3.1] - 2026-07-21
 

--- a/scpi_control/report_generator/analysis/comparison_analyzer.py
+++ b/scpi_control/report_generator/analysis/comparison_analyzer.py
@@ -26,6 +26,13 @@ from scpi_control.report_generator.utils.waveform_loader import WaveformLoader
 
 logger = logging.getLogger(__name__)
 
+# Display-name -> WaveformAnalyzer stat key, for names that don't normalize directly.
+_CRITERIA_ALIASES: Dict[str, str] = {
+    "peak_to_peak": "vpp",
+    "peaktopeak": "vpp",
+    "amplitude": "vamp",
+}
+
 # Units for MeasurementResult rows, keyed by WaveformAnalyzer statistic name.
 STAT_UNITS: Dict[str, str] = {
     "vmax": "V",
@@ -46,6 +53,7 @@ STAT_UNITS: Dict[str, str] = {
     "overshoot": "%",
     "undershoot": "%",
     "thd": "%",
+    "top_flatness": "%",
     "snr": "dB",
 }
 
@@ -104,6 +112,20 @@ class ComparisonAnalyzer:
             except (FileNotFoundError, ValueError, OSError) as e:
                 return f"Run '{run.label}': {filepath}: {e}"
         run.waveforms = waveforms
+        return None
+
+    @staticmethod
+    def _resolve_stat_key(name: str, stats: Dict) -> Optional[str]:
+        """Resolve a criterion's measurement_name to a stat key: exact, then
+        normalized (lower + spaces/hyphens -> underscores), then an alias map."""
+        if name in stats:
+            return name
+        norm = name.strip().lower().replace(" ", "_").replace("-", "_")
+        if norm in stats:
+            return norm
+        alias = _CRITERIA_ALIASES.get(norm)
+        if alias is not None and alias in stats:
+            return alias
         return None
 
     @staticmethod

--- a/scpi_control/report_generator/analysis/comparison_analyzer.py
+++ b/scpi_control/report_generator/analysis/comparison_analyzer.py
@@ -93,7 +93,7 @@ class ComparisonAnalyzer:
         for run in runset.runs:
             for wf in run.waveforms:
                 wf.analyze()
-            ComparisonAnalyzer._apply_criteria(run, runset.criteria_set)
+            ComparisonAnalyzer._apply_criteria(run, runset.criteria_set, warnings)
 
         matched, match_warnings = ComparisonAnalyzer._match_channels(runset.runs)
         warnings.extend(match_warnings)
@@ -129,35 +129,57 @@ class ComparisonAnalyzer:
         return None
 
     @staticmethod
-    def _apply_criteria(run: Run, criteria_set: Optional[CriteriaSet]) -> None:
-        """Build run.measurements from criteria (matched by statistic key) and set run.passed."""
+    def _apply_criteria(run: Run, criteria_set: Optional[CriteriaSet], warnings: List[str]) -> None:
+        """Build run.measurements from criteria (resolved to stat keys) and set
+        run.passed / run.incomplete. Only `critical` criteria gate the verdict;
+        un-evaluable criteria are surfaced as warnings, never silently dropped."""
         run.measurements = []
+        run.incomplete = False
         if criteria_set is None:
             run.passed = None
             return
-        evaluated: List[bool] = []
+        critical_pass: List[bool] = []
+        critical_unevaluable = False
         for wf in run.waveforms:
             stats = wf.statistics or {}
             for criteria in criteria_set.criteria_list:
                 if criteria.channel is not None and criteria.channel != wf.label:
                     continue
-                value = stats.get(criteria.measurement_name)
+                is_critical = (criteria.severity or "").lower() == "critical"
+                key = ComparisonAnalyzer._resolve_stat_key(criteria.measurement_name, stats)
+                value = stats.get(key) if key is not None else None
                 if value is None or not isinstance(value, (int, float)) or isinstance(value, bool):
+                    warnings.append(f"Run '{run.label}': criterion '{criteria.measurement_name}' on '{wf.label}' could not be evaluated (no numeric statistic)")
+                    if is_critical:
+                        critical_unevaluable = True
                     continue
                 outcome = criteria.validate(float(value))
                 run.measurements.append(
                     MeasurementResult(
                         name=criteria.measurement_name,
                         value=float(value),
-                        unit=STAT_UNITS.get(criteria.measurement_name, ""),
+                        unit=STAT_UNITS.get(key, ""),
                         channel=wf.label,
                         passed=outcome.passed,
                         criteria_min=criteria.min_value,
                         criteria_max=criteria.max_value,
                     )
                 )
-                evaluated.append(outcome.passed)
-        run.passed = all(evaluated) if evaluated else None
+                if outcome.passed is None:
+                    warnings.append(f"Run '{run.label}': criterion '{criteria.measurement_name}' on '{wf.label}' is not fully specified; not evaluated")
+                    if is_critical:
+                        critical_unevaluable = True
+                elif is_critical:
+                    critical_pass.append(outcome.passed)
+        if any(p is False for p in critical_pass):
+            run.passed = False
+        elif critical_unevaluable:
+            run.passed = None
+            run.incomplete = True
+        elif critical_pass:
+            run.passed = True
+        else:
+            run.passed = None
 
     @staticmethod
     def _match_channels(runs: List[Run]):
@@ -240,3 +262,4 @@ class ComparisonAnalyzer:
         if evaluated:
             result.yield_passed = sum(1 for run in evaluated if run.passed)
             result.yield_total = len(evaluated)
+        result.yield_incomplete = sum(1 for run in runset.runs if run.incomplete)

--- a/scpi_control/report_generator/comparison_report_builder.py
+++ b/scpi_control/report_generator/comparison_report_builder.py
@@ -12,6 +12,7 @@ from scpi_control.report_generator.models.comparison import MODE_COMPARISON, Com
 from scpi_control.report_generator.models.report_data import SUMMARY_SOURCE_COMPUTED, ReportMetadata, TestReport, TestSection
 from scpi_control.report_generator.models.report_elements import (
     STATUS_FAIL,
+    STATUS_INCOMPLETE,
     STATUS_PASS,
     ComparisonTable,
     DataManifest,
@@ -104,10 +105,14 @@ def _run_color(index: int) -> str:
     return _RUN_COLORS[index % len(_RUN_COLORS)]
 
 
-def _status(passed: Optional[bool]) -> Optional[str]:
-    if passed is None:
-        return None
-    return STATUS_PASS if passed else STATUS_FAIL
+def _run_verdict(run) -> Tuple[str, Optional[str]]:
+    if run.incomplete:
+        return "INCOMPLETE", STATUS_INCOMPLETE
+    if run.passed is True:
+        return "PASS", STATUS_PASS
+    if run.passed is False:
+        return "FAIL", STATUS_FAIL
+    return "—", None
 
 
 def _overview_section(result: ComparisonResult) -> TestSection:
@@ -117,8 +122,8 @@ def _overview_section(result: ComparisonResult) -> TestSection:
     rows = []
     for i, run in enumerate(runset.runs):
         label = run.label + (" (baseline)" if runset.mode == MODE_COMPARISON and i == runset.baseline_index else "")
-        verdict = "PASS" if run.passed else "FAIL" if run.passed is False else "—"
-        rows.append([TableCell(label), TableCell(run.metadata.dut_id or "—"), TableCell(run.metadata.condition or "—"), TableCell(str(len(run.files))), TableCell(verdict, status=_status(run.passed))])
+        verdict, vstatus = _run_verdict(run)
+        rows.append([TableCell(label), TableCell(run.metadata.dut_id or "—"), TableCell(run.metadata.condition or "—"), TableCell(str(len(run.files))), TableCell(verdict, status=vstatus)])
     section.comparison_table = ComparisonTable(title="Runs", headers=headers, rows=rows)
     if result.warnings:
         section.content = "Warnings:\n" + "\n".join(f"- {w}" for w in result.warnings)
@@ -189,8 +194,8 @@ def _batch_section(result: ComparisonResult) -> Tuple[TestSection, TestSection]:
     headers = ["Run", "DUT ID", "Result"] + [col_name(s, c) for c in channels for s in stats]
     rows = []
     for run in runset.runs:
-        verdict = "PASS" if run.passed else "FAIL" if run.passed is False else "—"
-        row = [TableCell(run.label), TableCell(run.metadata.dut_id or "—"), TableCell(verdict, status=_status(run.passed))]
+        verdict, vstatus = _run_verdict(run)
+        row = [TableCell(run.label), TableCell(run.metadata.dut_id or "—"), TableCell(verdict, status=vstatus)]
         for channel in channels:
             wf = next((w for w in run.waveforms if w.label == channel), None)
             for stat in stats:
@@ -273,7 +278,12 @@ def _executive_summary(result: ComparisonResult) -> str:
     else:
         parts = [f"Batch of {len(runset.runs)} runs."]
         if result.yield_total:
-            parts.append(f"Yield: {result.yield_passed}/{result.yield_total} passed ({100.0 * result.yield_passed / result.yield_total:.0f}%).")
+            txt = f"Yield: {result.yield_passed}/{result.yield_total} passed ({100.0 * result.yield_passed / result.yield_total:.0f}%)."
+            if result.yield_incomplete:
+                txt += f" {result.yield_incomplete} incomplete."
+            parts.append(txt)
+        elif result.yield_incomplete:
+            parts.append(f"{result.yield_incomplete} run(s) incomplete — criteria could not be evaluated.")
     if result.warnings:
         parts.append(f"{len(result.warnings)} warning(s) — see Overview.")
     return " ".join(parts)
@@ -329,7 +339,14 @@ def build_comparison_report(
     report.executive_summary = _executive_summary(result)
     report.summary_source = SUMMARY_SOURCE_COMPUTED
     evaluated = [run.passed for run in runset.runs if run.passed is not None]
-    report.overall_result = "FAIL" if False in evaluated else ("PASS" if evaluated else "INCONCLUSIVE")
+    if False in evaluated:
+        report.overall_result = "FAIL"
+    elif any(run.incomplete for run in runset.runs):
+        report.overall_result = "INCONCLUSIVE"
+    elif evaluated:
+        report.overall_result = "PASS"
+    else:
+        report.overall_result = "INCONCLUSIVE"
     return report
 
 

--- a/scpi_control/report_generator/generators/markdown_generator.py
+++ b/scpi_control/report_generator/generators/markdown_generator.py
@@ -584,6 +584,8 @@ class MarkdownReportGenerator(BaseReportGenerator):
                     text += " ✅"
                 elif cell.status == "fail":
                     text += " ❌"
+                elif cell.status == "incomplete":
+                    text += " ⚠️"
                 cells.append(text)
             lines.append("| " + " | ".join(cells) + " |")
         return "\n".join(lines)

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -1246,6 +1246,8 @@ class PDFReportGenerator(BaseReportGenerator):
                     style_commands.append(("TEXTCOLOR", (c, r), (c, r), colors.HexColor(self.branding.success_color)))
                 elif cell.status == "fail":
                     style_commands.append(("TEXTCOLOR", (c, r), (c, r), colors.HexColor(self.branding.failure_color)))
+                elif cell.status == "incomplete":
+                    style_commands.append(("TEXTCOLOR", (c, r), (c, r), colors.HexColor("#b58900")))
         element.setStyle(TableStyle(style_commands))
         return element
 

--- a/scpi_control/report_generator/models/comparison.py
+++ b/scpi_control/report_generator/models/comparison.py
@@ -40,6 +40,7 @@ class Run:
     waveforms: List[WaveformData] = field(default_factory=list)
     measurements: List[MeasurementResult] = field(default_factory=list)
     passed: Optional[bool] = None  # None when no criteria applied
+    incomplete: bool = False  # True when a critical criterion could not be evaluated
     load_errors: List[str] = field(default_factory=list)
 
 
@@ -102,4 +103,5 @@ class ComparisonResult:
     aggregates: Dict[str, Dict[str, AggregateStats]] = field(default_factory=dict)
     yield_passed: Optional[int] = None
     yield_total: Optional[int] = None
+    yield_incomplete: Optional[int] = None
     warnings: List[str] = field(default_factory=list)

--- a/scpi_control/report_generator/models/criteria.py
+++ b/scpi_control/report_generator/models/criteria.py
@@ -50,49 +50,55 @@ class MeasurementCriteria:
         Returns:
             CriteriaResult with pass/fail status and details
         """
-        passed = False
+        passed: Optional[bool] = None
         message = ""
 
         if self.comparison_type == ComparisonType.RANGE:
             if self.min_value is not None and self.max_value is not None:
                 passed = self.min_value <= value <= self.max_value
-                message = f"Value {value:.6g} is {'within' if passed else 'outside'} " f"range [{self.min_value:.6g}, {self.max_value:.6g}]"
+                message = f"Value {value:.6g} is {'within' if passed else 'outside'} range [{self.min_value:.6g}, {self.max_value:.6g}]"
+            elif self.min_value is not None:
+                passed = value >= self.min_value
+                message = f"Value {value:.6g} is {'at/above' if passed else 'below'} minimum {self.min_value:.6g}"
+            elif self.max_value is not None:
+                passed = value <= self.max_value
+                message = f"Value {value:.6g} is {'at/below' if passed else 'above'} maximum {self.max_value:.6g}"
             else:
-                passed = True
-                message = "Range criteria not fully specified"
+                passed = None
+                message = "Range criteria not specified"
 
         elif self.comparison_type == ComparisonType.MIN_ONLY:
             if self.min_value is not None:
                 passed = value >= self.min_value
-                message = f"Value {value:.6g} is {'above' if passed else 'below'} " f"minimum {self.min_value:.6g}"
+                message = f"Value {value:.6g} is {'above' if passed else 'below'} minimum {self.min_value:.6g}"
             else:
-                passed = True
+                passed = None
                 message = "Minimum value not specified"
 
         elif self.comparison_type == ComparisonType.MAX_ONLY:
             if self.max_value is not None:
                 passed = value <= self.max_value
-                message = f"Value {value:.6g} is {'below' if passed else 'above'} " f"maximum {self.max_value:.6g}"
+                message = f"Value {value:.6g} is {'below' if passed else 'above'} maximum {self.max_value:.6g}"
             else:
-                passed = True
+                passed = None
                 message = "Maximum value not specified"
 
         elif self.comparison_type == ComparisonType.EQUALS:
             if self.target_value is not None:
                 tolerance = self.tolerance if self.tolerance is not None else 0
                 passed = abs(value - self.target_value) <= tolerance
-                message = f"Value {value:.6g} is {'equal to' if passed else 'not equal to'} " f"target {self.target_value:.6g} (tolerance: ±{tolerance:.6g})"
+                message = f"Value {value:.6g} is {'equal to' if passed else 'not equal to'} target {self.target_value:.6g} (tolerance: ±{tolerance:.6g})"
             else:
-                passed = True
+                passed = None
                 message = "Target value not specified"
 
         elif self.comparison_type == ComparisonType.NOT_EQUALS:
             if self.target_value is not None:
                 tolerance = self.tolerance if self.tolerance is not None else 0
                 passed = abs(value - self.target_value) > tolerance
-                message = f"Value {value:.6g} is {'different from' if passed else 'equal to'} " f"target {self.target_value:.6g} (tolerance: ±{tolerance:.6g})"
+                message = f"Value {value:.6g} is {'different from' if passed else 'equal to'} target {self.target_value:.6g} (tolerance: ±{tolerance:.6g})"
             else:
-                passed = True
+                passed = None
                 message = "Target value not specified"
 
         return CriteriaResult(
@@ -140,12 +146,12 @@ class CriteriaResult:
 
     criteria: MeasurementCriteria
     value: float
-    passed: bool
+    passed: Optional[bool]
     message: str
 
     def __str__(self) -> str:
         """String representation."""
-        status = "PASS" if self.passed else "FAIL"
+        status = "PASS" if self.passed is True else "FAIL" if self.passed is False else "N/A"
         return f"[{status}] {self.criteria.measurement_name}: {self.message}"
 
 

--- a/scpi_control/report_generator/models/report_elements.py
+++ b/scpi_control/report_generator/models/report_elements.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 
 STATUS_PASS = "pass"
 STATUS_FAIL = "fail"
+STATUS_INCOMPLETE = "incomplete"
 
 
 @dataclass

--- a/scpi_control/report_generator/models/template.py
+++ b/scpi_control/report_generator/models/template.py
@@ -462,7 +462,7 @@ class ReportTemplate:
         """
         template = cls(
             name="Probe Calibration Template",
-            description=("Oscilloscope probe compensation check using the 1 kHz " "calibration square wave. Verifies a flat top with no " "overshoot, undershoot, or ringing."),
+            description=("Oscilloscope probe compensation check using the 1 kHz " "calibration square wave. Verifies a flat top with no " "overshoot or undershoot."),
             default_test_type="probe_calibration",
             default_test_procedure=(
                 "1. Connect the probe tip to the scope's ~1 kHz calibration "

--- a/scpi_control/report_generator/models/template.py
+++ b/scpi_control/report_generator/models/template.py
@@ -456,7 +456,7 @@ class ReportTemplate:
 
         Configured for the 1 kHz calibration square wave: links to the
         ``probe_calibration`` test type, ships a probe-comp procedure and
-        percentage-based pass/fail limits (overshoot, undershoot, ringing,
+        percentage-based pass/fail limits (overshoot, undershoot, and
         top flatness), and omits FFT (irrelevant to a comp check). No
         measurement data is baked in -- apply it to any capture.
         """
@@ -499,7 +499,7 @@ class ReportTemplate:
         template.add_section(
             SectionTemplate(
                 title="Flatness & Edge Analysis",
-                content=("Overshoot, undershoot, ringing, and top flatness against " "the compensation limits."),
+                content=("Overshoot, undershoot, and top flatness against " "the compensation limits."),
                 include_waveforms=True,
                 include_measurements=True,
                 order=2,
@@ -536,15 +536,6 @@ class ReportTemplate:
                 max_value=5.0,
                 severity="critical",
                 description="Dip below the flat base, as % of amplitude.",
-            )
-        )
-        criteria.add_criteria(
-            MeasurementCriteria(
-                measurement_name="Ringing",
-                comparison_type=ComparisonType.MAX_ONLY,
-                max_value=5.0,
-                severity="warning",
-                description="Post-transition oscillation, as % of amplitude.",
             )
         )
         criteria.add_criteria(

--- a/scpi_control/report_generator/utils/waveform_analyzer.py
+++ b/scpi_control/report_generator/utils/waveform_analyzer.py
@@ -85,6 +85,9 @@ class WaveformAnalyzer:
         # Signal quality metrics
         stats.update(WaveformAnalyzer.calculate_quality_stats(waveform))
 
+        # Calculate top flatness for flat-topped signals
+        stats["top_flatness"] = WaveformAnalyzer.calculate_top_flatness(waveform)
+
         # Calculate THD for periodic signals
         if signal_type in [SignalType.SINE, SignalType.SQUARE, SignalType.TRIANGLE, SignalType.SAWTOOTH]:
             thd = WaveformAnalyzer.calculate_thd(waveform)
@@ -446,7 +449,7 @@ class WaveformAnalyzer:
                 return f"{value*1e9:.2f} ns"
 
         # Percentage
-        elif name in ["duty_cycle", "overshoot", "undershoot"]:
+        elif name in ["duty_cycle", "overshoot", "undershoot", "top_flatness"]:
             return f"{value:.2f} %"
 
         # SNR (dB)
@@ -811,6 +814,41 @@ class WaveformAnalyzer:
         except Exception as e:
             logger.exception(f"Error calculating THD: {e}")
             return None
+
+    @staticmethod
+    def calculate_top_flatness(waveform: WaveformData) -> Optional[float]:
+        """Deviation across the settled high plateau of a two-level signal, as % of
+        amplitude (Vtop - Vbase). Peak-to-peak of the middle 60% of each high run
+        (excludes edges and overshoot). None for signals without a flat top."""
+        v = np.asarray(waveform.voltage, dtype=float)
+        if not WaveformAnalyzer._is_two_level(v):
+            return None
+        vtop, vbase = WaveformAnalyzer._estimate_top_base(v)
+        amp = vtop - vbase
+        if amp <= 0:
+            return None
+        mid = (vtop + vbase) / 2.0
+        high = v > mid
+        samples: list = []
+        start = None
+        for i, is_high in enumerate(high):
+            if is_high and start is None:
+                start = i
+            elif not is_high and start is not None:
+                run = list(range(start, i))
+                if len(run) >= 5:
+                    a, b = int(len(run) * 0.2), int(len(run) * 0.8)
+                    samples.extend(v[run[a:b]])
+                start = None
+        if start is not None:
+            run = list(range(start, len(high)))
+            if len(run) >= 5:
+                a, b = int(len(run) * 0.2), int(len(run) * 0.8)
+                samples.extend(v[run[a:b]])
+        if not samples:
+            return None
+        arr = np.asarray(samples, dtype=float)
+        return float((arr.max() - arr.min()) / amp * 100.0)
 
     @staticmethod
     def calculate_plateau_stability(waveform: WaveformData, signal_type: str) -> Dict[str, Optional[float]]:

--- a/tests/test_comparison_analyzer.py
+++ b/tests/test_comparison_analyzer.py
@@ -188,3 +188,13 @@ def test_non_numeric_criteria_value_is_skipped_not_raised(tmp_path):
     for run in result.runset.runs:
         assert run.measurements == []
         assert run.passed is None
+
+
+def test_resolve_stat_key_matches_display_names():
+    from scpi_control.report_generator.analysis.comparison_analyzer import ComparisonAnalyzer
+
+    stats = {"overshoot": 1.0, "top_flatness": 0.5, "vpp": 2.0}
+    assert ComparisonAnalyzer._resolve_stat_key("Overshoot", stats) == "overshoot"
+    assert ComparisonAnalyzer._resolve_stat_key("Top Flatness", stats) == "top_flatness"
+    assert ComparisonAnalyzer._resolve_stat_key("Peak-to-Peak", stats) == "vpp"
+    assert ComparisonAnalyzer._resolve_stat_key("Nonexistent", stats) is None

--- a/tests/test_comparison_analyzer.py
+++ b/tests/test_comparison_analyzer.py
@@ -198,3 +198,41 @@ def test_resolve_stat_key_matches_display_names():
     assert ComparisonAnalyzer._resolve_stat_key("Top Flatness", stats) == "top_flatness"
     assert ComparisonAnalyzer._resolve_stat_key("Peak-to-Peak", stats) == "vpp"
     assert ComparisonAnalyzer._resolve_stat_key("Nonexistent", stats) is None
+
+
+def _square_capture(tmp_path, name, channel=1):
+    """Write one clean 1 kHz cal-square capture (flat top -> overshoot/top_flatness ~0)."""
+    wf = make_waveform(SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, seed=42), 100_000.0, 2_000, channel=channel)
+    wf.provenance = AcquisitionProvenance(instrument=InstrumentInfo(model="Mock"))
+    path = tmp_path / name
+    Waveform(Mock()).save_waveform(wf, str(path), format="CSV")
+    return path
+
+
+def _square_batch(tmp_path, n_runs=2):
+    runs = [Run(label=f"DUT{i}", files=[_square_capture(tmp_path, f"dut{i}.csv")]) for i in range(n_runs)]
+    return RunSet(runs=runs, mode=MODE_BATCH)
+
+
+def test_probe_cal_preset_yields_real_verdict(tmp_path):
+    """The audit's dead scenario: probe-cal preset over clean cal squares -> real PASS."""
+    from scpi_control.report_generator.models.template import ReportTemplate
+
+    runset = _square_batch(tmp_path, n_runs=2)
+    runset.criteria_set = ReportTemplate.create_probe_calibration_template().criteria_set
+    result = ComparisonAnalyzer.analyze(runset)
+    assert all(r.passed is True for r in result.runset.runs)  # clean squares pass overshoot/undershoot (critical)
+    assert result.yield_total == 2 and result.yield_passed == 2
+    assert not any(r.incomplete for r in result.runset.runs)
+
+
+def test_unevaluable_critical_criterion_is_incomplete_not_pass(tmp_path):
+    runset = _square_batch(tmp_path, n_runs=2)
+    cs = CriteriaSet(name="x")
+    cs.add_criteria(MeasurementCriteria(measurement_name="nonexistent_stat", comparison_type=ComparisonType.MAX_ONLY, max_value=1.0, severity="critical"))
+    runset.criteria_set = cs
+    result = ComparisonAnalyzer.analyze(runset)
+    assert all(r.incomplete for r in result.runset.runs)
+    assert all(r.passed is None for r in result.runset.runs)
+    assert result.yield_incomplete == 2
+    assert any("could not be evaluated" in w for w in result.warnings)

--- a/tests/test_comparison_analyzer.py
+++ b/tests/test_comparison_analyzer.py
@@ -188,6 +188,10 @@ def test_non_numeric_criteria_value_is_skipped_not_raised(tmp_path):
     for run in result.runset.runs:
         assert run.measurements == []
         assert run.passed is None
+        # This criterion defaults to severity="critical" and can't be evaluated
+        # (no numeric statistic) -> the run is INCOMPLETE, not silently passed/dropped.
+        assert run.incomplete
+    assert any("could not be evaluated" in w for w in result.warnings)
 
 
 def test_resolve_stat_key_matches_display_names():

--- a/tests/test_comparison_builder.py
+++ b/tests/test_comparison_builder.py
@@ -198,3 +198,16 @@ def test_appendix_measurements_carry_run_label_in_channel(tmp_path):
     for run in result.runset.runs:
         for m in run.measurements:
             assert " · " not in (m.channel or "")
+
+
+def test_incomplete_run_renders_incomplete_verdict():
+    from scpi_control.report_generator.comparison_report_builder import _run_verdict
+    from scpi_control.report_generator.models.report_elements import STATUS_INCOMPLETE
+    from scpi_control.report_generator.models.comparison import Run
+
+    r = Run(label="DUT1", files=[])
+    r.incomplete = True
+    assert _run_verdict(r) == ("INCOMPLETE", STATUS_INCOMPLETE)
+    r2 = Run(label="DUT2", files=[])
+    r2.passed = True
+    assert _run_verdict(r2)[0] == "PASS"

--- a/tests/test_criteria_validate.py
+++ b/tests/test_criteria_validate.py
@@ -1,0 +1,29 @@
+"""MeasurementCriteria.validate: half-open RANGE is enforced; unspecified criteria are not-evaluable."""
+
+from scpi_control.report_generator.models.criteria import ComparisonType, MeasurementCriteria
+
+
+def test_range_min_only_is_enforced():
+    c = MeasurementCriteria("vpp", ComparisonType.RANGE, min_value=4.5)  # no max
+    assert c.validate(4.0).passed is False  # below min -> FAIL (was True)
+    assert c.validate(5.0).passed is True
+
+
+def test_range_max_only_is_enforced():
+    c = MeasurementCriteria("vpp", ComparisonType.RANGE, max_value=5.5)  # no min
+    assert c.validate(6.0).passed is False  # above max -> FAIL (was True)
+    assert c.validate(5.0).passed is True
+
+
+def test_range_no_bounds_is_not_evaluable():
+    assert MeasurementCriteria("vpp", ComparisonType.RANGE).validate(1.0).passed is None
+
+
+def test_min_only_unspecified_is_not_evaluable():
+    assert MeasurementCriteria("vpp", ComparisonType.MIN_ONLY).validate(1.0).passed is None
+
+
+def test_range_full_still_works():
+    c = MeasurementCriteria("vpp", ComparisonType.RANGE, min_value=1.0, max_value=2.0)
+    assert c.validate(1.5).passed is True
+    assert c.validate(3.0).passed is False

--- a/tests/test_probe_calibration_template.py
+++ b/tests/test_probe_calibration_template.py
@@ -16,6 +16,7 @@ def test_probe_calibration_template_config_and_round_trip():
     # Ships the compensation limits, keyed by measurement name.
     assert t.criteria_set is not None
     limits = {c.measurement_name: c for c in t.criteria_set.criteria_list}
+    assert set(limits) == {"Overshoot", "Undershoot", "Top Flatness"}
     assert limits["Overshoot"].max_value == 5.0
     assert limits["Undershoot"].max_value == 5.0
     assert limits["Top Flatness"].max_value == 2.0
@@ -26,4 +27,4 @@ def test_probe_calibration_template_config_and_round_trip():
     assert restored.include_fft_analysis is False
     assert len(restored.sections) == 4
     assert restored.criteria_set is not None
-    assert len(restored.criteria_set.criteria_list) == 4
+    assert len(restored.criteria_set.criteria_list) == 3

--- a/tests/test_waveform_analyzer_top_flatness.py
+++ b/tests/test_waveform_analyzer_top_flatness.py
@@ -1,0 +1,44 @@
+"""top_flatness: % deviation across the settled flat top; None off flat-tops."""
+
+import numpy as np
+
+from scpi_control.report_generator.models.report_data import WaveformData
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+
+
+def make_waveform(voltage, rate=1e6):
+    n = len(voltage)
+    return WaveformData(channel="C1", time=np.arange(n) / rate, voltage=voltage, sample_rate=rate, record_length=n)
+
+
+def _square(rate=1e6, cycles=6, n=6000, top=1.0, base=-1.0):
+    t = np.arange(n) / rate
+    return np.where(np.sin(2 * np.pi * (cycles * rate / n) * t) >= 0, top, base).astype(float)
+
+
+def test_flat_square_is_near_zero():
+    tf = WaveformAnalyzer.calculate_top_flatness(make_waveform(_square()))
+    assert tf is not None and tf < 0.5  # a perfectly flat top ~ 0 %
+
+
+def test_sloped_top_reports_expected_percent():
+    # square with a top that ramps by 0.04 across each high plateau (2% of the 2.0 amplitude)
+    n, rate, cycles = 6000, 1e6, 6
+    t = np.arange(n) / rate
+    base = np.where(np.sin(2 * np.pi * (cycles * rate / n) * t) >= 0, 1.0, -1.0).astype(float)
+    high = base > 0
+    # add a per-sample ramp only on the high plateaus, spanning ~0.04 over the record's high runs
+    ramp = np.linspace(-0.02, 0.02, n)
+    base[high] += ramp[high]
+    tf = WaveformAnalyzer.calculate_top_flatness(make_waveform(base))
+    assert tf is not None and 1.0 < tf < 4.0  # order ~2 %, robust band
+
+
+def test_sine_returns_none():
+    t = np.arange(6000) / 1e6
+    assert WaveformAnalyzer.calculate_top_flatness(make_waveform(np.sin(2 * np.pi * 1000 * t))) is None
+
+
+def test_analyze_includes_top_flatness_key():
+    stats = WaveformAnalyzer.analyze(make_waveform(_square()))
+    assert "top_flatness" in stats


### PR DESCRIPTION
## Summary

Sub-project #2 of the 2026-07-22 audit remediation. Fixes audit **theme #3 — the comparison/batch report's dead pass/fail spine**. The just-shipped comparison/batch feature (PR #94) produced vacuous verdicts: its only criteria template's names never matched the analyzer's statistics, un-evaluable criteria were silently dropped (inflating yield), and half-open `RANGE` criteria passed everything. This makes the verdicts mean something — sequenced **before cutting v4.0.0** so that release debuts the feature with trustworthy pass/fail.

## Fixed (audit findings)

| Finding | Fix |
|---|---|
| **H22** | Criteria now resolve to analyzer stat keys via case-insensitive normalization + a display-name alias map (`"Overshoot"`→`overshoot`, `"Top Flatness"`→`top_flatness`, `"Peak-to-Peak"`→`vpp`). The shipped probe-cal preset produced empty verdicts before this. |
| **H23** | A criterion that can't be evaluated is surfaced as a warning (never silently dropped); yield reports an explicit incomplete count instead of inflating the pass rate. |
| **M36** | Half-open `RANGE` criteria are enforced (min-only / max-only check their bound); an unspecified criterion returns "not evaluable", not an auto-pass. |

## Verdict semantics (new)

- **Severity-aware:** only `critical` criteria gate PASS/FAIL; `warning`/`info` criteria are reported but never gate.
- **Distinct `INCOMPLETE` state:** any critical FAIL → FAIL; else any critical criterion that couldn't be evaluated → INCOMPLETE (not an accidental PASS); else all critical pass → PASS; else "—". Rendered in the report tables and reflected in `overall_result` and yield.

## Added

- `top_flatness` waveform statistic (top-plateau deviation as % of amplitude; `None` for signals without a flat top).
- The probe-calibration preset now evaluates overshoot/undershoot (pass/fail, critical) and top flatness (warning). The unbacked `Ringing` criterion was dropped, and the preset's description no longer advertises it.

## Testing

Full suite **1200 → 1213 passing / 19 skipped**; `black`/`flake8` gates clean. The audit's exact dead scenario is now a regression test (`test_probe_cal_preset_yields_real_verdict`: probe-cal preset over clean cal squares → real 2/2 PASS with an honest yield), alongside tests for half-open RANGE enforcement, un-evaluable → INCOMPLETE with a real `yield_incomplete`, name resolution, and `top_flatness`. Single-run report rendering is provably unchanged (curated stat tables; `validate()` is unreachable from that path).

## Non-breaking

This makes an already-shipped-but-broken feature work; no API breaks. Folds into **v4.0.0** (whose MAJOR bump is already driven by sub-project #1's PSU/AWG breaking change).

## Deferred follow-ups (tracked, not in this PR)

- `top_flatness` isn't wired into the *single-run* report's curated stat table (it surfaces in the comparison criterion row + full-stats appendix).
- The INCOMPLETE cell colour is hardcoded `#b58900` (no `branding.warning_color` field yet); a `channel=None` un-evaluable criterion emits one warning per channel (informative but duplicate-ish).
- `top_flatness` aggregates across all high plateaus, so a longer capture can read differently than a short one for the same signal.

Remaining audit themes — mock fidelity, report escaping, server security, blind tests, provenance honesty — remain queued as follow-up sub-projects.
