### PR TITLE
Release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-07-22
+
 ### ⚠️ Breaking Changes
 
 - Power supply and function-generator readback (`measure_voltage`/`measure_current`/`measure_power`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "3.3.1"
+version = "4.0.0"
 description = "Universal Python library for SCPI test equipment via Ethernet/LAN, USB, GPIB, or serial. Drives oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies, and DAQ units. Waveform capture with acquisition provenance, raw-data extraction (load_waveform, scpi-extract), FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and synthetic-signal mocks for development without hardware."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "3.3.1"
+__version__ = "4.0.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
Release **v4.0.0** — `chore(release): 4.0.0` bumps `pyproject`, `scpi_control/__init__.py` `__version__`, and finalizes the CHANGELOG (`[Unreleased]` → `[4.0.0] - 2026-07-22`).

**MAJOR** bump, driven by a breaking change in readback behavior. Highlights below; see `CHANGELOG.md` for the full list.

## ⚠️ Breaking change (migration required)

- Power supply and function-generator readback (`measure_voltage`/`measure_current`/`measure_power`, setpoint/OVP/OCP getters, and AWG `frequency`/`amplitude`/`offset`/`phase`) now **raise `CommandError`** on an unparseable instrument response instead of silently returning `0.0`. **Migration:** wrap readback calls that may hit a malformed response and handle `CommandError` (previously you'd have silently logged a fake `0.0`).

## Added

- **Comparison & batch reports:** before/after comparison and multi-DUT batch reports (delta tables, per-DUT aggregates, yield) — Python API + GUI dialog. Raw-data appendix (SHA-256 manifest, provenance) and configurable sign-off block.
- `top_flatness` waveform statistic; the probe-calibration preset now evaluates overshoot/undershoot (pass/fail) and top flatness (warning).
- Dev tooling: `pytest-xdist` for parallel local test runs.

## Fixed

- **Trustworthy report numbers:** corrected THD (per-harmonic binning), noise/SNR (signal-free residual, not whole-signal RMS), `vamp` (Vtop−Vbase amplitude), overshoot/undershoot (flat-topped only), duty cycle (high-start captures), DC classification (offset-independent), FFT peak detection (sub-0-dB + off-by-one), SciPy window handling. Unified THD engine so the live spectrum and PDF reports agree. Metrics now return `None` ("N/A") when unknown rather than a fabricated value.
- **Comparison pass/fail spine:** criteria now match analyzer statistics (case-insensitive + aliases) — the shipped criteria template previously produced empty verdicts; un-evaluable criteria are surfaced as warnings (not silently dropped); half-open RANGE enforced; severity-aware verdicts with a distinct INCOMPLETE state; honest yield with an incomplete count.
- DAQ AI threshold suggestions bind numbers to their labels; report loader no longer drops acquisition provenance.

## Verification

Full suite **1213 passed / 19 skipped**; `black`/`flake8` gates clean. PyPI summary within the 512-char limit (430). `scpi_control.__version__ == "4.0.0"` (also stamped into capture provenance and the GUI About dialog).

After merge: tag `v4.0.0` on the merge commit and publish to PyPI.
