### PR TITLE
fix: absolute README image URLs for PyPI (4.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.1] - 2026-07-24
+
+### Fixed
+
+- Packaging: the six screenshots in the README are now absolute URLs, so they render on the PyPI
+  project page. They used repository-relative paths, which PyPI cannot resolve because it renders
+  the README with no repository context — the images showed as broken there while displaying
+  correctly on GitHub.
+
 ## [4.1.0] - 2026-07-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ The SCPI Instrument Control GUI provides a comprehensive interface for controlli
 
 ### Main Window
 
-![Main Window](docs/images/main_window.png)
+![Main Window](https://raw.githubusercontent.com/little-did-I-know/SCPI-Instrument-Control/main/docs/images/main_window.png)
 
 The main interface consists of:
 
@@ -410,7 +410,7 @@ The oscilloscope must be connected to your network (default SCPI port: 5025).
 
 ### Channel Controls
 
-![Channel Controls](docs/images/channel_controls.png)
+![Channel Controls](https://raw.githubusercontent.com/little-did-I-know/SCPI-Instrument-Control/main/docs/images/channel_controls.png)
 
 The **Channels** tab provides complete control over all input channels:
 
@@ -448,7 +448,7 @@ Acquisition → Live View (Ctrl+R)
 
 ### Visual Measurements
 
-![Visual Measurements](docs/images/visual_measurements.png)
+![Visual Measurements](https://raw.githubusercontent.com/little-did-I-know/SCPI-Instrument-Control/main/docs/images/visual_measurements.png)
 
 Interactive measurement markers that you can place and adjust directly on waveforms:
 
@@ -489,7 +489,7 @@ Interactive measurement markers that you can place and adjust directly on wavefo
 
 ### Automated Measurements
 
-![Measurements Panel](docs/images/measurements_panel.png)
+![Measurements Panel](https://raw.githubusercontent.com/little-did-I-know/SCPI-Instrument-Control/main/docs/images/measurements_panel.png)
 
 The **Measurements** tab provides quick access to standard oscilloscope measurements:
 
@@ -500,7 +500,7 @@ The **Measurements** tab provides quick access to standard oscilloscope measurem
 
 ### Cursors
 
-![Cursors](docs/images/cursors.png)
+![Cursors](https://raw.githubusercontent.com/little-did-I-know/SCPI-Instrument-Control/main/docs/images/cursors.png)
 
 Interactive cursors for precise measurements:
 
@@ -512,7 +512,7 @@ Interactive cursors for precise measurements:
 
 ### FFT Analysis
 
-![FFT Analysis](docs/images/fft_analysis.png)
+![FFT Analysis](https://raw.githubusercontent.com/little-did-I-know/SCPI-Instrument-Control/main/docs/images/fft_analysis.png)
 
 Frequency domain analysis:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "4.1.0"
+version = "4.1.1"
 description = "Universal Python library for SCPI test equipment via Ethernet/LAN, USB, GPIB, or serial. Drives oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies, and DAQ units. Waveform capture with acquisition provenance, raw-data extraction (load_waveform, scpi-extract), FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and synthetic-signal mocks for development without hardware."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
Patch release fixing broken screenshots on the PyPI project page.

## The problem

The six screenshots in `README.md` used repository-relative paths (`docs/images/*.png`). PyPI renders the long description with no repository context, so those paths cannot resolve and the images showed as broken there — while rendering correctly on GitHub, which is why it went unnoticed.

The badges were never affected: they already used absolute URLs.

## The fix

Rewrote the six references to absolute `raw.githubusercontent.com` URLs pinned to `main`. Verified the target URLs return HTTP 200.

## Note on scope

PyPI cannot re-render an already-published release, so the 4.1.0 page stays broken permanently. This is why the fix ships as its own patch release rather than waiting for the next feature release.

No library code changed — README, version bump, and changelog only.
