### PR TITLE
feat: web gateway security boundary (auth, ownership, SSRF gate, no-pickle) [v5.0.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- Web gateway: every `/api/*` request now requires a bearer token, and the live-stream
+  WebSocket requires one too. On first run `scpi-web` mints a token and prints a
+  `http://127.0.0.1:8765/?token=…` URL; mint more with `scpi-web token add <name>`.
+  **Migration:** scripted HTTP clients must send `Authorization: Bearer <token>`; WebSocket
+  clients must offer the `scpi-token.<token>` subprotocol (alongside a plain `scpi`). A
+  query-parameter token is accepted only on the initial web-UI page load and is rejected on
+  `/api/*`. `GET /api/health` stays unauthenticated. See the
+  [gateway security guide](docs/gateway/security.md).
+- Web gateway: the interactive API docs at `/docs` and `/redoc` are removed and the OpenAPI
+  schema moved to `/api/openapi.json` (token required) — the old locations served the whole
+  control surface unauthenticated.
+- Reference waveforms: stored metadata moved from a pickled dict to a JSON string so reference
+  files load without `allow_pickle`. Files saved by 4.x raise an error naming the file until
+  converted. **Migration:** run `scpi-web references migrate` once.
+
+### Added
+
+- Web gateway: named bearer tokens — `scpi-web token add|list|revoke <name>`, stored hashed in
+  `~/.siglent/tokens.json` (relocate with `--config-dir`).
+- Web gateway: session ownership. The identity that creates an instrument session may write to
+  it; anyone authenticated may read, stream, and export. Non-owner writes return `409`.
+  `POST /api/sessions/{id}/claim` takes over a session whose owner has been idle past
+  `--abandon-after` (default 300 s) and is not actively watching the stream;
+  `POST /api/sessions/{id}/owner` hands it over by name (or releases it with `""`). The web UI
+  shows a read-only badge and a claim button to non-owners.
+- Web gateway: `--allow-port` to permit instrument ports beyond 5025, `--max-sessions`
+  (default 8) to bound concurrent sessions, and an unauthenticated `GET /api/health` endpoint.
+- Web gateway: `scpi-web references migrate` converts pre-5.0 reference files to the new format
+  (atomic and idempotent; `--dir` to point at a non-default store).
+
+### Fixed
+
+- Security: loading a waveform or reference archive no longer unpickles it, so a crafted `.npz`
+  can no longer execute code via `scpi-extract`, the report generator's loader, or the gateway.
+  The one remaining place that reads the old pickled format is `scpi-web references migrate`,
+  which the user runs explicitly on their own files.
+- Security: reference lookup no longer honours absolute paths or `..` traversal, and listing
+  references no longer deserializes every file in the storage directory.
+- Security: session creation validates the target before connecting — hostnames are resolved
+  and every resolved address checked, loopback/link-local/cloud-metadata addresses are refused,
+  ports must be allowlisted, and a failed connect returns a generic message rather than
+  reflecting the peer's bytes (no SSRF port-scanning or banner-grabbing).
+- Web gateway: full-resolution CSV/JSON serialization of deep-memory captures runs off the
+  event loop, so one large export no longer freezes the gateway for other users; the session
+  cap holds correctly under concurrent requests.
+- Reference storage: `rename_reference` no longer leaks the source file handle (a Windows-only
+  `WinError 32` that made it fail); reference lookups now confine themselves to the storage
+  directory.
+- Web UI: file downloads (capture CSV, screenshot, waveform JSON, trend CSV) fetch with the
+  bearer token instead of bare `<a href>` links, which could not carry an `Authorization`
+  header and would have returned `401` against the authenticated gateway.
+
 ## [4.1.0] - 2026-07-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -620,13 +620,27 @@ Control instruments from any browser on your LAN:
 
 ```bash
 pip install scpi-instrument-control[web]   # includes the browser gateway
-scpi-web --host 0.0.0.0 --port 8765
+scpi-web                                   # first run prints a URL with a token
 ```
 
-Open `http://<gateway-pc>:8765`. Sessions can target real scopes by IP or a
-built-in mock (`mock: true`) for hardware-free use. The API is documented at
-`/docs` (OpenAPI). No authentication in this release — bind to `127.0.0.1`
-(the default) unless your LAN is trusted.
+On first run the gateway mints an access token and prints a ready-to-open URL
+(`http://127.0.0.1:8765/?token=…`). **Every request needs a token** — mint more
+with `scpi-web token add <name>`. Sessions can target real scopes by IP or a
+built-in mock (`mock: true`) for hardware-free use. The OpenAPI schema is served
+at `/api/openapi.json` (token required); the interactive `/docs`/`/redoc` UIs are
+disabled. Bind to `127.0.0.1` (the default) unless your LAN is trusted, and use
+`--host 0.0.0.0` to expose it.
+
+**Security model:** the gateway authenticates every request, gives each
+instrument session an owner (owner writes, everyone else watches), validates
+outbound connection targets, and caps concurrent sessions. It does **not**
+terminate TLS — put it behind a reverse proxy or keep it on a trusted network.
+See the **[Gateway security guide](docs/gateway/security.md)** for tokens,
+ownership, claiming, the SSRF gate, and deployment.
+
+> **Upgrading from 4.x:** the gateway now requires a token, and reference files
+> saved by 4.x must be converted once with `scpi-web references migrate`. Both
+> are covered in the security guide.
 
 Full documentation: [Web Gateway guide](https://little-did-I-know.github.io/SCPI-Instrument-Control/gateway/) — overview, browser UI tour, and the complete REST & WebSocket API reference.
 
@@ -651,9 +665,10 @@ make webapp-build         # build the UI into the server
 scpi-web --host 0.0.0.0   # serve API + UI on one port
 ```
 
-Open `http://<gateway-pc>:8765`. For UI development, run `scpi-web` in one
-terminal and `cd webapp/app && npm run dev` in another — Vite proxies `/api`
-(HTTP and WebSocket) to the gateway with hot reload.
+Open the tokened URL the gateway prints on startup. For UI development, run
+`scpi-web` in one terminal and `cd webapp/app && npm run dev` in another — Vite
+proxies `/api` (HTTP and WebSocket) to the gateway with hot reload; open the dev
+server with the `?token=…` from the gateway's startup URL so the UI picks it up.
 
 The home screen scans your LAN and lists instruments to connect to, resume, or
 open a shared session on — plus manual IP and a hardware-free mock.

--- a/docs/about/security.md
+++ b/docs/about/security.md
@@ -131,6 +131,21 @@ def safe_connect(ip_str):
 
 **Mitigation**: Implement appropriate timeouts and rate limiting in your code
 
+### Web gateway
+
+- The optional web gateway (`scpi-web`) authenticates every `/api/*` request
+  with a bearer token, except the unauthenticated `GET /api/health` probe
+- Instrument sessions are owned by the token that created them — only the
+  owner may issue writes; other tokens may read and watch
+- Outbound connection targets are validated (an SSRF gate) before the gateway
+  opens a socket to an instrument
+- Concurrent instrument sessions are capped
+- The gateway does **not** terminate TLS; traffic (including the bearer
+  token) is unencrypted unless you place it behind a TLS-terminating reverse
+  proxy or keep it on a trusted network
+
+See the [Gateway security guide](../gateway/security.md) for the full model.
+
 ## Dependency Security
 
 We use automated tools to monitor dependencies for known vulnerabilities:
@@ -183,4 +198,4 @@ If you have questions about this security policy, please open a GitHub Discussio
 
 ---
 
-**Last Updated**: 2025-12-30
+**Last Updated**: 2026-07-24

--- a/docs/examples/intermediate.md
+++ b/docs/examples/intermediate.md
@@ -515,7 +515,13 @@ python examples/gateway_rest_client.py
 Start the gateway first (in another terminal):
 
     pip install "SCPI-Instrument-Control[web]"
-    scpi-web
+    scpi-web            # prints a URL with a token on first run
+
+Every gateway request needs a bearer token. Mint one and export it before
+running this script:
+
+    scpi-web token add rest-demo     # prints the token once
+    export SCPI_WEB_TOKEN=scpi_...   # the token it printed
 
 Then run this script. It creates a hardware-free mock session, configures a
 channel, fetches full-resolution waveform data as JSON, and downloads a
@@ -527,10 +533,17 @@ Requirements:
 """
 
 import json
+import os
+import sys
+import urllib.error
 import urllib.request
 from typing import Optional, Union
 
 BASE = "http://127.0.0.1:8765/api"
+
+# The gateway authenticates every /api/* request with a bearer token. Read it
+# from the environment rather than hard-coding a credential in the script.
+TOKEN = os.environ.get("SCPI_WEB_TOKEN")
 
 Body = Optional[Union[dict, list]]  # examples run on the package floor, Python 3.9
 
@@ -538,6 +551,8 @@ Body = Optional[Union[dict, list]]  # examples run on the package floor, Python 
 def call(method: str, path: str, body: Body = None) -> bytes:
     data = None if body is None else json.dumps(body).encode()
     request = urllib.request.Request(BASE + path, data=data, method=method)
+    if TOKEN:
+        request.add_header("Authorization", "Bearer {0}".format(TOKEN))
     if data is not None:
         request.add_header("Content-Type", "application/json")
     with urllib.request.urlopen(request) as response:
@@ -549,6 +564,9 @@ def call_json(method: str, path: str, body: Body = None):
 
 
 def main() -> None:
+    if not TOKEN:
+        sys.exit("Set SCPI_WEB_TOKEN first — run 'scpi-web token add rest-demo' and export the token it prints.")
+
     # 1. Create a mock oscilloscope session (no hardware required)
     session = call_json("POST", "/sessions", {"mock": True, "label": "REST demo"})
     session_id = session["id"]

--- a/docs/gateway/api.md
+++ b/docs/gateway/api.md
@@ -6,6 +6,11 @@ are relative to the server root (default `http://127.0.0.1:8765`); every
 UI itself calls — everything documented here is exercised by the shipping
 frontend.
 
+Every route below requires `Authorization: Bearer <token>` **except**
+`GET /api/health`. See the [Gateway security guide](security.md) for how to
+mint a token, how ownership gates writes, and the WebSocket authentication
+handshake.
+
 ## Sessions & discovery
 
 | Method | Path | Body / params | Response | Errors |
@@ -126,11 +131,14 @@ Every error response is JSON: `{"error": "<ExceptionClassName>", "detail": "<mes
 
 ## Curl quickstart
 
-Create a mock session, configure a channel, and fetch its waveform as JSON — no hardware required (start the gateway first: `scpi-web`):
+Create a mock session, configure a channel, and fetch its waveform as JSON — no hardware required. Start the gateway first (`scpi-web` prints a token on first run; mint another with `scpi-web token add <name>`) and export it:
 
 ```bash
+export TOKEN=scpi_...   # from the gateway's startup output
+
 # 1. Create a mock scope session
 curl -s -X POST http://127.0.0.1:8765/api/sessions \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"mock": true, "label": "curl demo"}'
 # -> 201 {"id": "a1b2c3d4", "label": "curl demo", "mock": true, "address": null,
@@ -141,12 +149,15 @@ SESSION_ID=a1b2c3d4   # substitute the "id" from the response above
 
 # 2. Enable channel 1 and set its vertical scale
 curl -s -X PATCH "http://127.0.0.1:8765/api/sessions/$SESSION_ID/scope/channels/1" \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"enabled": true, "voltage_scale": 0.5}'
 
 # 3. Fetch channel 1's waveform as JSON, decimated to 200 points
-curl -s "http://127.0.0.1:8765/api/sessions/$SESSION_ID/scope/waveform?channels=1&max_points=200"
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:8765/api/sessions/$SESSION_ID/scope/waveform?channels=1&max_points=200"
 
 # 4. Clean up
-curl -s -X DELETE "http://127.0.0.1:8765/api/sessions/$SESSION_ID"
+curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:8765/api/sessions/$SESSION_ID"
 ```

--- a/docs/gateway/api.md
+++ b/docs/gateway/api.md
@@ -80,7 +80,7 @@ All paths under `/api/sessions/{id}/scope/`.
 | `POST` | `references` | `{name, channel}` — snapshots the channel's current waveform | **201** — the full updated reference list (same shape as `GET references`, replace-on-save if `name` already existed) | 400 empty name or out-of-range channel; 409 if the session is in an error/closed state |
 | `DELETE` | `references/{name}` | — | **204** No Content | 404 unknown reference name |
 | `GET` | `reference` | — | The active overlay: `{name, channel, t0, dt, points}` (`name`/`channel` are `null` when no reference is active) | — |
-| `PUT` | `reference` | `{name}` or `{name: null}` to clear | The active overlay (as above) | 404 unknown reference name |
+| `PUT` | `reference` | `{name}` or `{name: null}` to clear | The active overlay (as above) | 404 unknown reference name (**400** if the store holds un-migrated pre-5.0 files — run `scpi-web references migrate`) |
 
 Setting the active reference (via `PUT`) broadcasts a `reference` message, and every poll tick afterward broadcasts a `reference_stats` message with live correlation/deviation.
 

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -6,6 +6,11 @@ oscilloscope UI — no client install, no drivers, just a URL. V1 is
 scope-only, and the server supports named multi-sessions, so several
 instruments (or several views of the same instrument) can be open at once.
 
+> **Security first:** every request needs a bearer token. Read the
+> **[Gateway security guide](security.md)** for tokens, session ownership, the
+> SSRF gate, and deployment guidance before exposing the gateway beyond
+> `127.0.0.1`.
+
 ## Install and run
 
 ```bash
@@ -20,20 +25,24 @@ scpi-web
 python -m scpi_control.server
 ```
 
-By default the gateway listens on `http://127.0.0.1:8765`.
+By default the gateway listens on `http://127.0.0.1:8765`. On first run it
+mints an access token and prints a ready-to-open URL
+(`http://127.0.0.1:8765/?token=…`) — open that to reach the browser UI.
 
 ## Security posture
 
-The server binds to `127.0.0.1` by default, so it is not reachable from the
-network until you opt in. Exposing it to the LAN is an explicit choice:
+Every `/api/*` route (other than `GET /api/health`) requires a valid bearer
+token — there is no unauthenticated path. The server also binds to
+`127.0.0.1` by default, so it is not reachable from the network until you opt
+in. Exposing it to the LAN is an explicit choice:
 
 ```bash
 scpi-web --host 0.0.0.0
 ```
 
-There is **no authentication** in this release. Anyone who can reach the
-gateway's port can control the connected instruments. Only bind to `0.0.0.0`
-on networks you trust.
+See the **[Gateway security guide](security.md)** for the full model: tokens,
+session ownership, the SSRF gate that validates outbound connection targets,
+the session cap, and deployment guidance (TLS, reverse proxies).
 
 ## Mock-first
 
@@ -64,6 +73,8 @@ ever plugging in an instrument.
 
 ## Where to next
 
+- [Gateway security](security.md) — tokens, session ownership, the SSRF gate,
+  and deployment guidance
 - [Browser UI Tour](browser-ui.md) — a walkthrough of the home screen, canvas
   modes, and rail tabs
 - [REST & WebSocket API](api.md) — the complete wire reference, with a curl

--- a/docs/gateway/security.md
+++ b/docs/gateway/security.md
@@ -165,7 +165,8 @@ $ curl -X POST -H "Authorization: Bearer $TOKEN" \
 ```
 
 - The threshold is **`--abandon-after` seconds** (default **300**). Before it
-  elapses, `claim` returns **409** with how long to wait.
+  elapses, `claim` returns **409** naming the owner and how long they have been
+  idle (subtract that from `--abandon-after` for the remaining wait).
 - "Active" counts **reads and live-stream watching**, not just writes — so an
   owner watching a long capture, without touching a control, is *not* considered
   idle and cannot be claimed out from under them.
@@ -285,7 +286,7 @@ directory, when you run the command explicitly.
 |---|---|
 | **401** | Missing or invalid token |
 | **409** on a write | You are not the session owner (message names who is) |
-| **409** on `claim` | Owner still active/watching (message says how long to wait) |
+| **409** on `claim` | Owner still active/watching (message names them and their idle seconds) |
 | **409** on create | Session cap reached |
 | **400** on session create | Target address/port refused by the SSRF gate |
 | **WS close 1008** | WebSocket handshake was not authenticated |

--- a/docs/gateway/security.md
+++ b/docs/gateway/security.md
@@ -1,0 +1,291 @@
+# Gateway security
+
+The web gateway (`scpi-web`) puts your instruments on the network. Starting in
+**v5.0.0** it has a real security boundary: every request is authenticated, and
+each instrument session has an owner who alone may drive it. This page explains
+the model and how to work with it — from the browser, from `curl`, and from a
+Python script.
+
+> **Upgrading from 4.x?** Two things change for you: the gateway now requires a
+> token (see [Tokens](#tokens)), and saved reference files must be converted once
+> (see [Reference file migration](#reference-file-migration)). Both are covered
+> below.
+
+## The threat model, in one paragraph
+
+The gateway is designed for **a lab LAN with several trusted users sharing one
+gateway**. It is *not* hardened for the public internet, and it does not
+terminate TLS. The boundary stops an authenticated peer from doing things they
+should not — driving someone else's scope, scanning the internal network, or
+running code on the gateway host — and stops an unauthenticated peer from doing
+anything at all. It does **not** encrypt traffic; for that, put the gateway
+behind a reverse proxy or keep it on a network you trust. See
+[Deployment](#deployment) for the specifics.
+
+## First run
+
+Start the gateway and it mints a token for you and prints a ready-to-open URL:
+
+```console
+$ scpi-web
+Gateway ready. Open:
+
+    http://127.0.0.1:8765/?token=scpi_Qy8…f3A
+```
+
+Open that URL. The web UI lifts the token out of the address bar, stores it in
+the browser, and immediately strips it from the URL — so it does not linger in
+your history or leak through the `Referer` header of any link you click. From
+then on the UI sends the token automatically.
+
+The token named `default` is created only when no tokens exist yet. Restarting
+the gateway does **not** mint a new one or reprint the URL — your existing token
+keeps working. To get the URL again, mint another token (below) or read the
+token file.
+
+## Tokens
+
+Tokens are the gateway's credentials. They are long random strings prefixed
+`scpi_`, stored **hashed** (SHA-256) in `~/.siglent/tokens.json` — the raw token
+is shown once, at creation, and never written to disk or logged. Manage them
+with the `token` subcommands:
+
+```console
+$ scpi-web token add alice
+token 'alice' created. Copy it now, it is not stored:
+
+    scpi_7dK…2mР
+
+$ scpi-web token list
+alice
+default
+
+$ scpi-web token revoke default
+revoked 'default'
+```
+
+- **`token add <name>`** mints a token and prints it **once**. Copy it then; it
+  cannot be recovered. The *name* is the identity — it is what appears as a
+  session's owner and in any attribution.
+- **`token list`** shows names only, never secrets.
+- **`token revoke <name>`** removes a token. Revocation takes effect
+  **immediately** — the next request carrying that token is rejected, even
+  mid-session. Use it when a token is shared too widely or a laptop walks off.
+
+Every token is equal: there are no roles or scopes. Anyone with a valid token can
+create sessions and read any session; ownership (below) governs who may *write*.
+
+The token store lives under `~/.siglent` by default; relocate it with
+`--config-dir <path>` (which applies to `token add|list|revoke` and to serving).
+
+> **A malformed `tokens.json` is a hard error, by design.** If the file is
+> corrupt, the gateway refuses to start rather than falling back to "no tokens" —
+> because "no tokens" would be indistinguishable from a fresh install and could
+> silently open the gateway. Fix or remove the file.
+
+## Sending the token
+
+The token travels differently over HTTP and WebSocket, because browsers cannot
+set an `Authorization` header on a WebSocket handshake.
+
+### HTTP — `Authorization: Bearer`
+
+```console
+$ curl -H "Authorization: Bearer scpi_7dK…2mР" http://127.0.0.1:8765/api/sessions
+```
+
+A query-parameter token (`?token=…`) is accepted **only** on the initial page
+load of the web UI, and is **rejected** on every `/api/*` route. Putting a
+credential in an API URL would leak it into logs and history, so there is exactly
+one way in for the API: the header.
+
+```python
+import requests
+
+TOKEN = "scpi_7dK…2mР"
+s = requests.Session()
+s.headers["Authorization"] = f"Bearer {TOKEN}"
+
+s.post("http://127.0.0.1:8765/api/sessions", json={"label": "bench", "mock": True})
+```
+
+### WebSocket — the `scpi-token` subprotocol
+
+The live-waveform stream authenticates through the WebSocket subprotocol list.
+Offer **two** entries — the token-bearing one and the plain `scpi` fallback:
+
+```javascript
+new WebSocket(url, [`scpi-token.${token}`, "scpi"]);
+```
+
+The server reads the token from the `scpi-token.` entry and, on success, accepts
+the socket selecting the non-secret `scpi` subprotocol — it never echoes your
+token back in a response header. An unauthenticated handshake is closed with code
+**1008** (policy violation). If you only ever offer `scpi-token.<token>` with no
+`scpi` fallback, a real browser will fail the handshake, so always send both.
+
+### Health check
+
+`GET /api/health` is the one route that needs no token — it exists so a load
+balancer or a "is it up?" probe does not require a credential. It returns only
+`{"status": "ok"}` and touches no instrument.
+
+### API schema
+
+The OpenAPI schema is served at `/api/openapi.json` and requires a token like any
+other API route. The interactive `/docs` and `/redoc` UIs are **disabled** —
+they sat outside the authenticated path and would have published the whole
+control surface anonymously.
+
+## Ownership: owner writes, everyone watches
+
+Sharing a scope is the point of a gateway, but two people writing to the same
+instrument mid-capture is not. So:
+
+- The token that **creates** a session **owns** it.
+- **Any** authenticated user may **read** it — state, live stream, captures,
+  exports.
+- Only the **owner** may **write** — channel/timebase/trigger changes, raw SCPI
+  commands, starting/stopping logging, setting references, and closing the
+  session. A non-owner write returns **409 Conflict** with the owner's name in
+  the message.
+
+In the web UI, a session you do not own shows a **read-only** badge naming the
+owner; your view stays live, only the controls are gated.
+
+### Claiming an abandoned session
+
+If an owner walks away, their session should not stay locked forever. Any
+authenticated user can take it over once the owner has been inactive past a
+threshold:
+
+```console
+$ curl -X POST -H "Authorization: Bearer $TOKEN" \
+    http://127.0.0.1:8765/api/sessions/<id>/claim
+```
+
+- The threshold is **`--abandon-after` seconds** (default **300**). Before it
+  elapses, `claim` returns **409** with how long to wait.
+- "Active" counts **reads and live-stream watching**, not just writes — so an
+  owner watching a long capture, without touching a control, is *not* considered
+  idle and cannot be claimed out from under them.
+- An **unowned** session (created before ownership existed, or explicitly
+  released) is claimable immediately.
+
+### Handing off explicitly
+
+The current owner can pass a session to a named user:
+
+```console
+$ curl -X POST -H "Authorization: Bearer $OWNER_TOKEN" \
+    -H "Content-Type: application/json" -d '{"name": "bob"}' \
+    http://127.0.0.1:8765/api/sessions/<id>/owner
+```
+
+The `name` must be an existing token name; an unknown name is rejected with
+**400** and ownership does not change. Passing `""` **releases** the session
+(makes it unowned and immediately claimable) — that is the only way an owner lets
+go without naming a successor.
+
+## Connecting to instruments: the SSRF gate
+
+`POST /api/sessions` names a `host:port` and the gateway opens a TCP connection
+to it. Left unchecked, an authenticated user could aim that at any internal
+service and use the gateway as a port scanner or banner grabber. The gateway
+validates every target before connecting:
+
+- The hostname is **resolved first**, and **every** resolved address is checked —
+  so a name that resolves to a loopback or internal address is rejected, not just
+  a literal one.
+- **Loopback, link-local, cloud-metadata (169.254.169.254), multicast, reserved,
+  and unspecified** addresses are refused.
+- The port must be in an **allowlist** — by default just **5025**, the SCPI
+  raw-socket port. Permit others with `--allow-port <n>` (repeatable; 5025 stays
+  allowed).
+- A failed connection returns a **generic** message naming only the address you
+  supplied — never bytes read from the peer, so the gateway cannot be used to
+  read service banners.
+
+Ordinary private-LAN instruments (`192.168.x.x`, `10.x.x.x`) on port 5025 connect
+exactly as before. **Mock** sessions (`"mock": true`) open no socket and bypass
+the gate entirely — use them for hardware-free work.
+
+## Resource limits
+
+- **`--max-sessions` (default 8)** caps concurrent instrument sessions. Beyond
+  it, `POST /api/sessions` returns **409** until one is closed. The cap holds
+  under concurrent requests, so a burst cannot slip past it.
+- Full-resolution CSV/JSON serialization of deep-memory captures runs **off the
+  event loop**, so one large export does not freeze the gateway for everyone
+  else.
+
+## Reference file migration
+
+Reference-waveform metadata used to be stored as a Python pickle, which meant
+*loading* a reference file could execute code in it. As of v5.0.0 metadata is
+stored as JSON and files load without unpickling — closing that path.
+
+**Files saved by 4.x are in the old format and will not load** until converted.
+The gateway tells you so, naming the file. Convert them once:
+
+```console
+$ scpi-web references migrate
+converted 3, skipped 0, failed 0 in /home/you/.siglent/references
+```
+
+- Conversion is **atomic** — a file that fails to convert is left exactly as it
+  was, never truncated.
+- It is **idempotent** — running it again reports already-converted files as
+  skipped.
+- Point it at a non-default directory with `--dir <path>`.
+
+`references migrate` is the **only** part of the system that still reads the old
+pickled format, and it does so only on files already in your own storage
+directory, when you run the command explicitly.
+
+## Deployment
+
+| Concern | Guidance |
+|---|---|
+| **Bind address** | Defaults to `127.0.0.1` (local only). Use `--host 0.0.0.0` to reach it from the LAN — and only then does the token boundary matter. |
+| **TLS / encryption** | Out of scope for the gateway. Traffic (including the bearer token) is unencrypted. Put the gateway behind a TLS-terminating reverse proxy, or keep it on a trusted network. |
+| **Tokens in transit** | Because traffic is unencrypted, a token on an untrusted network can be captured. This is the main reason TLS-via-proxy is recommended for any non-loopback exposure. |
+| **Token storage** | `~/.siglent/tokens.json`, hashed, written `0600` where the platform supports it. Anyone who can read the *raw* tokens (e.g. from your shell history) can act as you — treat them like passwords. |
+| **Browser storage** | The UI keeps the token in `localStorage`. Any cross-site-scripting flaw in the app could read it; that is the accepted trade-off for tokens that also work from `curl` and scripts. |
+
+## What is intentionally not covered
+
+- **User accounts, passwords, roles, or scopes.** Tokens are flat and equal;
+  identity is the token name. This is deliberate — it needs no account
+  management and works identically from a browser, `curl`, and Python.
+- **TLS.** See the table above.
+- **Per-user reference storage.** References are a shared store; ownership
+  applies to live instrument sessions only.
+- **Rate limiting** beyond the session cap.
+
+## Quick reference
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--host` | `127.0.0.1` | Bind address; `0.0.0.0` exposes on the LAN |
+| `--port` | `8765` | Listen port |
+| `--config-dir` | `~/.siglent` | Where `tokens.json` lives |
+| `--allow-port <n>` | `{5025}` | Extra instrument port(s) the gateway may connect to (repeatable) |
+| `--max-sessions` | `8` | Concurrent instrument-session cap |
+| `--abandon-after` | `300` | Seconds of owner inactivity before a session can be claimed |
+
+| Command | Purpose |
+|---|---|
+| `scpi-web token add <name>` | Mint a token (printed once) |
+| `scpi-web token list` | List token names |
+| `scpi-web token revoke <name>` | Revoke a token immediately |
+| `scpi-web references migrate` | Convert pre-5.0 reference files |
+
+| Status | Meaning |
+|---|---|
+| **401** | Missing or invalid token |
+| **409** on a write | You are not the session owner (message names who is) |
+| **409** on `claim` | Owner still active/watching (message says how long to wait) |
+| **409** on create | Session cap reached |
+| **400** on session create | Target address/port refused by the SSRF gate |
+| **WS close 1008** | WebSocket handshake was not authenticated |

--- a/docs/gateway/security.md
+++ b/docs/gateway/security.md
@@ -68,9 +68,13 @@ revoked 'default'
   cannot be recovered. The *name* is the identity — it is what appears as a
   session's owner and in any attribution.
 - **`token list`** shows names only, never secrets.
-- **`token revoke <name>`** removes a token. Revocation takes effect
-  **immediately** — the next request carrying that token is rejected, even
-  mid-session. Use it when a token is shared too widely or a laptop walks off.
+- **`token revoke <name>`** removes a token from `tokens.json`. Use it when a
+  token is shared too widely or a laptop walks off.
+
+  > **A running gateway loads its tokens once, at startup.** `token revoke` (and
+  > `token add`) edit the file from a separate process, so **restart `scpi-web`
+  > for a revocation to take effect.** Until it restarts, a revoked token keeps
+  > working. If you have revoked a token because it leaked, restart the gateway.
 
 Every token is equal: there are no roles or scopes. Anyone with a valid token can
 create sessions and read any session; ownership (below) governs who may *write*.
@@ -279,7 +283,7 @@ directory, when you run the command explicitly.
 |---|---|
 | `scpi-web token add <name>` | Mint a token (printed once) |
 | `scpi-web token list` | List token names |
-| `scpi-web token revoke <name>` | Revoke a token immediately |
+| `scpi-web token revoke <name>` | Revoke a token (restart the gateway to apply) |
 | `scpi-web references migrate` | Convert pre-5.0 reference files |
 
 | Status | Meaning |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -22,7 +22,10 @@ First, install the library:
     scpi-web
     `
 
-    Then open <http://127.0.0.1:8765> in your browser.
+    On first run this prints a ready-to-open URL with an access token
+    (`http://127.0.0.1:8765/?token=…`) — open that in your browser. Every
+    request needs a token; see the
+    [Gateway security guide](../gateway/security.md) for details.
 
 === "Everything"
 `bash

--- a/examples/gateway_rest_client.py
+++ b/examples/gateway_rest_client.py
@@ -3,7 +3,13 @@
 Start the gateway first (in another terminal):
 
     pip install "SCPI-Instrument-Control[web]"
-    scpi-web
+    scpi-web            # prints a URL with a token on first run
+
+Every gateway request needs a bearer token. Mint one and export it before
+running this script:
+
+    scpi-web token add rest-demo     # prints the token once
+    export SCPI_WEB_TOKEN=scpi_...   # the token it printed
 
 Then run this script. It creates a hardware-free mock session, configures a
 channel, fetches full-resolution waveform data as JSON, and downloads a
@@ -15,10 +21,17 @@ Requirements:
 """
 
 import json
+import os
+import sys
+import urllib.error
 import urllib.request
 from typing import Optional, Union
 
 BASE = "http://127.0.0.1:8765/api"
+
+# The gateway authenticates every /api/* request with a bearer token. Read it
+# from the environment rather than hard-coding a credential in the script.
+TOKEN = os.environ.get("SCPI_WEB_TOKEN")
 
 Body = Optional[Union[dict, list]]  # examples run on the package floor, Python 3.9
 
@@ -26,6 +39,8 @@ Body = Optional[Union[dict, list]]  # examples run on the package floor, Python 
 def call(method: str, path: str, body: Body = None) -> bytes:
     data = None if body is None else json.dumps(body).encode()
     request = urllib.request.Request(BASE + path, data=data, method=method)
+    if TOKEN:
+        request.add_header("Authorization", "Bearer {0}".format(TOKEN))
     if data is not None:
         request.add_header("Content-Type", "application/json")
     with urllib.request.urlopen(request) as response:
@@ -37,6 +52,9 @@ def call_json(method: str, path: str, body: Body = None):
 
 
 def main() -> None:
+    if not TOKEN:
+        sys.exit("Set SCPI_WEB_TOKEN first — run 'scpi-web token add rest-demo' and export the token it prints.")
+
     # 1. Create a mock oscilloscope session (no hardware required)
     session = call_json("POST", "/sessions", {"mock": True, "label": "REST demo"})
     session_id = session["id"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
       - Advanced Features: user-guide/advanced-features.md
   - Web Gateway:
       - Overview: gateway/index.md
+      - Security: gateway/security.md
       - Browser UI Tour: gateway/browser-ui.md
       - REST & WebSocket API: gateway/api.md
   - GUI Application:

--- a/scpi_control/gui/main_window.py
+++ b/scpi_control/gui/main_window.py
@@ -1452,15 +1452,17 @@ class MainWindow(QMainWindow):
                 QMessageBox.critical(self, "Error", f"Failed to save reference:\n{str(e)}")
                 logger.error(f"Failed to save reference: {e}")
 
-    def _on_load_reference(self, filepath: str):
+    def _on_load_reference(self, name: str):
         """Handle load reference request.
 
         Args:
-            filepath: Path to reference file
+            name: Short reference name, as stored by ReferencePanel's list
+                items (not the absolute filepath -- load_reference() only
+                resolves names confined to the storage directory).
         """
         try:
             # Load reference
-            reference_data = self.reference_manager.load_reference(filepath)
+            reference_data = self.reference_manager.load_reference(name)
 
             if reference_data:
                 # Set reference in waveform display
@@ -1481,7 +1483,7 @@ class MainWindow(QMainWindow):
                     self.reference_panel.update_comparison_stats(correlation, rms_diff)
 
                 self.statusBar().showMessage("Reference loaded")
-                logger.info(f"Reference loaded: {filepath}")
+                logger.info(f"Reference loaded: {name}")
             else:
                 QMessageBox.warning(self, "Error", "Failed to load reference")
 
@@ -1489,27 +1491,30 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(self, "Error", f"Failed to load reference:\n{str(e)}")
             logger.error(f"Failed to load reference: {e}")
 
-    def _on_delete_reference(self, filepath: str):
+    def _on_delete_reference(self, name: str):
         """Handle delete reference request.
 
         Args:
-            filepath: Path to reference file
+            name: Short reference name, as stored by ReferencePanel's list
+                items (not the absolute filepath -- delete_reference() only
+                resolves names confined to the storage directory).
         """
         try:
             # Delete reference
-            success = self.reference_manager.delete_reference(filepath)
+            success = self.reference_manager.delete_reference(name)
 
             if success:
                 QMessageBox.information(self, "Deleted", "Reference deleted successfully")
-                logger.info(f"Reference deleted: {filepath}")
+                logger.info(f"Reference deleted: {name}")
 
                 # Refresh list
                 self._refresh_reference_list()
 
                 # Clear if this was the loaded reference
-                if self.waveform_display.get_reference_data():
-                    ref_path = self.waveform_display.get_reference_data().get("filepath")
-                    if ref_path == filepath:
+                loaded_data = self.waveform_display.get_reference_data()
+                if loaded_data:
+                    loaded_name = loaded_data.get("metadata", {}).get("name")
+                    if loaded_name == name:
                         self.waveform_display.clear_reference()
                         self.reference_panel._on_unload_reference()
             else:

--- a/scpi_control/gui/widgets/reference_panel.py
+++ b/scpi_control/gui/widgets/reference_panel.py
@@ -16,9 +16,9 @@ class ReferencePanel(QWidget):
     load, delete, and view information about each reference.
 
     Signals:
-        load_reference: Emitted when user requests to load a reference (filepath: str)
+        load_reference: Emitted when user requests to load a reference (name: str)
         save_reference: Emitted when user requests to save current waveform as reference
-        delete_reference: Emitted when user deletes a reference (filepath: str)
+        delete_reference: Emitted when user deletes a reference (name: str)
         show_difference: Emitted when user wants to show difference with reference
     """
 
@@ -176,12 +176,14 @@ class ReferencePanel(QWidget):
         Args:
             item: Selected list item
         """
-        # Get filepath from item data
-        filepath = item.data(Qt.ItemDataRole.UserRole)
+        # Get reference name from item data. Must be the short name, not the
+        # absolute filepath: _find_reference_file confines lookups to
+        # storage_dir and rejects paths outside it.
+        name = item.data(Qt.ItemDataRole.UserRole)
 
-        if filepath:
-            logger.info(f"Load reference requested: {filepath}")
-            self.load_reference.emit(filepath)
+        if name:
+            logger.info(f"Load reference requested: {name}")
+            self.load_reference.emit(name)
 
     def _on_delete_reference(self):
         """Handle delete reference button click."""
@@ -191,8 +193,7 @@ class ReferencePanel(QWidget):
             return
 
         item = selected_items[0]
-        name = item.text().split("\n")[0]  # Get first line (name)
-        filepath = item.data(Qt.ItemDataRole.UserRole)
+        name = item.data(Qt.ItemDataRole.UserRole)
 
         # Confirm deletion
         reply = QMessageBox.question(
@@ -203,8 +204,8 @@ class ReferencePanel(QWidget):
         )
 
         if reply == QMessageBox.StandardButton.Yes:
-            logger.info(f"Delete reference requested: {filepath}")
-            self.delete_reference.emit(filepath)
+            logger.info(f"Delete reference requested: {name}")
+            self.delete_reference.emit(name)
 
     def _on_show_difference_toggled(self, checked: bool):
         """Handle show difference toggle.
@@ -264,9 +265,10 @@ class ReferencePanel(QWidget):
             # Create item text
             item_text = f"{name}\n{channel} | {time_str} | {size_str}"
 
-            # Create list item
+            # Create list item. Store the short name, not the filepath: it's
+            # what load_reference()/delete_reference() accept post-security-fix.
             item = QListWidgetItem(item_text)
-            item.setData(Qt.ItemDataRole.UserRole, ref.get("filepath"))
+            item.setData(Qt.ItemDataRole.UserRole, name)
 
             self.reference_list.addItem(item)
 

--- a/scpi_control/reference_waveform.py
+++ b/scpi_control/reference_waveform.py
@@ -147,7 +147,10 @@ class ReferenceWaveform:
         """Load a reference waveform by name.
 
         Args:
-            name: Reference name or filename
+            name: The reference's short name, as saved (e.g. via save_reference
+                or shown in list_references()'s "name" field). A literal
+                on-disk filename only resolves in the near-impossible case of
+                a saved file with no timestamp suffix; see _find_reference_file.
 
         Returns:
             Dictionary with 'time', 'voltage', and 'metadata' keys, or None if not found
@@ -233,7 +236,10 @@ class ReferenceWaveform:
         """Delete a reference waveform.
 
         Args:
-            name: Reference name or filename
+            name: The reference's short name, as saved (e.g. via save_reference
+                or shown in list_references()'s "name" field). A literal
+                on-disk filename only resolves in the near-impossible case of
+                a saved file with no timestamp suffix; see _find_reference_file.
 
         Returns:
             True if deleted successfully, False otherwise
@@ -266,7 +272,11 @@ class ReferenceWaveform:
         """Rename a reference waveform.
 
         Args:
-            old_name: Current reference name
+            old_name: The reference's current short name, as saved (e.g. via
+                save_reference or shown in list_references()'s "name" field).
+                A literal on-disk filename only resolves in the near-impossible
+                case of a saved file with no timestamp suffix; see
+                _find_reference_file.
             new_name: New reference name
 
         Returns:
@@ -410,14 +420,20 @@ class ReferenceWaveform:
         any path on disk, which combined with pickled loads was an RCE vector.
 
         Args:
-            name: Reference name or filename
+            name: The reference's short name, as saved (e.g. via save_reference
+                or shown in list_references()'s "name" field). A literal
+                on-disk filename only resolves in the near-impossible case of
+                a saved file with no timestamp suffix -- otherwise this falls
+                through to the metadata scan below, matched against the
+                reference's saved name rather than its filename.
 
         Returns:
             Path to reference file or None if not found
         """
+        # _sanitize_name always falls back to "reference" for an all-stripped
+        # input, so `safe` is never empty here -- no not-found short-circuit
+        # is needed before trying it as a candidate filename.
         safe = self._sanitize_name(name)
-        if not safe:
-            return None
 
         root = self.storage_dir.resolve()
         for candidate_name in (safe, "{0}.npz".format(safe)):

--- a/scpi_control/reference_waveform.py
+++ b/scpi_control/reference_waveform.py
@@ -238,7 +238,16 @@ class ReferenceWaveform:
         Returns:
             True if deleted successfully, False otherwise
         """
-        filepath = self._find_reference_file(name)
+        try:
+            filepath = self._find_reference_file(name)
+        except (LegacyReferenceFormatError, CorruptReferenceError):
+            # Delete is a "remove it if present" operation: an unreadable
+            # file elsewhere in the directory is not proof the requested
+            # name exists, so treat it the same as not found rather than
+            # blocking every delete/replace-on-save of a name that was
+            # never actually saved.
+            logger.warning(f"Reference waveform not found: {name}")
+            return False
 
         if filepath is None:
             logger.warning(f"Reference waveform not found: {name}")
@@ -263,7 +272,15 @@ class ReferenceWaveform:
         Returns:
             True if renamed successfully, False otherwise
         """
-        old_filepath = self._find_reference_file(old_name)
+        try:
+            old_filepath = self._find_reference_file(old_name)
+        except (LegacyReferenceFormatError, CorruptReferenceError):
+            # Same reasoning as delete_reference: locating old_name is a
+            # "rename it if present" lookup, not a read request, so an
+            # unreadable file elsewhere in the directory must not block
+            # renaming a name that was never actually saved.
+            logger.warning(f"Reference waveform not found: {old_name}")
+            return False
 
         if old_filepath is None:
             logger.warning(f"Reference waveform not found: {old_name}")

--- a/scpi_control/reference_waveform.py
+++ b/scpi_control/reference_waveform.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-import os
+import zipfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -404,7 +404,10 @@ class ReferenceWaveform:
         return safe_name if safe_name else "reference"
 
     def _find_reference_file(self, name: str) -> Optional[Path]:
-        """Find reference file by name.
+        """Resolve ``name`` to a file inside storage_dir, or None.
+
+        Absolute paths and traversal are rejected outright: this used to accept
+        any path on disk, which combined with pickled loads was an RCE vector.
 
         Args:
             name: Reference name or filename
@@ -412,45 +415,38 @@ class ReferenceWaveform:
         Returns:
             Path to reference file or None if not found
         """
-        # If name is already a full path, use it
-        if os.path.isabs(name):
-            filepath = Path(name)
-            if filepath.exists():
-                return filepath
+        safe = self._sanitize_name(name)
+        if not safe:
             return None
 
-        # Try as filename directly
-        filepath = self.storage_dir / name
-        if filepath.exists():
-            return filepath
-
-        # Try with .npz extension
-        if not name.endswith(".npz"):
-            filepath = self.storage_dir / f"{name}.npz"
-            if filepath.exists():
-                return filepath
+        root = self.storage_dir.resolve()
+        for candidate_name in (safe, "{0}.npz".format(safe)):
+            candidate = (self.storage_dir / candidate_name).resolve()
+            if candidate.is_file() and candidate.is_relative_to(root):
+                return candidate
 
         # Search for files containing the name. A file we can't safely read
         # (legacy pickle or corrupt metadata) must not block a match that's
         # elsewhere in the directory -- keep scanning and only raise the first
         # such error if nothing in the whole directory actually matches.
         deferred_error = None
-        for filepath in self.storage_dir.glob("*.npz"):
+        for filepath in sorted(self.storage_dir.glob("*.npz")):
             try:
                 with np.load(filepath, allow_pickle=False) as data:
                     metadata = _read_metadata(data, filepath)
-                if metadata.get("name", "") == name:
-                    return filepath
-            except (LegacyReferenceFormatError, CorruptReferenceError) as exc:
-                # Can't safely read this file's embedded name without unpickling
-                # it, so remember the problem instead of raising immediately --
-                # a later file in the scan may still be the valid match the
-                # caller asked for.
-                if deferred_error is None:
+            except (OSError, ValueError, zipfile.BadZipFile, LegacyReferenceFormatError, CorruptReferenceError) as exc:
+                # Unreadable, corrupt, or pre-5.0 file: can't safely read this
+                # file's embedded name without unpickling it, so remember the
+                # problem instead of raising immediately -- a later file in the
+                # scan may still be the valid match the caller asked for. Named
+                # explicitly -- the bare `except:` this replaces is part of what
+                # the audit flagged here, and a blanket catch would hide real bugs.
+                if isinstance(exc, (LegacyReferenceFormatError, CorruptReferenceError)) and deferred_error is None:
                     deferred_error = exc
                 continue
-            except Exception:
-                continue
+
+            if metadata.get("name", "") == name:
+                return filepath
 
         if deferred_error is not None:
             raise deferred_error

--- a/scpi_control/reference_waveform.py
+++ b/scpi_control/reference_waveform.py
@@ -40,7 +40,7 @@ def _read_metadata(data, filepath) -> Dict[str, Any]:
         try:
             parsed = json.loads(str(data[REFERENCE_META_KEY]))
         except ValueError as exc:
-            raise CorruptReferenceError(filepath, exc)
+            raise CorruptReferenceError(filepath, exc) from exc
         # A truncated or hand-edited file can hold valid JSON of the wrong shape;
         # callers index this like a mapping, so reject anything else loudly here
         # rather than letting an AttributeError surface three frames away.
@@ -125,10 +125,16 @@ class ReferenceWaveform:
         metadata["num_samples"] = len(waveform.voltage)
         metadata["time_span"] = float(waveform.time[-1] - waveform.time[0]) if len(waveform.time) > 1 else 0.0
 
+        # Serialize outside the try block: a caller passing non-JSON-serializable
+        # metadata (e.g. a numpy array or np.int64) is a caller mistake, not an
+        # I/O failure, so let TypeError/ValueError surface as themselves instead
+        # of being folded into the IOError below.
+        metadata_json = json.dumps(metadata)
+
         try:
             # Save as NPZ with compression; metadata is stored as a JSON string so
             # loads never need allow_pickle=True.
-            np.savez_compressed(filepath, time=waveform.time, voltage=waveform.voltage, **{REFERENCE_META_KEY: json.dumps(metadata)})
+            np.savez_compressed(filepath, time=waveform.time, voltage=waveform.voltage, **{REFERENCE_META_KEY: metadata_json})
 
             logger.info(f"Reference waveform saved: {filepath}")
             return str(filepath)
@@ -407,20 +413,30 @@ class ReferenceWaveform:
             if filepath.exists():
                 return filepath
 
-        # Search for files containing the name
+        # Search for files containing the name. A file we can't safely read
+        # (legacy pickle or corrupt metadata) must not block a match that's
+        # elsewhere in the directory -- keep scanning and only raise the first
+        # such error if nothing in the whole directory actually matches.
+        deferred_error = None
         for filepath in self.storage_dir.glob("*.npz"):
             try:
                 with np.load(filepath, allow_pickle=False) as data:
                     metadata = _read_metadata(data, filepath)
                 if metadata.get("name", "") == name:
                     return filepath
-            except (LegacyReferenceFormatError, CorruptReferenceError):
+            except (LegacyReferenceFormatError, CorruptReferenceError) as exc:
                 # Can't safely read this file's embedded name without unpickling
-                # it, so let callers (e.g. load_reference) see the real problem
-                # instead of silently reporting "not found".
-                raise
+                # it, so remember the problem instead of raising immediately --
+                # a later file in the scan may still be the valid match the
+                # caller asked for.
+                if deferred_error is None:
+                    deferred_error = exc
+                continue
             except Exception:
                 continue
+
+        if deferred_error is not None:
+            raise deferred_error
 
         return None
 

--- a/scpi_control/reference_waveform.py
+++ b/scpi_control/reference_waveform.py
@@ -1,5 +1,6 @@
 """Reference waveform storage and management for comparison."""
 
+import json
 import logging
 import os
 from datetime import datetime
@@ -9,6 +10,46 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+REFERENCE_META_KEY = "meta_json"
+
+
+class LegacyReferenceFormatError(ValueError):
+    """A reference file still stores metadata as a pickled object array."""
+
+    def __init__(self, filepath) -> None:
+        super().__init__("{0} uses the pre-5.0 pickled reference format. Run 'scpi-web references migrate' to convert it.".format(filepath))
+        self.filepath = filepath
+
+
+class CorruptReferenceError(ValueError):
+    """A reference file's metadata block is present but unreadable."""
+
+    def __init__(self, filepath, detail) -> None:
+        super().__init__("{0} has an unreadable metadata block: {1}".format(filepath, detail))
+        self.filepath = filepath
+
+
+def _read_metadata(data, filepath) -> Dict[str, Any]:
+    """Extract the metadata dict from an open NpzFile, new format only.
+
+    Raises LegacyReferenceFormatError for pre-5.0 pickled files and
+    CorruptReferenceError for a present-but-unparseable/wrong-shaped block.
+    """
+    if REFERENCE_META_KEY in data.files:
+        try:
+            parsed = json.loads(str(data[REFERENCE_META_KEY]))
+        except ValueError as exc:
+            raise CorruptReferenceError(filepath, exc)
+        # A truncated or hand-edited file can hold valid JSON of the wrong shape;
+        # callers index this like a mapping, so reject anything else loudly here
+        # rather than letting an AttributeError surface three frames away.
+        if not isinstance(parsed, dict):
+            raise CorruptReferenceError(filepath, "expected a JSON object, got {0}".format(type(parsed).__name__))
+        return parsed
+    if "metadata" in data.files:
+        raise LegacyReferenceFormatError(filepath)
+    return {}
 
 
 class ReferenceWaveform:
@@ -85,8 +126,9 @@ class ReferenceWaveform:
         metadata["time_span"] = float(waveform.time[-1] - waveform.time[0]) if len(waveform.time) > 1 else 0.0
 
         try:
-            # Save as NPZ with compression
-            np.savez_compressed(filepath, time=waveform.time, voltage=waveform.voltage, metadata=metadata)
+            # Save as NPZ with compression; metadata is stored as a JSON string so
+            # loads never need allow_pickle=True.
+            np.savez_compressed(filepath, time=waveform.time, voltage=waveform.voltage, **{REFERENCE_META_KEY: json.dumps(metadata)})
 
             logger.info(f"Reference waveform saved: {filepath}")
             return str(filepath)
@@ -113,18 +155,21 @@ class ReferenceWaveform:
 
         try:
             # Load NPZ file
-            data = np.load(filepath, allow_pickle=True)
-
-            result = {
-                "time": data["time"],
-                "voltage": data["voltage"],
-                "metadata": data["metadata"].item() if "metadata" in data else {},
-                "filepath": str(filepath),
-            }
+            with np.load(filepath, allow_pickle=False) as data:
+                result = {
+                    "time": data["time"],
+                    "voltage": data["voltage"],
+                    "metadata": _read_metadata(data, filepath),
+                    "filepath": str(filepath),
+                }
 
             logger.info(f"Reference waveform loaded: {filepath}")
             return result
 
+        except (LegacyReferenceFormatError, CorruptReferenceError):
+            # Loud, actionable failures -- let the caller see them rather than
+            # silently reporting "not found".
+            raise
         except Exception as e:
             logger.error(f"Failed to load reference waveform: {e}")
             return None
@@ -142,22 +187,26 @@ class ReferenceWaveform:
             for filepath in self.storage_dir.glob("*.npz"):
                 try:
                     # Load metadata without loading full data
-                    data = np.load(filepath, allow_pickle=True)
-                    metadata = data["metadata"].item() if "metadata" in data else {}
+                    with np.load(filepath, allow_pickle=False) as data:
+                        try:
+                            metadata = _read_metadata(data, filepath)
+                        except LegacyReferenceFormatError:
+                            logger.warning("skipping %s: pre-5.0 format, run 'scpi-web references migrate'", filepath)
+                            continue
 
-                    ref_info = {
-                        "filename": filepath.name,
-                        "filepath": str(filepath),
-                        "name": metadata.get("name", filepath.stem),
-                        "timestamp": metadata.get("timestamp", ""),
-                        "channel": metadata.get("channel", "Unknown"),
-                        "num_samples": metadata.get("num_samples", 0),
-                        "time_span": metadata.get("time_span", 0.0),
-                        "min_voltage": metadata.get("min_voltage", 0.0),
-                        "max_voltage": metadata.get("max_voltage", 0.0),
-                        "file_size": filepath.stat().st_size,
-                        "modified_time": datetime.fromtimestamp(filepath.stat().st_mtime).isoformat(),
-                    }
+                        ref_info = {
+                            "filename": filepath.name,
+                            "filepath": str(filepath),
+                            "name": metadata.get("name", filepath.stem),
+                            "timestamp": metadata.get("timestamp", ""),
+                            "channel": metadata.get("channel", "Unknown"),
+                            "num_samples": metadata.get("num_samples", 0),
+                            "time_span": metadata.get("time_span", 0.0),
+                            "min_voltage": metadata.get("min_voltage", 0.0),
+                            "max_voltage": metadata.get("max_voltage", 0.0),
+                            "file_size": filepath.stat().st_size,
+                            "modified_time": datetime.fromtimestamp(filepath.stat().st_mtime).isoformat(),
+                        }
 
                     references.append(ref_info)
 
@@ -215,11 +264,13 @@ class ReferenceWaveform:
             return False
 
         try:
-            # Load and update metadata
-            data = np.load(old_filepath, allow_pickle=True)
-            time = data["time"]
-            voltage = data["voltage"]
-            metadata = data["metadata"].item() if "metadata" in data else {}
+            # Load and update metadata. Use a context manager so the NpzFile handle
+            # is closed before we unlink old_filepath below (Windows refuses to
+            # unlink a file that still has an open handle).
+            with np.load(old_filepath, allow_pickle=False) as data:
+                time = data["time"]
+                voltage = data["voltage"]
+                metadata = _read_metadata(data, old_filepath)
 
             # Update name in metadata
             metadata["name"] = new_name
@@ -231,7 +282,7 @@ class ReferenceWaveform:
             new_filepath = self.storage_dir / new_filename
 
             # Save with new name
-            np.savez_compressed(new_filepath, time=time, voltage=voltage, metadata=metadata)
+            np.savez_compressed(new_filepath, time=time, voltage=voltage, **{REFERENCE_META_KEY: json.dumps(metadata)})
 
             # Delete old file
             old_filepath.unlink()
@@ -359,11 +410,16 @@ class ReferenceWaveform:
         # Search for files containing the name
         for filepath in self.storage_dir.glob("*.npz"):
             try:
-                data = np.load(filepath, allow_pickle=True)
-                metadata = data["metadata"].item() if "metadata" in data else {}
+                with np.load(filepath, allow_pickle=False) as data:
+                    metadata = _read_metadata(data, filepath)
                 if metadata.get("name", "") == name:
                     return filepath
-            except:
+            except (LegacyReferenceFormatError, CorruptReferenceError):
+                # Can't safely read this file's embedded name without unpickling
+                # it, so let callers (e.g. load_reference) see the real problem
+                # instead of silently reporting "not found".
+                raise
+            except Exception:
                 continue
 
         return None

--- a/scpi_control/report_generator/utils/waveform_loader.py
+++ b/scpi_control/report_generator/utils/waveform_loader.py
@@ -106,7 +106,7 @@ class WaveformLoader:
     @staticmethod
     def _load_npz(filepath: Path) -> List[WaveformData]:
         """Load an NPZ, reading this library's schema exactly when present."""
-        data = np.load(filepath, allow_pickle=True)
+        data = np.load(filepath, allow_pickle=False)
 
         if _looks_like_ours(data.files):
             return [_from_loaded(_load_native(filepath))]

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -41,6 +41,12 @@ def main(argv=None) -> None:
     # value already parsed here. --allow-port has no subcommand use, so it is
     # simply never added to one.
     parser.add_argument("--allow-port", type=int, action="append", default=None, help="additional port the gateway may connect to (repeatable; 5025 is always allowed)")
+    # Registered ONLY on the top-level parser -- same trap as --allow-port
+    # above: a subparser's own --max-sessions with default=None would clobber
+    # a value already parsed here whenever the flag isn't repeated after the
+    # subcommand. --max-sessions has no subcommand use, so it is never added
+    # to one.
+    parser.add_argument("--max-sessions", type=int, default=8, help="maximum concurrent instrument sessions the gateway will hold open")
     _add_config_dir(parser)
 
     sub = parser.add_subparsers(dest="command")
@@ -89,7 +95,7 @@ def main(argv=None) -> None:
         raw = store.mint("default")
         print("\nGateway ready. Open:\n\n    http://{0}:{1}/?token={2}\n".format(args.host, args.port, raw))
     allowed_ports = frozenset(args.allow_port) | DEFAULT_ALLOWED_PORTS if args.allow_port else None
-    uvicorn.run(create_app(token_store=store, abandon_after=args.abandon_after, allowed_ports=allowed_ports), host=args.host, port=args.port)
+    uvicorn.run(create_app(token_store=store, abandon_after=args.abandon_after, allowed_ports=allowed_ports, max_sessions=args.max_sessions), host=args.host, port=args.port)
 
 
 if __name__ == "__main__":

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import uvicorn
 
 from scpi_control.server.app import create_app
-from scpi_control.server.auth import DEFAULT_CONFIG_DIR, DuplicateTokenName, TokenStore
+from scpi_control.server.auth import DEFAULT_CONFIG_DIR, TokenStore
 from scpi_control.server.netpolicy import DEFAULT_ALLOWED_PORTS
 
 
@@ -79,7 +79,11 @@ def main(argv=None) -> None:
         if args.token_command == "add":
             try:
                 print("token {0!r} created. Copy it now, it is not stored:\n\n    {1}\n".format(args.name, store.mint(args.name)))
-            except DuplicateTokenName as exc:
+            except ValueError as exc:
+                # Covers DuplicateTokenName (a ValueError subclass) as well as
+                # the bare ValueError mint() raises for an empty or
+                # whitespace-only name -- both must exit cleanly with a
+                # message, not surface as an uncaught traceback.
                 sys.exit(str(exc))
         elif args.token_command == "list":
             names = store.names()

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -48,7 +48,19 @@ def main(argv=None) -> None:
     revoke.add_argument("name")
     _add_config_dir(revoke, default=argparse.SUPPRESS)
 
+    references = sub.add_parser("references", help="reference file maintenance").add_subparsers(dest="references_command", required=True)
+    migrate = references.add_parser("migrate", help="convert pre-5.0 pickled reference files")
+    migrate.add_argument("--dir", default=None, help="reference storage directory (default: ~/.siglent/references)")
+
     args = parser.parse_args(argv)
+
+    if args.command == "references":
+        from scpi_control.server.migrate import migrate_references
+
+        target = args.dir if args.dir else str(DEFAULT_CONFIG_DIR / "references")
+        result = migrate_references(target)
+        print("converted {converted}, skipped {skipped}, failed {failed} in {0}".format(target, **result))
+        return
 
     if args.command == "token":
         store = _store(args)

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -90,6 +90,15 @@ def main(argv=None) -> None:
             print("revoked {0!r}".format(args.name))
         return
 
+    # Checked before anything else in the server-start path (ahead of minting
+    # a token or touching the config dir): SessionManager itself rejects
+    # max_sessions < 1, but that raw ValueError would surface after "Gateway
+    # ready" has already printed and a token has already been minted, reading
+    # like a crash rather than a configuration mistake. parser.error() prints
+    # a clear message and exits before any of that happens.
+    if args.max_sessions < 1:
+        parser.error("--max-sessions must be at least 1 (got {0})".format(args.max_sessions))
+
     store = _store(args)
     if store.is_empty():
         raw = store.mint("default")

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -34,6 +34,7 @@ def main(argv=None) -> None:
     parser = argparse.ArgumentParser(prog="scpi-web", description="SCPI Instrument Control web gateway")
     parser.add_argument("--host", default="127.0.0.1", help="bind address (use 0.0.0.0 to expose on the LAN)")
     parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--abandon-after", type=float, default=300.0, help="seconds of owner inactivity before another user may claim a session")
     _add_config_dir(parser)
 
     sub = parser.add_subparsers(dest="command")
@@ -69,7 +70,7 @@ def main(argv=None) -> None:
     if store.is_empty():
         raw = store.mint("default")
         print("\nGateway ready. Open:\n\n    http://{0}:{1}/?token={2}\n".format(args.host, args.port, raw))
-    uvicorn.run(create_app(token_store=store), host=args.host, port=args.port)
+    uvicorn.run(create_app(token_store=store, abandon_after=args.abandon_after), host=args.host, port=args.port)
 
 
 if __name__ == "__main__":

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -15,8 +15,19 @@ def _store(args) -> TokenStore:
     return TokenStore(str(config_dir / "tokens.json"))
 
 
-def _add_config_dir(parser) -> None:
-    parser.add_argument("--config-dir", default=None, help="directory holding tokens.json (default: ~/.siglent)")
+def _add_config_dir(parser, default=None) -> None:
+    """Register --config-dir.
+
+    Subparsers must use ``default=argparse.SUPPRESS`` rather than ``None``.
+    argparse's subparsers action reparses the remaining argv into a fresh
+    namespace and then unconditionally copies every attribute from it back
+    over the outer namespace -- so if a subparser's own --config-dir has a
+    concrete default, that default overwrites a value the top-level parser
+    already parsed whenever the flag isn't repeated after the subcommand.
+    SUPPRESS omits the attribute entirely when the flag is absent, so the
+    outer namespace's value (whatever position it was given in) survives.
+    """
+    parser.add_argument("--config-dir", default=default, help="directory holding tokens.json (default: ~/.siglent)")
 
 
 def main(argv=None) -> None:
@@ -29,12 +40,12 @@ def main(argv=None) -> None:
     token = sub.add_parser("token", help="manage access tokens").add_subparsers(dest="token_command", required=True)
     add = token.add_parser("add", help="mint a token (printed once)")
     add.add_argument("name")
-    _add_config_dir(add)
+    _add_config_dir(add, default=argparse.SUPPRESS)
     listing = token.add_parser("list", help="list token names")
-    _add_config_dir(listing)
+    _add_config_dir(listing, default=argparse.SUPPRESS)
     revoke = token.add_parser("revoke", help="revoke a token by name")
     revoke.add_argument("name")
-    _add_config_dir(revoke)
+    _add_config_dir(revoke, default=argparse.SUPPRESS)
 
     args = parser.parse_args(argv)
 

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -8,6 +8,7 @@ import uvicorn
 
 from scpi_control.server.app import create_app
 from scpi_control.server.auth import DEFAULT_CONFIG_DIR, DuplicateTokenName, TokenStore
+from scpi_control.server.netpolicy import DEFAULT_ALLOWED_PORTS
 
 
 def _store(args) -> TokenStore:
@@ -35,6 +36,11 @@ def main(argv=None) -> None:
     parser.add_argument("--host", default="127.0.0.1", help="bind address (use 0.0.0.0 to expose on the LAN)")
     parser.add_argument("--port", type=int, default=8765)
     parser.add_argument("--abandon-after", type=float, default=300.0, help="seconds of owner inactivity before another user may claim a session")
+    # Registered ONLY on the top-level parser -- see _add_config_dir's docstring
+    # for why the same option on a subparser (default=None) would clobber a
+    # value already parsed here. --allow-port has no subcommand use, so it is
+    # simply never added to one.
+    parser.add_argument("--allow-port", type=int, action="append", default=None, help="additional port the gateway may connect to (repeatable; 5025 is always allowed)")
     _add_config_dir(parser)
 
     sub = parser.add_subparsers(dest="command")
@@ -82,7 +88,8 @@ def main(argv=None) -> None:
     if store.is_empty():
         raw = store.mint("default")
         print("\nGateway ready. Open:\n\n    http://{0}:{1}/?token={2}\n".format(args.host, args.port, raw))
-    uvicorn.run(create_app(token_store=store, abandon_after=args.abandon_after), host=args.host, port=args.port)
+    allowed_ports = frozenset(args.allow_port) | DEFAULT_ALLOWED_PORTS if args.allow_port else None
+    uvicorn.run(create_app(token_store=store, abandon_after=args.abandon_after, allowed_ports=allowed_ports), host=args.host, port=args.port)
 
 
 if __name__ == "__main__":

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -1,18 +1,64 @@
 """Lab gateway entry point: python -m scpi_control.server / scpi-web."""
 
 import argparse
+import sys
+from pathlib import Path
 
 import uvicorn
 
 from scpi_control.server.app import create_app
+from scpi_control.server.auth import DEFAULT_CONFIG_DIR, DuplicateTokenName, TokenStore
+
+
+def _store(args) -> TokenStore:
+    config_dir = Path(args.config_dir) if args.config_dir else DEFAULT_CONFIG_DIR
+    return TokenStore(str(config_dir / "tokens.json"))
+
+
+def _add_config_dir(parser) -> None:
+    parser.add_argument("--config-dir", default=None, help="directory holding tokens.json (default: ~/.siglent)")
 
 
 def main(argv=None) -> None:
     parser = argparse.ArgumentParser(prog="scpi-web", description="SCPI Instrument Control web gateway")
     parser.add_argument("--host", default="127.0.0.1", help="bind address (use 0.0.0.0 to expose on the LAN)")
     parser.add_argument("--port", type=int, default=8765)
+    _add_config_dir(parser)
+
+    sub = parser.add_subparsers(dest="command")
+    token = sub.add_parser("token", help="manage access tokens").add_subparsers(dest="token_command", required=True)
+    add = token.add_parser("add", help="mint a token (printed once)")
+    add.add_argument("name")
+    _add_config_dir(add)
+    listing = token.add_parser("list", help="list token names")
+    _add_config_dir(listing)
+    revoke = token.add_parser("revoke", help="revoke a token by name")
+    revoke.add_argument("name")
+    _add_config_dir(revoke)
+
     args = parser.parse_args(argv)
-    uvicorn.run(create_app(), host=args.host, port=args.port)
+
+    if args.command == "token":
+        store = _store(args)
+        if args.token_command == "add":
+            try:
+                print("token {0!r} created. Copy it now, it is not stored:\n\n    {1}\n".format(args.name, store.mint(args.name)))
+            except DuplicateTokenName as exc:
+                sys.exit(str(exc))
+        elif args.token_command == "list":
+            names = store.names()
+            print("\n".join(names) if names else "no tokens")
+        elif args.token_command == "revoke":
+            if not store.revoke(args.name):
+                sys.exit("no token named {0!r}".format(args.name))
+            print("revoked {0!r}".format(args.name))
+        return
+
+    store = _store(args)
+    if store.is_empty():
+        raw = store.mint("default")
+        print("\nGateway ready. Open:\n\n    http://{0}:{1}/?token={2}\n".format(args.host, args.port, raw))
+    uvicorn.run(create_app(token_store=store), host=args.host, port=args.port)
 
 
 if __name__ == "__main__":

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -166,7 +166,7 @@ async def capture_csv(session_id: str, request: Request, channels: str = "1"):
         return [(c, scope.get_waveform(c)) for c in channel_list]
 
     captures = await run_job(session, capture)
-    csv_text = _build_csv(captures)
+    csv_text = await run_in_threadpool(_build_csv, captures)
     filename = "capture_{0}_C{1}.csv".format(session.id, "-".join(str(c) for c in channel_list))
     return PlainTextResponse(csv_text, media_type="text/csv", headers={"Content-Disposition": 'attachment; filename="{0}"'.format(filename)})
 
@@ -186,6 +186,10 @@ async def screenshot(session_id: str, request: Request):
     png = await run_job(session, grab)
     filename = "screenshot_{0}.png".format(session.id)
     return Response(content=png, media_type="image/png", headers={"Content-Disposition": 'attachment; filename="{0}"'.format(filename)})
+
+
+def _build_waveform_response(captures, max_points) -> dict:
+    return {"channels": [_waveform_json(c, data, max_points) for c, data in captures]}
 
 
 def _waveform_json(channel, data, max_points):
@@ -223,7 +227,7 @@ async def waveform_json(session_id: str, request: Request, channels: str = "1", 
 
     captures = await run_job(session, capture)
     cap = max_points if max_points > 0 else None
-    return {"channels": [_waveform_json(c, data, cap) for c, data in captures]}
+    return await run_in_threadpool(_build_waveform_response, captures, cap)
 
 
 def _math_state(scope):

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -10,6 +10,7 @@ from fastapi.responses import PlainTextResponse, Response
 
 from scpi_control.exceptions import InvalidParameterError
 from scpi_control.server.api.sessions import require_session
+from scpi_control.server.ownership import require_owner
 from scpi_control.server.schemas import (
     ALLOWED_COUPLING,
     ALLOWED_FILTER_KINDS,
@@ -51,7 +52,7 @@ async def get_state(session_id: str, request: Request):
 
 @router.patch("/sessions/{session_id}/scope/channels/{channel}")
 async def patch_channel(session_id: str, channel: int, body: ChannelPatch, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
     if body.coupling is not None and body.coupling.upper() not in ALLOWED_COUPLING:
         raise InvalidParameterError("invalid coupling: {0}".format(body.coupling))
 
@@ -75,7 +76,7 @@ async def patch_channel(session_id: str, channel: int, body: ChannelPatch, reque
 
 @router.patch("/sessions/{session_id}/scope/timebase")
 async def patch_timebase(session_id: str, body: TimebasePatch, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
 
     def apply(scope):
         scope.timebase = body.timebase
@@ -85,7 +86,7 @@ async def patch_timebase(session_id: str, body: TimebasePatch, request: Request)
 
 @router.patch("/sessions/{session_id}/scope/trigger")
 async def patch_trigger(session_id: str, body: TriggerPatch, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
 
     def apply(scope):
         trig = scope.trigger
@@ -105,7 +106,7 @@ async def patch_trigger(session_id: str, body: TriggerPatch, request: Request):
 
 @router.post("/sessions/{session_id}/scope/command")
 async def send_command(session_id: str, body: CommandIn, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
     command = body.command.strip()
     if not command:
         raise InvalidParameterError("empty command")
@@ -122,7 +123,7 @@ async def send_command(session_id: str, body: CommandIn, request: Request):
 
 @router.put("/sessions/{session_id}/scope/measurements")
 async def put_measurements(session_id: str, body: List[MeasurementItem], request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
     if session.recorder.state == "recording":
         raise SessionError("measurement selection is locked while recording")
     for item in body:
@@ -237,7 +238,7 @@ async def get_math(session_id: str, request: Request):
 
 @router.patch("/sessions/{session_id}/scope/math/{n}")
 async def patch_math(session_id: str, n: int, body: MathPatch, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
     if n not in (1, 2):
         raise InvalidParameterError("math channel must be 1 or 2")
     if body.expression is not None and not body.expression.strip():
@@ -262,7 +263,7 @@ async def get_spectrum(session_id: str, request: Request):
 
 @router.patch("/sessions/{session_id}/scope/spectrum")
 async def patch_spectrum(session_id: str, body: SpectrumPatch, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
     updates = {k: v for k, v in body.model_dump().items() if v is not None}
     if "window" in updates and updates["window"] not in ALLOWED_WINDOWS:
         raise InvalidParameterError("unknown window: {0}".format(updates["window"]))
@@ -284,7 +285,7 @@ async def get_filters(session_id: str, request: Request):
 
 @router.patch("/sessions/{session_id}/scope/filters/{n}")
 async def patch_filter(session_id: str, n: int, body: FilterPatch, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
     if n not in (1, 2):
         raise InvalidParameterError("filter must be 1 or 2")
     updates = {k: v for k, v in body.model_dump().items() if v is not None}
@@ -343,7 +344,7 @@ async def list_references(session_id: str, request: Request):
 
 @router.post("/sessions/{session_id}/scope/references", status_code=201)
 async def save_reference(session_id: str, body: ReferenceCreate, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
     name = body.name.strip()
     if not name:
         raise InvalidParameterError("reference name must not be empty")
@@ -364,7 +365,7 @@ async def save_reference(session_id: str, body: ReferenceCreate, request: Reques
 
 @router.delete("/sessions/{session_id}/scope/references/{name}", status_code=204)
 async def delete_reference(session_id: str, name: str, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
     store = _reference_store(request)
 
     def remove():
@@ -388,7 +389,7 @@ async def get_reference(session_id: str, request: Request):
 
 @router.put("/sessions/{session_id}/scope/reference")
 async def put_reference(session_id: str, body: ReferencePut, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
     if body.name is None:
         session.set_active_reference(None, None, None)
         return session.reference_overlay()
@@ -403,13 +404,13 @@ async def put_reference(session_id: str, body: ReferencePut, request: Request):
 
 @router.post("/sessions/{session_id}/scope/log/start")
 async def log_start(session_id: str, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
     return session.start_recording()
 
 
 @router.post("/sessions/{session_id}/scope/log/stop")
 async def log_stop(session_id: str, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
     return session.stop_recording()
 
 
@@ -460,7 +461,7 @@ _RUN_OPS = {
 
 @router.post("/sessions/{session_id}/scope/{op}")
 async def run_op(session_id: str, op: str, request: Request):
-    session = require_session(request, session_id)
+    session = require_owner(request, session_id)
     fn = _RUN_OPS.get(op)
     if fn is None:
         raise InvalidParameterError("unknown operation: {0}".format(op))

--- a/scpi_control/server/api/sessions.py
+++ b/scpi_control/server/api/sessions.py
@@ -45,6 +45,8 @@ async def create_session(body: SessionCreate, request: Request):
 
 @router.delete("/sessions/{session_id}", status_code=204)
 async def delete_session(session_id: str, request: Request):
-    require_session(request, session_id)
+    from scpi_control.server.ownership import require_owner
+
+    require_owner(request, session_id)
     await run_in_threadpool(get_manager(request).delete, session_id)
     return Response(status_code=204)

--- a/scpi_control/server/api/sessions.py
+++ b/scpi_control/server/api/sessions.py
@@ -68,17 +68,27 @@ async def claim_session(session_id: str, request: Request):
 
     session = require_session(request, session_id)
     identity = getattr(request.state, "identity", "")
-    retry_after = claim(session, identity, abandon_after(request))
-    if retry_after is not None:
+    if not claim(session, identity, abandon_after(request)):
         raise NotOwnerError(session.owner, time.monotonic() - session.owner_last_active)
     return session_out(session)
 
 
 @router.post("/sessions/{session_id}/owner")
 async def set_owner(session_id: str, body: OwnerPut, request: Request):
+    """Hand off ownership to ``body.name``, or release it with ``""``.
+
+    ``name`` must be a name registered in the token store; an unknown name
+    is rejected with 400 and ownership is left unchanged. An empty string
+    is an explicit release: it unowns the session, making it immediately
+    claimable by anyone. That is the only way an owner can let go of a
+    session without handing it to a specific person.
+    """
     from scpi_control.server.ownership import require_owner
 
     session = require_owner(request, session_id)
-    session.owner = body.name
+    name = body.name
+    if name and name not in request.app.state.tokens.names():
+        raise HTTPException(status_code=400, detail="unknown identity {0!r}".format(name))
+    session.owner = name
     session.touch()
     return session_out(session)

--- a/scpi_control/server/api/sessions.py
+++ b/scpi_control/server/api/sessions.py
@@ -1,9 +1,11 @@
 # scpi_control/server/api/sessions.py
+import time
+
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.concurrency import run_in_threadpool
 
 from scpi_control.models import MODEL_REGISTRY
-from scpi_control.server.schemas import ModelOut, SessionCreate, session_out
+from scpi_control.server.schemas import ModelOut, OwnerPut, SessionCreate, session_out
 
 router = APIRouter(tags=["sessions"])
 
@@ -16,6 +18,14 @@ def require_session(request: Request, session_id: str):
     session = get_manager(request).get(session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="unknown session {0}".format(session_id))
+    identity = getattr(request.state, "identity", "")
+    # A read from the owner is still owner activity: require_owner only fires
+    # on writes, so without this an owner who is watching state/reads during a
+    # capture (the normal case) would look idle and be claimable out from
+    # under them. Only refresh for the owner themselves -- a non-owner's read
+    # must never extend someone else's claim-protection window.
+    if session.owner and identity == session.owner:
+        session.touch()
     return session
 
 
@@ -50,3 +60,25 @@ async def delete_session(session_id: str, request: Request):
     require_owner(request, session_id)
     await run_in_threadpool(get_manager(request).delete, session_id)
     return Response(status_code=204)
+
+
+@router.post("/sessions/{session_id}/claim")
+async def claim_session(session_id: str, request: Request):
+    from scpi_control.server.ownership import NotOwnerError, abandon_after, claim
+
+    session = require_session(request, session_id)
+    identity = getattr(request.state, "identity", "")
+    retry_after = claim(session, identity, abandon_after(request))
+    if retry_after is not None:
+        raise NotOwnerError(session.owner, time.monotonic() - session.owner_last_active)
+    return session_out(session)
+
+
+@router.post("/sessions/{session_id}/owner")
+async def set_owner(session_id: str, body: OwnerPut, request: Request):
+    from scpi_control.server.ownership import require_owner
+
+    session = require_owner(request, session_id)
+    session.owner = body.name
+    session.touch()
+    return session_out(session)

--- a/scpi_control/server/api/sessions.py
+++ b/scpi_control/server/api/sessions.py
@@ -39,7 +39,7 @@ def get_session(session_id: str, request: Request):
 async def create_session(body: SessionCreate, request: Request):
     label = body.label or (body.model or ("Mock scope" if body.mock else body.address or ""))
     # InstrumentSession.open blocks on connect; keep the event loop free.
-    session = await run_in_threadpool(get_manager(request).create, label, address=body.address, port=body.port, mock=body.mock, model=body.model)
+    session = await run_in_threadpool(get_manager(request).create, label, address=body.address, port=body.port, mock=body.mock, model=body.model, owner=getattr(request.state, "identity", ""))
     return session_out(session)
 
 

--- a/scpi_control/server/api/stream.py
+++ b/scpi_control/server/api/stream.py
@@ -84,6 +84,14 @@ async def stream(websocket: WebSocket, session_id: str):
         loop.call_soon_threadsafe(_enqueue, outbox, message)
 
     unsubscribe = session.subscribe(on_message)
+    # A live stream is one long-lived connection, so require_session's
+    # per-request touch() never fires here -- an owner who is watching a
+    # capture would otherwise look idle to the claim rule. Mark the owner as
+    # watching for the lifetime of the connection instead (no-op if this
+    # identity isn't the owner); unmark unconditionally in finally so an
+    # abnormal disconnect releases it just like a clean close does.
+    identity = getattr(websocket.state, "identity", "")
+    unmark_owner_watching = session.mark_owner_watching(identity)
     receiver = None
     sender = None
     try:
@@ -100,6 +108,7 @@ async def stream(websocket: WebSocket, session_id: str):
         # Any failure on the send/receive path tears down quietly (no ASGI noise).
         pass
     finally:
+        unmark_owner_watching()
         unsubscribe()
         for task in (receiver, sender):
             if task is not None:

--- a/scpi_control/server/api/stream.py
+++ b/scpi_control/server/api/stream.py
@@ -91,10 +91,10 @@ async def stream(websocket: WebSocket, session_id: str):
     # identity isn't the owner); unmark unconditionally in finally so an
     # abnormal disconnect releases it just like a clean close does.
     identity = getattr(websocket.state, "identity", "")
-    unmark_owner_watching = session.mark_owner_watching(identity)
     receiver = None
     sender = None
     try:
+        unmark_owner_watching = session.mark_owner_watching(identity)
         initial = await asyncio.wrap_future(session.submit(read_state))
         await websocket.send_json({"type": "state", "state": initial})
         # Run the receiver (disconnect detection) and sender concurrently; whichever

--- a/scpi_control/server/api/stream.py
+++ b/scpi_control/server/api/stream.py
@@ -4,6 +4,7 @@ import contextlib
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from scpi_control.server.auth import WS_ACCEPT_SUBPROTOCOL
 from scpi_control.server.sessions import read_state
 
 router = APIRouter(tags=["stream"])
@@ -70,7 +71,11 @@ async def stream(websocket: WebSocket, session_id: str):
     if session is None:
         await websocket.close(code=4404)
         return
-    await websocket.accept()
+    # Echo the accept subprotocol back only when the client actually offered
+    # it: echoing an unoffered subprotocol is invalid per RFC 6455 and browsers
+    # fail the handshake either way -- offered-and-unechoed, or echoed-unoffered.
+    subprotocol = WS_ACCEPT_SUBPROTOCOL if WS_ACCEPT_SUBPROTOCOL in websocket.scope.get("subprotocols", []) else None
+    await websocket.accept(subprotocol=subprotocol)
 
     loop = asyncio.get_running_loop()
     outbox: "asyncio.Queue" = asyncio.Queue(maxsize=OUTBOX_MAXSIZE)

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -20,7 +20,7 @@ def _error_response(status: int, exc: BaseException) -> JSONResponse:
     return JSONResponse(status_code=status, content={"error": type(exc).__name__, "detail": str(exc)})
 
 
-def create_app(manager: Optional[SessionManager] = None, references_dir: Optional[str] = None, token_store: Optional[TokenStore] = None) -> FastAPI:
+def create_app(manager: Optional[SessionManager] = None, references_dir: Optional[str] = None, token_store: Optional[TokenStore] = None, abandon_after: float = 300.0) -> FastAPI:
     manager = manager if manager is not None else SessionManager()
 
     @asynccontextmanager
@@ -42,6 +42,10 @@ def create_app(manager: Optional[SessionManager] = None, references_dir: Optiona
     # mkdirs its storage directory, and most requests never need it.
     app.state.references_dir = references_dir
     app.state.references = None
+    # Seconds of owner inactivity before another identity may claim a session
+    # (scpi_control.server.ownership.claim); mutable at runtime so tests can
+    # drive it to 0 instead of sleeping for a real timeout.
+    app.state.abandon_after = abandon_after
 
     from scpi_control.server.api import discovery as discovery_api
     from scpi_control.server.api import scope as scope_api

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -27,11 +27,15 @@ def create_app(
     abandon_after: float = 300.0,
     allowed_ports: Optional[frozenset] = None,
 ) -> FastAPI:
-    # allowed_ports only affects a manager create_app builds itself: an
-    # explicitly-passed manager already carries its own policy (or the
-    # netpolicy default), and silently overriding it here would surprise a
-    # caller (e.g. a test) that constructed SessionManager(allowed_ports=...)
-    # on purpose.
+    # allowed_ports only ever seeds a manager create_app builds itself: an
+    # explicitly-passed manager already carries its own policy (or the netpolicy
+    # default). Silently overriding it here would surprise a caller (e.g. a test)
+    # that constructed SessionManager(allowed_ports=...) on purpose -- but silently
+    # *dropping* allowed_ports when both are given is just as surprising to a
+    # caller who assumed the two compose, and could leave the gateway with no
+    # port policy at all. Refuse the ambiguous combination instead of guessing.
+    if manager is not None and allowed_ports is not None:
+        raise ValueError("create_app() received both an explicit manager and allowed_ports; configure the port policy on the manager (SessionManager(allowed_ports=...)) instead.")
     manager = manager if manager is not None else SessionManager(allowed_ports=allowed_ports)
 
     @asynccontextmanager

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -29,7 +29,10 @@ def create_app(manager: Optional[SessionManager] = None, references_dir: Optiona
         # close_all() joins worker threads, so keep it off the event loop.
         await run_in_threadpool(app.state.manager.close_all)
 
-    app = FastAPI(title="SCPI Instrument Control Gateway", lifespan=lifespan)
+    # docs_url/redoc_url off and openapi_url moved under /api/ so the schema and
+    # HTML doc UIs sit behind AuthMiddleware like the rest of the instrument
+    # surface, instead of being served to anyone who reaches the port.
+    app = FastAPI(title="SCPI Instrument Control Gateway", lifespan=lifespan, docs_url=None, redoc_url=None, openapi_url="/api/openapi.json")
     app.state.manager = manager
     # A malformed token store must fail loudly (TokenStore.__init__ raises
     # ValueError) rather than be caught here and silently degrade to an empty

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -26,17 +26,19 @@ def create_app(
     token_store: Optional[TokenStore] = None,
     abandon_after: float = 300.0,
     allowed_ports: Optional[frozenset] = None,
+    max_sessions: Optional[int] = None,
 ) -> FastAPI:
-    # allowed_ports only ever seeds a manager create_app builds itself: an
-    # explicitly-passed manager already carries its own policy (or the netpolicy
-    # default). Silently overriding it here would surprise a caller (e.g. a test)
-    # that constructed SessionManager(allowed_ports=...) on purpose -- but silently
-    # *dropping* allowed_ports when both are given is just as surprising to a
-    # caller who assumed the two compose, and could leave the gateway with no
-    # port policy at all. Refuse the ambiguous combination instead of guessing.
-    if manager is not None and allowed_ports is not None:
-        raise ValueError("create_app() received both an explicit manager and allowed_ports; configure the port policy on the manager (SessionManager(allowed_ports=...)) instead.")
-    manager = manager if manager is not None else SessionManager(allowed_ports=allowed_ports)
+    # allowed_ports and max_sessions only ever seed a manager create_app builds
+    # itself: an explicitly-passed manager already carries its own policy (or
+    # the class defaults). Silently overriding it here would surprise a caller
+    # (e.g. a test) that constructed SessionManager(...) on purpose -- but
+    # silently *dropping* a policy argument when both are given is just as
+    # surprising to a caller who assumed they compose, and could leave the
+    # gateway with no port policy or session cap at all. Refuse the ambiguous
+    # combination instead of guessing.
+    if manager is not None and (allowed_ports is not None or max_sessions is not None):
+        raise ValueError("create_app() received both an explicit manager and allowed_ports/max_sessions; configure those on the manager (SessionManager(...)) instead.")
+    manager = manager if manager is not None else SessionManager(allowed_ports=allowed_ports, max_sessions=max_sessions if max_sessions is not None else 8)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -20,8 +20,19 @@ def _error_response(status: int, exc: BaseException) -> JSONResponse:
     return JSONResponse(status_code=status, content={"error": type(exc).__name__, "detail": str(exc)})
 
 
-def create_app(manager: Optional[SessionManager] = None, references_dir: Optional[str] = None, token_store: Optional[TokenStore] = None, abandon_after: float = 300.0) -> FastAPI:
-    manager = manager if manager is not None else SessionManager()
+def create_app(
+    manager: Optional[SessionManager] = None,
+    references_dir: Optional[str] = None,
+    token_store: Optional[TokenStore] = None,
+    abandon_after: float = 300.0,
+    allowed_ports: Optional[frozenset] = None,
+) -> FastAPI:
+    # allowed_ports only affects a manager create_app builds itself: an
+    # explicitly-passed manager already carries its own policy (or the
+    # netpolicy default), and silently overriding it here would surprise a
+    # caller (e.g. a test) that constructed SessionManager(allowed_ports=...)
+    # on purpose.
+    manager = manager if manager is not None else SessionManager(allowed_ports=allowed_ports)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -10,6 +10,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from scpi_control.exceptions import InvalidParameterError, SiglentError, SiglentTimeoutError
+from scpi_control.server.auth import AuthMiddleware, TokenStore
 from scpi_control.server.sessions import SessionError, SessionManager
 
 STATIC_DIR = Path(__file__).parent / "static"
@@ -19,7 +20,7 @@ def _error_response(status: int, exc: BaseException) -> JSONResponse:
     return JSONResponse(status_code=status, content={"error": type(exc).__name__, "detail": str(exc)})
 
 
-def create_app(manager: Optional[SessionManager] = None, references_dir: Optional[str] = None) -> FastAPI:
+def create_app(manager: Optional[SessionManager] = None, references_dir: Optional[str] = None, token_store: Optional[TokenStore] = None) -> FastAPI:
     manager = manager if manager is not None else SessionManager()
 
     @asynccontextmanager
@@ -30,6 +31,10 @@ def create_app(manager: Optional[SessionManager] = None, references_dir: Optiona
 
     app = FastAPI(title="SCPI Instrument Control Gateway", lifespan=lifespan)
     app.state.manager = manager
+    # A malformed token store must fail loudly (TokenStore.__init__ raises
+    # ValueError) rather than be caught here and silently degrade to an empty
+    # store, which would open the gateway to anonymous access.
+    app.state.tokens = token_store if token_store is not None else TokenStore()
     # Reference store is created lazily on first use: ReferenceWaveform.__init__
     # mkdirs its storage directory, and most requests never need it.
     app.state.references_dir = references_dir
@@ -44,6 +49,14 @@ def create_app(manager: Optional[SessionManager] = None, references_dir: Optiona
     app.include_router(scope_api.router, prefix="/api")
     app.include_router(stream_api.router, prefix="/api")
     app.include_router(discovery_api.router, prefix="/api")
+
+    @app.get("/api/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.get("/api/whoami")
+    async def whoami(request: Request):
+        return {"identity": getattr(request.state, "identity", None)}
 
     @app.exception_handler(InvalidParameterError)
     async def _invalid_parameter(request: Request, exc: InvalidParameterError):
@@ -87,5 +100,9 @@ def create_app(manager: Optional[SessionManager] = None, references_dir: Optiona
             if full_path and candidate.is_file() and candidate.is_relative_to(static_root):
                 return FileResponse(str(candidate))
             return FileResponse(str(index_file))
+
+    # Added last so it wraps everything above, including the SPA catch-all: pure
+    # ASGI middleware (not BaseHTTPMiddleware) so it also guards WebSocket scopes.
+    app.add_middleware(AuthMiddleware, store=app.state.tokens)
 
     return app

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -103,3 +103,67 @@ class TokenStore:
 
     def is_empty(self) -> bool:
         return not self._tokens
+
+
+EXEMPT_PATHS = frozenset({"/api/health"})
+WS_SUBPROTOCOL_PREFIX = "scpi-token."
+WS_ACCEPT_SUBPROTOCOL = "scpi"
+
+
+def _bearer(headers) -> str:
+    for key, value in headers:
+        if key == b"authorization":
+            text = value.decode("latin-1")
+            if text.lower().startswith("bearer "):
+                return text[7:].strip()
+            return ""
+    return ""
+
+
+class AuthMiddleware:
+    """Fail-closed ASGI middleware: every scope is authenticated unless exempt.
+
+    Handles ``http`` and ``websocket`` scopes itself rather than delegating to
+    BaseHTTPMiddleware, which never sees WebSocket upgrades.
+    """
+
+    def __init__(self, app, store: "TokenStore", exempt: Optional[frozenset] = None) -> None:
+        self.app = app
+        self.store = store
+        self.exempt = EXEMPT_PATHS if exempt is None else exempt
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+        path = scope.get("path", "")
+        # Only /api/* is guarded; the SPA and its assets are served anonymously
+        # so the browser can load the page that then asks for a token.
+        if path in self.exempt or not path.startswith("/api/"):
+            await self.app(scope, receive, send)
+            return
+        identity = self._identify(scope)
+        if identity is None:
+            await self._reject(scope, receive, send)
+            return
+        scope.setdefault("state", {})["identity"] = identity
+        await self.app(scope, receive, send)
+
+    def _identify(self, scope) -> Optional[str]:
+        if scope["type"] == "websocket":
+            for offered in scope.get("subprotocols", []):
+                if offered.startswith(WS_SUBPROTOCOL_PREFIX):
+                    return self.store.verify(offered[len(WS_SUBPROTOCOL_PREFIX) :])
+            return None
+        return self.store.verify(_bearer(scope.get("headers", [])))
+
+    async def _reject(self, scope, receive, send) -> None:
+        if scope["type"] == "websocket":
+            await receive()  # consume websocket.connect before closing
+            await send({"type": "websocket.close", "code": 1008})
+            return
+        body = json.dumps({"error": "Unauthorized", "detail": "missing or invalid bearer token"}).encode("utf-8")
+        await send(
+            {"type": "http.response.start", "status": 401, "headers": [(b"content-type", b"application/json"), (b"www-authenticate", b"Bearer"), (b"content-length", str(len(body)).encode("ascii"))]}
+        )
+        await send({"type": "http.response.body", "body": body})

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -85,8 +85,14 @@ class TokenStore:
         candidate = _hash(raw)
         for entry in self._tokens:
             if hmac.compare_digest(entry["hash"], candidate):
+                # In-memory only -- do NOT add self._save() back here. verify()
+                # runs inline on the event loop for every authenticated request;
+                # last_used is audit-flavoured metadata, not security state, and
+                # is not worth a synchronous tokens.json rewrite (+ chmod) plus an
+                # unsynchronized read-modify-write race on that hot path. The
+                # value still reaches disk whenever the store is next saved for a
+                # real reason (mint/revoke).
                 entry["last_used"] = _now()
-                self._save()
                 return str(entry["name"])
         return None
 
@@ -108,6 +114,28 @@ class TokenStore:
 EXEMPT_PATHS = frozenset({"/api/health"})
 WS_SUBPROTOCOL_PREFIX = "scpi-token."
 WS_ACCEPT_SUBPROTOCOL = "scpi"
+
+
+def _route_path(scope) -> str:
+    """``scope["path"]`` with any ASGI ``root_path`` prefix stripped.
+
+    Starlette's router matches routes on the path with ``root_path`` removed
+    (see ``starlette._utils.get_route_path``), not on the raw ``scope["path"]``.
+    Under a proxy-mounted deployment (``uvicorn --root-path /gw``) the raw path
+    for a request to /api/sessions is "/gw/api/sessions"; comparing that raw
+    value against ``/api/`` never matches, so the guard would wave the request
+    through and the router would then strip "/gw" and serve it anyway. Mirror
+    Starlette's own stripping here so the guard sees what the router sees.
+    """
+    path = scope.get("path", "")
+    root_path = scope.get("root_path", "")
+    if not root_path or not path.startswith(root_path):
+        return path
+    if path == root_path:
+        return ""
+    if path[len(root_path)] == "/":
+        return path[len(root_path) :]
+    return path
 
 
 def _bearer(headers) -> str:
@@ -136,7 +164,7 @@ class AuthMiddleware:
         if scope["type"] not in ("http", "websocket"):
             await self.app(scope, receive, send)
             return
-        path = scope.get("path", "")
+        path = _route_path(scope)
         # Only /api/* is guarded; the SPA and its assets are served anonymously
         # so the browser can load the page that then asks for a token.
         if path in self.exempt or not path.startswith("/api/"):

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -38,10 +38,30 @@ class TokenStore:
         self._tokens: List[Dict[str, Any]] = []
         if self.path.exists():
             try:
-                self._tokens = json.loads(self.path.read_text(encoding="utf-8")).get("tokens", [])
+                raw = json.loads(self.path.read_text(encoding="utf-8"))
+                self._tokens = self._validate_tokens(raw)
             except (ValueError, OSError) as exc:
                 # Never fall back to "no tokens" — that would silently open the gateway.
                 raise ValueError("token store {0} is unreadable: {1}".format(self.path, exc))
+
+    @staticmethod
+    def _validate_tokens(raw: Any) -> List[Dict[str, Any]]:
+        """Validate the parsed store shape; raise ValueError for anything malformed.
+
+        A store that parses as JSON but has the wrong shape must fail exactly like
+        corrupt JSON does -- never silently degrade to "no tokens".
+        """
+        if not isinstance(raw, dict):
+            raise ValueError("expected a JSON object at the top level, got {0}".format(type(raw).__name__))
+        tokens = raw.get("tokens", [])
+        if not isinstance(tokens, list):
+            raise ValueError('expected "tokens" to be a list, got {0}'.format(type(tokens).__name__))
+        for entry in tokens:
+            if not isinstance(entry, dict):
+                raise ValueError("expected each token entry to be an object, got {0}".format(type(entry).__name__))
+            if not isinstance(entry.get("name"), str) or not isinstance(entry.get("hash"), str):
+                raise ValueError('each token entry must have string "name" and "hash" keys')
+        return tokens
 
     def _save(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -1,0 +1,85 @@
+"""Bearer-token store for the lab gateway.
+
+Tokens are high-entropy machine-generated secrets, not user-chosen passwords, so
+SHA-256 is the right hash here: there is no guessable plaintext for a slow KDF to
+defend against. If user-supplied tokens are ever accepted this must change.
+"""
+
+import hashlib
+import hmac
+import json
+import os
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DEFAULT_CONFIG_DIR = Path.home() / ".siglent"
+TOKEN_PREFIX = "scpi_"
+
+
+class DuplicateTokenName(ValueError):
+    """Raised when minting a token with a name that already exists."""
+
+
+def _hash(raw: str) -> str:
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class TokenStore:
+    """Named bearer tokens persisted as {name, hash, created, last_used}."""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self.path = Path(path) if path is not None else DEFAULT_CONFIG_DIR / "tokens.json"
+        self._tokens: List[Dict[str, Any]] = []
+        if self.path.exists():
+            try:
+                self._tokens = json.loads(self.path.read_text(encoding="utf-8")).get("tokens", [])
+            except (ValueError, OSError) as exc:
+                # Never fall back to "no tokens" — that would silently open the gateway.
+                raise ValueError("token store {0} is unreadable: {1}".format(self.path, exc))
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps({"tokens": self._tokens}, indent=2), encoding="utf-8")
+        try:
+            os.chmod(self.path, 0o600)
+        except OSError:
+            pass  # best effort; Windows ACLs do not map onto POSIX modes
+
+    def mint(self, name: str) -> str:
+        if any(entry["name"] == name for entry in self._tokens):
+            raise DuplicateTokenName("a token named {0!r} already exists".format(name))
+        raw = TOKEN_PREFIX + secrets.token_urlsafe(32)
+        self._tokens.append({"name": name, "hash": _hash(raw), "created": _now(), "last_used": None})
+        self._save()
+        return raw
+
+    def verify(self, raw: str) -> Optional[str]:
+        if not raw:
+            return None
+        candidate = _hash(raw)
+        for entry in self._tokens:
+            if hmac.compare_digest(entry["hash"], candidate):
+                entry["last_used"] = _now()
+                self._save()
+                return str(entry["name"])
+        return None
+
+    def revoke(self, name: str) -> bool:
+        remaining = [entry for entry in self._tokens if entry["name"] != name]
+        if len(remaining) == len(self._tokens):
+            return False
+        self._tokens = remaining
+        self._save()
+        return True
+
+    def names(self) -> List[str]:
+        return [str(entry["name"]) for entry in self._tokens]
+
+    def is_empty(self) -> bool:
+        return not self._tokens

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -72,6 +72,14 @@ class TokenStore:
             pass  # best effort; Windows ACLs do not map onto POSIX modes
 
     def mint(self, name: str) -> str:
+        if not name or not name.strip():
+            # An empty (or whitespace-only) name mints a token whose identity
+            # is "" -- and require_owner() in ownership.py treats owner == ""
+            # as unowned, so every session that token creates is writable by
+            # any authenticated identity. That silently defeats the ownership
+            # boundary, so reject it outright rather than normalize it (e.g.
+            # by stripping): the operator needs to know and pick a real name.
+            raise ValueError("token name must not be empty or whitespace-only")
         if any(entry["name"] == name for entry in self._tokens):
             raise DuplicateTokenName("a token named {0!r} already exists".format(name))
         raw = TOKEN_PREFIX + secrets.token_urlsafe(32)
@@ -89,9 +97,12 @@ class TokenStore:
                 # runs inline on the event loop for every authenticated request;
                 # last_used is audit-flavoured metadata, not security state, and
                 # is not worth a synchronous tokens.json rewrite (+ chmod) plus an
-                # unsynchronized read-modify-write race on that hot path. The
-                # value still reaches disk whenever the store is next saved for a
-                # real reason (mint/revoke).
+                # unsynchronized read-modify-write race on that hot path. In the
+                # real deployment, mint/revoke run in a separate CLI process from
+                # the one serving requests, so this in-memory update is never
+                # written back by *this* process: last_used is effectively
+                # ephemeral for the life of the running server and must not be
+                # relied on as an audit record.
                 entry["last_used"] = _now()
                 return str(entry["name"])
         return None

--- a/scpi_control/server/migrate.py
+++ b/scpi_control/server/migrate.py
@@ -1,0 +1,114 @@
+"""One-shot conversion of pre-5.0 pickled reference files.
+
+Reference waveforms used to store their metadata dict as a pickled numpy
+object array; loading one required allow_pickle=True, which meant loading
+*any* .npz someone handed you could execute arbitrary code. That format is
+no longer written (see scpi_control/reference_waveform.py, which now stores
+metadata as a JSON string under REFERENCE_META_KEY and always loads with
+allow_pickle=False), but files saved before the change still exist on disk
+in the old, pickled format and now refuse to load at all.
+
+This module is -- deliberately -- the only place left in the codebase that
+passes allow_pickle=True. It runs exactly once per file, only when the user
+explicitly invokes 'scpi-web references migrate', against files that are
+already sitting in their own reference storage directory. It is not reachable
+from any network-facing code path. Do not add allow_pickle=True anywhere
+else, and do not lift this pattern into new code -- every other loader in
+this codebase depends on allow_pickle=False to keep a hostile .npz from
+smuggling in pickled bytecode.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+
+from scpi_control.reference_waveform import REFERENCE_META_KEY
+
+logger = logging.getLogger(__name__)
+
+
+def migrate_references(storage_dir: str) -> Dict[str, int]:
+    """Convert every pre-5.0 pickled .npz reference file in storage_dir.
+
+    A file already in the new format (REFERENCE_META_KEY present) or one
+    with no metadata block at all is counted as skipped and left untouched
+    -- migration never rewrites a file it doesn't need to, which is what
+    makes running it twice a no-op. A file that can't be read or converted
+    is counted as failed and, crucially, also left untouched: conversion
+    writes to a temporary file first and only replaces the original once
+    the write fully succeeds, so a failure never leaves a truncated or
+    half-written file where a readable (if old-format) one used to be.
+
+    Args:
+        storage_dir: Directory to scan for *.npz reference files.
+
+    Returns:
+        {"converted": n, "skipped": n, "failed": n}. The three counts always
+        sum to the number of .npz files examined.
+    """
+    result = {"converted": 0, "skipped": 0, "failed": 0}
+
+    for filepath in sorted(Path(storage_dir).glob("*.npz")):
+        try:
+            payload = _build_payload(filepath)
+        except Exception:
+            logger.warning("could not read %s, leaving it untouched", filepath, exc_info=True)
+            result["failed"] += 1
+            continue
+
+        if payload is None:
+            result["skipped"] += 1
+            continue
+
+        try:
+            _atomic_savez(filepath, payload)
+        except Exception:
+            logger.warning("could not convert %s, leaving it untouched", filepath, exc_info=True)
+            result["failed"] += 1
+            continue
+
+        result["converted"] += 1
+
+    return result
+
+
+def _build_payload(filepath: Path):
+    """Read filepath and return its arrays with metadata re-encoded as JSON.
+
+    Returns None if the file is already migrated or has no metadata to
+    migrate (both count as "skipped" by the caller). Raises if the file
+    can't be read at all (counted as "failed" by the caller).
+    """
+    with np.load(filepath, allow_pickle=True) as data:
+        if REFERENCE_META_KEY in data.files or "metadata" not in data.files:
+            return None
+
+        payload = {key: data[key] for key in data.files if key != "metadata"}
+        payload[REFERENCE_META_KEY] = json.dumps(data["metadata"].item())
+        return payload
+
+
+def _atomic_savez(filepath: Path, payload: Dict) -> None:
+    """Write payload as a new .npz and swap it in only once fully written.
+
+    np.savez_compressed writes directly to whatever path it's given; pointed
+    straight at the original file, a failure partway through (disk full,
+    interrupted process) would destroy the last readable copy. Writing to a
+    sibling temp file and swapping it in with os.replace -- atomic on both
+    POSIX and Windows for a same-directory rename -- means a failure here
+    always leaves the original file exactly as it was.
+    """
+    fd, tmp_name = tempfile.mkstemp(prefix="{0}.".format(filepath.stem), suffix=".npz", dir=str(filepath.parent))
+    os.close(fd)
+    tmp_path = Path(tmp_name)
+    try:
+        np.savez_compressed(str(tmp_path), **payload)
+        os.replace(str(tmp_path), str(filepath))
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise

--- a/scpi_control/server/migrate.py
+++ b/scpi_control/server/migrate.py
@@ -44,16 +44,28 @@ def migrate_references(storage_dir: str) -> Dict[str, int]:
     the write fully succeeds, so a failure never leaves a truncated or
     half-written file where a readable (if old-format) one used to be.
 
+    Before scanning, any leftover *.npz.tmp file is removed: that suffix is
+    only ever produced by _atomic_savez's own temp file, and one surviving
+    on disk means a previous run was killed (SIGKILL, power loss) between
+    the write and the os.replace swap. Such an orphan is not a reference
+    file -- it is not counted as converted, skipped, or failed.
+
     Args:
         storage_dir: Directory to scan for *.npz reference files.
 
     Returns:
         {"converted": n, "skipped": n, "failed": n}. The three counts always
-        sum to the number of .npz files examined.
+        sum to the number of .npz files examined -- stale temp files removed
+        during cleanup are not part of that count.
     """
     result = {"converted": 0, "skipped": 0, "failed": 0}
 
-    for filepath in sorted(Path(storage_dir).glob("*.npz")):
+    storage_path = Path(storage_dir)
+    for stale in sorted(storage_path.glob("*.npz.tmp")):
+        logger.info("removing stale temp file left by an interrupted run: %s", stale)
+        stale.unlink(missing_ok=True)
+
+    for filepath in sorted(storage_path.glob("*.npz")):
         try:
             payload = _build_payload(filepath)
         except Exception:
@@ -102,12 +114,24 @@ def _atomic_savez(filepath: Path, payload: Dict) -> None:
     sibling temp file and swapping it in with os.replace -- atomic on both
     POSIX and Windows for a same-directory rename -- means a failure here
     always leaves the original file exactly as it was.
+
+    The temp file is suffixed ".npz.tmp", not ".npz": migrate_references
+    scans with glob("*.npz"), and a temp file left behind by a killed
+    process (SIGKILL, power loss, anything that skips the except block
+    below) must never be picked up as if it were a reference file by a
+    later run. np.savez_compressed appends ".npz" to any string path that
+    doesn't already end in ".npz" -- passed the ".npz.tmp" name as a string,
+    it would silently divert the real write to a *third* file
+    ("....npz.tmp.npz") and leave the empty, just-created temp file to be
+    swapped in via os.replace, corrupting the target. Passing the already-
+    open file object instead sidesteps that renaming logic entirely (numpy
+    only string-checks paths, not file-like objects).
     """
-    fd, tmp_name = tempfile.mkstemp(prefix="{0}.".format(filepath.stem), suffix=".npz", dir=str(filepath.parent))
-    os.close(fd)
+    fd, tmp_name = tempfile.mkstemp(prefix="{0}.".format(filepath.stem), suffix=".npz.tmp", dir=str(filepath.parent))
     tmp_path = Path(tmp_name)
     try:
-        np.savez_compressed(str(tmp_path), **payload)
+        with os.fdopen(fd, "wb") as tmp_file:
+            np.savez_compressed(tmp_file, **payload)
         os.replace(str(tmp_path), str(filepath))
     except Exception:
         tmp_path.unlink(missing_ok=True)

--- a/scpi_control/server/netpolicy.py
+++ b/scpi_control/server/netpolicy.py
@@ -39,6 +39,14 @@ def _effective_address(ip: IPAddress) -> IPAddress:
 
 
 def validate_target(address: str, port: int, allowed_ports: Optional[frozenset] = None, resolver: Optional[Callable] = None) -> None:
+    """Reject a connection target that policy disallows, else return.
+
+    ``resolver`` must signal resolution failure with ``OSError`` (``socket.gaierror``,
+    which the default resolver raises, is a subclass). Anything else it raises is
+    treated as a bug in the resolver and propagates: converting arbitrary exceptions
+    into a "cannot resolve" rejection would disguise real defects as policy denials.
+    Either way no connection is attempted, so the failure is closed, not open.
+    """
     ports = DEFAULT_ALLOWED_PORTS if allowed_ports is None else allowed_ports
     if port not in ports:
         _reject(address, "port {0} is not in the allowed set {1}".format(port, sorted(ports)))

--- a/scpi_control/server/netpolicy.py
+++ b/scpi_control/server/netpolicy.py
@@ -1,0 +1,65 @@
+"""Address/port policy for outbound instrument connections.
+
+The gateway will happily open a TCP socket to whatever a caller names, so an
+authenticated user could otherwise use it as an internal port scanner. Resolve
+first, then judge every resolved address -- checking the hostname and connecting
+by name would let 'evil.example.com -> 127.0.0.1' through.
+
+IPv6 addresses can encode an IPv4 address inside them (e.g. '::ffff:127.0.0.1',
+an IPv4-mapped address). ipaddress.IPv6Address.is_loopback does NOT consider
+that form loopback -- it only matches '::1' -- so a naive check would let a
+mapped loopback/link-local/metadata address sail through the gate. We unwrap
+`ipv4_mapped` before applying the policy so the mapped IPv4 address is judged
+on its own terms.
+"""
+
+import ipaddress
+import socket
+from typing import Callable, Iterable, Optional, Union
+
+from scpi_control.exceptions import InvalidParameterError
+
+DEFAULT_ALLOWED_PORTS = frozenset({5025})
+
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+
+def _default_resolver(host: str) -> Iterable[str]:
+    return [info[4][0] for info in socket.getaddrinfo(host, None)]
+
+
+def _reject(address: str, reason: str) -> None:
+    raise InvalidParameterError("refusing to connect to {0}: {1}".format(address, reason))
+
+
+def _effective_address(ip: IPAddress) -> IPAddress:
+    """Unwrap an IPv4-mapped IPv6 address so it is judged as the IPv4 address it encodes."""
+    mapped = getattr(ip, "ipv4_mapped", None)
+    return mapped if mapped is not None else ip
+
+
+def validate_target(address: str, port: int, allowed_ports: Optional[frozenset] = None, resolver: Optional[Callable] = None) -> None:
+    ports = DEFAULT_ALLOWED_PORTS if allowed_ports is None else allowed_ports
+    if port not in ports:
+        _reject(address, "port {0} is not in the allowed set {1}".format(port, sorted(ports)))
+
+    resolve = resolver if resolver is not None else _default_resolver
+    try:
+        resolved = list(resolve(address))
+    except OSError as exc:
+        _reject(address, "cannot resolve ({0})".format(exc))
+        return  # pragma: no cover - _reject always raises; unreachable, keeps type checkers happy
+
+    if not resolved:
+        _reject(address, "resolves to no addresses")
+
+    for candidate in resolved:
+        try:
+            ip = ipaddress.ip_address(candidate)
+        except ValueError:
+            _reject(address, "resolved to an unusable address {0!r}".format(candidate))
+            continue  # pragma: no cover - unreachable, _reject always raises
+
+        effective = _effective_address(ip)
+        if effective.is_loopback or effective.is_link_local or effective.is_multicast or effective.is_reserved or effective.is_unspecified:
+            _reject(address, "resolves to the disallowed address {0}".format(ip))

--- a/scpi_control/server/ownership.py
+++ b/scpi_control/server/ownership.py
@@ -11,7 +11,6 @@ owner hand off explicitly.
 """
 
 import time
-from typing import Optional
 
 from fastapi import Request
 
@@ -79,8 +78,8 @@ def abandon_after(request: Request) -> float:
     return request.app.state.abandon_after
 
 
-def claim(session: InstrumentSession, identity: str, threshold: float) -> Optional[float]:
-    """Attempt to claim ``session`` for ``identity``.
+def claim(session: InstrumentSession, identity: str, threshold: float) -> bool:
+    """Attempt to claim ``session`` for ``identity``. Returns True on success.
 
     An unowned session, or one already owned by ``identity``, claims
     immediately -- note this ignores owner_last_active entirely for an
@@ -93,16 +92,16 @@ def claim(session: InstrumentSession, identity: str, threshold: float) -> Option
     ``threshold`` seconds ago. owner_last_active is time.monotonic()-based;
     ``threshold`` must be compared against a monotonic delta, never wall time.
 
-    Returns None on success (session.owner is now ``identity``), or the
-    number of seconds remaining before the session becomes claimable.
+    On success, session.owner is now ``identity``. On failure the caller is
+    expected to report the current owner and idle time itself (via
+    NotOwnerError) rather than rely on a return value here.
     """
     if session.owner and session.owner != identity:
         if session.owner_watching():
-            return threshold
+            return False
         idle = time.monotonic() - session.owner_last_active
-        remaining = threshold - idle
-        if remaining > 0:
-            return remaining
+        if idle < threshold:
+            return False
     session.owner = identity
     session.touch()
-    return None
+    return True

--- a/scpi_control/server/ownership.py
+++ b/scpi_control/server/ownership.py
@@ -4,11 +4,14 @@ Reads are open to any authenticated identity; writes belong to the session's
 owner. NotOwnerError subclasses SessionError so the app's existing handler maps
 it to 409 -- the code already used for session-state conflicts.
 
-Claim/handoff for abandoned sessions is a later feature; this module only
-enforces the boundary between the current owner and everyone else.
+Beyond the write boundary, this module also covers the escape hatch for a
+session whose owner walked away: claim() lets another identity take over an
+abandoned session, and the /owner route (api/sessions.py) lets the current
+owner hand off explicitly.
 """
 
 import time
+from typing import Optional
 
 from fastapi import Request
 
@@ -43,8 +46,16 @@ WRITE_ROUTES = frozenset(
         ("POST", "/sessions/{session_id}/scope/log/start"),
         ("POST", "/sessions/{session_id}/scope/log/stop"),
         ("POST", "/sessions/{session_id}/scope/{op}"),
+        ("POST", "/sessions/{session_id}/owner"),
     }
 )
+
+# Note: POST /sessions/{session_id}/claim is deliberately NOT in this set.
+# It is gated on ownership too, but a non-owner's request is its normal,
+# successful path (claiming) rather than something require_owner rejects --
+# it only 409s when the current owner is still active, a different kind of
+# conflict than "you are not the owner". tests/test_server_ownership.py's
+# bidirectional WRITE_ROUTES scan excludes it explicitly for that reason.
 
 
 class NotOwnerError(SessionError):
@@ -61,3 +72,37 @@ def require_owner(request: Request, session_id: str) -> InstrumentSession:
         raise NotOwnerError(session.owner, time.monotonic() - session.owner_last_active)
     session.touch()
     return session
+
+
+def abandon_after(request: Request) -> float:
+    """Seconds of owner inactivity before another identity may claim a session."""
+    return request.app.state.abandon_after
+
+
+def claim(session: InstrumentSession, identity: str, threshold: float) -> Optional[float]:
+    """Attempt to claim ``session`` for ``identity``.
+
+    An unowned session, or one already owned by ``identity``, claims
+    immediately -- note this ignores owner_last_active entirely for an
+    unowned session (owner == ""), since require_owner() touches that timer
+    even when there is no owner to attribute the activity to.
+
+    Otherwise the claim is refused while the owner is actively watching the
+    live stream (owner_watching()), regardless of the idle threshold, and
+    also refused if the owner has been active more recently than
+    ``threshold`` seconds ago. owner_last_active is time.monotonic()-based;
+    ``threshold`` must be compared against a monotonic delta, never wall time.
+
+    Returns None on success (session.owner is now ``identity``), or the
+    number of seconds remaining before the session becomes claimable.
+    """
+    if session.owner and session.owner != identity:
+        if session.owner_watching():
+            return threshold
+        idle = time.monotonic() - session.owner_last_active
+        remaining = threshold - idle
+        if remaining > 0:
+            return remaining
+    session.owner = identity
+    session.touch()
+    return None

--- a/scpi_control/server/ownership.py
+++ b/scpi_control/server/ownership.py
@@ -1,0 +1,53 @@
+"""Ownership rules for live instrument sessions.
+
+Reads are open to any authenticated identity; writes belong to the session's
+owner. NotOwnerError subclasses SessionError so the app's existing handler maps
+it to 409 -- the code already used for session-state conflicts.
+
+Claim/handoff for abandoned sessions is a later feature; this module only
+enforces the boundary between the current owner and everyone else.
+"""
+
+import time
+
+from scpi_control.server.api.sessions import require_session
+from scpi_control.server.sessions import InstrumentSession, SessionError
+
+# Router-relative paths (no /api prefix) that mutate instrument or session
+# state and are therefore gated on ownership rather than plain authentication.
+# Kept here as the single documented source of truth for the read/write split.
+WRITE_ROUTES = frozenset(
+    {
+        "/sessions/{session_id}",
+        "/sessions/{session_id}/scope/channels/{channel}",
+        "/sessions/{session_id}/scope/timebase",
+        "/sessions/{session_id}/scope/trigger",
+        "/sessions/{session_id}/scope/command",
+        "/sessions/{session_id}/scope/measurements",
+        "/sessions/{session_id}/scope/math/{n}",
+        "/sessions/{session_id}/scope/spectrum",
+        "/sessions/{session_id}/scope/filters/{n}",
+        "/sessions/{session_id}/scope/references",
+        "/sessions/{session_id}/scope/references/{name}",
+        "/sessions/{session_id}/scope/reference",
+        "/sessions/{session_id}/scope/log/start",
+        "/sessions/{session_id}/scope/log/stop",
+        "/sessions/{session_id}/scope/{op}",
+    }
+)
+
+
+class NotOwnerError(SessionError):
+    def __init__(self, owner: str, idle_seconds: float) -> None:
+        super().__init__("session is owned by {0!r} (idle {1:.0f}s); claim it or ask for a handoff".format(owner, idle_seconds))
+        self.owner = owner
+        self.since = idle_seconds
+
+
+def require_owner(request, session_id: str) -> InstrumentSession:
+    session = require_session(request, session_id)
+    identity = getattr(request.state, "identity", "")
+    if session.owner and session.owner != identity:
+        raise NotOwnerError(session.owner, time.monotonic() - session.owner_last_active)
+    session.touch()
+    return session

--- a/scpi_control/server/ownership.py
+++ b/scpi_control/server/ownership.py
@@ -10,29 +10,39 @@ enforces the boundary between the current owner and everyone else.
 
 import time
 
+from fastapi import Request
+
 from scpi_control.server.api.sessions import require_session
 from scpi_control.server.sessions import InstrumentSession, SessionError
 
-# Router-relative paths (no /api prefix) that mutate instrument or session
-# state and are therefore gated on ownership rather than plain authentication.
-# Kept here as the single documented source of truth for the read/write split.
+# (method, router-relative path) pairs -- no /api prefix -- that mutate
+# instrument or session state and are therefore gated on ownership rather
+# than plain authentication. Method-qualified because several paths here are
+# also GET routes that must stay open to any authenticated identity (e.g.
+# GET /sessions/{session_id} reads, DELETE .../{session_id} writes).
+#
+# Kept here as the documented read/write split, and made load-bearing by
+# tests/test_server_ownership.py, which parametrizes over this set to assert
+# each entry 409s for a non-owner, and separately walks the app's live route
+# table to assert every (method, path) NOT in this set stays open to a
+# non-owner -- so a route added to one side without the other fails a test.
 WRITE_ROUTES = frozenset(
     {
-        "/sessions/{session_id}",
-        "/sessions/{session_id}/scope/channels/{channel}",
-        "/sessions/{session_id}/scope/timebase",
-        "/sessions/{session_id}/scope/trigger",
-        "/sessions/{session_id}/scope/command",
-        "/sessions/{session_id}/scope/measurements",
-        "/sessions/{session_id}/scope/math/{n}",
-        "/sessions/{session_id}/scope/spectrum",
-        "/sessions/{session_id}/scope/filters/{n}",
-        "/sessions/{session_id}/scope/references",
-        "/sessions/{session_id}/scope/references/{name}",
-        "/sessions/{session_id}/scope/reference",
-        "/sessions/{session_id}/scope/log/start",
-        "/sessions/{session_id}/scope/log/stop",
-        "/sessions/{session_id}/scope/{op}",
+        ("DELETE", "/sessions/{session_id}"),
+        ("PATCH", "/sessions/{session_id}/scope/channels/{channel}"),
+        ("PATCH", "/sessions/{session_id}/scope/timebase"),
+        ("PATCH", "/sessions/{session_id}/scope/trigger"),
+        ("POST", "/sessions/{session_id}/scope/command"),
+        ("PUT", "/sessions/{session_id}/scope/measurements"),
+        ("PATCH", "/sessions/{session_id}/scope/math/{n}"),
+        ("PATCH", "/sessions/{session_id}/scope/spectrum"),
+        ("PATCH", "/sessions/{session_id}/scope/filters/{n}"),
+        ("POST", "/sessions/{session_id}/scope/references"),
+        ("DELETE", "/sessions/{session_id}/scope/references/{name}"),
+        ("PUT", "/sessions/{session_id}/scope/reference"),
+        ("POST", "/sessions/{session_id}/scope/log/start"),
+        ("POST", "/sessions/{session_id}/scope/log/stop"),
+        ("POST", "/sessions/{session_id}/scope/{op}"),
     }
 )
 
@@ -44,7 +54,7 @@ class NotOwnerError(SessionError):
         self.since = idle_seconds
 
 
-def require_owner(request, session_id: str) -> InstrumentSession:
+def require_owner(request: Request, session_id: str) -> InstrumentSession:
     session = require_session(request, session_id)
     identity = getattr(request.state, "identity", "")
     if session.owner and session.owner != identity:

--- a/scpi_control/server/schemas.py
+++ b/scpi_control/server/schemas.py
@@ -29,6 +29,7 @@ class SessionOut(BaseModel):
     dialect: str
     num_channels: int
     viewers: int = 0
+    owner: str = ""
 
 
 class ChannelPatch(BaseModel):
@@ -110,4 +111,5 @@ def session_out(session) -> Dict[str, Any]:
         dialect=session.dialect,
         num_channels=session.num_channels,
         viewers=session.viewers,
+        owner=session.owner,
     ).model_dump()

--- a/scpi_control/server/schemas.py
+++ b/scpi_control/server/schemas.py
@@ -91,6 +91,10 @@ class ReferencePut(BaseModel):
     name: Optional[str] = None
 
 
+class OwnerPut(BaseModel):
+    name: str
+
+
 class ModelOut(BaseModel):
     model_name: str
     series: str

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -423,16 +423,38 @@ class SessionManager:
         self._lock = threading.Lock()
         self.allowed_ports = allowed_ports
         self.max_sessions = max_sessions
+        # Slots claimed by an in-flight create() that hasn't registered yet.
+        # Counted alongside len(self._sessions) under the same lock as the
+        # cap check so the check and the reservation are one atomic step --
+        # see create() for why that matters.
+        self._pending = 0
 
     def create(self, label: str, *, address: Optional[str] = None, port: int = 5025, mock: bool = False, model: Optional[str] = None, owner: str = "", _connection=None) -> InstrumentSession:
         # Checked BEFORE InstrumentSession.open: opening spawns a worker thread
         # and blocks on a connect with a 30s timeout, so checking the cap after
         # the fact would let concurrent requests past the cap occupy every
         # threadpool worker anyway -- the exact exhaustion this guards against.
+        #
+        # The check alone isn't enough under concurrency: the lock used to be
+        # released between the check and registration, so N concurrent callers
+        # could all observe room and all proceed (TOCTOU) -- with a cap of 8
+        # and 100 concurrent requests, all 100 pass. Reserving a slot in
+        # self._pending under the SAME lock acquisition as the check closes
+        # that window: each successful check immediately claims capacity, so
+        # the next concurrent caller sees it. The reservation is always
+        # released -- via `finally` -- whether open() succeeds, raises from a
+        # connect timeout, or raises from validate_target's policy rejection,
+        # so a failed attempt can never leak a slot and permanently shrink
+        # the cap.
         with self._lock:
-            if len(self._sessions) >= self.max_sessions:
+            if len(self._sessions) + self._pending >= self.max_sessions:
                 raise SessionError("session limit reached ({0}); close a session first".format(self.max_sessions))
-        session = InstrumentSession.open(label, address=address, port=port, mock=mock, model=model, owner=owner, allowed_ports=self.allowed_ports, _connection=_connection)
+            self._pending += 1
+        try:
+            session = InstrumentSession.open(label, address=address, port=port, mock=mock, model=model, owner=owner, allowed_ports=self.allowed_ports, _connection=_connection)
+        finally:
+            with self._lock:
+                self._pending -= 1
         with self._lock:
             self._sessions[session.id] = session
         return session

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -126,6 +126,12 @@ class InstrumentSession:
         self.active_reference: Optional[Dict[str, Any]] = None  # {"name", "channel", "data": {"time","voltage",...}}
         self._shown: set = set()  # trace keys (M1/M2/F1/F2/SPEC) live on subscribers' canvases; worker-thread-only
         self.recorder = TrendRecorder()  # internally locked: worker appends, request threads control/read
+        self.owner = ""
+        self.owner_last_active = time.monotonic()
+
+    def touch(self) -> None:
+        """Record owner activity; feeds the abandoned-session claim rule."""
+        self.owner_last_active = time.monotonic()
 
     @classmethod
     def open(
@@ -137,6 +143,7 @@ class InstrumentSession:
         mock: bool = False,
         model: Optional[str] = None,
         poll_interval: float = 0.25,
+        owner: str = "",
         _connection=None,
     ) -> "InstrumentSession":
         if mock:
@@ -147,6 +154,7 @@ class InstrumentSession:
                 raise ValueError("address is required for a non-mock session")
             scope = Oscilloscope(address, port=port)
         session = cls(label, scope, mock, address, poll_interval)
+        session.owner = owner
         session._thread.start()
         try:
             session.submit(session._connect_job).result(timeout=30)
@@ -363,8 +371,8 @@ class SessionManager:
         self._sessions: Dict[str, InstrumentSession] = {}
         self._lock = threading.Lock()
 
-    def create(self, label: str, *, address: Optional[str] = None, port: int = 5025, mock: bool = False, model: Optional[str] = None, _connection=None) -> InstrumentSession:
-        session = InstrumentSession.open(label, address=address, port=port, mock=mock, model=model, _connection=_connection)
+    def create(self, label: str, *, address: Optional[str] = None, port: int = 5025, mock: bool = False, model: Optional[str] = None, owner: str = "", _connection=None) -> InstrumentSession:
+        session = InstrumentSession.open(label, address=address, port=port, mock=mock, model=model, owner=owner, _connection=_connection)
         with self._lock:
             self._sessions[session.id] = session
         return session

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -128,10 +128,42 @@ class InstrumentSession:
         self.recorder = TrendRecorder()  # internally locked: worker appends, request threads control/read
         self.owner = ""
         self.owner_last_active = time.monotonic()
+        self._owner_watchers = 0
 
     def touch(self) -> None:
         """Record owner activity; feeds the abandoned-session claim rule."""
         self.owner_last_active = time.monotonic()
+
+    def owner_watching(self) -> bool:
+        """True while at least one live stream opened by the current owner is connected.
+
+        A watching owner is never idle even though only writes touch()
+        owner_last_active -- the claim rule refuses outright while this is
+        true, regardless of the idle threshold.
+        """
+        return self._owner_watchers > 0
+
+    def mark_owner_watching(self, identity: str) -> Callable[[], None]:
+        """Register that ``identity`` opened the live stream; returns an unmark callback.
+
+        Only counts when ``identity`` is the current owner, so a non-owner's
+        stream never blocks a claim. The returned callback decrements exactly
+        once no matter how many times it is called, so it is safe to invoke
+        unconditionally from a ``finally`` block on any disconnect path
+        (clean close, error, or cancellation).
+        """
+        is_owner = bool(self.owner) and identity == self.owner
+        if is_owner:
+            self._owner_watchers += 1
+        released = False
+
+        def unmark() -> None:
+            nonlocal released
+            if is_owner and not released:
+                released = True
+                self._owner_watchers -= 1
+
+        return unmark
 
     @classmethod
     def open(

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -19,6 +19,7 @@ from scpi_control import Oscilloscope
 from scpi_control.connection.mock import MockConnection
 from scpi_control.exceptions import InvalidParameterError, SiglentConnectionError, SiglentError
 from scpi_control.server import compute
+from scpi_control.server.netpolicy import validate_target
 from scpi_control.server.recorder import TrendRecorder
 
 MAX_FRAME_POINTS = 2000
@@ -192,6 +193,7 @@ class InstrumentSession:
         model: Optional[str] = None,
         poll_interval: float = 0.25,
         owner: str = "",
+        allowed_ports: Optional[frozenset] = None,
         _connection=None,
     ) -> "InstrumentSession":
         if mock:
@@ -200,6 +202,7 @@ class InstrumentSession:
         else:
             if not address:
                 raise ValueError("address is required for a non-mock session")
+            validate_target(address, port, allowed_ports=allowed_ports)
             scope = Oscilloscope(address, port=port)
         session = cls(label, scope, mock, address, poll_interval)
         session.owner = owner
@@ -415,12 +418,13 @@ class InstrumentSession:
 class SessionManager:
     """Registry of live sessions. create() connects before registering."""
 
-    def __init__(self) -> None:
+    def __init__(self, allowed_ports: Optional[frozenset] = None) -> None:
         self._sessions: Dict[str, InstrumentSession] = {}
         self._lock = threading.Lock()
+        self.allowed_ports = allowed_ports
 
     def create(self, label: str, *, address: Optional[str] = None, port: int = 5025, mock: bool = False, model: Optional[str] = None, owner: str = "", _connection=None) -> InstrumentSession:
-        session = InstrumentSession.open(label, address=address, port=port, mock=mock, model=model, owner=owner, _connection=_connection)
+        session = InstrumentSession.open(label, address=address, port=port, mock=mock, model=model, owner=owner, allowed_ports=self.allowed_ports, _connection=_connection)
         with self._lock:
             self._sessions[session.id] = session
         return session

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -10,6 +10,7 @@ import queue
 import threading
 import time
 import uuid
+from collections import Counter
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -128,7 +129,11 @@ class InstrumentSession:
         self.recorder = TrendRecorder()  # internally locked: worker appends, request threads control/read
         self.owner = ""
         self.owner_last_active = time.monotonic()
-        self._owner_watchers = 0
+        # Live stream watchers, keyed by identity (not by "is this the
+        # owner"): a Counter rather than a set because the same identity may
+        # open two tabs and close one, so a plain membership test would drop
+        # the identity on the first close while the second tab is still live.
+        self._watchers: "Counter[str]" = Counter()
 
     def touch(self) -> None:
         """Record owner activity; feeds the abandoned-session claim rule."""
@@ -137,31 +142,42 @@ class InstrumentSession:
     def owner_watching(self) -> bool:
         """True while at least one live stream opened by the current owner is connected.
 
+        Evaluated at check time against the *current* owner and the live
+        per-identity watcher counts (see mark_owner_watching) -- never a
+        snapshot taken when some stream connected. Ownership can change
+        mid-stream via claim() or an explicit handoff, so "is the owner
+        watching" must always be asked fresh: a snapshot fails open (a
+        non-owner who claims the session while already watching would not
+        be protected) and also sticks stale (a former owner's lingering
+        socket would keep blocking claims after handoff).
+
         A watching owner is never idle even though only writes touch()
         owner_last_active -- the claim rule refuses outright while this is
         true, regardless of the idle threshold.
         """
-        return self._owner_watchers > 0
+        return bool(self.owner) and self._watchers[self.owner] > 0
 
     def mark_owner_watching(self, identity: str) -> Callable[[], None]:
         """Register that ``identity`` opened the live stream; returns an unmark callback.
 
-        Only counts when ``identity`` is the current owner, so a non-owner's
-        stream never blocks a claim. The returned callback decrements exactly
-        once no matter how many times it is called, so it is safe to invoke
-        unconditionally from a ``finally`` block on any disconnect path
-        (clean close, error, or cancellation).
+        Tracks the watching identity itself, not whether it happened to be
+        the owner at connect time -- owner_watching() does that comparison
+        later, at check time, against whoever owns the session *then*. The
+        returned callback decrements exactly once no matter how many times
+        it is called, so it is safe to invoke unconditionally from a
+        ``finally`` block on any disconnect path (clean close, error, or
+        cancellation).
         """
-        is_owner = bool(self.owner) and identity == self.owner
-        if is_owner:
-            self._owner_watchers += 1
+        self._watchers[identity] += 1
         released = False
 
         def unmark() -> None:
             nonlocal released
-            if is_owner and not released:
+            if not released:
                 released = True
-                self._owner_watchers -= 1
+                self._watchers[identity] -= 1
+                if self._watchers[identity] <= 0:
+                    del self._watchers[identity]
 
         return unmark
 

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -418,12 +418,20 @@ class InstrumentSession:
 class SessionManager:
     """Registry of live sessions. create() connects before registering."""
 
-    def __init__(self, allowed_ports: Optional[frozenset] = None) -> None:
+    def __init__(self, allowed_ports: Optional[frozenset] = None, max_sessions: int = 8) -> None:
         self._sessions: Dict[str, InstrumentSession] = {}
         self._lock = threading.Lock()
         self.allowed_ports = allowed_ports
+        self.max_sessions = max_sessions
 
     def create(self, label: str, *, address: Optional[str] = None, port: int = 5025, mock: bool = False, model: Optional[str] = None, owner: str = "", _connection=None) -> InstrumentSession:
+        # Checked BEFORE InstrumentSession.open: opening spawns a worker thread
+        # and blocks on a connect with a 30s timeout, so checking the cap after
+        # the fact would let concurrent requests past the cap occupy every
+        # threadpool worker anyway -- the exact exhaustion this guards against.
+        with self._lock:
+            if len(self._sessions) >= self.max_sessions:
+                raise SessionError("session limit reached ({0}); close a session first".format(self.max_sessions))
         session = InstrumentSession.open(label, address=address, port=port, mock=mock, model=model, owner=owner, allowed_ports=self.allowed_ports, _connection=_connection)
         with self._lock:
             self._sessions[session.id] = session

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -419,6 +419,14 @@ class SessionManager:
     """Registry of live sessions. create() connects before registering."""
 
     def __init__(self, allowed_ports: Optional[frozenset] = None, max_sessions: int = 8) -> None:
+        if max_sessions < 1:
+            # A cap below 1 doesn't disable the gateway -- it silently makes
+            # every create() a 409 "session limit reached (0)", which reads
+            # like a bug rather than a configuration mistake. Reject eagerly
+            # here (the library boundary) rather than relying solely on the
+            # CLI to catch it, since SessionManager is also constructed
+            # directly by embedders and tests.
+            raise ValueError("max_sessions must be at least 1 (got {0})".format(max_sessions))
         self._sessions: Dict[str, InstrumentSession] = {}
         self._lock = threading.Lock()
         self.allowed_ports = allowed_ports
@@ -441,22 +449,37 @@ class SessionManager:
         # and 100 concurrent requests, all 100 pass. Reserving a slot in
         # self._pending under the SAME lock acquisition as the check closes
         # that window: each successful check immediately claims capacity, so
-        # the next concurrent caller sees it. The reservation is always
-        # released -- via `finally` -- whether open() succeeds, raises from a
-        # connect timeout, or raises from validate_target's policy rejection,
+        # the next concurrent caller sees it.
+        #
+        # The reservation is released and the session registered in a SINGLE
+        # lock acquisition (below), not two: releasing the lock after
+        # decrementing self._pending and only later re-acquiring it to insert
+        # into self._sessions would reopen the same race one step later -- in
+        # that gap the slot is counted by neither self._pending nor
+        # self._sessions, so a concurrent caller's check can pass when it
+        # shouldn't. The `registered` flag lets the `finally` tell success
+        # from failure: on success the reservation was already released
+        # inside the try (alongside registration), so `finally` must not
+        # double-decrement; on any failure -- open() raising from a connect
+        # timeout, validate_target's policy rejection, or anything else --
+        # `registered` is still False and `finally` releases the reservation,
         # so a failed attempt can never leak a slot and permanently shrink
         # the cap.
         with self._lock:
             if len(self._sessions) + self._pending >= self.max_sessions:
                 raise SessionError("session limit reached ({0}); close a session first".format(self.max_sessions))
             self._pending += 1
+        registered = False
         try:
             session = InstrumentSession.open(label, address=address, port=port, mock=mock, model=model, owner=owner, allowed_ports=self.allowed_ports, _connection=_connection)
-        finally:
             with self._lock:
                 self._pending -= 1
-        with self._lock:
-            self._sessions[session.id] = session
+                self._sessions[session.id] = session
+                registered = True
+        finally:
+            if not registered:
+                with self._lock:
+                    self._pending -= 1
         return session
 
     def list(self) -> List[InstrumentSession]:

--- a/scpi_control/waveform_io.py
+++ b/scpi_control/waveform_io.py
@@ -114,7 +114,7 @@ def _channel_value(raw: Any) -> Optional[Union[int, str]]:
 
 
 def _load_npz(path: Path) -> LoadedWaveform:
-    data = np.load(path, allow_pickle=True)
+    data = np.load(path, allow_pickle=False)
     if ws.TIME not in data.files or ws.VOLTAGE not in data.files:
         raise ValueError(f"{path} does not contain '{ws.TIME}'/'{ws.VOLTAGE}' arrays; not a scpi_control waveform file")
     metadata: Dict[str, Any] = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,46 @@
 """Fixtures shared across the test suite."""
 
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 
 from scpi_control.report_generator.models.report_data import WaveformData
+
+
+@pytest.fixture(autouse=True)
+def _no_real_home(monkeypatch, tmp_path):
+    """Never let a test touch the real home directory's default config/storage.
+
+    Per-test discipline has already failed once: a CLI test invoked without
+    pinning --config-dir minted a live token into the developer's actual
+    ~/.siglent/tokens.json. This fixture is the backstop so that mistake
+    cannot happen again, regardless of which test makes it.
+
+    Two known hazards, both worked around here:
+
+    - ``scpi_control.server.auth.DEFAULT_CONFIG_DIR`` is computed once at
+      import time (``Path.home() / ".siglent"``), so monkeypatching
+      ``Path.home`` after import does not affect it -- the module attribute
+      itself has to be patched. ``scpi_control.server.__main__`` imports that
+      same name by value (``from ... import DEFAULT_CONFIG_DIR``), which
+      copies the binding at import time, so it is patched separately too.
+    - ``scpi_control.reference_waveform.ReferenceWaveform.__init__`` calls
+      ``Path.home()`` at runtime when no ``storage_dir`` is given, so
+      patching ``Path.home`` globally covers that path.
+
+    This only changes *default* resolution: tests that pass an explicit path
+    (e.g. ``TokenStore(str(tmp_path / "tokens.json"))``) never consult
+    ``Path.home()`` or ``DEFAULT_CONFIG_DIR`` and are unaffected.
+    """
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    monkeypatch.setattr("scpi_control.server.auth.DEFAULT_CONFIG_DIR", fake_home / ".siglent")
+    monkeypatch.setattr("scpi_control.server.__main__.DEFAULT_CONFIG_DIR", fake_home / ".siglent")
+    yield fake_home
 
 
 @contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,20 @@ def ollama_sdk(capabilities=("completion", "tools")):
         yield fake, cls
 
 
+@pytest.fixture()
+def gateway_auth(tmp_path):
+    """(token_store, headers, raw_token) for an authenticated gateway test client.
+
+    raw_token is needed by WebSocket tests: default client headers do not apply
+    to the handshake, which authenticates via subprotocol instead.
+    """
+    from scpi_control.server.auth import TokenStore
+
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    raw = store.mint("tester")
+    return store, {"Authorization": "Bearer {0}".format(raw)}, raw
+
+
 @pytest.fixture
 def bursty_waveform():
     """A sine carrying 20 multi-sample spikes -- more real transients than the

--- a/tests/route_introspection.py
+++ b/tests/route_introspection.py
@@ -1,0 +1,66 @@
+"""Version-robust enumeration of the gateway's ``/api`` route surface.
+
+FastAPI/Starlette changed how ``include_router`` structures the route table.
+Starlette <= 0.46 flattens each included router's sub-routes directly into
+``app.routes``; Starlette >= 1.0 instead wraps every include in an
+``_IncludedRouter`` whose ``original_router`` holds the sub-routes with
+router-relative paths. Walking only the top level of ``app.routes`` and
+filtering on ``isinstance(route, APIRoute)`` therefore finds almost nothing on
+the newer Starlette -- which is exactly what broke CI (fresh ``fastapi``,
+Starlette 1.x) while a locally-pinned Starlette 0.46 passed.
+
+Enumerate through surfaces that are stable across both layouts instead: the
+OpenAPI schema for HTTP routes (it yields full paths and methods regardless of
+how the routers are nested), and a recursive walk for the WebSocket routes the
+schema omits.
+"""
+
+from fastapi.routing import APIWebSocketRoute
+
+from scpi_control.server.auth import EXEMPT_PATHS
+
+
+def iter_http_routes(app):
+    """Yield ``(METHOD, full_path)`` for each ``/api/`` HTTP route, minus exempt.
+
+    Sourced from ``app.openapi()`` so it reports full paths independent of
+    router nesting. ``HEAD``/``OPTIONS`` (which OpenAPI does not list anyway) and
+    the exempt paths (e.g. ``/api/health``) are excluded, matching what the auth
+    guard actually protects.
+    """
+    for path, operations in app.openapi().get("paths", {}).items():
+        if not path.startswith("/api/") or path in EXEMPT_PATHS:
+            continue
+        for method in operations:
+            upper = method.upper()
+            if upper in ("HEAD", "OPTIONS"):
+                continue
+            yield upper, path
+
+
+def _walk(routes):
+    """Yield every leaf route, descending includes on either Starlette layout."""
+    for route in routes:
+        included = getattr(route, "original_router", None)  # Starlette >= 1.0 _IncludedRouter
+        subroutes = getattr(route, "routes", None)  # Mount / sub-router
+        if included is not None:
+            yield from _walk(included.routes)
+        elif subroutes:
+            yield from _walk(subroutes)
+        else:
+            yield route
+
+
+def iter_ws_routes(app):
+    """Yield the full path of every ``/api/`` WebSocket route.
+
+    OpenAPI omits WebSocket endpoints, so these come from a recursive walk. On
+    the newer Starlette the leaf path is router-relative; this app mounts every
+    router under ``/api``, so a relative leaf is prefixed accordingly.
+    """
+    for route in _walk(app.routes):
+        if not isinstance(route, APIWebSocketRoute):
+            continue
+        path = route.path if route.path.startswith("/api/") else "/api" + route.path
+        if path.startswith("/api/"):
+            yield path

--- a/tests/test_gui_initialization.py
+++ b/tests/test_gui_initialization.py
@@ -2,10 +2,21 @@
 
 import sys
 
+import numpy as np
 import pytest
 
 pytest.importorskip("PyQt6")
+from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QApplication
+
+
+class _Waveform:
+    """Minimal stand-in for a captured waveform, just enough for save_reference."""
+
+    def __init__(self):
+        self.time = np.linspace(0, 1, 16)
+        self.voltage = np.sin(self.time)
+        self.channel = 1
 
 
 @pytest.fixture(scope="module")
@@ -87,6 +98,40 @@ def test_reference_panel_creation(qapp):
     assert panel is not None
     assert hasattr(panel, "load_reference")
     assert hasattr(panel, "save_reference")
+
+
+def test_reference_panel_list_items_carry_loadable_names(qapp, tmp_path):
+    """The panel must feed load_reference/delete_reference a short *name*.
+
+    reference_waveform._find_reference_file now confines lookups to
+    storage_dir (the RCE-closing security fix) and no longer accepts the
+    absolute filepath that list_references() also returns. If
+    ReferencePanel.update_reference_list ever goes back to storing
+    ref["filepath"] as a list item's payload -- which is what the Load and
+    Delete buttons emit -- load_reference/delete_reference silently return
+    None/False for every reference, with no exception raised. Reproduce that
+    failure mode at the panel+store boundary here instead of relying on a
+    human clicking the button and finding nothing happens.
+    """
+    from scpi_control.gui.widgets.reference_panel import ReferencePanel
+    from scpi_control.reference_waveform import ReferenceWaveform
+
+    store = ReferenceWaveform(str(tmp_path))
+    store.save_reference(_Waveform(), "panel-ref")
+
+    panel = ReferencePanel()
+    panel.update_reference_list(store.list_references())
+
+    item = panel.reference_list.item(0)
+    payload = item.data(Qt.ItemDataRole.UserRole)
+
+    # This is exactly what _on_load_reference_item/_on_delete_reference emit
+    # via the load_reference/delete_reference signals.
+    loaded = store.load_reference(payload)
+    assert loaded is not None
+    assert loaded["metadata"]["name"] == "panel-ref"
+
+    assert store.delete_reference(payload) is True
 
 
 def test_protocol_decode_panel_creation(qapp):

--- a/tests/test_pickle_safety.py
+++ b/tests/test_pickle_safety.py
@@ -1,0 +1,51 @@
+"""A crafted .npz must never execute its payload when loaded (audit H21/M53)."""
+
+import numpy as np
+import pytest
+
+from scpi_control.waveform_io import load_waveform
+
+MARKER = []
+
+
+class _Payload:
+    """Pickle that would call a side-effecting function on load."""
+
+    def __reduce__(self):
+        return (_touch, ())
+
+
+def _touch():
+    MARKER.append("executed")
+    return 0
+
+
+def _write_malicious_npz(path):
+    # The payload must be the object-array element itself (not pre-serialized
+    # bytes) -- np.array(pickle.dumps(_Payload()), dtype=object) would pickle
+    # a harmless bytes object, never calling _Payload.__reduce__ on load. It
+    # must also live under a key the loader actually reads: numpy loads NPZ
+    # members lazily, so a key like "evil" that _load_npz never touches never
+    # triggers deserialization regardless of allow_pickle. meta_-prefixed
+    # keys are read unconditionally, so that's what a real attacker would use.
+    with open(path, "wb") as handle:
+        np.savez(handle, time=np.arange(4, dtype=float), voltage=np.zeros(4), meta_evil=np.array(_Payload(), dtype=object))
+
+
+def test_loading_a_pickled_payload_does_not_execute_it(tmp_path):
+    MARKER.clear()
+    path = tmp_path / "evil.npz"
+    _write_malicious_npz(path)
+    # numpy raises ValueError ("Object arrays cannot be loaded when
+    # allow_pickle=False"). Assert that type, not bare Exception, so an
+    # unrelated failure (missing file, bad parse) cannot pass for the fix.
+    with pytest.raises(ValueError):
+        load_waveform(str(path))
+    assert MARKER == [], "pickle payload executed during load"
+
+
+def test_ordinary_npz_still_round_trips(tmp_path):
+    path = tmp_path / "ok.npz"
+    np.savez(path, time=np.arange(4, dtype=float), voltage=np.ones(4), channel=np.array(1))
+    loaded = load_waveform(str(path))
+    assert len(loaded.voltage) == 4

--- a/tests/test_pickle_safety.py
+++ b/tests/test_pickle_safety.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+from scpi_control.report_generator.utils.waveform_loader import WaveformLoader
 from scpi_control.waveform_io import load_waveform
 
 MARKER = []
@@ -49,3 +50,32 @@ def test_ordinary_npz_still_round_trips(tmp_path):
     np.savez(path, time=np.arange(4, dtype=float), voltage=np.ones(4), channel=np.array(1))
     loaded = load_waveform(str(path))
     assert len(loaded.voltage) == 4
+
+
+def _write_malicious_npz_for_report_loader(path):
+    # report_generator.utils.waveform_loader.WaveformLoader._load_npz is a
+    # SEPARATE implementation from waveform_io._load_npz above -- it does not
+    # read meta_-prefixed keys at all. It first checks (by key name only,
+    # ws.TIME/ws.VOLTAGE/ws.CHANNEL/ws.SAMPLE_RATE) whether the file "looks
+    # like ours"; if so it delegates to waveform_io.load_waveform, i.e. the
+    # site already covered above. Omitting one of those four keys forces the
+    # OTHER branch, _npz_heuristic, which is this loader's own code and is
+    # what we need to exercise here.
+    #
+    # _npz_heuristic builds its voltage-key list with:
+    #   [k for k in data.files if k != time_key and np.asarray(data[k])...]
+    # That touches data[k] -- triggering deserialization -- for every key
+    # other than the chosen time key, unconditionally, before it ever checks
+    # whether the key looks like voltage data. So a payload under any
+    # non-time key (no meta_ prefix needed) is read on every load attempt.
+    with open(path, "wb") as handle:
+        np.savez(handle, time=np.arange(4, dtype=float), evil=np.array(_Payload(), dtype=object))
+
+
+def test_report_loader_does_not_execute_pickle_payload(tmp_path):
+    MARKER.clear()
+    path = tmp_path / "evil_report.npz"
+    _write_malicious_npz_for_report_loader(path)
+    with pytest.raises(ValueError):
+        WaveformLoader.load(path)
+    assert MARKER == [], "pickle payload executed during report-generator load"

--- a/tests/test_reference_format.py
+++ b/tests/test_reference_format.py
@@ -1,7 +1,6 @@
 """Reference storage moves off pickled metadata onto a JSON string."""
 
 import json
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -53,71 +52,60 @@ def test_listing_does_not_unpickle_legacy_files(tmp_path):
     assert [entry["name"] for entry in listed] == ["good"]
 
 
-def _force_glob_order(monkeypatch, storage_dir, ordered_paths):
-    """Make storage_dir.glob("*.npz") yield ordered_paths regardless of filesystem order.
+def _legacy_and_good(tmp_path, legacy_sorts_last=False):
+    """Create one un-migrated legacy file and one valid new-format reference.
 
-    _find_reference_file's fallback scan is glob-order dependent, so tests that
-    pin "a match is found regardless of where the legacy file sorts" need
-    deterministic control over that order rather than relying on incidental
-    filesystem/OS behaviour (which is exactly the kind of luck this bug hid
-    behind).
+    _find_reference_file's fallback scan iterates ``sorted(glob("*.npz"))``,
+    so the scan order it actually sees is fixed by filename, not by directory
+    iteration order -- faking the latter (e.g. via a patched Path.glob) has no
+    effect once sorted() runs over it. To genuinely exercise "the unreadable
+    legacy file is encountered before the match" vs. "...after it", the
+    legacy file's name is chosen so it sorts before or after the good
+    reference's name for real.
     """
-    real_glob = Path.glob
-
-    def fake_glob(self, pattern, *args, **kwargs):
-        if self == storage_dir and pattern == "*.npz":
-            return iter(ordered_paths)
-        return real_glob(self, pattern, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "glob", fake_glob)
-
-
-def _legacy_and_good(tmp_path):
-    """Create one un-migrated legacy file and one valid new-format reference."""
-    legacy = tmp_path / "aaa_legacy.npz"
-    np.savez_compressed(legacy, time=np.arange(4, dtype=float), voltage=np.zeros(4), metadata={"name": "legacy"})
     store = ReferenceWaveform(str(tmp_path))
     store.save_reference(_Waveform(), "zzz-good")
-    good = next(p for p in tmp_path.glob("*.npz") if p != legacy)
+    good = next(tmp_path.glob("*.npz"))
+
+    # "zzz-good_<timestamp>.npz" vs "aaa_legacy.npz"/"zzzz_legacy.npz": the
+    # 4th character ('-' vs 'z') decides sort order in the latter case, so
+    # this reliably lands after the good file regardless of the timestamp.
+    legacy_name = "zzzz_legacy.npz" if legacy_sorts_last else "aaa_legacy.npz"
+    legacy = tmp_path / legacy_name
+    np.savez_compressed(legacy, time=np.arange(4, dtype=float), voltage=np.zeros(4), metadata={"name": "legacy"})
     return store, legacy, good
 
 
-def test_load_reference_finds_valid_entry_when_legacy_file_sorts_first(tmp_path, monkeypatch):
-    store, legacy, good = _legacy_and_good(tmp_path)
-    _force_glob_order(monkeypatch, store.storage_dir, [legacy, good])
+def test_load_reference_finds_valid_entry_when_legacy_file_sorts_first(tmp_path):
+    store, legacy, good = _legacy_and_good(tmp_path, legacy_sorts_last=False)
+    assert sorted(tmp_path.glob("*.npz")) == [legacy, good]
 
     loaded = store.load_reference("zzz-good")
     assert loaded is not None
     assert loaded["metadata"]["name"] == "zzz-good"
 
 
-def test_load_reference_finds_valid_entry_when_legacy_file_sorts_last(tmp_path, monkeypatch):
-    store, legacy, good = _legacy_and_good(tmp_path)
-    _force_glob_order(monkeypatch, store.storage_dir, [good, legacy])
+def test_load_reference_finds_valid_entry_when_legacy_file_sorts_last(tmp_path):
+    store, legacy, good = _legacy_and_good(tmp_path, legacy_sorts_last=True)
+    assert sorted(tmp_path.glob("*.npz")) == [good, legacy]
 
     loaded = store.load_reference("zzz-good")
     assert loaded is not None
     assert loaded["metadata"]["name"] == "zzz-good"
 
 
-def test_delete_reference_succeeds_despite_legacy_file_in_directory(tmp_path, monkeypatch):
+def test_delete_reference_succeeds_despite_legacy_file_in_directory(tmp_path):
     store, legacy, good = _legacy_and_good(tmp_path)
-    _force_glob_order(monkeypatch, store.storage_dir, [legacy, good])
 
     assert store.delete_reference("zzz-good") is True
     assert not good.exists()
     assert legacy.exists()
 
 
-def test_rename_reference_succeeds_despite_legacy_file_in_directory(tmp_path, monkeypatch):
+def test_rename_reference_succeeds_despite_legacy_file_in_directory(tmp_path):
     store, legacy, good = _legacy_and_good(tmp_path)
-    _force_glob_order(monkeypatch, store.storage_dir, [legacy, good])
 
     assert store.rename_reference("zzz-good", "renamed") is True
-    # rename_reference wrote a new file our forced ordering doesn't know about;
-    # revert to real directory order to look it up (legacy is still present, so
-    # this still exercises the mixed-directory lookup, just without a pinned order).
-    monkeypatch.undo()
     assert store.load_reference("renamed") is not None
 
 

--- a/tests/test_reference_format.py
+++ b/tests/test_reference_format.py
@@ -138,6 +138,45 @@ def test_non_dict_json_metadata_raises_corrupt_reference_error(tmp_path):
         store.load_reference("badmeta")
 
 
+def _only_legacy(tmp_path):
+    """Create a directory containing nothing but one un-migrated legacy file."""
+    legacy = tmp_path / "aaa_legacy.npz"
+    np.savez_compressed(legacy, time=np.arange(4, dtype=float), voltage=np.zeros(4), metadata={"name": "legacy"})
+    store = ReferenceWaveform(str(tmp_path))
+    return store, legacy
+
+
+def test_delete_reference_on_brand_new_name_returns_false_despite_legacy_file(tmp_path):
+    """delete_reference is a 'remove it if present' op: an unreadable legacy
+    file elsewhere in the directory is not proof the requested name exists,
+    so a name that was never saved must come back False, not raise."""
+    store, legacy = _only_legacy(tmp_path)
+    assert store.delete_reference("brand-new-name") is False
+    assert legacy.exists()
+
+
+def test_replace_on_save_loop_terminates_despite_legacy_file(tmp_path):
+    """Mirrors the server's replace-on-save shape (scope.py's
+    `while store.delete_reference(name): pass`) for a name being saved for
+    the first time -- it must terminate rather than raise."""
+    store, legacy = _only_legacy(tmp_path)
+    iterations = 0
+    while store.delete_reference("brand-new-name"):
+        iterations += 1
+        assert iterations < 100  # guard against an infinite loop masking the bug
+    assert iterations == 0
+    assert legacy.exists()
+
+
+def test_load_reference_still_raises_despite_delete_fix(tmp_path):
+    """The read path keeps its migrate hint: only delete_reference should
+    swallow the deferred legacy error, not load_reference."""
+    store, legacy = _only_legacy(tmp_path)
+    with pytest.raises(LegacyReferenceFormatError) as excinfo:
+        store.load_reference("brand-new-name")
+    assert "references migrate" in str(excinfo.value)
+
+
 def test_non_serializable_array_metadata_raises_type_error_not_io_error(tmp_path):
     store = ReferenceWaveform(str(tmp_path))
     with pytest.raises(TypeError):

--- a/tests/test_reference_format.py
+++ b/tests/test_reference_format.py
@@ -1,0 +1,52 @@
+"""Reference storage moves off pickled metadata onto a JSON string."""
+
+import json
+
+import numpy as np
+import pytest
+
+from scpi_control.reference_waveform import LegacyReferenceFormatError, ReferenceWaveform
+
+
+class _Waveform:
+    def __init__(self):
+        self.time = np.linspace(0, 1, 16)
+        self.voltage = np.sin(self.time)
+        self.channel = 1
+
+
+def test_saved_reference_has_no_object_array(tmp_path):
+    store = ReferenceWaveform(str(tmp_path))
+    store.save_reference(_Waveform(), "base")
+    saved = list(tmp_path.glob("*.npz"))[0]
+    with np.load(saved, allow_pickle=False) as data:
+        assert "meta_json" in data.files
+        assert "metadata" not in data.files
+        assert json.loads(str(data["meta_json"]))["name"] == "base"
+
+
+def test_new_format_round_trips(tmp_path):
+    store = ReferenceWaveform(str(tmp_path))
+    store.save_reference(_Waveform(), "base")
+    loaded = store.load_reference("base")
+    assert loaded is not None
+    assert loaded["metadata"]["name"] == "base"
+    assert len(loaded["time"]) == 16
+
+
+def test_legacy_pickled_file_raises_with_migrate_hint(tmp_path):
+    legacy = tmp_path / "ref_legacy.npz"
+    np.savez_compressed(legacy, time=np.arange(4, dtype=float), voltage=np.zeros(4), metadata={"name": "legacy"})
+    store = ReferenceWaveform(str(tmp_path))
+    with pytest.raises(LegacyReferenceFormatError) as excinfo:
+        store.load_reference("legacy")
+    assert "references migrate" in str(excinfo.value)
+
+
+def test_listing_does_not_unpickle_legacy_files(tmp_path):
+    legacy = tmp_path / "ref_legacy.npz"
+    np.savez_compressed(legacy, time=np.arange(4, dtype=float), voltage=np.zeros(4), metadata={"name": "legacy"})
+    store = ReferenceWaveform(str(tmp_path))
+    store.save_reference(_Waveform(), "good")
+    listed = store.list_references()
+    assert [entry["name"] for entry in listed] == ["good"]

--- a/tests/test_reference_format.py
+++ b/tests/test_reference_format.py
@@ -1,11 +1,12 @@
 """Reference storage moves off pickled metadata onto a JSON string."""
 
 import json
+from pathlib import Path
 
 import numpy as np
 import pytest
 
-from scpi_control.reference_waveform import LegacyReferenceFormatError, ReferenceWaveform
+from scpi_control.reference_waveform import CorruptReferenceError, LegacyReferenceFormatError, REFERENCE_META_KEY, ReferenceWaveform
 
 
 class _Waveform:
@@ -50,3 +51,109 @@ def test_listing_does_not_unpickle_legacy_files(tmp_path):
     store.save_reference(_Waveform(), "good")
     listed = store.list_references()
     assert [entry["name"] for entry in listed] == ["good"]
+
+
+def _force_glob_order(monkeypatch, storage_dir, ordered_paths):
+    """Make storage_dir.glob("*.npz") yield ordered_paths regardless of filesystem order.
+
+    _find_reference_file's fallback scan is glob-order dependent, so tests that
+    pin "a match is found regardless of where the legacy file sorts" need
+    deterministic control over that order rather than relying on incidental
+    filesystem/OS behaviour (which is exactly the kind of luck this bug hid
+    behind).
+    """
+    real_glob = Path.glob
+
+    def fake_glob(self, pattern, *args, **kwargs):
+        if self == storage_dir and pattern == "*.npz":
+            return iter(ordered_paths)
+        return real_glob(self, pattern, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "glob", fake_glob)
+
+
+def _legacy_and_good(tmp_path):
+    """Create one un-migrated legacy file and one valid new-format reference."""
+    legacy = tmp_path / "aaa_legacy.npz"
+    np.savez_compressed(legacy, time=np.arange(4, dtype=float), voltage=np.zeros(4), metadata={"name": "legacy"})
+    store = ReferenceWaveform(str(tmp_path))
+    store.save_reference(_Waveform(), "zzz-good")
+    good = next(p for p in tmp_path.glob("*.npz") if p != legacy)
+    return store, legacy, good
+
+
+def test_load_reference_finds_valid_entry_when_legacy_file_sorts_first(tmp_path, monkeypatch):
+    store, legacy, good = _legacy_and_good(tmp_path)
+    _force_glob_order(monkeypatch, store.storage_dir, [legacy, good])
+
+    loaded = store.load_reference("zzz-good")
+    assert loaded is not None
+    assert loaded["metadata"]["name"] == "zzz-good"
+
+
+def test_load_reference_finds_valid_entry_when_legacy_file_sorts_last(tmp_path, monkeypatch):
+    store, legacy, good = _legacy_and_good(tmp_path)
+    _force_glob_order(monkeypatch, store.storage_dir, [good, legacy])
+
+    loaded = store.load_reference("zzz-good")
+    assert loaded is not None
+    assert loaded["metadata"]["name"] == "zzz-good"
+
+
+def test_delete_reference_succeeds_despite_legacy_file_in_directory(tmp_path, monkeypatch):
+    store, legacy, good = _legacy_and_good(tmp_path)
+    _force_glob_order(monkeypatch, store.storage_dir, [legacy, good])
+
+    assert store.delete_reference("zzz-good") is True
+    assert not good.exists()
+    assert legacy.exists()
+
+
+def test_rename_reference_succeeds_despite_legacy_file_in_directory(tmp_path, monkeypatch):
+    store, legacy, good = _legacy_and_good(tmp_path)
+    _force_glob_order(monkeypatch, store.storage_dir, [legacy, good])
+
+    assert store.rename_reference("zzz-good", "renamed") is True
+    # rename_reference wrote a new file our forced ordering doesn't know about;
+    # revert to real directory order to look it up (legacy is still present, so
+    # this still exercises the mixed-directory lookup, just without a pinned order).
+    monkeypatch.undo()
+    assert store.load_reference("renamed") is not None
+
+
+def test_lookup_still_raises_when_only_legacy_files_match_no_valid_entry(tmp_path):
+    """No-match-found case still surfaces the deferred error (unchanged from before)."""
+    legacy = tmp_path / "aaa_legacy.npz"
+    np.savez_compressed(legacy, time=np.arange(4, dtype=float), voltage=np.zeros(4), metadata={"name": "legacy"})
+    store = ReferenceWaveform(str(tmp_path))
+    with pytest.raises(LegacyReferenceFormatError):
+        store.load_reference("legacy")
+
+
+def test_non_dict_json_metadata_raises_corrupt_reference_error(tmp_path):
+    bad = tmp_path / "badmeta.npz"
+    np.savez_compressed(bad, time=np.arange(4, dtype=float), voltage=np.zeros(4), **{REFERENCE_META_KEY: json.dumps([1, 2, 3])})
+    store = ReferenceWaveform(str(tmp_path))
+    with pytest.raises(CorruptReferenceError):
+        store.load_reference("badmeta")
+
+
+def test_non_serializable_array_metadata_raises_type_error_not_io_error(tmp_path):
+    store = ReferenceWaveform(str(tmp_path))
+    with pytest.raises(TypeError):
+        store.save_reference(_Waveform(), "bad-meta", metadata={"cal": np.arange(3)})
+
+
+def test_numpy_int64_metadata_value_raises_type_error_not_io_error(tmp_path):
+    store = ReferenceWaveform(str(tmp_path))
+    with pytest.raises(TypeError):
+        store.save_reference(_Waveform(), "int64-meta", metadata={"count": np.int64(5)})
+
+
+def test_corrupt_json_metadata_chains_original_exception(tmp_path):
+    bad = tmp_path / "badjson.npz"
+    np.savez_compressed(bad, time=np.arange(4, dtype=float), voltage=np.zeros(4), **{REFERENCE_META_KEY: "{not valid json"})
+    store = ReferenceWaveform(str(tmp_path))
+    with pytest.raises(CorruptReferenceError) as excinfo:
+        store.load_reference("badjson")
+    assert excinfo.value.__cause__ is not None

--- a/tests/test_reference_migration.py
+++ b/tests/test_reference_migration.py
@@ -1,0 +1,121 @@
+"""One-shot migration of pre-5.0 pickled reference files."""
+
+import json
+
+import numpy as np
+
+from scpi_control.reference_waveform import ReferenceWaveform
+from scpi_control.server.__main__ import main
+from scpi_control.server.migrate import migrate_references
+
+
+def _write_legacy(path, name):
+    np.savez_compressed(path, time=np.arange(4, dtype=float), voltage=np.zeros(4), metadata={"name": name, "channel": 1})
+
+
+def test_legacy_file_is_converted(tmp_path):
+    _write_legacy(tmp_path / "ref_old.npz", "old")
+    result = migrate_references(str(tmp_path))
+    assert result == {"converted": 1, "skipped": 0, "failed": 0}
+    with np.load(tmp_path / "ref_old.npz", allow_pickle=False) as data:
+        assert "metadata" not in data.files
+        assert json.loads(str(data["meta_json"]))["name"] == "old"
+
+
+def test_converted_file_loads_through_the_normal_path(tmp_path):
+    _write_legacy(tmp_path / "ref_old.npz", "old")
+    migrate_references(str(tmp_path))
+    loaded = ReferenceWaveform(str(tmp_path)).load_reference("old")
+    assert loaded is not None
+    assert loaded["metadata"]["name"] == "old"
+    assert list(loaded["voltage"]) == [0.0, 0.0, 0.0, 0.0]
+
+
+def test_already_migrated_files_are_skipped(tmp_path):
+    target = tmp_path / "ref_old.npz"
+    _write_legacy(target, "old")
+    migrate_references(str(tmp_path))
+
+    # Prove the second pass is a genuine no-op, not merely a clean exit: the
+    # file must be byte-for-byte and mtime identical after the "skip".
+    before_bytes = target.read_bytes()
+    before_mtime = target.stat().st_mtime_ns
+
+    result = migrate_references(str(tmp_path))
+
+    assert result == {"converted": 0, "skipped": 1, "failed": 0}
+    assert target.read_bytes() == before_bytes
+    assert target.stat().st_mtime_ns == before_mtime
+
+
+def test_unreadable_file_is_counted_not_fatal(tmp_path):
+    broken = tmp_path / "ref_broken.npz"
+    broken.write_bytes(b"not an npz")
+    result = migrate_references(str(tmp_path))
+    assert result == {"converted": 0, "skipped": 0, "failed": 1}
+    # The broken file itself must survive untouched -- "not fatal" means the
+    # run continues, not that the unreadable file gets silently replaced.
+    assert broken.read_bytes() == b"not an npz"
+
+
+def test_counts_sum_to_files_examined(tmp_path):
+    _write_legacy(tmp_path / "ref_legacy.npz", "legacy")
+    already = tmp_path / "ref_new.npz"
+    np.savez_compressed(already, time=np.arange(4, dtype=float), voltage=np.zeros(4), meta_json=json.dumps({"name": "new"}))
+    (tmp_path / "ref_broken.npz").write_bytes(b"garbage")
+
+    result = migrate_references(str(tmp_path))
+
+    assert result == {"converted": 1, "skipped": 1, "failed": 1}
+    assert sum(result.values()) == 3
+
+
+def test_failed_conversion_leaves_original_file_intact(tmp_path, monkeypatch):
+    storage = tmp_path / "refs"
+    storage.mkdir()
+    target = storage / "ref_old.npz"
+    _write_legacy(target, "old")
+    before_bytes = target.read_bytes()
+
+    def _boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("scpi_control.server.migrate.np.savez_compressed", _boom)
+
+    result = migrate_references(str(storage))
+
+    assert result == {"converted": 0, "skipped": 0, "failed": 1}
+    # A conversion that dies partway through must not leave a truncated
+    # replacement -- the original, still-readable-as-legacy file must remain.
+    assert target.read_bytes() == before_bytes
+    assert target.exists()
+    # No leftover temp file should linger in the storage directory either.
+    assert sorted(p.name for p in storage.iterdir()) == ["ref_old.npz"]
+
+
+def test_cli_references_migrate_dispatches_and_prints_summary(tmp_path, capsys):
+    _write_legacy(tmp_path / "ref_old.npz", "old")
+
+    main(["references", "migrate", "--dir", str(tmp_path)])
+
+    printed = capsys.readouterr().out
+    assert "converted 1" in printed
+    assert "skipped 0" in printed
+    assert "failed 0" in printed
+    with np.load(tmp_path / "ref_old.npz", allow_pickle=False) as data:
+        assert "meta_json" in data.files
+
+
+def test_cli_references_migrate_defaults_to_config_dir_references_subdir(tmp_path, capsys):
+    # No --dir given: must resolve under DEFAULT_CONFIG_DIR (patched to the
+    # fake home by the autouse _no_real_home fixture), never the real home.
+    default_refs = tmp_path / "fake-home" / ".siglent" / "references"
+    default_refs.mkdir(parents=True)
+    _write_legacy(default_refs / "ref_old.npz", "old")
+
+    main(["references", "migrate"])
+
+    printed = capsys.readouterr().out
+    assert "converted 1" in printed
+    with np.load(default_refs / "ref_old.npz", allow_pickle=False) as data:
+        assert "meta_json" in data.files

--- a/tests/test_reference_migration.py
+++ b/tests/test_reference_migration.py
@@ -1,6 +1,8 @@
 """One-shot migration of pre-5.0 pickled reference files."""
 
 import json
+import logging
+from pathlib import Path
 
 import numpy as np
 
@@ -77,7 +79,19 @@ def test_failed_conversion_leaves_original_file_intact(tmp_path, monkeypatch):
     _write_legacy(target, "old")
     before_bytes = target.read_bytes()
 
-    def _boom(*args, **kwargs):
+    def _boom(file, *args, **kwargs):
+        # A real partial write leaves garbage bytes sitting wherever
+        # savez_compressed was writing before it died -- reproduce that
+        # here. A naive implementation that writes straight over the
+        # original file (no temp file, no os.replace) would corrupt
+        # ref_old.npz right here and fail the assertions below; only the
+        # atomic temp-file-then-swap approach leaves the original untouched,
+        # because the garbage lands in a temp file that then gets unlinked.
+        if hasattr(file, "write"):
+            file.write(b"garbage from a partial write")
+            file.flush()
+        else:
+            Path(file).write_bytes(b"garbage from a partial write")
         raise OSError("disk full")
 
     monkeypatch.setattr("scpi_control.server.migrate.np.savez_compressed", _boom)
@@ -91,6 +105,38 @@ def test_failed_conversion_leaves_original_file_intact(tmp_path, monkeypatch):
     assert target.exists()
     # No leftover temp file should linger in the storage directory either.
     assert sorted(p.name for p in storage.iterdir()) == ["ref_old.npz"]
+
+
+def test_orphaned_temp_file_is_ignored_by_the_scan(tmp_path):
+    # A leftover *.npz.tmp from a killed run has none of the structure
+    # _build_payload expects. If the scan's "*.npz" glob matched it, it
+    # would blow up in np.load and get counted as failed. It must simply
+    # never be examined by the converted/skipped/failed loop at all.
+    orphan = tmp_path / "ref_old.abcd1234.npz.tmp"
+    orphan.write_bytes(b"partial write from a process that got SIGKILLed")
+    _write_legacy(tmp_path / "ref_old.npz", "old")
+
+    result = migrate_references(str(tmp_path))
+
+    assert result == {"converted": 1, "skipped": 0, "failed": 0}
+
+
+def test_stale_temp_file_is_cleaned_up_and_logged(tmp_path, caplog):
+    # Simulates the process being killed between the temp-file write and
+    # os.replace in a *previous* run: the orphan must be swept up (and
+    # mentioned in the log) at the start of the *next* run, or it litters
+    # the directory forever.
+    orphan = tmp_path / "ref_old.abcd1234.npz.tmp"
+    orphan.write_bytes(b"partial write from a process that got SIGKILLed")
+
+    with caplog.at_level(logging.INFO, logger="scpi_control.server.migrate"):
+        result = migrate_references(str(tmp_path))
+
+    assert not orphan.exists()
+    # A stale temp file is not a reference file -- it must not be counted
+    # as converted, skipped, or failed.
+    assert result == {"converted": 0, "skipped": 0, "failed": 0}
+    assert orphan.name in caplog.text
 
 
 def test_cli_references_migrate_dispatches_and_prints_summary(tmp_path, capsys):

--- a/tests/test_reference_migration.py
+++ b/tests/test_reference_migration.py
@@ -102,6 +102,10 @@ def test_failed_conversion_leaves_original_file_intact(tmp_path, monkeypatch):
     # A conversion that dies partway through must not leave a truncated
     # replacement -- the original, still-readable-as-legacy file must remain.
     assert target.read_bytes() == before_bytes
+    # Byte-identity alone would also hold for a file that was never readable
+    # in the first place, so prove the survivor is still a loadable archive.
+    with np.load(target, allow_pickle=True) as survivor:
+        assert survivor["metadata"].item()["name"] == "old"
     assert target.exists()
     # No leftover temp file should linger in the storage directory either.
     assert sorted(p.name for p in storage.iterdir()) == ["ref_old.npz"]

--- a/tests/test_reference_path_safety.py
+++ b/tests/test_reference_path_safety.py
@@ -1,0 +1,31 @@
+"""Reference lookup must not escape the storage directory (audit H21)."""
+
+import numpy as np
+
+from scpi_control.reference_waveform import ReferenceWaveform
+
+
+def test_absolute_path_is_not_honoured(tmp_path):
+    outside = tmp_path / "outside.npz"
+    np.savez_compressed(outside, time=np.arange(4, dtype=float), voltage=np.zeros(4))
+    store = ReferenceWaveform(str(tmp_path / "refs"))
+    assert store.load_reference(str(outside)) is None
+
+
+def test_traversal_is_not_honoured(tmp_path):
+    outside = tmp_path / "outside.npz"
+    np.savez_compressed(outside, time=np.arange(4, dtype=float), voltage=np.zeros(4))
+    store = ReferenceWaveform(str(tmp_path / "refs"))
+    assert store.load_reference("../outside.npz") is None
+    assert store.load_reference("..\\outside.npz") is None
+
+
+def test_ordinary_name_still_resolves(tmp_path):
+    class _Waveform:
+        time = np.linspace(0, 1, 8)
+        voltage = np.zeros(8)
+        channel = 1
+
+    store = ReferenceWaveform(str(tmp_path))
+    store.save_reference(_Waveform(), "base")
+    assert store.load_reference("base") is not None

--- a/tests/test_reference_waveform.py
+++ b/tests/test_reference_waveform.py
@@ -1,0 +1,146 @@
+"""Characterization tests: current observable behaviour of ReferenceWaveform.
+
+Written BEFORE the storage format changes, asserting only on the public API so
+they stay valid across the migration. If one of these fails, the behaviour
+changed -- that is the signal they exist to give.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scpi_control.reference_waveform import ReferenceWaveform
+
+
+class _Waveform:
+    def __init__(self, channel=1, samples=32):
+        self.time = np.linspace(0, 1e-3, samples)
+        self.voltage = np.sin(2 * np.pi * 1000 * self.time)
+        self.channel = channel
+
+
+@pytest.fixture()
+def store(tmp_path):
+    return ReferenceWaveform(str(tmp_path))
+
+
+def test_storage_dir_is_created(tmp_path):
+    target = tmp_path / "nested" / "refs"
+    ReferenceWaveform(str(target))
+    assert target.is_dir()
+
+
+def test_save_returns_a_path_that_exists(store):
+    saved = store.save_reference(_Waveform(), "baseline")
+    assert saved
+    assert Path(saved).exists()
+
+
+def test_round_trip_preserves_samples(store):
+    waveform = _Waveform()
+    store.save_reference(waveform, "baseline")
+    loaded = store.load_reference("baseline")
+    assert loaded is not None
+    assert np.allclose(loaded["time"], waveform.time)
+    assert np.allclose(loaded["voltage"], waveform.voltage)
+
+
+def test_metadata_carries_name_and_derived_stats(store):
+    store.save_reference(_Waveform(), "baseline")
+    metadata = store.load_reference("baseline")["metadata"]
+    assert metadata["name"] == "baseline"
+    assert metadata["num_samples"] == 32
+    assert metadata["channel"] == 1
+    for key in ("min_voltage", "max_voltage", "mean_voltage", "std_voltage", "time_span", "timestamp"):
+        assert key in metadata
+
+
+def test_unknown_name_loads_as_none(store):
+    assert store.load_reference("never-saved") is None
+
+
+def test_list_references_reports_saved_entries(store):
+    store.save_reference(_Waveform(), "one")
+    store.save_reference(_Waveform(channel=2), "two")
+    listed = store.list_references()
+    assert sorted(entry["name"] for entry in listed) == ["one", "two"]
+    for entry in listed:
+        for key in ("name", "channel", "timestamp", "num_samples", "time_span"):
+            assert key in entry
+
+
+def test_list_is_empty_for_a_fresh_store(store):
+    assert store.list_references() == []
+
+
+def test_delete_removes_the_reference(store):
+    store.save_reference(_Waveform(), "doomed")
+    assert store.delete_reference("doomed") is True
+    assert store.load_reference("doomed") is None
+
+
+def test_deleting_an_unknown_reference_reports_false(store):
+    assert store.delete_reference("ghost") is False
+
+
+def test_storage_size_grows_after_a_save(store):
+    before = store.get_storage_size()
+    store.save_reference(_Waveform(), "sized")
+    assert store.get_storage_size() > before
+
+
+def test_names_with_path_characters_are_sanitized(store):
+    store.save_reference(_Waveform(), "weird/name:with*chars")
+    for saved in Path(store.storage_dir).glob("*.npz"):
+        assert "/" not in saved.name and ":" not in saved.name and "*" not in saved.name
+
+
+# --- Additional characterization coverage: other storage-affecting public methods ---
+# rename_reference and clear_all_references are part of the same public surface
+# (they go through _find_reference_file / the npz metadata just like save/load/
+# list/delete) but were not in the brief's test list. Pinning them here too so
+# the coming format/path-resolution migration has to prove them unchanged as well.
+
+
+@pytest.mark.xfail(
+    condition=sys.platform.startswith("win"),
+    reason=(
+        "Pre-existing bug (not introduced by this test suite): rename_reference() keeps the "
+        "np.load() NpzFile from the source file alive (never closes it) while it still holds "
+        "time/voltage/metadata references, then calls old_filepath.unlink() on that same file. "
+        "Windows refuses to unlink a file with an open handle, so this raises WinError 32 and "
+        "rename_reference returns False instead of True. Likely POSIX-safe, since unlinking an "
+        "open file is permitted there. rename_reference has no other callers in the codebase. "
+        "strict=True so this starts failing loudly (XPASS) if a future change fixes it, as a "
+        "reminder to drop the xfail."
+    ),
+    strict=True,
+)
+def test_rename_reference_moves_data_to_the_new_name(store):
+    waveform = _Waveform()
+    store.save_reference(waveform, "old-name")
+    assert store.rename_reference("old-name", "new-name") is True
+
+    assert store.load_reference("old-name") is None
+    loaded = store.load_reference("new-name")
+    assert loaded is not None
+    assert loaded["metadata"]["name"] == "new-name"
+    assert np.allclose(loaded["voltage"], waveform.voltage)
+
+
+def test_renaming_an_unknown_reference_reports_false(store):
+    assert store.rename_reference("ghost", "whatever") is False
+
+
+def test_clear_all_references_removes_everything_and_reports_count(store):
+    store.save_reference(_Waveform(), "one")
+    store.save_reference(_Waveform(), "two")
+    assert store.clear_all_references() == 2
+    assert store.list_references() == []
+    assert store.get_storage_size() == 0
+
+
+def test_clear_all_references_on_empty_store_reports_zero(store):
+    assert store.clear_all_references() == 0

--- a/tests/test_reference_waveform.py
+++ b/tests/test_reference_waveform.py
@@ -6,11 +6,13 @@ changed -- that is the signal they exist to give.
 """
 
 import sys
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import numpy as np
 import pytest
 
+import scpi_control.reference_waveform as reference_waveform_module
 from scpi_control.reference_waveform import ReferenceWaveform
 
 
@@ -38,6 +40,16 @@ def test_save_returns_a_path_that_exists(store):
     assert Path(saved).exists()
 
 
+def test_save_none_waveform_raises_value_error(store):
+    with pytest.raises(ValueError):
+        store.save_reference(None, "baseline")
+
+
+def test_save_empty_name_raises_value_error(store):
+    with pytest.raises(ValueError):
+        store.save_reference(_Waveform(), "")
+
+
 def test_round_trip_preserves_samples(store):
     waveform = _Waveform()
     store.save_reference(waveform, "baseline")
@@ -57,6 +69,20 @@ def test_metadata_carries_name_and_derived_stats(store):
         assert key in metadata
 
 
+def test_caller_supplied_metadata_survives_round_trip_alongside_derived_fields(store):
+    store.save_reference(_Waveform(), "with-extra", metadata={"custom_key": "custom_value", "author": "tester"})
+    metadata = store.load_reference("with-extra")["metadata"]
+
+    # Caller-supplied keys survive.
+    assert metadata["custom_key"] == "custom_value"
+    assert metadata["author"] == "tester"
+
+    # Derived keys are still present alongside them.
+    assert metadata["name"] == "with-extra"
+    assert metadata["num_samples"] == 32
+    assert metadata["channel"] == 1
+
+
 def test_unknown_name_loads_as_none(store):
     assert store.load_reference("never-saved") is None
 
@@ -69,6 +95,41 @@ def test_list_references_reports_saved_entries(store):
     for entry in listed:
         for key in ("name", "channel", "timestamp", "num_samples", "time_span"):
             assert key in entry
+
+
+def test_list_references_sorted_by_timestamp_descending(store, monkeypatch):
+    """list_references() documents sorting by timestamp, descending.
+
+    Timestamps come from datetime.now().isoformat() at save time, so two real
+    saves in a fast test run can land in the same resolution tick and make a
+    strict-ordering assertion flaky. To pin the sort behaviour deterministically
+    without touching production code, the `datetime` name imported into
+    reference_waveform.py is monkeypatched with a stand-in whose now() always
+    advances, guaranteeing each save gets a strictly later timestamp than the
+    last -- everything else (real datetime instances, fromtimestamp) is left
+    untouched.
+    """
+
+    class _StepDatetime:
+        _current = [datetime(2024, 1, 1, 0, 0, 0)]
+
+        @classmethod
+        def now(cls):
+            cls._current[0] += timedelta(seconds=1)
+            return cls._current[0]
+
+        @staticmethod
+        def fromtimestamp(*args, **kwargs):
+            return datetime.fromtimestamp(*args, **kwargs)
+
+    monkeypatch.setattr(reference_waveform_module, "datetime", _StepDatetime)
+
+    store.save_reference(_Waveform(), "first")
+    store.save_reference(_Waveform(), "second")
+    store.save_reference(_Waveform(), "third")
+
+    listed = store.list_references()
+    assert [entry["name"] for entry in listed] == ["third", "second", "first"]
 
 
 def test_list_is_empty_for_a_fresh_store(store):

--- a/tests/test_reference_waveform.py
+++ b/tests/test_reference_waveform.py
@@ -5,7 +5,6 @@ they stay valid across the migration. If one of these fails, the behaviour
 changed -- that is the signal they exist to give.
 """
 
-import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -165,20 +164,6 @@ def test_names_with_path_characters_are_sanitized(store):
 # the coming format/path-resolution migration has to prove them unchanged as well.
 
 
-@pytest.mark.xfail(
-    condition=sys.platform.startswith("win"),
-    reason=(
-        "Pre-existing bug (not introduced by this test suite): rename_reference() keeps the "
-        "np.load() NpzFile from the source file alive (never closes it) while it still holds "
-        "time/voltage/metadata references, then calls old_filepath.unlink() on that same file. "
-        "Windows refuses to unlink a file with an open handle, so this raises WinError 32 and "
-        "rename_reference returns False instead of True. Likely POSIX-safe, since unlinking an "
-        "open file is permitted there. rename_reference has no other callers in the codebase. "
-        "strict=True so this starts failing loudly (XPASS) if a future change fixes it, as a "
-        "reminder to drop the xfail."
-    ),
-    strict=True,
-)
 def test_rename_reference_moves_data_to_the_new_name(store):
     waveform = _Waveform()
     store.save_reference(waveform, "old-name")

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -325,21 +325,28 @@ class TestViewers:
         assert connected and connected[0]["viewers"] == 0
 
 
-def test_cli_parses_defaults(monkeypatch):
+def test_cli_parses_defaults(tmp_path, monkeypatch):
     import scpi_control.server.__main__ as cli
+    from scpi_control.server.auth import TokenStore
 
     captured = {}
+    create_app_calls = []
+
+    def fake_create_app(**kwargs):
+        create_app_calls.append(kwargs)
+        return object()
 
     def fake_run(app, host, port, **kwargs):
         captured.update(host=host, port=port)
 
-    # create_app() with no token_store default-constructs a TokenStore against the
-    # real ~/.siglent/tokens.json; stub it out so this test never touches that file.
-    monkeypatch.setattr(cli, "create_app", lambda: object())
+    # --config-dir points at tmp_path so this never touches the developer's real
+    # ~/.siglent/tokens.json; create_app is stubbed so no real ASGI app is built.
+    monkeypatch.setattr(cli, "create_app", fake_create_app)
     monkeypatch.setattr(cli.uvicorn, "run", fake_run)
-    cli.main([])
+    cli.main(["--config-dir", str(tmp_path)])
     assert captured == {"host": "127.0.0.1", "port": 8765}
-    cli.main(["--host", "0.0.0.0", "--port", "9000"])
+    assert isinstance(create_app_calls[0]["token_store"], TokenStore)
+    cli.main(["--host", "0.0.0.0", "--port", "9000", "--config-dir", str(tmp_path)])
     assert captured == {"host": "0.0.0.0", "port": 9000}
 
 

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -11,19 +11,23 @@ from scpi_control.server.sessions import SessionManager  # noqa: E402
 
 
 @pytest.fixture()
-def client():
+def client(gateway_auth):
+    store, headers, _raw = gateway_auth
     manager = SessionManager()
-    app = create_app(manager)
+    app = create_app(manager, token_store=store)
     with TestClient(app) as test_client:
+        test_client.headers.update(headers)  # every request in this module is now authenticated
         yield test_client
     manager.close_all()
 
 
 @pytest.fixture()
-def ref_client(tmp_path):
+def ref_client(tmp_path, gateway_auth):
+    store, headers, _raw = gateway_auth
     manager = SessionManager()
-    app = create_app(manager, references_dir=str(tmp_path))
+    app = create_app(manager, references_dir=str(tmp_path), token_store=store)
     with TestClient(app) as test_client:
+        test_client.headers.update(headers)
         yield test_client
     manager.close_all()
 
@@ -62,11 +66,12 @@ def test_wrong_method_405_keeps_allow_header(client):
     assert "allow" in {k.lower() for k in response.headers}
 
 
-def test_lifespan_shutdown_closes_sessions():
+def test_lifespan_shutdown_closes_sessions(gateway_auth):
     # Fix 6: leaving the app context (lifespan teardown) closes live sessions.
+    store, headers, _raw = gateway_auth
     manager = SessionManager()
-    with TestClient(create_app(manager)) as client:
-        body = client.post("/api/sessions", json={"mock": True}).json()
+    with TestClient(create_app(manager, token_store=store)) as client:
+        body = client.post("/api/sessions", json={"mock": True}, headers=headers).json()
         session = manager.get(body["id"])
         assert session.state == "connected"
     # No explicit close_all() -> the lifespan teardown must have closed it.
@@ -328,6 +333,9 @@ def test_cli_parses_defaults(monkeypatch):
     def fake_run(app, host, port, **kwargs):
         captured.update(host=host, port=port)
 
+    # create_app() with no token_store default-constructs a TokenStore against the
+    # real ~/.siglent/tokens.json; stub it out so this test never touches that file.
+    monkeypatch.setattr(cli, "create_app", lambda: object())
     monkeypatch.setattr(cli.uvicorn, "run", fake_run)
     cli.main([])
     assert captured == {"host": "127.0.0.1", "port": 8765}
@@ -522,10 +530,12 @@ class TestReferences:
 
 
 @pytest.fixture()
-def managed_client():
+def managed_client(gateway_auth):
+    store, headers, _raw = gateway_auth
     manager = SessionManager()
-    app = create_app(manager)
+    app = create_app(manager, token_store=store)
     with TestClient(app) as test_client:
+        test_client.headers.update(headers)
         yield test_client, manager
     manager.close_all()
 

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -350,6 +350,19 @@ def test_cli_parses_defaults(tmp_path, monkeypatch):
     assert captured == {"host": "0.0.0.0", "port": 9000}
 
 
+@pytest.mark.parametrize("max_sessions", ["0", "-1"])
+def test_cli_rejects_non_positive_max_sessions(tmp_path, max_sessions, capsys):
+    # LOW 5: --max-sessions 0 (or negative) must not silently start a gateway
+    # that refuses every session with a confusing 409; reject it at the CLI
+    # with a clear message and a nonzero exit, before create_app/uvicorn run.
+    import scpi_control.server.__main__ as cli
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["--config-dir", str(tmp_path), "--max-sessions", max_sessions])
+    assert exc_info.value.code != 0
+    assert "--max-sessions" in capsys.readouterr().err
+
+
 class TestScreenshot:
     def test_screenshot_returns_png(self, client):
         sid = create_mock_session(client)["id"]

--- a/tests/test_server_auth_coverage.py
+++ b/tests/test_server_auth_coverage.py
@@ -1,22 +1,32 @@
 # tests/test_server_auth_coverage.py
 """Regression coverage for review findings against the auth boundary.
 
-Two things live here that the other auth test modules don't cover:
+Three things live here that the other auth test modules don't cover:
 
 - Critical 1: a proxy-mounted deployment (``uvicorn --root-path /gw``) must not
   let ``scope["path"]`` still carrying the mount prefix slip an ``/api/*``
   request past the guard.
 - Important 2: the OpenAPI schema and HTML doc UIs must sit behind the same
   guard as the rest of the instrument-control surface, not float outside it.
+- Critical 3: this is the load-bearing test of the whole sub-project. It walks
+  the *real* route table -- rather than a hand-maintained list -- so a new
+  router mounted under /api/ is covered by this guard the day it is added,
+  instead of silently slipping through anonymous. Note that /api/openapi.json
+  is registered by FastAPI as a plain ``starlette.routing.Route``, not an
+  ``APIRoute`` (it is added via ``add_route``, not a decorator), so the
+  enumeration below never sees it -- that path is exercised separately by
+  ``test_guarded_openapi_requires_a_token`` above.
 """
 
 import pytest
 
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
+from fastapi.routing import APIRoute, APIWebSocketRoute  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 from scpi_control.server.app import create_app  # noqa: E402
+from scpi_control.server.auth import EXEMPT_PATHS, TokenStore  # noqa: E402
 from scpi_control.server.sessions import SessionManager  # noqa: E402
 
 
@@ -97,3 +107,62 @@ def test_guarded_openapi_serves_the_schema_with_a_token(client):
     response = test_client.get("/api/openapi.json", headers=headers)
     assert response.status_code == 200
     assert _looks_like_openapi_schema(response)
+
+
+# --- Critical 3: every route in the real table rejects anonymous access ----
+
+PLACEHOLDERS = {"session_id": "nope", "channel": "1", "n": "1", "name": "ref", "op": "run"}
+
+
+def _concrete(path):
+    for key, value in PLACEHOLDERS.items():
+        path = path.replace("{" + key + "}", value)
+    return path
+
+
+def _http_routes(app):
+    for route in app.routes:
+        if isinstance(route, APIRoute) and route.path.startswith("/api/") and route.path not in EXEMPT_PATHS:
+            for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
+                yield method, route.path
+
+
+def _ws_routes(app):
+    for route in app.routes:
+        if isinstance(route, APIWebSocketRoute) and route.path.startswith("/api/"):
+            yield route.path
+
+
+@pytest.fixture(scope="module")
+def enumerated_app(tmp_path_factory):
+    store = TokenStore(str(tmp_path_factory.mktemp("cfg") / "tokens.json"))
+    store.mint("tester")
+    manager = SessionManager()
+    application = create_app(manager, token_store=store)
+    yield application
+    manager.close_all()
+
+
+def test_route_table_is_not_empty(enumerated_app):
+    # A guard on an empty table would pass vacuously; pin a floor so the
+    # enumeration itself is verified to be finding real routes.
+    assert len(list(_http_routes(enumerated_app))) >= 30
+    assert len(list(_ws_routes(enumerated_app))) >= 1
+
+
+def test_every_api_route_rejects_anonymous(enumerated_app):
+    with TestClient(enumerated_app) as test_client:
+        unguarded = []
+        for method, path in _http_routes(enumerated_app):
+            response = test_client.request(method, _concrete(path))
+            if response.status_code != 401:
+                unguarded.append("{0} {1} -> {2}".format(method, path, response.status_code))
+        assert not unguarded, "unauthenticated access reached: {0}".format(unguarded)
+
+
+def test_every_ws_route_rejects_anonymous(enumerated_app):
+    with TestClient(enumerated_app) as test_client:
+        for path in _ws_routes(enumerated_app):
+            with pytest.raises(Exception):
+                with test_client.websocket_connect(_concrete(path)):
+                    pass

--- a/tests/test_server_auth_coverage.py
+++ b/tests/test_server_auth_coverage.py
@@ -1,0 +1,99 @@
+# tests/test_server_auth_coverage.py
+"""Regression coverage for review findings against the auth boundary.
+
+Two things live here that the other auth test modules don't cover:
+
+- Critical 1: a proxy-mounted deployment (``uvicorn --root-path /gw``) must not
+  let ``scope["path"]`` still carrying the mount prefix slip an ``/api/*``
+  request past the guard.
+- Important 2: the OpenAPI schema and HTML doc UIs must sit behind the same
+  guard as the rest of the instrument-control surface, not float outside it.
+"""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scpi_control.server.app import create_app  # noqa: E402
+from scpi_control.server.sessions import SessionManager  # noqa: E402
+
+
+@pytest.fixture()
+def client(gateway_auth):
+    store, headers, _raw = gateway_auth
+    manager = SessionManager()
+    app = create_app(manager, token_store=store)
+    with TestClient(app) as test_client:
+        yield test_client, headers
+    manager.close_all()
+
+
+# --- Critical 1: root_path must be stripped before the /api/* guard check --
+
+
+def test_root_path_prefixed_api_request_without_credentials_is_401(gateway_auth):
+    """Reproduces the bypass: Starlette's router strips ``root_path`` before
+    matching routes, so under ``uvicorn --root-path /gw`` a request that
+    arrives as scope["path"] == "/gw/api/sessions" is served as
+    "/api/sessions". Testing the raw, unstripped path here let it slip past
+    the guard entirely -- 200 with the live session list, no credentials.
+    """
+    store, _headers, _raw = gateway_auth
+    manager = SessionManager()
+    app = create_app(manager, token_store=store)
+    with TestClient(app, root_path="/gw") as client:
+        response = client.get("/gw/api/sessions")
+        assert response.status_code == 401
+    manager.close_all()
+
+
+def test_root_path_prefixed_api_request_with_credentials_is_served(gateway_auth):
+    store, headers, _raw = gateway_auth
+    manager = SessionManager()
+    app = create_app(manager, token_store=store)
+    with TestClient(app, root_path="/gw") as client:
+        response = client.get("/gw/api/sessions", headers=headers)
+        assert response.status_code == 200
+    manager.close_all()
+
+
+def test_root_path_prefixed_health_check_stays_exempt(gateway_auth):
+    store, _headers, _raw = gateway_auth
+    manager = SessionManager()
+    app = create_app(manager, token_store=store)
+    with TestClient(app, root_path="/gw") as client:
+        response = client.get("/gw/api/health")
+        assert response.status_code == 200
+    manager.close_all()
+
+
+# --- Important 2: API docs must sit behind the guard ------------------------
+
+
+def _looks_like_openapi_schema(response) -> bool:
+    try:
+        body = response.json()
+    except ValueError:
+        return False
+    return isinstance(body, dict) and "openapi" in body and "paths" in body
+
+
+def test_top_level_docs_urls_do_not_expose_the_schema(client):
+    test_client, _headers = client
+    for path in ("/openapi.json", "/docs", "/redoc"):
+        assert not _looks_like_openapi_schema(test_client.get(path))
+
+
+def test_guarded_openapi_requires_a_token(client):
+    test_client, _headers = client
+    response = test_client.get("/api/openapi.json")
+    assert response.status_code == 401
+
+
+def test_guarded_openapi_serves_the_schema_with_a_token(client):
+    test_client, headers = client
+    response = test_client.get("/api/openapi.json", headers=headers)
+    assert response.status_code == 200
+    assert _looks_like_openapi_schema(response)

--- a/tests/test_server_auth_coverage.py
+++ b/tests/test_server_auth_coverage.py
@@ -22,13 +22,13 @@ import pytest
 
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
-from fastapi.routing import APIRoute, APIWebSocketRoute  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from starlette.websockets import WebSocketDisconnect  # noqa: E402
 
 from scpi_control.server.app import create_app  # noqa: E402
-from scpi_control.server.auth import EXEMPT_PATHS, TokenStore  # noqa: E402
+from scpi_control.server.auth import TokenStore  # noqa: E402
 from scpi_control.server.sessions import SessionManager  # noqa: E402
+from tests.route_introspection import iter_http_routes, iter_ws_routes  # noqa: E402
 
 
 @pytest.fixture()
@@ -121,17 +121,14 @@ def _concrete(path):
     return path
 
 
+# Enumeration is version-robust (see tests/route_introspection.py): Starlette 1.x
+# nests include_router routes so walking app.routes flat finds almost none.
 def _http_routes(app):
-    for route in app.routes:
-        if isinstance(route, APIRoute) and route.path.startswith("/api/") and route.path not in EXEMPT_PATHS:
-            for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
-                yield method, route.path
+    return iter_http_routes(app)
 
 
 def _ws_routes(app):
-    for route in app.routes:
-        if isinstance(route, APIWebSocketRoute) and route.path.startswith("/api/"):
-            yield route.path
+    return iter_ws_routes(app)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_server_auth_coverage.py
+++ b/tests/test_server_auth_coverage.py
@@ -24,6 +24,7 @@ fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
 from fastapi.routing import APIRoute, APIWebSocketRoute  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
+from starlette.websockets import WebSocketDisconnect  # noqa: E402
 
 from scpi_control.server.app import create_app  # noqa: E402
 from scpi_control.server.auth import EXEMPT_PATHS, TokenStore  # noqa: E402
@@ -161,8 +162,13 @@ def test_every_api_route_rejects_anonymous(enumerated_app):
 
 
 def test_every_ws_route_rejects_anonymous(enumerated_app):
+    # Assert the 1008 policy-violation code specifically. A bare
+    # pytest.raises(Exception) passes vacuously here: an unknown session id
+    # closes with 4404 regardless of auth, so the test would stay green with
+    # the WebSocket guard entirely removed.
     with TestClient(enumerated_app) as test_client:
         for path in _ws_routes(enumerated_app):
-            with pytest.raises(Exception):
+            with pytest.raises(WebSocketDisconnect) as excinfo:
                 with test_client.websocket_connect(_concrete(path)):
                     pass
+            assert excinfo.value.code == 1008, "{0} closed {1}, not a policy violation".format(path, excinfo.value.code)

--- a/tests/test_server_auth_middleware.py
+++ b/tests/test_server_auth_middleware.py
@@ -1,0 +1,89 @@
+"""Auth middleware: HTTP bearer, WS subprotocol, exempt paths, identity."""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scpi_control.server.app import create_app  # noqa: E402
+from scpi_control.server.auth import TokenStore  # noqa: E402
+from scpi_control.server.sessions import SessionManager  # noqa: E402
+
+
+@pytest.fixture()
+def store(tmp_path):
+    return TokenStore(str(tmp_path / "tokens.json"))
+
+
+@pytest.fixture()
+def token(store):
+    return store.mint("tester")
+
+
+@pytest.fixture()
+def client(store, token):
+    manager = SessionManager()
+    app = create_app(manager, token_store=store)
+    with TestClient(app) as test_client:
+        yield test_client
+    manager.close_all()
+
+
+def auth(token):
+    return {"Authorization": "Bearer {0}".format(token)}
+
+
+def test_anonymous_api_request_is_401(client):
+    response = client.get("/api/sessions")
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+def test_valid_token_is_accepted(client, token):
+    response = client.get("/api/sessions", headers=auth(token))
+    assert response.status_code == 200
+
+
+def test_wrong_token_is_401(client):
+    response = client.get("/api/sessions", headers=auth("scpi_bogus"))
+    assert response.status_code == 401
+
+
+def test_malformed_authorization_header_is_401(client, token):
+    assert client.get("/api/sessions", headers={"Authorization": token}).status_code == 401
+    assert client.get("/api/sessions", headers={"Authorization": "Basic abc"}).status_code == 401
+
+
+def test_health_is_exempt(client):
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_query_param_token_is_rejected_on_api(client, token):
+    response = client.get("/api/sessions?token={0}".format(token))
+    assert response.status_code == 401
+
+
+def test_error_body_keeps_the_shared_shape(client):
+    body = client.get("/api/sessions").json()
+    assert body["error"] and body["detail"]
+
+
+def test_identity_is_attached(client, token):
+    response = client.get("/api/whoami", headers=auth(token))
+    assert response.status_code == 200
+    assert response.json()["identity"] == "tester"
+
+
+def test_websocket_without_subprotocol_is_rejected(client):
+    with pytest.raises(Exception):
+        with client.websocket_connect("/api/sessions/nope/stream"):
+            pass
+
+
+def test_websocket_with_a_bad_token_is_rejected(client):
+    with pytest.raises(Exception):
+        with client.websocket_connect("/api/sessions/nope/stream", subprotocols=["scpi-token.scpi_bogus", "scpi"]):
+            pass

--- a/tests/test_server_auth_middleware.py
+++ b/tests/test_server_auth_middleware.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 from starlette.websockets import WebSocketDisconnect  # noqa: E402
 
 from scpi_control.server.app import create_app  # noqa: E402
-from scpi_control.server.auth import TokenStore  # noqa: E402
+from scpi_control.server.auth import TokenStore, _route_path  # noqa: E402
 from scpi_control.server.sessions import SessionManager  # noqa: E402
 
 
@@ -93,3 +93,36 @@ def test_websocket_with_a_bad_token_is_rejected(client):
         with client.websocket_connect("/api/sessions/nope/stream", subprotocols=["scpi-token.scpi_bogus", "scpi"]):
             pass
     assert exc_info.value.code == 1008
+
+
+def test_route_path_matches_starlette_private_helper():
+    """``_route_path`` is a deliberate copy of ``starlette._utils.get_route_path``.
+
+    Importing the private name in production code would turn any upstream
+    rename into an ImportError at boot, and this project pins no Starlette
+    version, so a routine ``pip install -U`` must not be able to brick a
+    gateway that has to come up. The tradeoff is silent drift: if upstream
+    ever changes its root_path stripping, our copy could quietly diverge and
+    the root_path auth-bypass ``_route_path`` exists to close could reopen.
+
+    Import the private helper here, in the test only -- never in
+    scpi_control/server/auth.py -- and skip cleanly (not fail) if it
+    disappears; the point is a red signal on drift, not a broken suite on a
+    routine Starlette upgrade.
+    """
+    starlette_utils = pytest.importorskip("starlette._utils")
+    get_route_path = getattr(starlette_utils, "get_route_path", None)
+    if get_route_path is None:
+        pytest.skip("starlette._utils.get_route_path no longer exists; drift guard is stale")
+
+    scopes = [
+        {"path": "/api/sessions", "root_path": ""},  # no root_path (typical deployment)
+        {"path": "/gw/api/sessions", "root_path": "/gw"},  # normal proxy mount
+        {"path": "/gw/api/sessions", "root_path": "/gw/"},  # trailing slash on root_path
+        {"path": "/gwapi/x", "root_path": "/gw"},  # coincidental prefix, not a path boundary
+        {"path": "/gw", "root_path": "/gw"},  # path == root_path
+        {"path": "/api/sessions", "root_path": "/other"},  # root_path is not a prefix at all
+        {"path": "/gw/gw/api/sessions", "root_path": "/gw"},  # doubled prefix
+    ]
+    for scope in scopes:
+        assert _route_path(scope) == get_route_path(scope), scope

--- a/tests/test_server_auth_middleware.py
+++ b/tests/test_server_auth_middleware.py
@@ -5,6 +5,7 @@ import pytest
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient  # noqa: E402
+from starlette.websockets import WebSocketDisconnect  # noqa: E402
 
 from scpi_control.server.app import create_app  # noqa: E402
 from scpi_control.server.auth import TokenStore  # noqa: E402
@@ -78,12 +79,17 @@ def test_identity_is_attached(client, token):
 
 
 def test_websocket_without_subprotocol_is_rejected(client):
-    with pytest.raises(Exception):
+    # session id "nope" would 4404 regardless of auth (stream.py:71), so the
+    # session must never be reached: assert the specific 1008 the middleware
+    # sends on unauthenticated WS scopes, not just "closed somehow".
+    with pytest.raises(WebSocketDisconnect) as exc_info:
         with client.websocket_connect("/api/sessions/nope/stream"):
             pass
+    assert exc_info.value.code == 1008
 
 
 def test_websocket_with_a_bad_token_is_rejected(client):
-    with pytest.raises(Exception):
+    with pytest.raises(WebSocketDisconnect) as exc_info:
         with client.websocket_connect("/api/sessions/nope/stream", subprotocols=["scpi-token.scpi_bogus", "scpi"]):
             pass
+    assert exc_info.value.code == 1008

--- a/tests/test_server_auth_store.py
+++ b/tests/test_server_auth_store.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from scpi_control.server.__main__ import main
 from scpi_control.server.auth import DuplicateTokenName, TokenStore
 
 
@@ -42,6 +43,36 @@ def test_duplicate_name_rejected(tmp_path):
     store.mint("robin")
     with pytest.raises(DuplicateTokenName):
         store.mint("robin")
+
+
+def test_mint_rejects_empty_name(tmp_path):
+    # An empty name mints a token whose identity is "" -- and require_owner()
+    # in ownership.py treats owner == "" as unowned, so every session that
+    # token creates is writable by any authenticated identity. Reject it here
+    # rather than let that degenerate identity into existence.
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    with pytest.raises(ValueError):
+        store.mint("")
+
+
+def test_mint_rejects_whitespace_only_name(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    with pytest.raises(ValueError):
+        store.mint("   ")
+
+
+def test_mint_still_accepts_a_normal_name(tmp_path):
+    # Guard against over-rejecting: a real name must still mint cleanly.
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    raw = store.mint("robin")
+    assert store.verify(raw) == "robin"
+
+
+def test_cli_token_add_empty_name_exits_nonzero_and_writes_nothing(tmp_path):
+    with pytest.raises(SystemExit) as excinfo:
+        main(["token", "add", "", "--config-dir", str(tmp_path)])
+    assert excinfo.value.code != 0
+    assert TokenStore(str(tmp_path / "tokens.json")).names() == []
 
 
 def test_store_reloads_from_disk(tmp_path):

--- a/tests/test_server_auth_store.py
+++ b/tests/test_server_auth_store.py
@@ -84,6 +84,21 @@ def test_entry_missing_hash_is_rejected(tmp_path):
         TokenStore(str(path))
 
 
+def test_verify_does_not_write_to_disk(tmp_path):
+    # last_used is audit-flavoured metadata, updated in memory only: a
+    # synchronous rewrite of tokens.json (plus chmod) on every authenticated
+    # request would put blocking disk I/O, and an unsynchronized
+    # read-modify-write race, on the hot path of every API call.
+    path = tmp_path / "tokens.json"
+    store = TokenStore(str(path))
+    raw = store.mint("robin")
+    before_mtime = path.stat().st_mtime_ns
+    before_contents = path.read_bytes()
+    assert store.verify(raw) == "robin"
+    assert path.stat().st_mtime_ns == before_mtime
+    assert path.read_bytes() == before_contents
+
+
 def test_names_lists_without_secrets(tmp_path):
     store = TokenStore(str(tmp_path / "tokens.json"))
     store.mint("robin")

--- a/tests/test_server_auth_store.py
+++ b/tests/test_server_auth_store.py
@@ -63,6 +63,27 @@ def test_corrupt_store_is_not_silently_empty(tmp_path):
         TokenStore(str(path))
 
 
+def test_top_level_array_is_rejected(tmp_path):
+    path = tmp_path / "tokens.json"
+    path.write_text(json.dumps([{"name": "robin", "hash": "deadbeef"}]))
+    with pytest.raises(ValueError):
+        TokenStore(str(path))
+
+
+def test_tokens_as_string_is_rejected(tmp_path):
+    path = tmp_path / "tokens.json"
+    path.write_text(json.dumps({"tokens": "robin"}))
+    with pytest.raises(ValueError):
+        TokenStore(str(path))
+
+
+def test_entry_missing_hash_is_rejected(tmp_path):
+    path = tmp_path / "tokens.json"
+    path.write_text(json.dumps({"tokens": [{"name": "robin"}]}))
+    with pytest.raises(ValueError):
+        TokenStore(str(path))
+
+
 def test_names_lists_without_secrets(tmp_path):
     store = TokenStore(str(tmp_path / "tokens.json"))
     store.mint("robin")

--- a/tests/test_server_auth_store.py
+++ b/tests/test_server_auth_store.py
@@ -1,6 +1,7 @@
 """Token store: hashing, verification, revocation, persistence."""
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -105,3 +106,39 @@ def test_names_lists_without_secrets(tmp_path):
     store.mint("bench-laptop")
     assert sorted(store.names()) == ["bench-laptop", "robin"]
     assert json.loads((tmp_path / "tokens.json").read_text())["tokens"][0]["name"]
+
+
+def test_no_argument_defaults_never_touch_the_real_home(tmp_path):
+    """Proves the autouse `_no_real_home` guard in conftest.py actually works.
+
+    TokenStore() and ReferenceWaveform() with no arguments both fall back to
+    a path derived from the real home directory unless something redirects
+    them. This is the regression that already bit this branch once (a CLI
+    test minted a live token into the developer's real ~/.siglent/tokens.json).
+    If this assertion ever starts failing, the guard fixture has broken and
+    every other test in the suite is one missed `--config-dir`/`storage_dir`
+    away from writing outside the sandbox again.
+    """
+    import os
+
+    from scpi_control.reference_waveform import ReferenceWaveform
+    from scpi_control.server.auth import TokenStore as UnpinnedTokenStore
+
+    # os.path.expanduser bypasses pathlib entirely, so it still reports the
+    # genuine home directory even though this test's autouse fixture has
+    # monkeypatched Path.home() for the duration of the test. Note this can't
+    # be asserted as "not an ancestor of the resolved path" -- on this
+    # machine tmp_path itself lives under the real home (...\AppData\Local\
+    # Temp\...), so that relationship would hold true even when the guard is
+    # broken. Compare against the exact real-default path instead.
+    real_home = Path(os.path.expanduser("~"))
+    real_default_token_path = real_home / ".siglent" / "tokens.json"
+    real_default_reference_dir = real_home / ".siglent" / "references"
+
+    store = UnpinnedTokenStore()
+    assert tmp_path in store.path.parents
+    assert store.path != real_default_token_path
+
+    reference = ReferenceWaveform()
+    assert tmp_path in reference.storage_dir.parents
+    assert reference.storage_dir != real_default_reference_dir

--- a/tests/test_server_auth_store.py
+++ b/tests/test_server_auth_store.py
@@ -1,0 +1,71 @@
+"""Token store: hashing, verification, revocation, persistence."""
+
+import json
+
+import pytest
+
+from scpi_control.server.auth import DuplicateTokenName, TokenStore
+
+
+def test_minted_token_verifies_to_its_name(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    raw = store.mint("robin")
+    assert raw.startswith("scpi_")
+    assert store.verify(raw) == "robin"
+
+
+def test_raw_token_is_not_stored(tmp_path):
+    path = tmp_path / "tokens.json"
+    store = TokenStore(str(path))
+    raw = store.mint("robin")
+    assert raw not in path.read_text()
+
+
+def test_unknown_token_does_not_verify(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    store.mint("robin")
+    assert store.verify("scpi_nope") is None
+    assert store.verify("") is None
+
+
+def test_revoked_token_stops_verifying(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    raw = store.mint("robin")
+    assert store.revoke("robin") is True
+    assert store.verify(raw) is None
+    assert store.revoke("robin") is False
+
+
+def test_duplicate_name_rejected(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    store.mint("robin")
+    with pytest.raises(DuplicateTokenName):
+        store.mint("robin")
+
+
+def test_store_reloads_from_disk(tmp_path):
+    path = str(tmp_path / "tokens.json")
+    raw = TokenStore(path).mint("robin")
+    assert TokenStore(path).verify(raw) == "robin"
+
+
+def test_is_empty_tracks_contents(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    assert store.is_empty() is True
+    store.mint("robin")
+    assert store.is_empty() is False
+
+
+def test_corrupt_store_is_not_silently_empty(tmp_path):
+    path = tmp_path / "tokens.json"
+    path.write_text("{ this is not json")
+    with pytest.raises(ValueError):
+        TokenStore(str(path))
+
+
+def test_names_lists_without_secrets(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    store.mint("robin")
+    store.mint("bench-laptop")
+    assert sorted(store.names()) == ["bench-laptop", "robin"]
+    assert json.loads((tmp_path / "tokens.json").read_text())["tokens"][0]["name"]

--- a/tests/test_server_cli_tokens.py
+++ b/tests/test_server_cli_tokens.py
@@ -1,0 +1,61 @@
+"""scpi-web token subcommands and first-run bootstrap."""
+
+import pytest
+
+from scpi_control.server.__main__ import main
+from scpi_control.server.auth import TokenStore
+
+
+def test_token_add_prints_the_raw_token_once(tmp_path, capsys):
+    main(["token", "add", "robin", "--config-dir", str(tmp_path)])
+    printed = capsys.readouterr().out
+    assert "scpi_" in printed
+    raw = [word for word in printed.split() if word.startswith("scpi_")][0]
+    assert TokenStore(str(tmp_path / "tokens.json")).verify(raw) == "robin"
+
+
+def test_token_list_shows_names_not_secrets(tmp_path, capsys):
+    main(["token", "add", "robin", "--config-dir", str(tmp_path)])
+    capsys.readouterr()
+    main(["token", "list", "--config-dir", str(tmp_path)])
+    printed = capsys.readouterr().out
+    assert "robin" in printed
+    assert "scpi_" not in printed
+
+
+def test_token_revoke_removes_it(tmp_path, capsys):
+    main(["token", "add", "robin", "--config-dir", str(tmp_path)])
+    main(["token", "revoke", "robin", "--config-dir", str(tmp_path)])
+    assert TokenStore(str(tmp_path / "tokens.json")).names() == []
+
+
+def test_revoking_unknown_name_exits_nonzero(tmp_path):
+    with pytest.raises(SystemExit) as excinfo:
+        main(["token", "revoke", "ghost", "--config-dir", str(tmp_path)])
+    assert excinfo.value.code != 0
+
+
+def test_duplicate_name_exits_nonzero(tmp_path):
+    main(["token", "add", "robin", "--config-dir", str(tmp_path)])
+    with pytest.raises(SystemExit) as excinfo:
+        main(["token", "add", "robin", "--config-dir", str(tmp_path)])
+    assert excinfo.value.code != 0
+
+
+def test_serve_bootstraps_a_token_and_prints_url(tmp_path, capsys, monkeypatch):
+    started = {}
+    monkeypatch.setattr("uvicorn.run", lambda app, host, port: started.update(host=host, port=port))
+    main(["--config-dir", str(tmp_path), "--port", "9999"])
+    printed = capsys.readouterr().out
+    assert "?token=scpi_" in printed
+    assert started["port"] == 9999
+    assert TokenStore(str(tmp_path / "tokens.json")).names() == ["default"]
+
+
+def test_serve_does_not_remint_when_tokens_exist(tmp_path, capsys, monkeypatch):
+    monkeypatch.setattr("uvicorn.run", lambda app, host, port: None)
+    main(["token", "add", "robin", "--config-dir", str(tmp_path)])
+    capsys.readouterr()
+    main(["--config-dir", str(tmp_path)])
+    assert TokenStore(str(tmp_path / "tokens.json")).names() == ["robin"]
+    assert "?token=" not in capsys.readouterr().out

--- a/tests/test_server_cli_tokens.py
+++ b/tests/test_server_cli_tokens.py
@@ -59,3 +59,79 @@ def test_serve_does_not_remint_when_tokens_exist(tmp_path, capsys, monkeypatch):
     main(["--config-dir", str(tmp_path)])
     assert TokenStore(str(tmp_path / "tokens.json")).names() == ["robin"]
     assert "?token=" not in capsys.readouterr().out
+
+
+# --- --config-dir ordering regressions -------------------------------------
+#
+# argparse's subparsers action reparses the remaining argv into a fresh
+# namespace and then unconditionally copies every attribute from it back
+# over the outer namespace. Each `token <cmd>` subparser also declares its
+# own `--config-dir` (with default=None) so it can accept the flag *after*
+# the subcommand; but when the flag is given *before* the subcommand
+# instead, that per-subparser default of None was clobbering the value the
+# top-level parser had already parsed. `scpi-web --config-dir X token add
+# name` -- a completely natural invocation -- silently fell back to the
+# real ~/.siglent. Every test above places --config-dir *after* the
+# subcommand, which is why none of them caught it. These assert the
+# directory actually used, not merely a zero exit code.
+
+
+def test_config_dir_before_subcommand_is_used_for_token_add(tmp_path, capsys):
+    main(["--config-dir", str(tmp_path), "token", "add", "robin"])
+    printed = capsys.readouterr().out
+    raw = [word for word in printed.split() if word.startswith("scpi_")][0]
+    assert (tmp_path / "tokens.json").exists()
+    assert TokenStore(str(tmp_path / "tokens.json")).verify(raw) == "robin"
+
+
+def test_config_dir_after_subcommand_is_used_for_token_add(tmp_path, capsys):
+    main(["token", "add", "robin", "--config-dir", str(tmp_path)])
+    printed = capsys.readouterr().out
+    raw = [word for word in printed.split() if word.startswith("scpi_")][0]
+    assert (tmp_path / "tokens.json").exists()
+    assert TokenStore(str(tmp_path / "tokens.json")).verify(raw) == "robin"
+
+
+def test_config_dir_before_subcommand_is_used_for_token_list(tmp_path, capsys):
+    main(["--config-dir", str(tmp_path), "token", "add", "robin"])
+    capsys.readouterr()
+    main(["--config-dir", str(tmp_path), "token", "list"])
+    printed = capsys.readouterr().out
+    assert "robin" in printed
+    assert (tmp_path / "tokens.json").exists()
+
+
+def test_config_dir_after_subcommand_is_used_for_token_list(tmp_path, capsys):
+    main(["token", "add", "robin", "--config-dir", str(tmp_path)])
+    capsys.readouterr()
+    main(["token", "list", "--config-dir", str(tmp_path)])
+    printed = capsys.readouterr().out
+    assert "robin" in printed
+    assert (tmp_path / "tokens.json").exists()
+
+
+def test_config_dir_before_subcommand_is_used_for_token_revoke(tmp_path):
+    main(["--config-dir", str(tmp_path), "token", "add", "robin"])
+    # Asserted before the revoke: otherwise a buggy resolution that sends
+    # both the add and the revoke to the same *wrong* directory still leaves
+    # tmp_path's (nonexistent) store trivially empty, masking the bug.
+    assert (tmp_path / "tokens.json").exists()
+    main(["--config-dir", str(tmp_path), "token", "revoke", "robin"])
+    assert TokenStore(str(tmp_path / "tokens.json")).names() == []
+
+
+def test_config_dir_after_subcommand_is_used_for_token_revoke(tmp_path):
+    main(["token", "add", "robin", "--config-dir", str(tmp_path)])
+    main(["token", "revoke", "robin", "--config-dir", str(tmp_path)])
+    assert TokenStore(str(tmp_path / "tokens.json")).names() == []
+
+
+def test_config_dir_before_bare_serve_bootstraps_into_given_directory(tmp_path, capsys, monkeypatch):
+    """The bare serve path has no subcommand, so --config-dir only has one
+    position to appear in -- but it must still land in tmp_path, not the
+    real ~/.siglent, and this asserts that directly rather than trusting a
+    zero exit code."""
+    monkeypatch.setattr("uvicorn.run", lambda app, host, port: None)
+    main(["--config-dir", str(tmp_path), "--port", "9999"])
+    assert (tmp_path / "tokens.json").exists()
+    assert TokenStore(str(tmp_path / "tokens.json")).names() == ["default"]

--- a/tests/test_server_e2e_auth.py
+++ b/tests/test_server_e2e_auth.py
@@ -1,0 +1,56 @@
+"""End-to-end: mint a token, drive a session, hit every boundary."""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient  # noqa: E402
+from starlette.websockets import WebSocketDisconnect  # noqa: E402
+
+from scpi_control.server.app import create_app  # noqa: E402
+from scpi_control.server.auth import TokenStore  # noqa: E402
+from scpi_control.server.sessions import SessionManager  # noqa: E402
+
+
+def test_full_authenticated_lifecycle(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    owner_raw = store.mint("owner")
+    other_raw = store.mint("other")
+    manager = SessionManager()
+    app = create_app(manager, token_store=store, references_dir=str(tmp_path / "refs"))
+
+    with TestClient(app) as client:
+        owner = {"Authorization": "Bearer {0}".format(owner_raw)}
+        other = {"Authorization": "Bearer {0}".format(other_raw)}
+
+        assert client.get("/api/health").status_code == 200
+        assert client.get("/api/sessions").status_code == 401
+
+        created = client.post("/api/sessions", json={"label": "bench", "mock": True}, headers=owner)
+        assert created.status_code == 201
+        sid = created.json()["id"]
+        assert created.json()["owner"] == "owner"
+
+        assert client.get("/api/sessions/{0}/scope/state".format(sid), headers=other).status_code == 200
+        assert client.post("/api/sessions/{0}/scope/command".format(sid), json={"command": "*RST"}, headers=other).status_code == 409
+        assert client.post("/api/sessions/{0}/scope/command".format(sid), json={"command": "*RST"}, headers=owner).status_code == 200
+
+        with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=["scpi-token.{0}".format(owner_raw), "scpi"]) as socket:
+            assert socket.receive_json()["type"]
+
+        # Same, real session id, but no subprotocol offered at all: the
+        # rejection must come from AuthMiddleware, not from stream.py's own
+        # unknown-session 4404 (which a bogus id like "nope" would give either
+        # way and would prove nothing about the auth boundary specifically).
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with client.websocket_connect("/api/sessions/{0}/stream".format(sid)):
+                pass
+        assert exc_info.value.code == 1008
+
+        revoked = store.revoke("other")
+        assert revoked is True
+        assert client.get("/api/sessions", headers=other).status_code == 401
+
+        assert client.delete("/api/sessions/{0}".format(sid), headers=owner).status_code == 204
+
+    manager.close_all()

--- a/tests/test_server_limits.py
+++ b/tests/test_server_limits.py
@@ -1,0 +1,56 @@
+"""Resource limits: session cap and off-loop serialization (audit M47/M48)."""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scpi_control.server.app import create_app  # noqa: E402
+from scpi_control.server.auth import TokenStore  # noqa: E402
+from scpi_control.server.sessions import SessionManager  # noqa: E402
+
+
+@pytest.fixture()
+def capped_client(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    headers = {"Authorization": "Bearer {0}".format(store.mint("tester"))}
+    manager = SessionManager(max_sessions=2)
+    app = create_app(manager, token_store=store)
+    with TestClient(app) as client:
+        client.headers.update(headers)
+        yield client
+    manager.close_all()
+
+
+def test_sessions_beyond_the_cap_are_refused(capped_client):
+    for _ in range(2):
+        assert capped_client.post("/api/sessions", json={"label": "s", "mock": True}).status_code == 201
+    response = capped_client.post("/api/sessions", json={"label": "s", "mock": True})
+    assert response.status_code == 409
+    assert "limit" in response.json()["detail"].lower()
+
+
+def test_closing_a_session_frees_a_slot(capped_client):
+    first = capped_client.post("/api/sessions", json={"label": "s", "mock": True}).json()["id"]
+    capped_client.post("/api/sessions", json={"label": "s", "mock": True})
+    assert capped_client.delete("/api/sessions/{0}".format(first)).status_code == 204
+    assert capped_client.post("/api/sessions", json={"label": "s", "mock": True}).status_code == 201
+
+
+def test_capture_csv_runs_off_the_event_loop(capped_client, monkeypatch):
+    calls = []
+    import scpi_control.server.api.scope as scope_api
+
+    original = scope_api.run_in_threadpool
+
+    async def spy(fn, *args, **kwargs):
+        calls.append(getattr(fn, "__name__", repr(fn)))
+        return await original(fn, *args, **kwargs)
+
+    monkeypatch.setattr(scope_api, "run_in_threadpool", spy)
+    sid = capped_client.post("/api/sessions", json={"label": "s", "mock": True}).json()["id"]
+    assert capped_client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid)).status_code == 200
+    # Name the specific function: asserting the list is merely non-empty would
+    # pass on any unrelated threadpool call in this module.
+    assert "_build_csv" in calls, "CSV serialization still runs on the event loop"

--- a/tests/test_server_limits.py
+++ b/tests/test_server_limits.py
@@ -54,3 +54,46 @@ def test_capture_csv_runs_off_the_event_loop(capped_client, monkeypatch):
     # Name the specific function: asserting the list is merely non-empty would
     # pass on any unrelated threadpool call in this module.
     assert "_build_csv" in calls, "CSV serialization still runs on the event loop"
+
+
+def test_capture_waveform_runs_off_the_event_loop(capped_client, monkeypatch):
+    # The waveform JSON route is the larger payload and the motivating
+    # deep-memory scenario -- it deserves the same off-loop guarantee as CSV.
+    calls = []
+    import scpi_control.server.api.scope as scope_api
+
+    original = scope_api.run_in_threadpool
+
+    async def spy(fn, *args, **kwargs):
+        calls.append(getattr(fn, "__name__", repr(fn)))
+        return await original(fn, *args, **kwargs)
+
+    monkeypatch.setattr(scope_api, "run_in_threadpool", spy)
+    sid = capped_client.post("/api/sessions", json={"label": "s", "mock": True}).json()["id"]
+    assert capped_client.get("/api/sessions/{0}/scope/waveform?channels=1".format(sid)).status_code == 200
+    # Name the specific function: asserting the list is merely non-empty would
+    # pass on any unrelated threadpool call in this module.
+    assert "_build_waveform_response" in calls, "waveform serialization still runs on the event loop"
+
+
+class TestCreateAppMutualExclusionGuard:
+    # LOW 4: create_app() must refuse an explicit manager combined with
+    # allowed_ports/max_sessions (the latter would be silently dropped or
+    # ambiguously composed otherwise). Nothing previously asserted this
+    # guard exists -- it could be deleted silently and all other tests would
+    # stay green.
+    def test_manager_with_allowed_ports_raises(self):
+        manager = SessionManager()
+        try:
+            with pytest.raises(ValueError):
+                create_app(manager, allowed_ports=frozenset({5025}))
+        finally:
+            manager.close_all()
+
+    def test_manager_with_max_sessions_raises(self):
+        manager = SessionManager()
+        try:
+            with pytest.raises(ValueError):
+                create_app(manager, max_sessions=4)
+        finally:
+            manager.close_all()

--- a/tests/test_server_netpolicy.py
+++ b/tests/test_server_netpolicy.py
@@ -1,0 +1,77 @@
+"""Address/port policy for session creation (audit H32)."""
+
+import pytest
+
+from scpi_control.exceptions import InvalidParameterError
+from scpi_control.server.netpolicy import DEFAULT_ALLOWED_PORTS, validate_target
+
+
+def fake_resolver(mapping):
+    def resolve(host):
+        return mapping[host]
+
+    return resolve
+
+
+def test_ordinary_lan_address_is_allowed():
+    validate_target("192.168.1.50", 5025, resolver=fake_resolver({"192.168.1.50": ["192.168.1.50"]}))
+
+
+def test_loopback_is_rejected():
+    with pytest.raises(InvalidParameterError):
+        validate_target("127.0.0.1", 5025, resolver=fake_resolver({"127.0.0.1": ["127.0.0.1"]}))
+
+
+def test_link_local_and_metadata_are_rejected():
+    for address in ("169.254.1.1", "169.254.169.254"):
+        with pytest.raises(InvalidParameterError):
+            validate_target(address, 5025, resolver=fake_resolver({address: [address]}))
+
+
+def test_hostname_resolving_to_loopback_is_rejected():
+    with pytest.raises(InvalidParameterError):
+        validate_target("evil.example.com", 5025, resolver=fake_resolver({"evil.example.com": ["127.0.0.1"]}))
+
+
+def test_any_resolved_address_failing_policy_rejects_the_whole_target():
+    resolver = fake_resolver({"mixed.example.com": ["192.168.1.50", "127.0.0.1"]})
+    with pytest.raises(InvalidParameterError):
+        validate_target("mixed.example.com", 5025, resolver=resolver)
+
+
+def test_port_outside_the_allowlist_is_rejected():
+    resolver = fake_resolver({"192.168.1.50": ["192.168.1.50"]})
+    for port in (22, 6379, 80):
+        with pytest.raises(InvalidParameterError):
+            validate_target("192.168.1.50", port, resolver=resolver)
+
+
+def test_extra_ports_can_be_allowed():
+    resolver = fake_resolver({"192.168.1.50": ["192.168.1.50"]})
+    validate_target("192.168.1.50", 1861, allowed_ports=frozenset({5025, 1861}), resolver=resolver)
+
+
+def test_unresolvable_host_is_rejected():
+    def boom(host):
+        raise OSError("nope")
+
+    with pytest.raises(InvalidParameterError):
+        validate_target("nowhere.invalid", 5025, resolver=boom)
+
+
+def test_default_allowlist_is_just_the_scpi_port():
+    assert DEFAULT_ALLOWED_PORTS == frozenset({5025})
+
+
+def test_ipv4_mapped_ipv6_loopback_is_rejected():
+    # '::ffff:127.0.0.1' is IPv6's textual encoding of the IPv4 loopback address.
+    # ipaddress.IPv6Address.is_loopback does NOT recognize this form (it only
+    # matches '::1'), so a naive check would let this bypass the gate.
+    address = "::ffff:127.0.0.1"
+    with pytest.raises(InvalidParameterError):
+        validate_target("evil.example.com", 5025, resolver=fake_resolver({"evil.example.com": [address]}))
+
+
+def test_ipv6_loopback_is_rejected():
+    with pytest.raises(InvalidParameterError):
+        validate_target("::1", 5025, resolver=fake_resolver({"::1": ["::1"]}))

--- a/tests/test_server_ownership.py
+++ b/tests/test_server_ownership.py
@@ -1,5 +1,7 @@
 """Session ownership: the creating identity owns the session."""
 
+import time
+
 import pytest
 
 fastapi = pytest.importorskip("fastapi")
@@ -75,6 +77,7 @@ _BODIES = {
     ("POST", "/sessions/{session_id}/scope/command"): {"command": "*RST"},
     ("PUT", "/sessions/{session_id}/scope/measurements"): [{"channel": 1, "mtype": "PKPK"}],
     ("POST", "/sessions/{session_id}/scope/references"): {"name": "ref", "channel": 1},
+    ("POST", "/sessions/{session_id}/owner"): {"name": "carol"},
 }
 
 
@@ -100,6 +103,13 @@ def test_write_route_rejects_non_owner(two_users, method, path):
 _QUERY_OVERRIDES = {"/api/discover": {"cidr": "127.0.0.1/32"}}
 _BODY_OVERRIDES = {("POST", "/api/sessions"): {"label": "s2", "mock": True}}
 
+# /claim is deliberately excluded from the scan below: unlike WRITE_ROUTES,
+# a non-owner's request is its normal success path, and it 409s only when the
+# owner is still active -- a different conflict than "not the owner", so it
+# is neither a WRITE_ROUTES entry nor an always-open read route (see the note
+# next to WRITE_ROUTES in ownership.py).
+_OWNERSHIP_CONFLICT_EXEMPT = {("POST", "/api/sessions/{session_id}/claim")}
+
 
 def test_non_write_routes_stay_open_to_non_owner(two_users):
     """Walk the live route table for every (method, path) NOT in WRITE_ROUTES
@@ -116,7 +126,7 @@ def test_non_write_routes_stay_open_to_non_owner(two_users):
         if not isinstance(route, APIRoute) or not route.path.startswith("/api/"):
             continue
         for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
-            if (method, route.path) in write_paths:
+            if (method, route.path) in write_paths or (method, route.path) in _OWNERSHIP_CONFLICT_EXEMPT:
                 continue
             checked += 1
             url = _concrete(route.path, sid)
@@ -128,3 +138,126 @@ def test_non_write_routes_stay_open_to_non_owner(two_users):
     # verified to be checking real routes, not an accidentally-empty set.
     assert checked >= 15
     assert not gated, "non-owner unexpectedly got 409 on: {0}".format(gated)
+
+
+# --- Claim and handoff --------------------------------------------------
+
+
+def test_claim_is_refused_while_owner_is_active(two_users):
+    client, owner, other = two_users
+    sid = _make_session(client, owner)["id"]
+    response = client.post("/api/sessions/{0}/claim".format(sid), headers=other)
+    assert response.status_code == 409
+    assert response.json()["detail"]
+
+
+def test_claim_succeeds_once_owner_is_idle(two_users, monkeypatch):
+    client, owner, other = two_users
+    sid = _make_session(client, owner)["id"]
+    # Make the idle threshold trivially small rather than sleeping.
+    client.app.state.abandon_after = 0.0
+    response = client.post("/api/sessions/{0}/claim".format(sid), headers=other)
+    assert response.status_code == 200
+    # two_users mints identities "alice" (owner) / "bob" (other) -- not the
+    # local variable names "owner"/"other" used for readability here.
+    assert response.json()["owner"] == "bob"
+    assert client.patch("/api/sessions/{0}/scope/timebase".format(sid), json={"timebase": 1e-3}, headers=other).status_code == 200
+
+
+def test_owner_can_hand_off_explicitly(two_users):
+    client, owner, other = two_users
+    sid = _make_session(client, owner)["id"]
+    response = client.post("/api/sessions/{0}/owner".format(sid), json={"name": "other"}, headers=owner)
+    assert response.status_code == 200
+    assert response.json()["owner"] == "other"
+
+
+def test_non_owner_cannot_hand_off(two_users):
+    client, owner, other = two_users
+    sid = _make_session(client, owner)["id"]
+    assert client.post("/api/sessions/{0}/owner".format(sid), json={"name": "other"}, headers=other).status_code == 409
+
+
+def test_claim_succeeds_immediately_on_unowned_session():
+    """An unowned session (owner == "") is claimable regardless of
+    owner_last_active -- require_owner touches that timer even with no owner
+    (see ownership.require_owner), so claim() must not read a fresh
+    owner_last_active on an unowned session as "owner activity".
+    """
+    from scpi_control.server.ownership import claim
+    from scpi_control.server.sessions import SessionManager
+
+    manager = SessionManager()
+    try:
+        session = manager.create("s", mock=True)
+        assert session.owner == ""
+        session.owner_last_active = time.monotonic()  # as fresh as possible
+        assert claim(session, "someone", 300.0) is None
+        assert session.owner == "someone"
+    finally:
+        manager.close_all()
+
+
+def test_owner_activity_on_read_route_resets_idle_claim_window(two_users):
+    """A read route (require_session) must count as owner activity, or a
+    watching-but-not-writing owner (the normal case while a capture runs)
+    looks idle and can be claimed out from under them.
+    """
+    client, owner, other = two_users
+    sid = _make_session(client, owner)["id"]
+    session = client.app.state.manager.get(sid)
+    session.owner_last_active -= 1000.0  # simulate a long-idle owner
+    client.app.state.abandon_after = 1.0
+    assert client.get("/api/sessions/{0}/scope/state".format(sid), headers=owner).status_code == 200
+    response = client.post("/api/sessions/{0}/claim".format(sid), headers=other)
+    assert response.status_code == 409
+
+
+@pytest.fixture()
+def two_users_ws(tmp_path):
+    """Like ``two_users``, but also exposes raw tokens as WS subprotocols.
+
+    WebSocket handshakes ignore default client headers; auth is via
+    subprotocol instead (see tests/test_server_stream_ws.py).
+    """
+    from scpi_control.server.auth import TokenStore
+
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    alice_raw = store.mint("alice")
+    bob_raw = store.mint("bob")
+    alice = {"Authorization": "Bearer {0}".format(alice_raw)}
+    bob = {"Authorization": "Bearer {0}".format(bob_raw)}
+    alice_ws = ["scpi-token.{0}".format(alice_raw), "scpi"]
+    bob_ws = ["scpi-token.{0}".format(bob_raw), "scpi"]
+    manager = SessionManager()
+    app = create_app(manager, token_store=store)
+    with TestClient(app) as client:
+        yield client, alice, bob, alice_ws, bob_ws
+    manager.close_all()
+
+
+def test_claim_is_refused_while_owner_is_watching_stream(two_users_ws):
+    """The owner-watching flag must block a claim even when the idle
+    threshold alone would allow it -- without the flag, this would 200.
+    """
+    client, alice, bob, alice_ws, _bob_ws = two_users_ws
+    sid = _make_session(client, alice)["id"]
+    client.app.state.abandon_after = 0.0  # threshold alone would allow the claim
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=alice_ws) as ws:
+        assert ws.receive_json()["type"] == "state"
+        response = client.post("/api/sessions/{0}/claim".format(sid), headers=bob)
+        assert response.status_code == 409
+        assert response.json()["detail"]
+
+
+def test_claim_succeeds_after_owner_stream_disconnects(two_users_ws):
+    """The owner-watching flag must clear on disconnect, or an owner who
+    closed their stream tab stays permanently unclaimable.
+    """
+    client, alice, bob, alice_ws, _bob_ws = two_users_ws
+    sid = _make_session(client, alice)["id"]
+    client.app.state.abandon_after = 0.0
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=alice_ws) as ws:
+        assert ws.receive_json()["type"] == "state"
+    response = client.post("/api/sessions/{0}/claim".format(sid), headers=bob)
+    assert response.status_code == 200

--- a/tests/test_server_ownership.py
+++ b/tests/test_server_ownership.py
@@ -6,13 +6,13 @@ import pytest
 
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
-from fastapi.routing import APIRoute  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 from scpi_control.server.app import create_app  # noqa: E402
 from scpi_control.server.auth import TokenStore  # noqa: E402
 from scpi_control.server.ownership import WRITE_ROUTES  # noqa: E402
 from scpi_control.server.sessions import SessionManager  # noqa: E402
+from tests.route_introspection import iter_http_routes  # noqa: E402
 
 
 @pytest.fixture()
@@ -122,17 +122,16 @@ def test_non_write_routes_stay_open_to_non_owner(two_users):
 
     checked = 0
     gated = []
-    for route in client.app.routes:
-        if not isinstance(route, APIRoute) or not route.path.startswith("/api/"):
+    # iter_http_routes is version-robust: Starlette 1.x nests include_router
+    # routes so a flat app.routes walk finds almost none (see route_introspection).
+    for method, path in iter_http_routes(client.app):
+        if (method, path) in write_paths or (method, path) in _OWNERSHIP_CONFLICT_EXEMPT:
             continue
-        for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
-            if (method, route.path) in write_paths or (method, route.path) in _OWNERSHIP_CONFLICT_EXEMPT:
-                continue
-            checked += 1
-            url = _concrete(route.path, sid)
-            response = client.request(method, url, headers=bob, json=_BODY_OVERRIDES.get((method, url)), params=_QUERY_OVERRIDES.get(url))
-            if response.status_code == 409:
-                gated.append("{0} {1} -> {2}".format(method, route.path, response.status_code))
+        checked += 1
+        url = _concrete(path, sid)
+        response = client.request(method, url, headers=bob, json=_BODY_OVERRIDES.get((method, url)), params=_QUERY_OVERRIDES.get(url))
+        if response.status_code == 409:
+            gated.append("{0} {1} -> {2}".format(method, path, response.status_code))
 
     # A guard on an empty table would pass vacuously; pin a floor so this is
     # verified to be checking real routes, not an accidentally-empty set.

--- a/tests/test_server_ownership.py
+++ b/tests/test_server_ownership.py
@@ -178,7 +178,7 @@ def test_owner_can_hand_off_explicitly(two_users):
 def test_non_owner_cannot_hand_off(two_users):
     client, owner, other = two_users
     sid = _make_session(client, owner)["id"]
-    assert client.post("/api/sessions/{0}/owner".format(sid), json={"name": "other"}, headers=other).status_code == 409
+    assert client.post("/api/sessions/{0}/owner".format(sid), json={"name": "bob"}, headers=other).status_code == 409
 
 
 def test_hand_off_to_unknown_identity_is_rejected(two_users):
@@ -222,6 +222,35 @@ def test_claim_succeeds_immediately_on_unowned_session():
         assert session.owner == "someone"
     finally:
         manager.close_all()
+
+
+def test_non_owner_read_does_not_refresh_owner_last_active(two_users):
+    """require_session only touches owner_last_active for the owner's own
+    reads. A non-owner polling a read route (e.g. GET /scope/state during a
+    capture) must never extend the owner's claim-protection window, or an
+    authenticated non-owner could keep a session permanently unclaimable
+    just by reading it -- defeating the claim mechanism entirely.
+    """
+    client, owner, other = two_users
+    sid = _make_session(client, owner)["id"]
+    session = client.app.state.manager.get(sid)
+    session.owner_last_active -= 1000.0
+    stale = session.owner_last_active
+    assert client.get("/api/sessions/{0}/scope/state".format(sid), headers=other).status_code == 200
+    assert session.owner_last_active == stale
+
+
+def test_owner_read_refreshes_owner_last_active(two_users):
+    """Paired with the non-owner test above: the owner's own read must still
+    count as activity, or a watching-but-not-writing owner looks idle.
+    """
+    client, owner, _other = two_users
+    sid = _make_session(client, owner)["id"]
+    session = client.app.state.manager.get(sid)
+    session.owner_last_active -= 1000.0
+    stale = session.owner_last_active
+    assert client.get("/api/sessions/{0}/scope/state".format(sid), headers=owner).status_code == 200
+    assert session.owner_last_active > stale
 
 
 def test_owner_activity_on_read_route_resets_idle_claim_window(two_users):
@@ -344,7 +373,15 @@ def test_watcher_released_on_abnormal_disconnect(two_users_ws, monkeypatch):
     sid = _make_session(client, alice)["id"]
     client.app.state.abandon_after = 0.0
 
+    raised = []
+
     def _boom(_scope):
+        # Recording the call is inside the same body as the raise, so if a
+        # future edit swaps this helper for a non-raising stand-in (e.g.
+        # ``return {}``), the whole body -- including this append -- goes
+        # with it, and the assertion below catches the decay into a
+        # duplicate of the clean-close test.
+        raised.append(True)
         raise RuntimeError("simulated mid-stream failure")
 
     monkeypatch.setattr(stream_module, "read_state", _boom)
@@ -354,7 +391,67 @@ def test_watcher_released_on_abnormal_disconnect(two_users_ws, monkeypatch):
     with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=alice_ws):
         pass
 
+    assert raised, "abnormal path never exercised -- read_state must raise, not return"
+
     # If the watcher slot leaked, alice would still read as "watching" and
     # this claim (owner idle, threshold 0) would be wrongly refused.
     response = client.post("/api/sessions/{0}/claim".format(sid), headers=bob)
     assert response.status_code == 200
+
+
+# --- A Counter, not a set: same identity, two tabs --------------------------
+
+
+def test_owner_watching_survives_one_of_two_tabs_closing(two_users_ws):
+    """The owner opens the live stream in two tabs. Closing one tab must not
+    clear the watching flag while the other is still open -- this is the
+    exact scenario a Counter was chosen over a set to handle: a plain
+    membership set would drop the identity on the first close even though a
+    second tab from the same identity is still live.
+    """
+    client, alice, bob, alice_ws, _bob_ws = two_users_ws
+    sid = _make_session(client, alice)["id"]
+    client.app.state.abandon_after = 0.0  # idle threshold alone would allow the claim
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=alice_ws) as ws1:
+        assert ws1.receive_json()["type"] == "state"
+        with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=alice_ws) as ws2:
+            assert ws2.receive_json()["type"] == "state"
+        # ws2 (second tab) just closed; ws1 (same identity) is still open,
+        # so the owner must still read as watching.
+        response = client.post("/api/sessions/{0}/claim".format(sid), headers=bob)
+        assert response.status_code == 409
+    # Both tabs are now closed -- no longer watching.
+    response = client.post("/api/sessions/{0}/claim".format(sid), headers=bob)
+    assert response.status_code == 200
+
+
+def test_release_owner_watching_callback_is_idempotent():
+    """The unmark callback returned by mark_owner_watching must decrement at
+    most once even if invoked twice (e.g. a duplicate release on some
+    disconnect path). Without the idempotency latch, a second call on one
+    tab's callback would wrongly clear a still-live second tab from the same
+    identity, and the per-identity count would be able to go negative.
+    """
+    from scpi_control.server.sessions import SessionManager
+
+    manager = SessionManager()
+    try:
+        session = manager.create("s", mock=True)
+        session.owner = "alice"
+        unmark_tab1 = session.mark_owner_watching("alice")
+        unmark_tab2 = session.mark_owner_watching("alice")  # a second open tab
+        assert session._watchers["alice"] == 2
+
+        unmark_tab1()
+        assert session._watchers["alice"] == 1
+        unmark_tab1()  # duplicate release of the same tab's callback
+        assert session._watchers["alice"] >= 0
+        assert session._watchers["alice"] == 1  # unchanged: idempotent, tab2 still live
+        # tab2 never released its slot -- the owner must still read as watching.
+        assert session.owner_watching() is True
+
+        unmark_tab2()
+        assert session._watchers["alice"] >= 0
+        assert session.owner_watching() is False
+    finally:
+        manager.close_all()

--- a/tests/test_server_ownership.py
+++ b/tests/test_server_ownership.py
@@ -1,0 +1,41 @@
+"""Session ownership: the creating identity owns the session."""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scpi_control.server.app import create_app  # noqa: E402
+from scpi_control.server.auth import TokenStore  # noqa: E402
+from scpi_control.server.sessions import SessionManager  # noqa: E402
+
+
+@pytest.fixture()
+def two_users(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    owner = {"Authorization": "Bearer {0}".format(store.mint("owner"))}
+    other = {"Authorization": "Bearer {0}".format(store.mint("other"))}
+    manager = SessionManager()
+    app = create_app(manager, token_store=store)
+    with TestClient(app) as client:
+        yield client, owner, other
+    manager.close_all()
+
+
+def _make_session(client, headers):
+    response = client.post("/api/sessions", json={"label": "s", "mock": True}, headers=headers)
+    assert response.status_code == 201
+    return response.json()
+
+
+def test_creator_becomes_owner(two_users):
+    client, owner, _ = two_users
+    assert _make_session(client, owner)["owner"] == "owner"
+
+
+def test_owner_is_visible_in_listing(two_users):
+    client, owner, other = two_users
+    _make_session(client, owner)
+    listed = client.get("/api/sessions", headers=other).json()
+    assert listed[0]["owner"] == "owner"

--- a/tests/test_server_ownership.py
+++ b/tests/test_server_ownership.py
@@ -4,22 +4,24 @@ import pytest
 
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")
+from fastapi.routing import APIRoute  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 from scpi_control.server.app import create_app  # noqa: E402
 from scpi_control.server.auth import TokenStore  # noqa: E402
+from scpi_control.server.ownership import WRITE_ROUTES  # noqa: E402
 from scpi_control.server.sessions import SessionManager  # noqa: E402
 
 
 @pytest.fixture()
 def two_users(tmp_path):
     store = TokenStore(str(tmp_path / "tokens.json"))
-    owner = {"Authorization": "Bearer {0}".format(store.mint("owner"))}
-    other = {"Authorization": "Bearer {0}".format(store.mint("other"))}
+    alice = {"Authorization": "Bearer {0}".format(store.mint("alice"))}
+    bob = {"Authorization": "Bearer {0}".format(store.mint("bob"))}
     manager = SessionManager()
     app = create_app(manager, token_store=store)
     with TestClient(app) as client:
-        yield client, owner, other
+        yield client, alice, bob
     manager.close_all()
 
 
@@ -30,45 +32,99 @@ def _make_session(client, headers):
 
 
 def test_creator_becomes_owner(two_users):
-    client, owner, _ = two_users
-    assert _make_session(client, owner)["owner"] == "owner"
+    client, alice, _bob = two_users
+    assert _make_session(client, alice)["owner"] == "alice"
 
 
 def test_owner_is_visible_in_listing(two_users):
-    client, owner, other = two_users
-    _make_session(client, owner)
-    listed = client.get("/api/sessions", headers=other).json()
-    assert listed[0]["owner"] == "owner"
-
-
-def test_non_owner_cannot_patch_timebase(two_users):
-    client, owner, other = two_users
-    sid = _make_session(client, owner)["id"]
-    response = client.patch("/api/sessions/{0}/scope/timebase".format(sid), json={"timebase": 1e-3}, headers=other)
-    assert response.status_code == 409
-    assert "owner" in response.json()["detail"]
-
-
-def test_non_owner_cannot_send_raw_commands(two_users):
-    client, owner, other = two_users
-    sid = _make_session(client, owner)["id"]
-    response = client.post("/api/sessions/{0}/scope/command".format(sid), json={"command": "*RST"}, headers=other)
-    assert response.status_code == 409
-
-
-def test_non_owner_cannot_delete_the_session(two_users):
-    client, owner, other = two_users
-    sid = _make_session(client, owner)["id"]
-    assert client.delete("/api/sessions/{0}".format(sid), headers=other).status_code == 409
+    client, alice, bob = two_users
+    _make_session(client, alice)
+    listed = client.get("/api/sessions", headers=bob).json()
+    assert listed[0]["owner"] == "alice"
 
 
 def test_non_owner_can_read_state(two_users):
-    client, owner, other = two_users
-    sid = _make_session(client, owner)["id"]
-    assert client.get("/api/sessions/{0}/scope/state".format(sid), headers=other).status_code == 200
+    client, alice, bob = two_users
+    sid = _make_session(client, alice)["id"]
+    assert client.get("/api/sessions/{0}/scope/state".format(sid), headers=bob).status_code == 200
 
 
 def test_owner_can_still_write(two_users):
-    client, owner, _ = two_users
-    sid = _make_session(client, owner)["id"]
-    assert client.patch("/api/sessions/{0}/scope/timebase".format(sid), json={"timebase": 1e-3}, headers=owner).status_code == 200
+    client, alice, _bob = two_users
+    sid = _make_session(client, alice)["id"]
+    assert client.patch("/api/sessions/{0}/scope/timebase".format(sid), json={"timebase": 1e-3}, headers=alice).status_code == 200
+
+
+# --- Bidirectional enumeration over WRITE_ROUTES -----------------------------
+#
+# WRITE_ROUTES is (method, router-relative path) pairs. Path placeholders are
+# filled with values valid enough to clear routing/body validation and reach
+# the ownership check, which every gated handler performs before anything
+# else -- so the specific placeholder/body values otherwise don't matter.
+
+_PLACEHOLDERS = {"channel": "1", "n": "1", "name": "ref", "op": "run"}
+
+# Bodies for routes whose pydantic model has required fields; FastAPI validates
+# the body before the handler runs, so a missing required field (or a missing
+# body entirely -- the body *parameter* has no default even when every field
+# on its model does) would 422 before ever reaching require_owner. Routes with
+# no body parameter tolerate the "{}" default fine, so only the routes that
+# need specific required fields get an explicit entry here.
+_BODIES = {
+    ("PATCH", "/sessions/{session_id}/scope/timebase"): {"timebase": 1e-3},
+    ("POST", "/sessions/{session_id}/scope/command"): {"command": "*RST"},
+    ("PUT", "/sessions/{session_id}/scope/measurements"): [{"channel": 1, "mtype": "PKPK"}],
+    ("POST", "/sessions/{session_id}/scope/references"): {"name": "ref", "channel": 1},
+}
+
+
+def _concrete(path, session_id):
+    path = path.replace("{session_id}", session_id)
+    for key, value in _PLACEHOLDERS.items():
+        path = path.replace("{" + key + "}", value)
+    return path
+
+
+@pytest.mark.parametrize("method,path", sorted(WRITE_ROUTES))
+def test_write_route_rejects_non_owner(two_users, method, path):
+    client, alice, bob = two_users
+    sid = _make_session(client, alice)["id"]
+    url = "/api" + _concrete(path, sid)
+    response = client.request(method, url, headers=bob, json=_BODIES.get((method, path), {}))
+    assert response.status_code == 409
+    assert "alice" in response.json()["detail"]
+
+
+# Query params for non-write routes that would otherwise do something
+# expensive or unbounded by default (a real LAN scan for /discover).
+_QUERY_OVERRIDES = {"/api/discover": {"cidr": "127.0.0.1/32"}}
+_BODY_OVERRIDES = {("POST", "/api/sessions"): {"label": "s2", "mock": True}}
+
+
+def test_non_write_routes_stay_open_to_non_owner(two_users):
+    """Walk the live route table for every (method, path) NOT in WRITE_ROUTES
+    and assert a non-owner never gets 409 -- i.e. the read/write split in
+    WRITE_ROUTES is exhaustive in both directions, not just for the write side.
+    """
+    client, alice, bob = two_users
+    sid = _make_session(client, alice)["id"]
+    write_paths = {(method, "/api" + path) for method, path in WRITE_ROUTES}
+
+    checked = 0
+    gated = []
+    for route in client.app.routes:
+        if not isinstance(route, APIRoute) or not route.path.startswith("/api/"):
+            continue
+        for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
+            if (method, route.path) in write_paths:
+                continue
+            checked += 1
+            url = _concrete(route.path, sid)
+            response = client.request(method, url, headers=bob, json=_BODY_OVERRIDES.get((method, url)), params=_QUERY_OVERRIDES.get(url))
+            if response.status_code == 409:
+                gated.append("{0} {1} -> {2}".format(method, route.path, response.status_code))
+
+    # A guard on an empty table would pass vacuously; pin a floor so this is
+    # verified to be checking real routes, not an accidentally-empty set.
+    assert checked >= 15
+    assert not gated, "non-owner unexpectedly got 409 on: {0}".format(gated)

--- a/tests/test_server_ownership.py
+++ b/tests/test_server_ownership.py
@@ -151,7 +151,7 @@ def test_claim_is_refused_while_owner_is_active(two_users):
     assert response.json()["detail"]
 
 
-def test_claim_succeeds_once_owner_is_idle(two_users, monkeypatch):
+def test_claim_succeeds_once_owner_is_idle(two_users):
     client, owner, other = two_users
     sid = _make_session(client, owner)["id"]
     # Make the idle threshold trivially small rather than sleeping.
@@ -167,15 +167,41 @@ def test_claim_succeeds_once_owner_is_idle(two_users, monkeypatch):
 def test_owner_can_hand_off_explicitly(two_users):
     client, owner, other = two_users
     sid = _make_session(client, owner)["id"]
-    response = client.post("/api/sessions/{0}/owner".format(sid), json={"name": "other"}, headers=owner)
+    response = client.post("/api/sessions/{0}/owner".format(sid), json={"name": "bob"}, headers=owner)
     assert response.status_code == 200
-    assert response.json()["owner"] == "other"
+    assert response.json()["owner"] == "bob"
+    # Functional check, not just the echoed field: bob can now write, alice cannot.
+    assert client.patch("/api/sessions/{0}/scope/timebase".format(sid), json={"timebase": 1e-3}, headers=other).status_code == 200
+    assert client.patch("/api/sessions/{0}/scope/timebase".format(sid), json={"timebase": 1e-3}, headers=owner).status_code == 409
 
 
 def test_non_owner_cannot_hand_off(two_users):
     client, owner, other = two_users
     sid = _make_session(client, owner)["id"]
     assert client.post("/api/sessions/{0}/owner".format(sid), json={"name": "other"}, headers=other).status_code == 409
+
+
+def test_hand_off_to_unknown_identity_is_rejected(two_users):
+    """name must be a real token-store identity; a typo must not silently
+    write-lock the session for everyone until abandon_after elapses.
+    """
+    client, owner, _other = two_users
+    sid = _make_session(client, owner)["id"]
+    response = client.post("/api/sessions/{0}/owner".format(sid), json={"name": "carol"}, headers=owner)
+    assert response.status_code == 400
+    assert client.get("/api/sessions/{0}".format(sid), headers=owner).json()["owner"] == "alice"
+
+
+def test_hand_off_to_empty_name_releases_ownership(two_users):
+    """An empty name is the documented explicit release: it unowns the
+    session so it becomes immediately claimable, with no named recipient.
+    """
+    client, owner, other = two_users
+    sid = _make_session(client, owner)["id"]
+    response = client.post("/api/sessions/{0}/owner".format(sid), json={"name": ""}, headers=owner)
+    assert response.status_code == 200
+    assert response.json()["owner"] == ""
+    assert client.post("/api/sessions/{0}/claim".format(sid), headers=other).status_code == 200
 
 
 def test_claim_succeeds_immediately_on_unowned_session():
@@ -192,7 +218,7 @@ def test_claim_succeeds_immediately_on_unowned_session():
         session = manager.create("s", mock=True)
         assert session.owner == ""
         session.owner_last_active = time.monotonic()  # as fresh as possible
-        assert claim(session, "someone", 300.0) is None
+        assert claim(session, "someone", 300.0) is True
         assert session.owner == "someone"
     finally:
         manager.close_all()
@@ -259,5 +285,76 @@ def test_claim_succeeds_after_owner_stream_disconnects(two_users_ws):
     client.app.state.abandon_after = 0.0
     with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=alice_ws) as ws:
         assert ws.receive_json()["type"] == "state"
+    response = client.post("/api/sessions/{0}/claim".format(sid), headers=bob)
+    assert response.status_code == 200
+
+
+# --- Owner-watching must track identity, not a connect-time snapshot -------
+
+
+def test_claim_while_watching_protects_new_owner_from_reclaim(two_users_ws):
+    """Bob opens the stream while alice still owns the session, then claims
+    it -- the natural "Claim" button flow in a UI that already has the
+    stream open. A boolean snapshot computed at connect time (before bob
+    was owner) never flips true for him, so alice could reclaim mid-capture.
+    Watching must be evaluated against the *current* owner at claim time.
+    """
+    client, alice, bob, _alice_ws, bob_ws = two_users_ws
+    sid = _make_session(client, alice)["id"]
+    client.app.state.abandon_after = 0.0  # idle threshold alone would allow either claim
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=bob_ws) as ws:
+        assert ws.receive_json()["type"] == "state"
+        response = client.post("/api/sessions/{0}/claim".format(sid), headers=bob)
+        assert response.status_code == 200
+        assert response.json()["owner"] == "bob"
+        # bob is now owner and already watching -- alice must not be able to
+        # reclaim out from under him.
+        response = client.post("/api/sessions/{0}/claim".format(sid), headers=alice)
+        assert response.status_code == 409
+
+
+def test_handoff_with_stale_watcher_stays_claimable(two_users_ws):
+    """Alice watches, then explicitly hands off to bob. Alice's browser tab
+    stays open (a stale watcher). owner_watching() must key off bob -- the
+    current owner -- not alice's lingering socket, or the session becomes
+    permanently unclaimable despite bob (the actual owner) never watching.
+    """
+    client, alice, bob, alice_ws, _bob_ws = two_users_ws
+    sid = _make_session(client, alice)["id"]
+    client.app.state.abandon_after = 0.0
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=alice_ws) as ws:
+        assert ws.receive_json()["type"] == "state"
+        response = client.post("/api/sessions/{0}/owner".format(sid), json={"name": "bob"}, headers=alice)
+        assert response.status_code == 200
+        assert response.json()["owner"] == "bob"
+        # bob (the current owner) isn't watching -- alice's stale socket must
+        # not block a claim.
+        response = client.post("/api/sessions/{0}/claim".format(sid), headers=alice)
+        assert response.status_code == 200
+
+
+def test_watcher_released_on_abnormal_disconnect(two_users_ws, monkeypatch):
+    """The finally block in the stream route must release the watcher slot
+    even when the connection tears down abnormally -- the handler raises
+    before ever sending a frame -- rather than via a clean client close.
+    """
+    from scpi_control.server.api import stream as stream_module
+
+    client, alice, bob, alice_ws, _bob_ws = two_users_ws
+    sid = _make_session(client, alice)["id"]
+    client.app.state.abandon_after = 0.0
+
+    def _boom(_scope):
+        raise RuntimeError("simulated mid-stream failure")
+
+    monkeypatch.setattr(stream_module, "read_state", _boom)
+    # No receive_json here: the handler crashes before it ever sends a
+    # frame, so waiting on one would hang forever waiting for a message
+    # that never arrives.
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=alice_ws):
+        pass
+
+    # If the watcher slot leaked, alice would still read as "watching" and
+    # this claim (owner idle, threshold 0) would be wrongly refused.
     response = client.post("/api/sessions/{0}/claim".format(sid), headers=bob)
     assert response.status_code == 200

--- a/tests/test_server_ownership.py
+++ b/tests/test_server_ownership.py
@@ -39,3 +39,36 @@ def test_owner_is_visible_in_listing(two_users):
     _make_session(client, owner)
     listed = client.get("/api/sessions", headers=other).json()
     assert listed[0]["owner"] == "owner"
+
+
+def test_non_owner_cannot_patch_timebase(two_users):
+    client, owner, other = two_users
+    sid = _make_session(client, owner)["id"]
+    response = client.patch("/api/sessions/{0}/scope/timebase".format(sid), json={"timebase": 1e-3}, headers=other)
+    assert response.status_code == 409
+    assert "owner" in response.json()["detail"]
+
+
+def test_non_owner_cannot_send_raw_commands(two_users):
+    client, owner, other = two_users
+    sid = _make_session(client, owner)["id"]
+    response = client.post("/api/sessions/{0}/scope/command".format(sid), json={"command": "*RST"}, headers=other)
+    assert response.status_code == 409
+
+
+def test_non_owner_cannot_delete_the_session(two_users):
+    client, owner, other = two_users
+    sid = _make_session(client, owner)["id"]
+    assert client.delete("/api/sessions/{0}".format(sid), headers=other).status_code == 409
+
+
+def test_non_owner_can_read_state(two_users):
+    client, owner, other = two_users
+    sid = _make_session(client, owner)["id"]
+    assert client.get("/api/sessions/{0}/scope/state".format(sid), headers=other).status_code == 200
+
+
+def test_owner_can_still_write(two_users):
+    client, owner, _ = two_users
+    sid = _make_session(client, owner)["id"]
+    assert client.patch("/api/sessions/{0}/scope/timebase".format(sid), json={"timebase": 1e-3}, headers=owner).status_code == 200

--- a/tests/test_server_sessions.py
+++ b/tests/test_server_sessions.py
@@ -225,6 +225,39 @@ def test_open_connect_timeout_raises_connection_error(monkeypatch):
 from scpi_control.server.sessions import SessionManager
 
 
+class _StallingLock:
+    """Wraps a real threading.Lock; on its Nth release, blocks the releasing
+    thread until a gate opens.
+
+    Lets a test stall SessionManager.create() at an exact lock hand-off
+    (rather than relying on sleep-based timing) so a gap between two
+    separate ``with self._lock:`` blocks can be reproduced deterministically.
+    The real lock is released before the stall, so other threads are free to
+    acquire it while the stalled thread is paused -- exactly the residual
+    over-admission window under test.
+    """
+
+    def __init__(self, stall_after_release, on_stall, proceed_gate):
+        self._real = threading.Lock()
+        self._release_count = 0
+        self._stall_after_release = stall_after_release
+        self._on_stall = on_stall
+        self._proceed_gate = proceed_gate
+        self._stalled_once = False
+
+    def __enter__(self):
+        self._real.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._real.release()
+        self._release_count += 1
+        if self._release_count == self._stall_after_release and not self._stalled_once:
+            self._stalled_once = True
+            self._on_stall()
+            self._proceed_gate.wait(timeout=10.0)
+
+
 class TestSessionManager:
     def _manager_with_one(self):
         manager = SessionManager()
@@ -322,7 +355,76 @@ class TestSessionManager:
                 done, not_done = concurrent.futures.wait(futures, timeout=10.0)
                 assert not not_done, "a worker did not finish after the gate opened"
 
-            assert len(outcomes) <= cap, "successful creations ({0}) exceeded the cap ({1})".format(len(outcomes), cap)
+            assert len(outcomes) == cap, "successful creations ({0}) did not match the cap ({1})".format(len(outcomes), cap)
         finally:
             gate.set()
             manager.close_all()
+
+    def test_no_over_admission_window_between_pending_release_and_registration(self):
+        # MEDIUM 1: the reservation used to be decremented (under the lock),
+        # the lock released, and only then re-acquired to register the
+        # session -- a gap during which the slot is counted by neither
+        # self._sessions nor self._pending. Stall a creator exactly there
+        # (after the pending-decrement release, before the register
+        # acquire) via a lock wrapper that blocks on its Nth release, and
+        # prove a concurrent create() is wrongly admitted while cap=1.
+        manager = SessionManager(max_sessions=1)
+        stalled = threading.Event()
+        proceed = threading.Event()
+        # Release #1 is the initial check+reserve block; release #2 is the
+        # pending-decrement block that runs right after InstrumentSession.open
+        # returns. Stalling there -- before the registration block's own
+        # acquire -- lands the stalled thread exactly in the window under test.
+        manager._lock = _StallingLock(stall_after_release=2, on_stall=stalled.set, proceed_gate=proceed)
+
+        result = {}
+
+        def first():
+            conn = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+            result["first"] = manager.create("first", mock=True, _connection=conn)
+
+        t = threading.Thread(target=first)
+        t.start()
+        try:
+            assert stalled.wait(timeout=5.0), "first creator never reached the post-decrement window"
+            conn2 = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+            with pytest.raises(SessionError):
+                manager.create("second", mock=True, _connection=conn2)
+        finally:
+            proceed.set()
+            t.join(timeout=5.0)
+            manager.close_all()
+
+    def test_open_never_called_when_cap_already_full(self, monkeypatch):
+        # MEDIUM 2: the cap check must run BEFORE InstrumentSession.open --
+        # open() spawns a worker thread and blocks on a 30s connect, so
+        # checking afterwards would let a full-cap caller pay that cost (and
+        # tie up a threadpool worker) anyway. Only ordering in create()
+        # enforces this; spy on open() to prove it is never reached once the
+        # cap is full, rather than just checking the resulting session count.
+        manager = SessionManager(max_sessions=1)
+        conn = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+        manager.create("first", mock=True, _connection=conn)
+
+        calls = []
+        original_open = InstrumentSession.open
+
+        def spy(*args, **kwargs):
+            calls.append((args, kwargs))
+            return original_open(*args, **kwargs)
+
+        monkeypatch.setattr(InstrumentSession, "open", spy)
+        try:
+            conn2 = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+            with pytest.raises(SessionError):
+                manager.create("second", mock=True, _connection=conn2)
+            assert calls == [], "InstrumentSession.open must not be called once the cap is already full"
+        finally:
+            manager.close_all()
+
+    @pytest.mark.parametrize("max_sessions", [0, -1])
+    def test_rejects_non_positive_max_sessions(self, max_sessions):
+        # LOW 5: max_sessions < 1 yields a gateway that refuses every create()
+        # with a 409 -- a footgun that looks like a crash. Reject it eagerly.
+        with pytest.raises(ValueError):
+            SessionManager(max_sessions=max_sessions)

--- a/tests/test_server_sessions.py
+++ b/tests/test_server_sessions.py
@@ -102,6 +102,26 @@ def test_open_failure_raises_and_leaves_no_thread():
     assert threading.active_count() <= before + 1
 
 
+class GatedConnection(MockConnection):
+    """A mock whose connect() blocks on a shared gate until the test releases it.
+
+    Lets a test hold every concurrent InstrumentSession.open() call inside
+    connect() at once, so a check-then-register race in SessionManager.create
+    can be reproduced deterministically (every worker guaranteed to be
+    "inside the window") instead of relying on unlucky thread scheduling.
+    """
+
+    def __init__(self, *args, gate, on_enter, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._gate = gate
+        self._on_enter = on_enter
+
+    def connect(self):
+        self._on_enter()
+        self._gate.wait(timeout=10.0)
+        super().connect()
+
+
 class KillableMock(MockConnection):
     """A mock whose connection can be pulled mid-session, as if the wire dropped."""
 
@@ -233,3 +253,76 @@ class TestSessionManager:
         with pytest.raises(SiglentError):
             manager.create("bad", mock=True, _connection=conn)
         assert manager.list() == []
+
+    def test_failed_create_releases_its_reservation(self):
+        # A failed attempt must not leak its cap reservation -- otherwise the
+        # cap permanently shrinks by one per failure until restart.
+        manager = SessionManager(max_sessions=2)
+        for _ in range(3):
+            conn = FailingMock("mock", idn=LEGACY_IDN)
+            with pytest.raises(SiglentError):
+                manager.create("bad", mock=True, _connection=conn)
+        try:
+            for i in range(2):
+                conn = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+                assert manager.create("ok-{0}".format(i), mock=True, _connection=conn) is not None
+            with pytest.raises(SessionError):
+                manager.create("over", mock=True, _connection=MockConnection("mock", idn=LEGACY_IDN))
+        finally:
+            manager.close_all()
+
+    def test_concurrent_create_never_exceeds_the_cap(self):
+        # TOCTOU regression: SessionManager.create used to check the cap and
+        # release the lock before InstrumentSession.open() ran, so N
+        # concurrent callers could all observe room and all proceed. Force
+        # the race deterministically by gating every connect() behind a
+        # threading.Event: no create() call can register a session until the
+        # gate opens, so every worker is guaranteed to have made (or been
+        # denied) its cap check before any of them can succeed -- regardless
+        # of scheduling order.
+        cap = 3
+        workers = 9
+        manager = SessionManager(max_sessions=cap)
+        gate = threading.Event()
+        state_lock = threading.Lock()
+        counters = {"entered": 0, "finished": 0}
+
+        def on_enter():
+            with state_lock:
+                counters["entered"] += 1
+
+        def make_conn():
+            return GatedConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3, gate=gate, on_enter=on_enter)
+
+        outcomes = []
+        outcomes_lock = threading.Lock()
+
+        def worker(i):
+            try:
+                session = manager.create("bench-{0}".format(i), mock=True, _connection=make_conn())
+                with outcomes_lock:
+                    outcomes.append(session)
+            except SessionError:
+                pass
+            finally:
+                with state_lock:
+                    counters["finished"] += 1
+
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+                futures = [pool.submit(worker, i) for i in range(workers)]
+                # Quiescence point: every worker is either blocked in connect()
+                # (having already passed the cap check) or has already been
+                # rejected by it. No thread can register while the gate is
+                # shut, so this condition is reachable regardless of whether
+                # the fix is present -- it never depends on beating a race.
+                reached = _wait_for(lambda: counters["entered"] + counters["finished"] >= workers, timeout=5.0)
+                gate.set()  # always release, even on a timed-out wait, to avoid hanging workers
+                assert reached, "workers did not reach the gate/rejection quiescence point in time"
+                done, not_done = concurrent.futures.wait(futures, timeout=10.0)
+                assert not not_done, "a worker did not finish after the gate opened"
+
+            assert len(outcomes) <= cap, "successful creations ({0}) exceeded the cap ({1})".format(len(outcomes), cap)
+        finally:
+            gate.set()
+            manager.close_all()

--- a/tests/test_server_spa.py
+++ b/tests/test_server_spa.py
@@ -13,14 +13,16 @@ from scpi_control.server.sessions import SessionManager  # noqa: E402
 
 
 @pytest.fixture()
-def static_client(tmp_path, monkeypatch):
+def static_client(tmp_path, monkeypatch, gateway_auth):
     static_dir = tmp_path / "static"
     static_dir.mkdir()
     (static_dir / "index.html").write_text("<!doctype html><title>gateway</title>", encoding="utf-8")
     (static_dir / "app.js").write_text("console.log('x')", encoding="utf-8")
     monkeypatch.setattr(app_module, "STATIC_DIR", static_dir)
+    store, headers, _raw = gateway_auth
     manager = SessionManager()
-    with TestClient(create_app(manager)) as client:
+    with TestClient(create_app(manager, token_store=store)) as client:
+        client.headers.update(headers)
         yield client
     manager.close_all()
 
@@ -47,14 +49,15 @@ def test_unknown_api_path_still_json_404(static_client):
     assert set(response.json()) == {"error", "detail"}
 
 
-def test_no_static_build_still_boots():
+def test_no_static_build_still_boots(gateway_auth):
+    store, headers, _raw = gateway_auth
     manager = SessionManager()
-    with TestClient(create_app(manager)) as client:
-        assert client.get("/api/sessions").status_code == 200
+    with TestClient(create_app(manager, token_store=store)) as client:
+        assert client.get("/api/sessions", headers=headers).status_code == 200
     manager.close_all()
 
 
-def test_encoded_traversal_is_contained(tmp_path, monkeypatch):
+def test_encoded_traversal_is_contained(tmp_path, monkeypatch, gateway_auth):
     # secret lives OUTSIDE the served static dir
     secret = tmp_path / "secret.txt"
     secret.write_text("TOP SECRET", encoding="utf-8")
@@ -62,8 +65,9 @@ def test_encoded_traversal_is_contained(tmp_path, monkeypatch):
     static_dir.mkdir()
     (static_dir / "index.html").write_text("<!doctype html><title>gateway</title>", encoding="utf-8")
     monkeypatch.setattr(app_module, "STATIC_DIR", static_dir)
+    store, _headers, _raw = gateway_auth
     manager = SessionManager()
-    with TestClient(create_app(manager)) as client:
+    with TestClient(create_app(manager, token_store=store)) as client:
         # Starlette decodes %2e%2e -> .. before the path param reaches the handler
         for payload in ("/%2e%2e/secret.txt", "/../secret.txt", "/%2e%2e%2fsecret.txt"):
             response = client.get(payload)

--- a/tests/test_server_ssrf.py
+++ b/tests/test_server_ssrf.py
@@ -34,11 +34,32 @@ def test_non_scpi_port_is_refused(client):
     assert "6379" in response.json()["detail"]
 
 
-def test_refusal_does_not_echo_peer_bytes(client):
+def test_port_rejection_response_contains_only_the_synthetic_policy_reason(client):
+    # Port 22 is rejected on the port-allowlist check alone (netpolicy.py), before
+    # any resolution or connection attempt -- this never reaches Oscilloscope or
+    # SocketConnection, so it cannot exercise (or guard) the socket layer. It only
+    # confirms the HTTP-level rejection body is exactly netpolicy's synthetic
+    # reason text, with nothing else appended. For the guarantee that a real
+    # connection failure can't leak peer-read bytes, see
+    # tests/test_socket_connection.py::TestSocketConnect::test_connect_failure_does_not_leak_peer_bytes.
     response = client.post("/api/sessions", json={"label": "x", "address": "192.168.99.99", "port": 22})
     assert response.status_code == 400
-    assert "SSH" not in response.text and "OpenSSH" not in response.text
+    assert response.json()["detail"] == "refusing to connect to 192.168.99.99: port 22 is not in the allowed set [5025]"
 
 
 def test_mock_sessions_bypass_the_policy(client):
     assert client.post("/api/sessions", json={"label": "x", "mock": True}).status_code == 201
+
+
+def test_create_app_rejects_manager_and_allowed_ports_together(tmp_path):
+    # allowed_ports is silently dropped when a manager is also passed in (it only
+    # seeds a manager create_app builds itself). A caller who passes both would
+    # reasonably assume the two compose, and could end up with no port policy at
+    # all instead of the stricter one they asked for. That must fail loudly.
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    manager = SessionManager()
+    try:
+        with pytest.raises(ValueError):
+            create_app(manager, token_store=store, allowed_ports=frozenset({5025, 1861}))
+    finally:
+        manager.close_all()

--- a/tests/test_server_ssrf.py
+++ b/tests/test_server_ssrf.py
@@ -1,0 +1,44 @@
+"""Session creation refuses disallowed targets and does not reflect peer bytes."""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scpi_control.server.app import create_app  # noqa: E402
+from scpi_control.server.auth import TokenStore  # noqa: E402
+from scpi_control.server.sessions import SessionManager  # noqa: E402
+
+
+@pytest.fixture()
+def client(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    headers = {"Authorization": "Bearer {0}".format(store.mint("tester"))}
+    manager = SessionManager()
+    app = create_app(manager, token_store=store)
+    with TestClient(app) as test_client:
+        test_client.headers.update(headers)
+        yield test_client
+    manager.close_all()
+
+
+def test_loopback_target_is_refused(client):
+    response = client.post("/api/sessions", json={"label": "x", "address": "127.0.0.1", "port": 5025})
+    assert response.status_code == 400
+
+
+def test_non_scpi_port_is_refused(client):
+    response = client.post("/api/sessions", json={"label": "x", "address": "192.168.99.99", "port": 6379})
+    assert response.status_code == 400
+    assert "6379" in response.json()["detail"]
+
+
+def test_refusal_does_not_echo_peer_bytes(client):
+    response = client.post("/api/sessions", json={"label": "x", "address": "192.168.99.99", "port": 22})
+    assert response.status_code == 400
+    assert "SSH" not in response.text and "OpenSSH" not in response.text
+
+
+def test_mock_sessions_bypass_the_policy(client):
+    assert client.post("/api/sessions", json={"label": "x", "mock": True}).status_code == 201

--- a/tests/test_server_stream_ws.py
+++ b/tests/test_server_stream_ws.py
@@ -17,22 +17,33 @@ from scpi_control.server.sessions import SessionManager  # noqa: E402
 
 
 @pytest.fixture()
-def client():
+def client(gateway_auth):
+    store, headers, _raw = gateway_auth
     manager = SessionManager()
-    app = create_app(manager)
+    app = create_app(manager, token_store=store)
     with TestClient(app) as test_client:
+        test_client.headers.update(headers)
         yield test_client
     manager.close_all()
 
 
 @pytest.fixture()
-def client_manager():
+def client_manager(gateway_auth):
     """Like ``client`` but also hands back the manager for white-box assertions."""
+    store, headers, _raw = gateway_auth
     manager = SessionManager()
-    app = create_app(manager)
+    app = create_app(manager, token_store=store)
     with TestClient(app) as test_client:
+        test_client.headers.update(headers)
         yield test_client, manager
     manager.close_all()
+
+
+@pytest.fixture()
+def ws_subprotocols(gateway_auth):
+    """WebSocket handshakes ignore default client headers; auth via subprotocol."""
+    _store, _headers, raw = gateway_auth
+    return ["scpi-token.{0}".format(raw), "scpi"]
 
 
 def _create_mock(client):
@@ -41,9 +52,9 @@ def _create_mock(client):
     return response.json()["id"]
 
 
-def test_stream_sends_initial_state_then_waveforms(client):
+def test_stream_sends_initial_state_then_waveforms(client, ws_subprotocols):
     sid = _create_mock(client)
-    with client.websocket_connect("/api/sessions/{0}/stream".format(sid)) as ws:
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=ws_subprotocols) as ws:
         first = ws.receive_json()
         assert first["type"] == "state"
         assert first["state"]["channels"]["1"]["enabled"] is True
@@ -58,9 +69,9 @@ def test_stream_sends_initial_state_then_waveforms(client):
             pytest.fail("no waveform frame received")
 
 
-def test_stream_relays_state_broadcast_after_mutation(client):
+def test_stream_relays_state_broadcast_after_mutation(client, ws_subprotocols):
     sid = _create_mock(client)
-    with client.websocket_connect("/api/sessions/{0}/stream".format(sid)) as ws:
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=ws_subprotocols) as ws:
         assert ws.receive_json()["type"] == "state"
         response = client.patch("/api/sessions/{0}/scope/timebase".format(sid), json={"timebase": 0.002})
         assert response.status_code == 200
@@ -72,9 +83,9 @@ def test_stream_relays_state_broadcast_after_mutation(client):
             pytest.fail("no state broadcast observed")
 
 
-def test_stream_unknown_session_closes(client):
+def test_stream_unknown_session_closes(client, ws_subprotocols):
     with pytest.raises(Exception):
-        with client.websocket_connect("/api/sessions/nope/stream") as ws:
+        with client.websocket_connect("/api/sessions/nope/stream", subprotocols=ws_subprotocols) as ws:
             ws.receive_json()
 
 
@@ -113,13 +124,13 @@ def test_enqueue_preserves_control_and_drops_incoming_waveform():
 # --- Fix 2: idle sessions still notice client disconnect -------------------
 
 
-def test_idle_stream_detects_disconnect_and_unsubscribes(client_manager):
+def test_idle_stream_detects_disconnect_and_unsubscribes(client_manager, ws_subprotocols):
     client, manager = client_manager
     sid = _create_mock(client)
     session = manager.get(sid)
     # Disable ch1 -> the session now publishes nothing, so the sender parks.
     assert client.patch("/api/sessions/{0}/scope/channels/1".format(sid), json={"enabled": False}).status_code == 200
-    with client.websocket_connect("/api/sessions/{0}/stream".format(sid)) as ws:
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=ws_subprotocols) as ws:
         assert ws.receive_json()["type"] == "state"
     # Client context exited -> disconnect. The receiver must notice and unsubscribe.
     deadline = time.time() + 5
@@ -131,9 +142,9 @@ def test_idle_stream_detects_disconnect_and_unsubscribes(client_manager):
 # --- Fix 5: deleting a session closes its streams --------------------------
 
 
-def test_delete_session_closes_stream(client):
+def test_delete_session_closes_stream(client, ws_subprotocols):
     sid = _create_mock(client)
-    with client.websocket_connect("/api/sessions/{0}/stream".format(sid)) as ws:
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=ws_subprotocols) as ws:
         assert ws.receive_json()["type"] == "state"
         assert client.delete("/api/sessions/{0}".format(sid)).status_code == 204
         closed_seen = False

--- a/tests/test_server_stream_ws.py
+++ b/tests/test_server_stream_ws.py
@@ -13,6 +13,7 @@ from starlette.websockets import WebSocketDisconnect  # noqa: E402
 
 from scpi_control.server.api.stream import _enqueue  # noqa: E402
 from scpi_control.server.app import create_app  # noqa: E402
+from scpi_control.server.auth import WS_ACCEPT_SUBPROTOCOL  # noqa: E402
 from scpi_control.server.sessions import SessionManager  # noqa: E402
 
 
@@ -87,6 +88,26 @@ def test_stream_unknown_session_closes(client, ws_subprotocols):
     with pytest.raises(Exception):
         with client.websocket_connect("/api/sessions/nope/stream", subprotocols=ws_subprotocols) as ws:
             ws.receive_json()
+
+
+# --- Important 5: the accepted subprotocol must be negotiated, not silent --
+
+
+def test_stream_negotiates_the_accept_subprotocol_when_offered(client, ws_subprotocols):
+    # A real browser fails the handshake if it offered Sec-WebSocket-Protocol
+    # and the 101 response echoes none, so the accept must select one back.
+    sid = _create_mock(client)
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=ws_subprotocols) as ws:
+        assert ws.accepted_subprotocol == WS_ACCEPT_SUBPROTOCOL
+
+
+def test_stream_does_not_echo_a_subprotocol_the_client_never_offered(client, gateway_auth):
+    # Echoing WS_ACCEPT_SUBPROTOCOL when the client didn't offer it is equally
+    # invalid, so a client authenticating without the "scpi" offer gets none.
+    _store, _headers, raw = gateway_auth
+    sid = _create_mock(client)
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=["scpi-token.{0}".format(raw)]) as ws:
+        assert ws.accepted_subprotocol is None
 
 
 # --- Fix 1: bounded outbox with drop-oldest --------------------------------

--- a/tests/test_socket_connection.py
+++ b/tests/test_socket_connection.py
@@ -73,6 +73,32 @@ class TestSocketConnect:
         with pytest.raises(Exception):
             conn.connect()
 
+    def test_connect_failure_does_not_leak_peer_bytes(self, mock_socket):
+        """A connect() failure must never surface bytes read from the peer.
+
+        connect() has no legitimate reason to call recv() at all -- it only opens
+        the socket -- but if a future change folded a banner/peek read into the
+        failure path, an attacker-controlled peer could get its bytes echoed into
+        exception text that reaches lower-trust callers (e.g. the SSRF-guarded
+        gateway API; see tests/test_server_ssrf.py). Prime recv() with a
+        realistic banner so the peer "sent" something before connect() itself
+        fails, and assert the error text carries none of it.
+        """
+        banner = b"SSH-2.0-OpenSSH_9.6 SECRETBANNER"
+        mock_socket.recv.return_value = banner
+        mock_socket.connect.side_effect = socket.error("Connection refused")
+
+        conn = SocketConnection("192.168.1.100")
+
+        with pytest.raises(Exception) as exc_info:
+            conn.connect()
+
+        message = str(exc_info.value)
+        assert banner.decode("ascii") not in message
+        assert "SSH-2.0-OpenSSH_9.6" not in message
+        assert "SECRETBANNER" not in message
+        assert "SSH" not in message
+
     def test_already_connected(self, mock_socket):
         """Test connecting when already connected."""
         conn = SocketConnection("192.168.1.100")

--- a/webapp/app/package.json
+++ b/webapp/app/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc --noEmit && tsc --noEmit -p tsconfig.node.json && vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "react": "^19.2.7",

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { TokenGate } from "./features/auth/TokenGate";
 import { AnalysisPanel } from "./features/controls/AnalysisPanel";
 import { ChannelsPanel } from "./features/controls/ChannelsPanel";
 import { MathPanel } from "./features/controls/MathPanel";
@@ -31,38 +32,40 @@ export default function App() {
   useStream(session?.id ?? null);
   useReferenceSeed(session?.id ?? null);
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100vh", background: "var(--lc-bg)", fontFamily: "var(--font-ui)" }}>
-      <header style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", padding: "10px 14px", background: "var(--lc-panel)", borderBottom: "1px solid var(--lc-border)" }}>
-        <strong style={{ color: "var(--lc-text)" }}>SCPI Instrument Control</strong>
-        <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-xs)", color: "var(--lc-muted)" }}>{session ? `${session.model} · ${session.address ?? "mock"}` : "no instrument"}</span>
-        <span style={{ marginLeft: "auto" }}>
-          <StatusIndicator state={status} />
-        </span>
-      </header>
-      <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)", display: "flex", flexDirection: "column", gap: "var(--space-3)", minHeight: 0 }}>
-        {session === null && <HomeScreen onConnected={(s) => useSession.getState().setSession(s)} />}
-        {session !== null && <ReadoutStrip />}
-        {session !== null && (
-          <div style={{ flex: 1, display: "flex", gap: "var(--space-3)", minHeight: 0 }}>
-            <div style={{ width: "280px", flexShrink: 0, overflowY: "auto" }}>
-              <Tabs tabs={RAIL_TABS} value={railTab} onChange={setRailTab}>
-                {railTab === "Channels" && <ChannelsPanel />}
-                {railTab === "Trigger" && <TriggerPanel />}
-                {railTab === "Math" && <MathPanel />}
-                {railTab === "Analysis" && <AnalysisPanel />}
-                {railTab === "Reference" && <ReferencePanel />}
-                {railTab === "Log" && <LogPanel />}
-                {railTab === "Measure" && <MeasurePanel />}
-                {railTab === "Terminal" && <TerminalPanel />}
-              </Tabs>
+    <TokenGate>
+      <div style={{ display: "flex", flexDirection: "column", height: "100vh", background: "var(--lc-bg)", fontFamily: "var(--font-ui)" }}>
+        <header style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", padding: "10px 14px", background: "var(--lc-panel)", borderBottom: "1px solid var(--lc-border)" }}>
+          <strong style={{ color: "var(--lc-text)" }}>SCPI Instrument Control</strong>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-xs)", color: "var(--lc-muted)" }}>{session ? `${session.model} · ${session.address ?? "mock"}` : "no instrument"}</span>
+          <span style={{ marginLeft: "auto" }}>
+            <StatusIndicator state={status} />
+          </span>
+        </header>
+        <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)", display: "flex", flexDirection: "column", gap: "var(--space-3)", minHeight: 0 }}>
+          {session === null && <HomeScreen onConnected={(s) => useSession.getState().setSession(s)} />}
+          {session !== null && <ReadoutStrip />}
+          {session !== null && (
+            <div style={{ flex: 1, display: "flex", gap: "var(--space-3)", minHeight: 0 }}>
+              <div style={{ width: "280px", flexShrink: 0, overflowY: "auto" }}>
+                <Tabs tabs={RAIL_TABS} value={railTab} onChange={setRailTab}>
+                  {railTab === "Channels" && <ChannelsPanel />}
+                  {railTab === "Trigger" && <TriggerPanel />}
+                  {railTab === "Math" && <MathPanel />}
+                  {railTab === "Analysis" && <AnalysisPanel />}
+                  {railTab === "Reference" && <ReferencePanel />}
+                  {railTab === "Log" && <LogPanel />}
+                  {railTab === "Measure" && <MeasurePanel />}
+                  {railTab === "Terminal" && <TerminalPanel />}
+                </Tabs>
+              </div>
+              <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "var(--space-3)", minWidth: 0 }}>
+                {viewMode === "Time" ? <WaveformCanvas /> : viewMode === "Spectrum" ? <SpectrumCanvas /> : <TrendCanvas />}
+                <ScopeToolbar viewToggle={<ViewModeToggle value={viewMode} onChange={setViewMode} />} />
+              </div>
             </div>
-            <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "var(--space-3)", minWidth: 0 }}>
-              {viewMode === "Time" ? <WaveformCanvas /> : viewMode === "Spectrum" ? <SpectrumCanvas /> : <TrendCanvas />}
-              <ScopeToolbar viewToggle={<ViewModeToggle value={viewMode} onChange={setViewMode} />} />
-            </div>
-          </div>
-        )}
-      </main>
-    </div>
+          )}
+        </main>
+      </div>
+    </TokenGate>
   );
 }

--- a/webapp/app/src/api/client.test.ts
+++ b/webapp/app/src/api/client.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError, api } from "./client";
+import { clearToken, setToken } from "./token";
 
 function mockFetch(body: unknown, init: { status?: number } = {}) {
   const status = init.status ?? 200;
@@ -12,6 +13,8 @@ function mockFetch(body: unknown, init: { status?: number } = {}) {
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
 }
+
+beforeEach(() => clearToken());
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -46,5 +49,32 @@ describe("api client", () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe("/api/sessions/abc/scope/single");
     expect(init.method).toBe("POST");
+  });
+
+  it("attaches the stored token as a bearer header", async () => {
+    setToken("scpi_abc123");
+    const fetchMock = mockFetch({ run_state: "TRIGD", timebase: 0.001, channels: {}, trigger: { mode: "AUTO", source: null, level: null, slope: null, coupling: null } });
+    await api.runOp("abc", "single");
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer scpi_abc123");
+  });
+
+  it("omits the Authorization header when no token is stored", async () => {
+    const fetchMock = mockFetch({ run_state: "TRIGD", timebase: 0.001, channels: {}, trigger: { mode: "AUTO", source: null, level: null, slope: null, coupling: null } });
+    await api.runOp("abc", "single");
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init.headers);
+    expect(headers.has("Authorization")).toBe(false);
+  });
+
+  it("preserves the JSON Content-Type header alongside the bearer token", async () => {
+    setToken("scpi_abc123");
+    const fetchMock = mockFetch({ id: "abc", label: "Mock scope", mock: true, address: null, state: "connected", idn: "x", model: "SDS1104X-E", dialect: "legacy", num_channels: 4, viewers: 0 }, { status: 201 });
+    await api.createSession({ mock: true });
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init.headers);
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("Authorization")).toBe("Bearer scpi_abc123");
   });
 });

--- a/webapp/app/src/api/client.ts
+++ b/webapp/app/src/api/client.ts
@@ -43,6 +43,7 @@ function json(method: string, body: unknown): RequestInit {
 const scope = (id: string) => `/api/sessions/${id}/scope`;
 
 export const api = {
+  whoami: () => request<{ identity: string }>("/api/whoami"),
   models: () => request<ModelInfo[]>("/api/models"),
   discover: (cidr?: string) => request<DiscoveredDevice[]>(cidr ? `/api/discover?cidr=${encodeURIComponent(cidr)}` : "/api/discover"),
   createSession: (body: SessionCreate) => request<SessionInfo>("/api/sessions", json("POST", body)),

--- a/webapp/app/src/api/client.ts
+++ b/webapp/app/src/api/client.ts
@@ -1,4 +1,5 @@
 import type { ChannelPatch, DiscoveredDevice, FilterConfig, LogData, LogInfo, MeasurementValue, ModelInfo, ReferenceInfo, ReferenceOverlay, RunOp, ScopeState, SessionCreate, SessionInfo, SpectrumConfig, TriggerPatch } from "./types";
+import { getToken } from "./token";
 
 export class ApiError extends Error {
   status: number;
@@ -15,7 +16,10 @@ export class ApiError extends Error {
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(path, init);
+  const token = getToken();
+  const headers = new Headers(init?.headers);
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  const response = await fetch(path, { ...init, headers });
   if (!response.ok) {
     let error = "Error";
     let detail = "request failed";

--- a/webapp/app/src/api/client.ts
+++ b/webapp/app/src/api/client.ts
@@ -50,6 +50,7 @@ export const api = {
   listSessions: () => request<SessionInfo[]>("/api/sessions"),
   getSession: (id: string) => request<SessionInfo>(`/api/sessions/${id}`),
   deleteSession: (id: string) => request<void>(`/api/sessions/${id}`, { method: "DELETE" }),
+  claimSession: (id: string) => request<SessionInfo>(`/api/sessions/${id}/claim`, { method: "POST" }),
   getState: (id: string) => request<ScopeState>(`${scope(id)}/state`),
   patchChannel: (id: string, channel: number, body: ChannelPatch) => request<ScopeState>(`${scope(id)}/channels/${channel}`, json("PATCH", body)),
   patchTimebase: (id: string, timebase: number) => request<ScopeState>(`${scope(id)}/timebase`, json("PATCH", { timebase })),

--- a/webapp/app/src/api/download.test.ts
+++ b/webapp/app/src/api/download.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { downloadAuthenticated } from "./download";
+import { setToken, clearToken } from "./token";
+
+describe("downloadAuthenticated", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("sends the bearer token with the request", async () => {
+    setToken("scpi_dl");
+    const fetchMock = vi.fn().mockResolvedValue(new Response(new Blob(["data"]), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("URL", { ...URL, createObjectURL: vi.fn(() => "blob:x"), revokeObjectURL: vi.fn() });
+    await downloadAuthenticated("/api/thing.csv", "thing.csv");
+    const headers = new Headers(fetchMock.mock.calls[0][1].headers);
+    expect(headers.get("Authorization")).toBe("Bearer scpi_dl");
+  });
+
+  it("throws ApiError on a 401 instead of downloading an error page", async () => {
+    clearToken();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Unauthorized", detail: "no token" }), { status: 401 })));
+    await expect(downloadAuthenticated("/api/thing.csv", "thing.csv")).rejects.toThrow();
+  });
+
+  it("revokes the object URL after triggering the download", async () => {
+    setToken("scpi_dl");
+    const revoke = vi.fn();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(new Blob(["data"]), { status: 200 })));
+    vi.stubGlobal("URL", { ...URL, createObjectURL: vi.fn(() => "blob:x"), revokeObjectURL: revoke });
+    await downloadAuthenticated("/api/thing.csv", "thing.csv");
+    expect(revoke).toHaveBeenCalledWith("blob:x");
+  });
+});

--- a/webapp/app/src/api/download.ts
+++ b/webapp/app/src/api/download.ts
@@ -1,0 +1,38 @@
+import { ApiError } from "./client";
+import { getToken } from "./token";
+
+/** Fetch a file with the bearer token, then hand it to the browser as a download.
+ *
+ * A plain <a href download> cannot carry an Authorization header, and the server
+ * rejects query-parameter tokens on /api/* — so authenticated downloads have to
+ * go through fetch and a blob URL.
+ */
+export async function downloadAuthenticated(url: string, filename: string): Promise<void> {
+  const token = getToken();
+  const headers = new Headers();
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    let error = "Error";
+    let detail = "download failed";
+    try {
+      const body = await response.json();
+      error = body.error ?? error;
+      detail = body.detail ?? detail;
+    } catch {
+      // non-JSON error body: keep defaults
+    }
+    throw new ApiError(response.status, error, detail);
+  }
+  const objectUrl = URL.createObjectURL(await response.blob());
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = objectUrl;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}

--- a/webapp/app/src/api/token.test.ts
+++ b/webapp/app/src/api/token.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { captureTokenFromUrl, clearToken, getToken, setToken } from "./token";
+
+describe("token storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("round-trips a token", () => {
+    setToken("scpi_abc");
+    expect(getToken()).toBe("scpi_abc");
+  });
+
+  it("returns null when unset", () => {
+    expect(getToken()).toBeNull();
+  });
+
+  it("clears a token", () => {
+    setToken("scpi_abc");
+    clearToken();
+    expect(getToken()).toBeNull();
+  });
+
+  it("captures a token from the URL and strips it", () => {
+    window.history.replaceState({}, "", "/?token=scpi_fromurl");
+    captureTokenFromUrl();
+    expect(getToken()).toBe("scpi_fromurl");
+    expect(window.location.search).not.toContain("token");
+  });
+
+  it("leaves an existing token alone when the URL has none", () => {
+    setToken("scpi_existing");
+    captureTokenFromUrl();
+    expect(getToken()).toBe("scpi_existing");
+  });
+});

--- a/webapp/app/src/api/token.ts
+++ b/webapp/app/src/api/token.ts
@@ -1,0 +1,24 @@
+const STORAGE_KEY = "scpi.token";
+
+export function getToken(): string | null {
+  return localStorage.getItem(STORAGE_KEY);
+}
+
+export function setToken(value: string): void {
+  localStorage.setItem(STORAGE_KEY, value);
+}
+
+export function clearToken(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+/** Move a ?token= from the initial SPA load into storage, then strip it from the URL. */
+export function captureTokenFromUrl(): void {
+  const params = new URLSearchParams(window.location.search);
+  const fromUrl = params.get("token");
+  if (!fromUrl) return;
+  setToken(fromUrl);
+  params.delete("token");
+  const query = params.toString();
+  window.history.replaceState({}, "", window.location.pathname + (query ? `?${query}` : ""));
+}

--- a/webapp/app/src/api/types.ts
+++ b/webapp/app/src/api/types.ts
@@ -33,6 +33,7 @@ export type SessionInfo = {
   dialect: string;
   num_channels: number;
   viewers: number;
+  owner: string;
 };
 
 export type DiscoveredDevice = {

--- a/webapp/app/src/features/auth/TokenGate.test.tsx
+++ b/webapp/app/src/features/auth/TokenGate.test.tsx
@@ -3,11 +3,13 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TokenGate } from "./TokenGate";
 import { clearToken, getToken, setToken } from "../../api/token";
+import { useIdentity } from "../../store/identity";
 
 describe("TokenGate", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.restoreAllMocks();
+    useIdentity.getState().clearIdentity();
   });
 
   it("asks for a token when none is stored", () => {
@@ -29,6 +31,23 @@ describe("TokenGate", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Unauthorized", detail: "bad" }), { status: 401 })));
     render(<TokenGate><div>inside</div></TokenGate>);
     await waitFor(() => expect(screen.getByLabelText(/access token/i)).toBeInTheDocument());
+  });
+
+  it("captures whoami's identity so the rest of the app can read it", async () => {
+    setToken("scpi_good");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ identity: "robin" }), { status: 200 })));
+    render(<TokenGate><div>inside</div></TokenGate>);
+    await waitFor(() => expect(screen.getByText("inside")).toBeInTheDocument());
+    expect(useIdentity.getState().identity).toBe("robin");
+  });
+
+  it("clears the identity when a stored token is rejected", async () => {
+    setToken("scpi_stale");
+    useIdentity.getState().setIdentity("stale-identity");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Unauthorized", detail: "bad" }), { status: 401 })));
+    render(<TokenGate><div>inside</div></TokenGate>);
+    await waitFor(() => expect(screen.getByLabelText(/access token/i)).toBeInTheDocument());
+    expect(useIdentity.getState().identity).toBeNull();
   });
 
   it("clears the rejected token so a blank resubmit can't silently reuse it", async () => {

--- a/webapp/app/src/features/auth/TokenGate.test.tsx
+++ b/webapp/app/src/features/auth/TokenGate.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TokenGate } from "./TokenGate";
+import { clearToken, getToken, setToken } from "../../api/token";
+
+describe("TokenGate", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("asks for a token when none is stored", () => {
+    clearToken();
+    render(<TokenGate><div>inside</div></TokenGate>);
+    expect(screen.getByLabelText(/access token/i)).toBeInTheDocument();
+    expect(screen.queryByText("inside")).not.toBeInTheDocument();
+  });
+
+  it("renders children once a token verifies", async () => {
+    setToken("scpi_good");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ identity: "robin" }), { status: 200 })));
+    render(<TokenGate><div>inside</div></TokenGate>);
+    await waitFor(() => expect(screen.getByText("inside")).toBeInTheDocument());
+  });
+
+  it("re-prompts when the stored token is rejected", async () => {
+    setToken("scpi_stale");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Unauthorized", detail: "bad" }), { status: 401 })));
+    render(<TokenGate><div>inside</div></TokenGate>);
+    await waitFor(() => expect(screen.getByLabelText(/access token/i)).toBeInTheDocument());
+  });
+
+  it("clears the rejected token so a blank resubmit can't silently reuse it", async () => {
+    setToken("scpi_stale");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Unauthorized", detail: "bad" }), { status: 401 })));
+    render(<TokenGate><div>inside</div></TokenGate>);
+    await waitFor(() => expect(screen.getByLabelText(/access token/i)).toBeInTheDocument());
+    expect(getToken()).toBeNull();
+  });
+
+  it("accepts a pasted token", async () => {
+    clearToken();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ identity: "robin" }), { status: 200 })));
+    render(<TokenGate><div>inside</div></TokenGate>);
+    await userEvent.type(screen.getByLabelText(/access token/i), "scpi_pasted");
+    await userEvent.click(screen.getByRole("button", { name: /connect/i }));
+    await waitFor(() => expect(screen.getByText("inside")).toBeInTheDocument());
+  });
+
+  it("explains how to obtain a token", () => {
+    clearToken();
+    render(<TokenGate><div>inside</div></TokenGate>);
+    expect(screen.getByText(/scpi-web token add/i)).toBeInTheDocument();
+  });
+
+  it("does not discard a stored token on a network error, and lets the user retry without retyping it", async () => {
+    setToken("scpi_good");
+    const fetchMock = vi.fn().mockRejectedValueOnce(new TypeError("Failed to fetch")).mockResolvedValueOnce(new Response(JSON.stringify({ identity: "robin" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<TokenGate><div>inside</div></TokenGate>);
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/could not reach|connection/i);
+    // a network blip is not proof the token is bad: it must still be in storage
+    expect(getToken()).toBe("scpi_good");
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    await waitFor(() => expect(screen.getByText("inside")).toBeInTheDocument());
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not discard a stored token on a non-401 server error", async () => {
+    setToken("scpi_good");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "ServerError", detail: "restarting" }), { status: 500 })));
+    render(<TokenGate><div>inside</div></TokenGate>);
+    await screen.findByRole("alert");
+    expect(getToken()).toBe("scpi_good");
+  });
+});

--- a/webapp/app/src/features/auth/TokenGate.tsx
+++ b/webapp/app/src/features/auth/TokenGate.tsx
@@ -55,7 +55,14 @@ export function TokenGate({ children }: { children: React.ReactNode }) {
   }, [check]);
 
   if (status === "ready") return <>{children}</>;
-  if (status === "checking") return <p>Connecting…</p>;
+  // aria-live so a screen-reader user hears the wait; without it the first
+  // screen of the app is silent until it resolves.
+  if (status === "checking")
+    return (
+      <p role="status" aria-live="polite">
+        Connecting…
+      </p>
+    );
 
   return (
     <div style={{ display: "flex", justifyContent: "center", padding: "var(--space-4)" }}>

--- a/webapp/app/src/features/auth/TokenGate.tsx
+++ b/webapp/app/src/features/auth/TokenGate.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useState } from "react";
+import { ApiError, api } from "../../api/client";
+import { clearToken, getToken, setToken } from "../../api/token";
+import { Button } from "../../ds/Button";
+import { GroupBox } from "../../ds/GroupBox";
+
+type Status = "checking" | "needs-token" | "ready";
+
+const UNAUTHORIZED = "That token was not accepted.";
+const UNREACHABLE = "Could not reach the server. Check your connection and try again.";
+
+/**
+ * Gates the app behind a verified bearer token. Every request already
+ * carries whatever token is in storage; this is the one place that finds
+ * out whether that token actually works, and is therefore also the one
+ * place that can tell the user how to get a good one.
+ *
+ * A 401 means the token itself is bad, so it's cleared — a stale credential
+ * shouldn't linger and keep failing silently. Any other failure (the
+ * gateway restarting, a dropped connection) says nothing about the token,
+ * so it's left in storage and the user can just retry.
+ */
+export function TokenGate({ children }: { children: React.ReactNode }) {
+  const [status, setStatus] = useState<Status>("checking");
+  const [value, setValue] = useState("");
+  const [error, setError] = useState("");
+  const [hasStoredToken, setHasStoredToken] = useState(false);
+
+  const check = useCallback(async () => {
+    if (!getToken()) {
+      setHasStoredToken(false);
+      setError("");
+      setStatus("needs-token");
+      return;
+    }
+    try {
+      await api.whoami();
+      setError("");
+      setStatus("ready");
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        clearToken();
+        setHasStoredToken(false);
+        setError(UNAUTHORIZED);
+      } else {
+        setHasStoredToken(true);
+        setError(UNREACHABLE);
+      }
+      setStatus("needs-token");
+    }
+  }, []);
+
+  useEffect(() => {
+    void check();
+  }, [check]);
+
+  if (status === "ready") return <>{children}</>;
+  if (status === "checking") return <p>Connecting…</p>;
+
+  return (
+    <div style={{ display: "flex", justifyContent: "center", padding: "var(--space-4)" }}>
+      <div style={{ width: "min(360px, 100%)" }}>
+        <GroupBox title="Sign in">
+          <form
+            style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}
+            onSubmit={(event) => {
+              event.preventDefault();
+              const trimmed = value.trim();
+              if (!trimmed) return;
+              setToken(trimmed);
+              setValue("");
+              setStatus("checking");
+              void check();
+            }}
+          >
+            <label htmlFor="token" style={{ fontSize: "var(--text-sm)", color: "var(--lc-text)" }}>
+              Access token
+            </label>
+            <input
+              id="token"
+              type="password"
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+              autoComplete="off"
+              style={{ padding: "6px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--text-sm)", border: "1px solid var(--lc-border-strong)", borderRadius: "var(--lc-radius-sm)", background: "var(--lc-control)", color: "var(--lc-text)" }}
+            />
+            <div style={{ display: "flex", gap: "var(--space-1)" }}>
+              <Button type="submit" variant="primary" disabled={!value.trim()} fullWidth>
+                Connect
+              </Button>
+              {hasStoredToken && (
+                <Button
+                  type="button"
+                  onClick={() => {
+                    setStatus("checking");
+                    void check();
+                  }}
+                >
+                  Retry
+                </Button>
+              )}
+            </div>
+            {error ? (
+              <p role="alert" style={{ margin: 0, padding: "8px 10px", borderRadius: "var(--radius-sm)", background: "color-mix(in srgb, var(--danger) 12%, transparent)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>
+                {error}
+              </p>
+            ) : null}
+            <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--lc-muted)" }}>
+              No token? Run <code>scpi-web token add &lt;name&gt;</code> on the gateway host to mint one.
+            </p>
+          </form>
+        </GroupBox>
+      </div>
+    </div>
+  );
+}

--- a/webapp/app/src/features/auth/TokenGate.tsx
+++ b/webapp/app/src/features/auth/TokenGate.tsx
@@ -46,6 +46,11 @@ export function TokenGate({ children }: { children: React.ReactNode }) {
         setHasStoredToken(false);
         setError(UNAUTHORIZED);
       } else {
+        // Identity is deliberately left alone here, mirroring the token: an
+        // unreachable server says nothing about who you are. That is safe only
+        // because check() runs once on mount and never again after "ready", so
+        // a stale identity can't coexist with this error screen. If periodic
+        // re-validation is ever added, clear the identity here too.
         setHasStoredToken(true);
         setError(UNREACHABLE);
       }

--- a/webapp/app/src/features/auth/TokenGate.tsx
+++ b/webapp/app/src/features/auth/TokenGate.tsx
@@ -3,6 +3,7 @@ import { ApiError, api } from "../../api/client";
 import { clearToken, getToken, setToken } from "../../api/token";
 import { Button } from "../../ds/Button";
 import { GroupBox } from "../../ds/GroupBox";
+import { useIdentity } from "../../store/identity";
 
 type Status = "checking" | "needs-token" | "ready";
 
@@ -34,12 +35,14 @@ export function TokenGate({ children }: { children: React.ReactNode }) {
       return;
     }
     try {
-      await api.whoami();
+      const { identity } = await api.whoami();
+      useIdentity.getState().setIdentity(identity);
       setError("");
       setStatus("ready");
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {
         clearToken();
+        useIdentity.getState().clearIdentity();
         setHasStoredToken(false);
         setError(UNAUTHORIZED);
       } else {

--- a/webapp/app/src/features/controls/AnalysisPanel.test.tsx
+++ b/webapp/app/src/features/controls/AnalysisPanel.test.tsx
@@ -14,7 +14,7 @@ const FILTERS: FilterConfig[] = [
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
   vi.spyOn(api, "getSpectrum").mockResolvedValue(SPECTRUM);
   vi.spyOn(api, "getFilters").mockResolvedValue(FILTERS);
 });

--- a/webapp/app/src/features/controls/ChannelsPanel.test.tsx
+++ b/webapp/app/src/features/controls/ChannelsPanel.test.tsx
@@ -17,7 +17,7 @@ const STATE = {
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "SDS1104X-E", dialect: "legacy", num_channels: 2, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "SDS1104X-E", dialect: "legacy", num_channels: 2, viewers: 0, owner: "" });
   useSession.getState().applyState(STATE);
 });
 afterEach(() => vi.restoreAllMocks());

--- a/webapp/app/src/features/controls/MathPanel.test.tsx
+++ b/webapp/app/src/features/controls/MathPanel.test.tsx
@@ -8,7 +8,7 @@ import { useSession } from "../../store/session";
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
 });
 afterEach(() => vi.restoreAllMocks());
 

--- a/webapp/app/src/features/controls/ScopeToolbar.test.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.test.tsx
@@ -9,7 +9,7 @@ const STATE = { run_state: "STOP", timebase: 0.001, channels: { "1": { enabled: 
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
   useSession.getState().applyState(STATE);
 });
 afterEach(() => vi.restoreAllMocks());

--- a/webapp/app/src/features/controls/ScopeToolbar.test.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.test.tsx
@@ -3,16 +3,21 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ScopeToolbar } from "./ScopeToolbar";
 import { api } from "../../api/client";
+import { setToken } from "../../api/token";
 import { useSession } from "../../store/session";
 
 const STATE = { run_state: "STOP", timebase: 0.001, channels: { "1": { enabled: true, voltage_scale: 0.5, voltage_offset: 0, coupling: "DC", probe_ratio: 10 } }, trigger: { mode: "AUTO", source: "C1", level: 0, slope: "POS", coupling: "DC" } };
 
 beforeEach(() => {
+  localStorage.clear();
   useSession.getState().clearSession();
   useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
   useSession.getState().applyState(STATE);
 });
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("ScopeToolbar", () => {
   it.each([
@@ -38,6 +43,27 @@ describe("ScopeToolbar", () => {
     render(<ScopeToolbar />);
     await userEvent.click(screen.getByRole("button", { name: "Run" }));
     expect(await screen.findByRole("alert")).toHaveTextContent("session abc is error");
+  });
+
+  it("downloads the waveform JSON with the bearer token", async () => {
+    setToken("scpi_wave");
+    const fetchMock = vi.fn().mockResolvedValue(new Response(new Blob(["data"]), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("URL", { ...URL, createObjectURL: vi.fn(() => "blob:x"), revokeObjectURL: vi.fn() });
+    render(<ScopeToolbar />);
+    await userEvent.click(screen.getByRole("button", { name: "JSON" }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/sessions/abc/scope/waveform?channels=1");
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer scpi_wave");
+  });
+
+  it("surfaces a waveform download failure instead of silently doing nothing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Unauthorized", detail: "missing bearer token" }), { status: 401 })));
+    render(<ScopeToolbar />);
+    await userEvent.click(screen.getByRole("button", { name: "JSON" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("missing bearer token");
   });
 
   it("returns to disconnected even if the session is already gone (DELETE 404)", async () => {

--- a/webapp/app/src/features/controls/ScopeToolbar.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { ReactNode } from "react";
 import { ApiError, api } from "../../api/client";
+import { downloadAuthenticated } from "../../api/download";
 import type { ChannelState, RunOp } from "../../api/types";
 import { Button } from "../../ds/Button";
 import { Toolbar, ToolbarSeparator } from "../../ds/Toolbar";
@@ -22,7 +23,7 @@ export function ScopeToolbar({ viewToggle }: { viewToggle?: ReactNode }) {
     .sort((a, b) => a - b);
   const [error, setError] = useState<string | null>(null);
 
-  const linkStyle = { fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "6px 12px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", textDecoration: "none" } as const;
+  const linkStyle = { fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "6px 12px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", background: "transparent", cursor: "pointer" } as const;
   const disabledLinkStyle = { ...linkStyle, color: "var(--lc-muted)", opacity: 0.6 };
 
   async function op(next: RunOp) {
@@ -30,6 +31,16 @@ export function ScopeToolbar({ viewToggle }: { viewToggle?: ReactNode }) {
     setError(null);
     try {
       await api.runOp(session.id, next);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  async function downloadWaveformJson() {
+    if (!session) return;
+    setError(null);
+    try {
+      await downloadAuthenticated(api.waveformJsonUrl(session.id, enabled), "waveform.json");
     } catch (err) {
       setError(err instanceof ApiError ? err.detail : String(err));
     }
@@ -56,9 +67,9 @@ export function ScopeToolbar({ viewToggle }: { viewToggle?: ReactNode }) {
             {!session || enabled.length === 0 ? (
               <span style={disabledLinkStyle}>JSON</span>
             ) : (
-              <a href={api.waveformJsonUrl(session.id, enabled)} download style={linkStyle}>
+              <button type="button" onClick={downloadWaveformJson} style={linkStyle}>
                 JSON
-              </a>
+              </button>
             )}
             <ScreenshotButton />
             <Button variant="danger" onClick={disconnect}>Disconnect</Button>

--- a/webapp/app/src/features/controls/TriggerPanel.test.tsx
+++ b/webapp/app/src/features/controls/TriggerPanel.test.tsx
@@ -16,7 +16,7 @@ const NULL_TRIGGER_STATE = {
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
 });
 afterEach(() => vi.restoreAllMocks());
 

--- a/webapp/app/src/features/export/ExportButton.test.tsx
+++ b/webapp/app/src/features/export/ExportButton.test.tsx
@@ -1,17 +1,21 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ExportButton } from "./ExportButton";
+import { setToken } from "../../api/token";
 import { useSession } from "../../store/session";
 
 const BASE = { run_state: "STOP", timebase: 0.001, trigger: { mode: "AUTO", source: "C1", level: 0, slope: "POS", coupling: "DC" } };
 
 beforeEach(() => {
+  localStorage.clear();
   useSession.getState().clearSession();
   useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
 });
+afterEach(() => vi.unstubAllGlobals());
 
 describe("ExportButton", () => {
-  it("links to the capture URL for enabled channels only", () => {
+  it("downloads the capture URL for enabled channels only, with the bearer token", async () => {
     useSession.getState().applyState({
       ...BASE,
       channels: {
@@ -20,15 +24,34 @@ describe("ExportButton", () => {
         "3": { enabled: true, voltage_scale: 1, voltage_offset: 0, coupling: "DC", probe_ratio: 1 },
       },
     });
+    setToken("scpi_export");
+    const fetchMock = vi.fn().mockResolvedValue(new Response(new Blob(["data"]), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("URL", { ...URL, createObjectURL: vi.fn(() => "blob:x"), revokeObjectURL: vi.fn() });
+
     render(<ExportButton />);
-    const link = screen.getByRole("link", { name: /export csv/i });
-    expect(link).toHaveAttribute("href", "/api/sessions/abc/scope/capture.csv?channels=1,3");
-    expect(link).toHaveAttribute("download");
+    await userEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/sessions/abc/scope/capture.csv?channels=1,3");
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer scpi_export");
   });
 
   it("is disabled when no channel is enabled", () => {
     useSession.getState().applyState({ ...BASE, channels: { "1": { enabled: false, voltage_scale: 1, voltage_offset: 0, coupling: "DC", probe_ratio: 1 } } });
     render(<ExportButton />);
-    expect(screen.getByText(/export csv/i).closest("a")).toBeNull();
+    expect(screen.getByText(/export csv/i).closest("button")).toBeNull();
+  });
+
+  it("surfaces a download failure instead of silently doing nothing", async () => {
+    useSession.getState().applyState({ ...BASE, channels: { "1": { enabled: true, voltage_scale: 1, voltage_offset: 0, coupling: "DC", probe_ratio: 1 } } });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Unauthorized", detail: "missing bearer token" }), { status: 401 })));
+
+    render(<ExportButton />);
+    await userEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("missing bearer token");
   });
 });

--- a/webapp/app/src/features/export/ExportButton.test.tsx
+++ b/webapp/app/src/features/export/ExportButton.test.tsx
@@ -7,7 +7,7 @@ const BASE = { run_state: "STOP", timebase: 0.001, trigger: { mode: "AUTO", sour
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
 });
 
 describe("ExportButton", () => {

--- a/webapp/app/src/features/export/ExportButton.tsx
+++ b/webapp/app/src/features/export/ExportButton.tsx
@@ -1,4 +1,6 @@
-import { api } from "../../api/client";
+import { useState } from "react";
+import { ApiError, api } from "../../api/client";
+import { downloadAuthenticated } from "../../api/download";
 import type { ChannelState } from "../../api/types";
 import { useSession } from "../../store/session";
 
@@ -13,15 +15,30 @@ export function ExportButton() {
     .filter(([, channel]) => channel.enabled)
     .map(([key]) => Number(key))
     .sort((a, b) => a - b);
+  const [error, setError] = useState<string | null>(null);
 
-  const style = { fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "6px 12px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", textDecoration: "none" } as const;
+  const style = { fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "6px 12px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", background: "transparent", cursor: "pointer" } as const;
 
   if (!session || enabled.length === 0) {
     return <span style={{ ...style, color: "var(--lc-muted)", opacity: 0.6 }}>Export CSV</span>;
   }
+
+  async function handleClick() {
+    if (!session) return;
+    setError(null);
+    try {
+      await downloadAuthenticated(api.captureUrl(session.id, enabled), `capture_${session.id}_C${enabled.join("-")}.csv`);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
   return (
-    <a href={api.captureUrl(session.id, enabled)} download style={style}>
-      Export CSV
-    </a>
+    <>
+      <button type="button" onClick={handleClick} style={style}>
+        Export CSV
+      </button>
+      {error && <div role="alert" style={{ color: "var(--danger)", fontSize: "var(--text-sm)" }}>{error}</div>}
+    </>
   );
 }

--- a/webapp/app/src/features/export/ScreenshotButton.test.tsx
+++ b/webapp/app/src/features/export/ScreenshotButton.test.tsx
@@ -1,19 +1,46 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ScreenshotButton } from "./ScreenshotButton";
+import { setToken } from "../../api/token";
 import { useSession } from "../../store/session";
 
-beforeEach(() => useSession.getState().clearSession());
+beforeEach(() => {
+  localStorage.clear();
+  useSession.getState().clearSession();
+});
+afterEach(() => vi.unstubAllGlobals());
 
 describe("ScreenshotButton", () => {
-  it("links to the screenshot URL when connected", () => {
+  it("downloads the screenshot URL with the bearer token when connected", async () => {
     useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+    setToken("scpi_shot");
+    const fetchMock = vi.fn().mockResolvedValue(new Response(new Blob(["data"]), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("URL", { ...URL, createObjectURL: vi.fn(() => "blob:x"), revokeObjectURL: vi.fn() });
+
     render(<ScreenshotButton />);
-    expect(screen.getByRole("link", { name: /screenshot/i })).toHaveAttribute("href", "/api/sessions/abc/scope/screenshot.png");
+    await userEvent.click(screen.getByRole("button", { name: /screenshot/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/sessions/abc/scope/screenshot.png");
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer scpi_shot");
   });
 
-  it("is not a link with no session", () => {
+  it("is not a button with no session", () => {
     render(<ScreenshotButton />);
-    expect(screen.getByText(/screenshot/i).closest("a")).toBeNull();
+    expect(screen.getByText(/screenshot/i).closest("button")).toBeNull();
+  });
+
+  it("surfaces a download failure instead of silently doing nothing", async () => {
+    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Unauthorized", detail: "missing bearer token" }), { status: 401 })));
+
+    render(<ScreenshotButton />);
+    await userEvent.click(screen.getByRole("button", { name: /screenshot/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("missing bearer token");
   });
 });

--- a/webapp/app/src/features/export/ScreenshotButton.test.tsx
+++ b/webapp/app/src/features/export/ScreenshotButton.test.tsx
@@ -7,7 +7,7 @@ beforeEach(() => useSession.getState().clearSession());
 
 describe("ScreenshotButton", () => {
   it("links to the screenshot URL when connected", () => {
-    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
     render(<ScreenshotButton />);
     expect(screen.getByRole("link", { name: /screenshot/i })).toHaveAttribute("href", "/api/sessions/abc/scope/screenshot.png");
   });

--- a/webapp/app/src/features/export/ScreenshotButton.tsx
+++ b/webapp/app/src/features/export/ScreenshotButton.tsx
@@ -1,14 +1,32 @@
-import { api } from "../../api/client";
+import { useState } from "react";
+import { ApiError, api } from "../../api/client";
+import { downloadAuthenticated } from "../../api/download";
 import { useSession } from "../../store/session";
 
-const style = { fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "6px 12px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", textDecoration: "none" } as const;
+const style = { fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "6px 12px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", background: "transparent", cursor: "pointer" } as const;
 
 export function ScreenshotButton() {
   const session = useSession((s) => s.session);
+  const [error, setError] = useState<string | null>(null);
+
   if (!session) return <span style={{ ...style, color: "var(--lc-muted)", opacity: 0.6 }}>Screenshot</span>;
+
+  async function handleClick() {
+    if (!session) return;
+    setError(null);
+    try {
+      await downloadAuthenticated(api.screenshotUrl(session.id), "screenshot.png");
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
   return (
-    <a href={api.screenshotUrl(session.id)} download style={style}>
-      Screenshot
-    </a>
+    <>
+      <button type="button" onClick={handleClick} style={style}>
+        Screenshot
+      </button>
+      {error && <div role="alert" style={{ color: "var(--danger)", fontSize: "var(--text-sm)" }}>{error}</div>}
+    </>
   );
 }

--- a/webapp/app/src/features/home/DeviceCard.tsx
+++ b/webapp/app/src/features/home/DeviceCard.tsx
@@ -1,5 +1,6 @@
-import type { DiscoveredDevice } from "../../api/types";
+import type { DiscoveredDevice, SessionInfo } from "../../api/types";
 import { Button } from "../../ds/Button";
+import { OwnerBadge } from "../sessions/OwnerBadge";
 import { kindMeta } from "./kinds";
 
 export type DeviceCardProps = {
@@ -8,9 +9,15 @@ export type DeviceCardProps = {
   busy?: boolean;
   onConnect: (device: DiscoveredDevice) => void;
   onOpen: (device: DiscoveredDevice) => void;
+  // Only meaningful for variant "session": the full session record (for
+  // ownership) and the viewer's own identity. Both are optional because
+  // "available" cards never carry them.
+  session?: SessionInfo;
+  identity?: string | null;
+  onClaimed?: () => void;
 };
 
-export function DeviceCard({ device, variant, busy = false, onConnect, onOpen }: DeviceCardProps) {
+export function DeviceCard({ device, variant, busy = false, onConnect, onOpen, session, identity, onClaimed }: DeviceCardProps) {
   const meta = kindMeta(device.kind);
   const viewers = device.viewers ?? 0;
 
@@ -47,6 +54,9 @@ export function DeviceCard({ device, variant, busy = false, onConnect, onOpen }:
         {device.address ? ` · ${device.address}` : ""}
         {device.dialect ? ` · ${device.dialect}` : ""}
       </div>
+      {variant === "session" && session && identity != null && (
+        <OwnerBadge session={session} identity={identity} onClaimed={onClaimed ?? (() => {})} />
+      )}
       <div style={{ display: "flex", justifyContent: "flex-end" }}>{action}</div>
     </div>
   );

--- a/webapp/app/src/features/home/GettingStarted.test.tsx
+++ b/webapp/app/src/features/home/GettingStarted.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { GettingStarted } from "./GettingStarted";
+
+describe("GettingStarted", () => {
+  it("points to the authenticated OpenAPI schema instead of the disabled /docs UI", () => {
+    render(<GettingStarted />);
+    expect(screen.queryByRole("link", { name: "/docs" })).not.toBeInTheDocument();
+    expect(screen.getByText(/\/api\/openapi\.json/)).toBeInTheDocument();
+    expect(screen.getByText(/bearer token/i)).toBeInTheDocument();
+    expect(screen.getByText(/interactive docs UI is disabled/i)).toBeInTheDocument();
+  });
+});

--- a/webapp/app/src/features/home/GettingStarted.tsx
+++ b/webapp/app/src/features/home/GettingStarted.tsx
@@ -5,9 +5,7 @@ export function GettingStarted() {
       <ul style={{ margin: "var(--space-2) 0 0", paddingLeft: "var(--space-4)", color: "var(--lc-muted)" }}>
         <li>Find your instrument's IP (its Utility / I/O menu).</li>
         <li>Enable LAN / SCPI on the instrument.</li>
-        <li>
-          Explore the API at <a href="/docs">/docs</a>.
-        </li>
+        <li>The API schema is served at /api/openapi.json and needs the same bearer token as the rest of the API; the interactive docs UI is disabled.</li>
         <li>No hardware? Start a <b>Mock scope</b>.</li>
       </ul>
     </details>

--- a/webapp/app/src/features/home/HomeScreen.test.tsx
+++ b/webapp/app/src/features/home/HomeScreen.test.tsx
@@ -11,7 +11,7 @@ afterEach(() => {
   localStorage.clear();
 });
 
-const SESSION: SessionInfo = { id: "abc", label: "bench", mock: false, address: "192.168.1.50", state: "connected", idn: "Siglent,SDS824X HD,1,1", model: "SDS824X HD", dialect: "modern", num_channels: 4, viewers: 0 };
+const SESSION: SessionInfo = { id: "abc", label: "bench", mock: false, address: "192.168.1.50", state: "connected", idn: "Siglent,SDS824X HD,1,1", model: "SDS824X HD", dialect: "modern", num_channels: 4, viewers: 0, owner: "" };
 const FREE: DiscoveredDevice = { address: "192.168.1.51", idn: "x", manufacturer: "Siglent", model: "SDS1104X-E", dialect: "legacy", kind: "scope", connected: false };
 
 describe("HomeScreen", () => {

--- a/webapp/app/src/features/home/HomeScreen.test.tsx
+++ b/webapp/app/src/features/home/HomeScreen.test.tsx
@@ -5,10 +5,12 @@ import { HomeScreen } from "./HomeScreen";
 import { api } from "../../api/client";
 import { getRecent } from "./recent";
 import type { DiscoveredDevice, SessionInfo } from "../../api/types";
+import { useIdentity } from "../../store/identity";
 
 afterEach(() => {
   vi.restoreAllMocks();
   localStorage.clear();
+  useIdentity.getState().clearIdentity();
 });
 
 const SESSION: SessionInfo = { id: "abc", label: "bench", mock: false, address: "192.168.1.50", state: "connected", idn: "Siglent,SDS824X HD,1,1", model: "SDS824X HD", dialect: "modern", num_channels: 4, viewers: 0, owner: "" };
@@ -118,5 +120,88 @@ describe("HomeScreen", () => {
     render(<HomeScreen onConnected={vi.fn()} />);
     await userEvent.click(await screen.findByRole("button", { name: "Connect SDS1104X-E" }));
     expect(await screen.findByRole("alert")).toHaveTextContent("connection timed out");
+  });
+});
+
+describe("HomeScreen ownership badge", () => {
+  const OWNED: SessionInfo = { ...SESSION, id: "owned1", address: "192.168.1.52", owner: "alice" };
+
+  it("shows the read-only badge and claim control for a session owned by someone else", async () => {
+    useIdentity.getState().setIdentity("robin");
+    vi.spyOn(api, "listSessions").mockResolvedValue([OWNED]);
+    vi.spyOn(api, "discover").mockResolvedValue([]);
+    render(<HomeScreen onConnected={vi.fn()} />);
+
+    await screen.findByRole("button", { name: "Open SDS824X HD" });
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+    expect(screen.getByText(/alice/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /claim/i })).toBeInTheDocument();
+  });
+
+  it("hides the badge when the viewer is the session's own owner", async () => {
+    useIdentity.getState().setIdentity("alice");
+    vi.spyOn(api, "listSessions").mockResolvedValue([OWNED]);
+    vi.spyOn(api, "discover").mockResolvedValue([]);
+    render(<HomeScreen onConnected={vi.fn()} />);
+
+    await screen.findByRole("button", { name: "Open SDS824X HD" });
+    expect(screen.queryByText(/read-only/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /claim/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the badge for an unowned session (writable by anyone)", async () => {
+    useIdentity.getState().setIdentity("robin");
+    vi.spyOn(api, "listSessions").mockResolvedValue([SESSION]); // owner: ""
+    vi.spyOn(api, "discover").mockResolvedValue([]);
+    render(<HomeScreen onConnected={vi.fn()} />);
+
+    await screen.findByRole("button", { name: "Open SDS824X HD" });
+    expect(screen.queryByText(/read-only/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /claim/i })).not.toBeInTheDocument();
+  });
+
+  it("does not disable the Open button for a non-owner (reads stay available)", async () => {
+    useIdentity.getState().setIdentity("robin");
+    vi.spyOn(api, "listSessions").mockResolvedValue([OWNED]);
+    vi.spyOn(api, "discover").mockResolvedValue([]);
+    render(<HomeScreen onConnected={vi.fn()} />);
+
+    const open = await screen.findByRole("button", { name: "Open SDS824X HD" });
+    expect(open).toBeEnabled();
+  });
+
+  it("surfaces a failed claim's detail without getting stuck", async () => {
+    useIdentity.getState().setIdentity("robin");
+    vi.spyOn(api, "listSessions").mockResolvedValue([OWNED]);
+    vi.spyOn(api, "discover").mockResolvedValue([]);
+    const { ApiError } = await import("../../api/client");
+    vi.spyOn(api, "claimSession").mockRejectedValue(new ApiError(409, "Conflict", "owner is actively watching the stream"));
+    render(<HomeScreen onConnected={vi.fn()} />);
+
+    await screen.findByRole("button", { name: "Open SDS824X HD" });
+    const claim = screen.getByRole("button", { name: /claim/i });
+    await userEvent.click(claim);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("owner is actively watching the stream");
+    expect(claim).toBeEnabled();
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+  });
+
+  it("refreshes the session list after a successful claim, so the badge reflects the new owner", async () => {
+    useIdentity.getState().setIdentity("robin");
+    // The claim doesn't push its response into state on its own — HomeScreen
+    // must re-fetch, so simulate the server reporting the new owner on the
+    // *next* listSessions call, same as it would after a real claim.
+    const listSessions = vi.spyOn(api, "listSessions").mockResolvedValueOnce([OWNED]).mockResolvedValue([{ ...OWNED, owner: "robin" }]);
+    vi.spyOn(api, "discover").mockResolvedValue([]);
+    vi.spyOn(api, "claimSession").mockResolvedValue({ ...OWNED, owner: "robin" });
+    render(<HomeScreen onConnected={vi.fn()} />);
+
+    await screen.findByRole("button", { name: "Open SDS824X HD" });
+    const callsBefore = listSessions.mock.calls.length;
+    await userEvent.click(screen.getByRole("button", { name: /claim/i }));
+
+    await waitFor(() => expect(listSessions.mock.calls.length).toBeGreaterThan(callsBefore));
+    await waitFor(() => expect(screen.queryByText(/read-only/i)).not.toBeInTheDocument());
   });
 });

--- a/webapp/app/src/features/home/HomeScreen.tsx
+++ b/webapp/app/src/features/home/HomeScreen.tsx
@@ -9,6 +9,7 @@ import { InstrumentDashboard } from "./InstrumentDashboard";
 import { ManualConnect } from "./ManualConnect";
 import { RecentBar } from "./RecentBar";
 import { pushRecent, type RecentEntry } from "./recent";
+import { useIdentity } from "../../store/identity";
 
 type Props = { onConnected: (session: SessionInfo) => void };
 
@@ -20,6 +21,7 @@ function sessionAsDevice(s: SessionInfo): DiscoveredDevice {
 
 export function HomeScreen({ onConnected }: Props) {
   const [devices, setDevices] = useState<DiscoveredDevice[]>([]);
+  const [sessions, setSessions] = useState<SessionInfo[]>([]);
   const [scanning, setScanning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -27,12 +29,14 @@ export function HomeScreen({ onConnected }: Props) {
   const [busy, setBusy] = useState(false);
   const [lastScanned, setLastScanned] = useState<string>("not scanned yet");
   const busyRef = useRef(false);
+  const identity = useIdentity((s) => s.identity);
 
   const scan = useCallback(async () => {
     setScanning(true);
     setError(null);
     try {
       const sessions = await api.listSessions();
+      setSessions(sessions);
       const heldSeed = sessions.map(sessionAsDevice); // ALL held sessions, real + mock
       const heldAddrs = new Set(sessions.map((s) => s.address).filter((a): a is string => a !== null));
       // seed the sessions zone immediately, before the slow discover scan resolves
@@ -109,7 +113,7 @@ export function HomeScreen({ onConnected }: Props) {
         <div style={{ flex: 3, display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
           <RecentBar onReconnect={onReconnect} />
           {actionError && <div role="alert" style={{ padding: "8px 10px", borderRadius: "var(--radius-sm)", background: "color-mix(in srgb, var(--danger) 12%, transparent)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>{actionError}</div>}
-          <InstrumentDashboard devices={devices} scanning={scanning} error={error} busyKey={busyKey} onConnect={onConnectDevice} onOpen={onOpenDevice} />
+          <InstrumentDashboard devices={devices} scanning={scanning} error={error} busyKey={busyKey} onConnect={onConnectDevice} onOpen={onOpenDevice} sessions={sessions} identity={identity} onClaimed={scan} />
         </div>
         <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "var(--space-2)", minWidth: 220 }}>
           <GroupBox title="Connect manually"><ManualConnect busy={busy} onConnectAddress={onConnectAddress} onConnectMock={onConnectMock} /></GroupBox>

--- a/webapp/app/src/features/home/InstrumentDashboard.tsx
+++ b/webapp/app/src/features/home/InstrumentDashboard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { DiscoveredDevice } from "../../api/types";
+import type { DiscoveredDevice, SessionInfo } from "../../api/types";
 import { DeviceCard } from "./DeviceCard";
 import { deviceKey } from "./deviceKey";
 import { KIND_META, KIND_ORDER, type Kind } from "./kinds";
@@ -11,12 +11,17 @@ export type DashboardProps = {
   busyKey: string | null;
   onConnect: (device: DiscoveredDevice) => void;
   onOpen: (device: DiscoveredDevice) => void;
+  // Held sessions in full (for ownership) plus the viewer's own identity and
+  // a way to refresh after a claim. Only ever consulted for "session" cards.
+  sessions?: SessionInfo[];
+  identity?: string | null;
+  onClaimed?: () => void;
 };
 
 const zoneHeading = { fontSize: "var(--text-xs)", textTransform: "uppercase" as const, letterSpacing: "0.05em", color: "var(--lc-text-2)", fontWeight: 700, margin: "0 0 var(--space-2)" };
 const grid = { display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", gap: "var(--space-2)" };
 
-export function InstrumentDashboard({ devices, scanning, error, busyKey, onConnect, onOpen }: DashboardProps) {
+export function InstrumentDashboard({ devices, scanning, error, busyKey, onConnect, onOpen, sessions, identity, onClaimed }: DashboardProps) {
   const [query, setQuery] = useState("");
   const held = devices.filter((d) => d.connected);
   const available = devices.filter((d) => !d.connected);
@@ -25,7 +30,20 @@ export function InstrumentDashboard({ devices, scanning, error, busyKey, onConne
   const filtered = q ? available.filter((d) => `${d.model} ${d.address ?? ""} ${d.kind}`.toLowerCase().includes(q)) : available;
 
   function cardFor(device: DiscoveredDevice, variant: "available" | "session") {
-    return <DeviceCard key={deviceKey(device)} device={device} variant={variant} busy={busyKey !== null && busyKey === deviceKey(device)} onConnect={onConnect} onOpen={onOpen} />;
+    const session = variant === "session" ? sessions?.find((s) => s.id === device.session_id) : undefined;
+    return (
+      <DeviceCard
+        key={deviceKey(device)}
+        device={device}
+        variant={variant}
+        busy={busyKey !== null && busyKey === deviceKey(device)}
+        onConnect={onConnect}
+        onOpen={onOpen}
+        session={session}
+        identity={identity}
+        onClaimed={onClaimed}
+      />
+    );
   }
 
   return (

--- a/webapp/app/src/features/measure/MeasurePanel.test.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.test.tsx
@@ -9,7 +9,7 @@ const STATE = { run_state: "STOP", timebase: 0.001, channels: { "1": { enabled: 
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
   useSession.getState().applyState(STATE);
 });
 afterEach(() => vi.restoreAllMocks());

--- a/webapp/app/src/features/readout/ReadoutStrip.test.tsx
+++ b/webapp/app/src/features/readout/ReadoutStrip.test.tsx
@@ -5,7 +5,7 @@ import { useSession } from "../../store/session";
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
   useSession.getState().applyState({
     run_state: "TRIGD",
     timebase: 0.001,

--- a/webapp/app/src/features/reference/ReferencePanel.test.tsx
+++ b/webapp/app/src/features/reference/ReferencePanel.test.tsx
@@ -11,7 +11,7 @@ const OVERLAY = { name: "golden", channel: 1, t0: 0, dt: 1, points: [1] };
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
 });
 afterEach(() => vi.restoreAllMocks());
 

--- a/webapp/app/src/features/sessions/OwnerBadge.test.tsx
+++ b/webapp/app/src/features/sessions/OwnerBadge.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { OwnerBadge } from "./OwnerBadge";
+
+const session = { id: "s1", label: "scope", owner: "robin", mock: true } as never;
+
+describe("OwnerBadge", () => {
+  it("shows nothing intrusive when you are the owner", () => {
+    render(<OwnerBadge session={session} identity="robin" onClaimed={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /claim/i })).not.toBeInTheDocument();
+  });
+
+  it("marks the session read-only for a non-owner", () => {
+    render(<OwnerBadge session={session} identity="someone-else" onClaimed={vi.fn()} />);
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+    expect(screen.getByText(/robin/)).toBeInTheDocument();
+  });
+
+  it("offers a claim button to a non-owner", () => {
+    render(<OwnerBadge session={session} identity="someone-else" onClaimed={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /claim/i })).toBeInTheDocument();
+  });
+});

--- a/webapp/app/src/features/sessions/OwnerBadge.tsx
+++ b/webapp/app/src/features/sessions/OwnerBadge.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { ApiError, api } from "../../api/client";
+import { Button } from "../../ds/Button";
+import type { SessionInfo } from "../../api/types";
+
+export type OwnerBadgeProps = {
+  session: SessionInfo;
+  identity: string;
+  onClaimed: () => void;
+};
+
+/**
+ * Surfaces session ownership for a non-owner. The server enforces write
+ * ownership (owner-only writes, everyone else gets 409) — this is the one
+ * place that tells a non-owner *why* their writes would fail and offers a
+ * path to take over. Deliberately renders nothing for the owner and for an
+ * unowned session (`owner === ""`): reads (state, stream, captures, exports)
+ * keep working for everyone regardless, so there is nothing to warn about
+ * and no reason to add chrome the owner has to look past.
+ */
+export function OwnerBadge({ session, identity, onClaimed }: OwnerBadgeProps) {
+  const [error, setError] = useState("");
+  const [claiming, setClaiming] = useState(false);
+
+  if (!session.owner || session.owner === identity) return null;
+
+  const claim = async () => {
+    setClaiming(true);
+    setError("");
+    try {
+      await api.claimSession(session.id);
+      onClaimed();
+    } catch (caught) {
+      // The server's 409 detail explains *why* the claim failed (owner still
+      // active, or owner watching the stream) — that text is the only way the
+      // user learns the owner is still there, so it must reach the screen.
+      setError(caught instanceof ApiError ? caught.detail || caught.message : caught instanceof Error ? caught.message : "Claim failed.");
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "5px",
+          fontSize: "var(--text-2xs)",
+          color: "var(--warning)",
+          border: "1px solid var(--lc-border)",
+          borderRadius: "var(--radius-pill)",
+          padding: "1px 9px",
+        }}
+      >
+        <strong>Read-only</strong> — owned by {session.owner}
+      </span>
+      <Button type="button" size="sm" disabled={claiming} onClick={() => void claim()}>
+        {claiming ? "Claiming…" : "Claim"}
+      </Button>
+      {error ? (
+        <span role="alert" style={{ fontSize: "var(--text-xs)", color: "var(--danger)" }}>
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/webapp/app/src/features/terminal/TerminalPanel.test.tsx
+++ b/webapp/app/src/features/terminal/TerminalPanel.test.tsx
@@ -7,7 +7,7 @@ import { useSession } from "../../store/session";
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
 });
 afterEach(() => vi.restoreAllMocks());
 

--- a/webapp/app/src/features/trend/LogPanel.test.tsx
+++ b/webapp/app/src/features/trend/LogPanel.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LogPanel } from "./LogPanel";
 import { clearTrend } from "./trend";
 import { ApiError, api } from "../../api/client";
+import { setToken } from "../../api/token";
 import type { LogInfo } from "../../api/types";
 import { useSession } from "../../store/session";
 
@@ -12,12 +13,16 @@ const RECORDING: LogInfo = { state: "recording", started_at: 100, row_count: 0, 
 
 beforeEach(() => {
   clearTrend();
+  localStorage.clear();
   useSession.getState().clearSession();
   useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
   vi.spyOn(api, "getLog").mockResolvedValue(IDLE);
   vi.spyOn(api, "getLogData").mockResolvedValue({ columns: [], rows: [] });
 });
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("LogPanel", () => {
   it("seeds status from the server on mount", async () => {
@@ -41,11 +46,34 @@ describe("LogPanel", () => {
     expect(stop).toHaveBeenCalledWith("abc");
   });
 
-  it("links the CSV export once a recording exists, disabled before", async () => {
+  it("enables the CSV download once a recording exists, disabled before", async () => {
     render(<LogPanel />);
-    expect(screen.getByText("Download CSV").closest("a")).toBeNull(); // no recording yet: not a link
+    expect(screen.getByText("Download CSV").closest("button")).toBeNull(); // no recording yet: not a button
     act(() => useSession.getState().applyLogStatus(RECORDING));
-    await waitFor(() => expect(screen.getByRole("link", { name: "Download CSV" })).toHaveAttribute("href", "/api/sessions/abc/scope/log.csv"));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Download CSV" })).toBeInTheDocument());
+  });
+
+  it("downloads the trend CSV with the bearer token", async () => {
+    setToken("scpi_trend");
+    const fetchMock = vi.fn().mockResolvedValue(new Response(new Blob(["data"]), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("URL", { ...URL, createObjectURL: vi.fn(() => "blob:x"), revokeObjectURL: vi.fn() });
+    render(<LogPanel />);
+    act(() => useSession.getState().applyLogStatus(RECORDING));
+    await userEvent.click(await screen.findByRole("button", { name: "Download CSV" }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/sessions/abc/scope/log.csv");
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer scpi_trend");
+  });
+
+  it("surfaces a CSV download failure instead of silently doing nothing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Unauthorized", detail: "missing bearer token" }), { status: 401 })));
+    render(<LogPanel />);
+    act(() => useSession.getState().applyLogStatus(RECORDING));
+    await userEvent.click(await screen.findByRole("button", { name: "Download CSV" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("missing bearer token");
   });
 
   it("surfaces a start error", async () => {

--- a/webapp/app/src/features/trend/LogPanel.test.tsx
+++ b/webapp/app/src/features/trend/LogPanel.test.tsx
@@ -13,7 +13,7 @@ const RECORDING: LogInfo = { state: "recording", started_at: 100, row_count: 0, 
 beforeEach(() => {
   clearTrend();
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
   vi.spyOn(api, "getLog").mockResolvedValue(IDLE);
   vi.spyOn(api, "getLogData").mockResolvedValue({ columns: [], rows: [] });
 });

--- a/webapp/app/src/features/trend/LogPanel.tsx
+++ b/webapp/app/src/features/trend/LogPanel.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import { ApiError, api } from "../../api/client";
+import { downloadAuthenticated } from "../../api/download";
 import { getTrend, seedTrend, subscribeTrend } from "./trend";
 import { Button } from "../../ds/Button";
 import { GroupBox } from "../../ds/GroupBox";
 import { useSession } from "../../store/session";
 
-const linkStyle = { fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "6px 12px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", textDecoration: "none", alignSelf: "flex-start" } as const;
+const linkStyle = { fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "6px 12px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", background: "transparent", cursor: "pointer", alignSelf: "flex-start" } as const;
 const mutedStyle = { color: "var(--lc-muted)", fontSize: "var(--text-sm)" } as const;
 
 export function LogPanel() {
@@ -61,6 +62,16 @@ export function LogPanel() {
 
   const startedText = logStatus?.started_at != null ? new Date(logStatus.started_at * 1000).toLocaleTimeString() : null;
 
+  async function downloadCsv() {
+    if (!session) return;
+    setError(null);
+    try {
+      await downloadAuthenticated(api.logCsvUrl(session.id), "trend.csv");
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
       <GroupBox title="Recording">
@@ -74,9 +85,9 @@ export function LogPanel() {
       </GroupBox>
       <GroupBox title="Export">
         {session && hasLog ? (
-          <a href={api.logCsvUrl(session.id)} download style={linkStyle}>
+          <button type="button" onClick={downloadCsv} style={linkStyle}>
             Download CSV
-          </a>
+          </button>
         ) : (
           <span style={{ ...linkStyle, color: "var(--lc-muted)", opacity: 0.6 }}>Download CSV</span>
         )}

--- a/webapp/app/src/features/trend/TrendCanvas.test.tsx
+++ b/webapp/app/src/features/trend/TrendCanvas.test.tsx
@@ -8,7 +8,7 @@ import { useSession } from "../../store/session";
 beforeEach(() => {
   clearTrend();
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
 });
 afterEach(() => vi.restoreAllMocks());
 

--- a/webapp/app/src/features/waveform/SpectrumCanvas.test.tsx
+++ b/webapp/app/src/features/waveform/SpectrumCanvas.test.tsx
@@ -11,7 +11,7 @@ const FRAME = { channel: 1, f0: 0, df: 10, points: [-60, -20, -60, -80], db: tru
 beforeEach(() => {
   clearSpectrum();
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
 });
 afterEach(() => vi.restoreAllMocks());
 

--- a/webapp/app/src/main.tsx
+++ b/webapp/app/src/main.tsx
@@ -3,6 +3,9 @@ import ReactDOM from "react-dom/client";
 import "@design/styles.css";
 import "./ds/ds.css";
 import App from "./App";
+import { captureTokenFromUrl } from "./api/token";
+
+captureTokenFromUrl();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/webapp/app/src/store/identity.test.ts
+++ b/webapp/app/src/store/identity.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useIdentity } from "./identity";
+
+beforeEach(() => useIdentity.getState().clearIdentity());
+
+describe("identity store", () => {
+  it("starts with no identity", () => {
+    expect(useIdentity.getState().identity).toBeNull();
+  });
+
+  it("setIdentity stores the whoami name", () => {
+    useIdentity.getState().setIdentity("robin");
+    expect(useIdentity.getState().identity).toBe("robin");
+  });
+
+  it("clearIdentity resets to null", () => {
+    useIdentity.getState().setIdentity("robin");
+    useIdentity.getState().clearIdentity();
+    expect(useIdentity.getState().identity).toBeNull();
+  });
+});

--- a/webapp/app/src/store/identity.ts
+++ b/webapp/app/src/store/identity.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+
+type IdentityStore = {
+  identity: string | null;
+  setIdentity: (identity: string) => void;
+  clearIdentity: () => void;
+};
+
+/**
+ * Who this browser is, as far as the gateway is concerned. TokenGate learns
+ * this once per verified token (the `whoami` response is the token's name)
+ * and stores it here so anything in the tree — e.g. OwnerBadge deciding
+ * whether the current viewer owns a session — can read it without a prop
+ * drilled all the way from the token check.
+ */
+export const useIdentity = create<IdentityStore>((set) => ({
+  identity: null,
+  setIdentity: (identity) => set({ identity }),
+  clearIdentity: () => set({ identity: null }),
+}));

--- a/webapp/app/src/store/session.test.ts
+++ b/webapp/app/src/store/session.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { useSession } from "./session";
 import type { ScopeState, SessionInfo } from "../api/types";
 
-const SESSION: SessionInfo = { id: "abc", label: "bench", mock: false, address: "192.168.1.50", state: "connected", idn: "Siglent,SDS824X HD,1,1", model: "SDS824X HD", dialect: "modern", num_channels: 4, viewers: 0 };
+const SESSION: SessionInfo = { id: "abc", label: "bench", mock: false, address: "192.168.1.50", state: "connected", idn: "Siglent,SDS824X HD,1,1", model: "SDS824X HD", dialect: "modern", num_channels: 4, viewers: 0, owner: "" };
 
 const STATE: ScopeState = {
   run_state: "STOP",

--- a/webapp/app/src/stream/useStream.test.ts
+++ b/webapp/app/src/stream/useStream.test.ts
@@ -37,7 +37,7 @@ class FakeWebSocket {
   }
 }
 
-const SESSION = { id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 };
+const SESSION = { id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" };
 
 beforeEach(() => {
   vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
@@ -86,7 +86,7 @@ describe("useStream", () => {
   });
 
   it("treats a closed message as a clean session end", async () => {
-    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0 });
+    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
     renderHook(() => useStream("abc"));
     FakeWebSocket.last!.emit({ type: "closed" });
     await waitFor(() => expect(useSession.getState().session).toBeNull());

--- a/webapp/app/src/stream/useStream.test.ts
+++ b/webapp/app/src/stream/useStream.test.ts
@@ -5,17 +5,20 @@ import { useSession } from "../store/session";
 import { getFrame, clearFrames } from "../features/waveform/frames";
 import { getSpectrum, clearSpectrum } from "../features/waveform/spectrum";
 import { clearTrend, getTrend, seedTrend } from "../features/trend/trend";
+import { setToken, clearToken } from "../api/token";
 
 class FakeWebSocket {
   static last: FakeWebSocket | null = null;
   url: string;
+  protocols: string[] | undefined;
   onmessage: ((event: { data: string }) => void) | null = null;
   onclose: ((event: { code: number }) => void) | null = null;
   onerror: (() => void) | null = null;
   closed = false;
 
-  constructor(url: string) {
+  constructor(url: string, protocols?: string | string[]) {
     this.url = url;
+    this.protocols = protocols === undefined ? undefined : ([] as string[]).concat(protocols);
     FakeWebSocket.last = this;
   }
 
@@ -42,6 +45,7 @@ beforeEach(() => {
   clearFrames();
   clearSpectrum();
   clearTrend();
+  clearToken();
 });
 
 const STATE = { run_state: "STOP", timebase: 0.001, channels: { "1": { enabled: true, voltage_scale: 0.5, voltage_offset: 0, coupling: "DC", probe_ratio: 10 } }, trigger: { mode: "AUTO", source: "C1", level: 0, slope: "POS", coupling: "DC" } };
@@ -205,5 +209,17 @@ describe("useStream", () => {
     FakeWebSocket.last!.emit({ type: "measurements", values: [{ channel: 1, mtype: "PKPK", value: 2 }], timestamp: 101 });
     await waitFor(() => expect(useSession.getState().measurements.length).toBe(1));
     expect(getTrend().rows).toEqual([]);
+  });
+
+  it("offers the token subprotocol", () => {
+    setToken("scpi_wstoken");
+    renderHook(() => useStream("abc"));
+    expect(FakeWebSocket.last?.protocols).toEqual(["scpi-token.scpi_wstoken", "scpi"]);
+  });
+
+  it("offers no token subprotocol when unauthenticated", () => {
+    clearToken();
+    renderHook(() => useStream("abc"));
+    expect(FakeWebSocket.last?.protocols).toEqual(["scpi"]);
   });
 });

--- a/webapp/app/src/stream/useStream.ts
+++ b/webapp/app/src/stream/useStream.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { getToken } from "../api/token";
 import type { StreamMessage } from "../api/types";
 import { appendTrend, clearTrend, seedTrend } from "../features/trend/trend";
 import { clearFrames, setFrame } from "../features/waveform/frames";
@@ -12,7 +13,9 @@ export function useStream(sessionId: string | null): void {
     if (!sessionId) return;
 
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const socket = new WebSocket(`${protocol}//${window.location.host}/api/sessions/${sessionId}/stream`);
+    const token = getToken();
+    const subprotocols = token ? [`scpi-token.${token}`, "scpi"] : ["scpi"];
+    const socket = new WebSocket(`${protocol}//${window.location.host}/api/sessions/${sessionId}/stream`, subprotocols);
     let ended = false;
 
     socket.onmessage = (event: MessageEvent) => {


### PR DESCRIPTION
Closes the 2026-07-22 audit's **theme #5** — "the network gateway has no security boundary" — and the related deserialization-RCE findings. The web gateway (`scpi-web`) previously had no authentication, no bound on what it would connect to, and a load path that executed attacker-supplied code. This adds a full boundary.

**Breaking — targets v5.0.0.** The gateway now requires a token, and reference files change format. Migration is covered in the new [gateway security guide](docs/gateway/security.md) and the changelog.

## What changed

### ⚠️ Breaking
- **Authentication is mandatory.** Every `/api/*` request needs `Authorization: Bearer <token>`; the WebSocket stream needs the `scpi-token.<token>` subprotocol. First run mints a token and prints a `?token=…` URL. `GET /api/health` stays open. `/docs` and `/redoc` are removed; the schema moved to `/api/openapi.json` (token required) — the old locations served the whole control surface anonymously.
- **Reference metadata is now JSON, not pickle.** Files saved by 4.x must be converted once with `scpi-web references migrate`.

### Added
- Named bearer tokens (`scpi-web token add|list|revoke`), stored hashed in `~/.siglent/tokens.json`.
- **Session ownership** — the creating identity writes; anyone authenticated reads/streams/exports; non-owner writes get 409. `claim` (idle-timeout takeover, honouring an actively-watching owner) and `owner` (named handoff / release). The web UI shows a read-only badge and claim button to non-owners.
- `--allow-port`, `--max-sessions` (default 8), `--abandon-after` (default 300 s), `scpi-web references migrate`.

### Fixed (security)
- Loading a waveform or reference archive no longer unpickles it — a crafted `.npz` can no longer execute code via `scpi-extract`, the report loader, or the gateway. The one remaining pickle read is the explicit `references migrate` command.
- Reference lookup no longer honours absolute paths or `..` traversal; listing no longer deserializes every file in the directory.
- Session creation validates the target — resolve-then-check-every-address, loopback/link-local/metadata refused, port allowlist, no banner reflection (closes the SSRF).
- Deep-memory serialization runs off the event loop; the session cap holds under concurrency; a Windows `rename_reference` handle leak fixed; authenticated file downloads in the web UI.

## How it was built

Subagent-driven, 24 tasks, each with an adversarial per-task review + mutation testing, plus a final whole-branch review. Worth noting for reviewers: **the review loop caught nine defects that originated in the plan's own example code** — including a Critical `root_path` auth bypass, a data-destroying bug in the migration command, a session cap that didn't hold under concurrency, and a docs claim that revocation was immediate when it requires a restart. Two reviews also surfaced regressions the plan didn't cover (broken authenticated downloads; an unwired ownership badge), which became their own tasks.

**Known limitation (documented, accepted):** `scpi-web token revoke` edits `tokens.json`, but a running gateway loads tokens once at startup — so a revocation takes effect on restart, not live. The security guide states this plainly. Live cross-process revocation (mtime-reload + atomic save) is a possible follow-up.

## Verification
- Python suite: **1606 passed / 19 skipped**.
- Frontend: **193 passed** across 40 files; `tsc --noEmit` clean.
- New coverage includes a fail-closed route-enumeration test, an end-to-end authenticated lifecycle (create → cross-identity read/write → WS auth → mid-session revoke → delete), and a malicious-`.npz` regression proven by mutation to detect real code execution.

## Not included (intentionally)
- The v5.0.0 breaks batched earlier — SPD OVP/OCP capability flip, `MockConnection` strict default, modern `WF?` shim removal — remain in 4.1.0's Deprecated section for their own release-time work.
- TLS (put the gateway behind a proxy), user accounts/roles, per-user reference storage. See the security guide's "not covered" section.
