### PR TITLE
chore(release): 5.0.0 — security boundary + deferred breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-07-24
+
 ### ⚠️ Breaking Changes
 
 - Web gateway: every `/api/*` request now requires a bearer token, and the live-stream
@@ -23,6 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reference waveforms: stored metadata moved from a pickled dict to a JSON string so reference
   files load without `allow_pickle`. Files saved by 4.x raise an error naming the file until
   converted. **Migration:** run `scpi-web references migrate` once.
+- Power supply (SPD3303X/-E): `ovp_level`/`ocp_level` now raise `NotImplementedError` — the
+  SPD3303X command set has no protection subsystem, so these calls never armed anything on real
+  hardware (they emitted a `FutureWarning` in 4.1.0). The model's `has_ovp`/`has_ocp` capabilities
+  are now `False`. **Migration:** stop calling these on an SPD3303X; gate on
+  `has_ovp`/`has_ocp` if you support multiple PSU models.
+- Testing: `MockConnection` now defaults to `strict=True`, so an unmatched PSU/AWG/DAQ query raises
+  `TimeoutError` like real hardware instead of returning `""`. **Migration:** pass `strict=False`
+  explicitly to restore the old lenient behavior.
+- Testing: `MockConnection` no longer answers the legacy `C<n>:WF?` waveform read on a
+  modern-dialect instance (SDS800X HD / SDS5000X); it now times out, matching real modern
+  hardware, which documents no such command. Legacy-dialect scopes are unaffected.
 
 ### Added
 

--- a/docs/examples/intermediate.md
+++ b/docs/examples/intermediate.md
@@ -1054,10 +1054,15 @@ def demo_real_world_scenario():
     print("\nScenario: Testing a device at different voltage levels")
     print("Logging power consumption at each voltage step")
 
-    # Set up protection
-    psu.output1.ovp_level = 15.0
-    psu.output1.ocp_level = 2.0
-    print(f"\nSafety limits: OVP={psu.output1.ovp_level}V, OCP={psu.output1.ocp_level}A")
+    # Set up protection (SPD3303X has no protection subsystem -- QS0503X-E01B
+    # p.36 -- so ovp_level/ocp_level raise NotImplementedError; guard like the
+    # OVP/OCP demo above)
+    if psu.model_capability.has_ovp and psu.model_capability.has_ocp:
+        psu.output1.ovp_level = 15.0
+        psu.output1.ocp_level = 2.0
+        print(f"\nSafety limits: OVP={psu.output1.ovp_level}V, OCP={psu.output1.ocp_level}A")
+    else:
+        print("\nSafety limits: OVP/OCP not supported on this model")
 
     # Start data logging
     with PSUDataLogger(psu, "characterization_log.csv", outputs=[1]) as logger:

--- a/examples/psu_advanced_features.py
+++ b/examples/psu_advanced_features.py
@@ -255,10 +255,15 @@ def demo_real_world_scenario():
     print("\nScenario: Testing a device at different voltage levels")
     print("Logging power consumption at each voltage step")
 
-    # Set up protection
-    psu.output1.ovp_level = 15.0
-    psu.output1.ocp_level = 2.0
-    print(f"\nSafety limits: OVP={psu.output1.ovp_level}V, OCP={psu.output1.ocp_level}A")
+    # Set up protection (SPD3303X has no protection subsystem -- QS0503X-E01B
+    # p.36 -- so ovp_level/ocp_level raise NotImplementedError; guard like the
+    # OVP/OCP demo above)
+    if psu.model_capability.has_ovp and psu.model_capability.has_ocp:
+        psu.output1.ovp_level = 15.0
+        psu.output1.ocp_level = 2.0
+        print(f"\nSafety limits: OVP={psu.output1.ovp_level}V, OCP={psu.output1.ocp_level}A")
+    else:
+        print("\nSafety limits: OVP/OCP not supported on this model")
 
     # Start data logging
     with PSUDataLogger(psu, "characterization_log.csv", outputs=[1]) as logger:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "4.1.1"
+version = "5.0.0"
 description = "Universal Python library for SCPI test equipment via Ethernet/LAN, USB, GPIB, or serial. Drives oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies, and DAQ units. Waveform capture with acquisition provenance, raw-data extraction (load_waveform, scpi-extract), FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and synthetic-signal mocks for development without hardware."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "4.1.1"
+__version__ = "5.0.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -754,6 +754,16 @@ class MockConnection(BaseConnection):
                 payload = siglent.build_waveform_data(self)
                 return payload[:size] if size is not None else payload
 
+        # v5.0.0: the legacy C<n>:WF? DAT2/DESC block was answered on modern
+        # dialects as a back-compat shim "until v5.0.0" (Task 18). That date
+        # has arrived -- the modern programming guide documents no such
+        # command, so a modern instance must no longer serve it. Real modern
+        # hardware gives no response at all to an unrecognized/legacy
+        # waveform read; model that honestly, same as the query() timeout
+        # path above.
+        if self.scope_dialect == "modern":
+            raise exceptions.TimeoutError(f"MockConnection ({self.scope_dialect}) has no response for read_raw() after writes={self.writes!r}")
+
         personality = _PERSONALITIES.get(self.scope_vendor, siglent)
         payload = personality.build_waveform_response(self)
         return payload[:size] if size is not None else payload

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -70,10 +70,11 @@ class MockConnection(BaseConnection):
         daq_idn: str = "Keysight Technologies,34970A,MY12345678,A.01.02",
         daq_readings: str = "1.234,2.345,3.456",
         tek_badges: Optional[Dict[int, Dict[str, str]]] = None,
-        # strict: When True, unmatched PSU/AWG/DAQ queries raise TimeoutError
-        # instead of returning "", matching real instruments. Default False
-        # in 4.1.0 for compatibility; becomes the default in v5.0.0.
-        strict: bool = False,
+        # strict: When True (the default as of v5.0.0), unmatched PSU/AWG/DAQ
+        # queries raise TimeoutError instead of returning "", matching real
+        # instruments. Pass strict=False to restore the old lenient
+        # "return empty string" behavior (the default through 4.1.0).
+        strict: bool = True,
     ):
         super().__init__(host, port, timeout)
         channels = channel_states.keys() if channel_states else range(1, 3)

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -298,9 +298,12 @@ def handle_query(conn, command: str) -> Optional[str]:
 def build_waveform_response(conn) -> bytes:
     """Construct a minimal Siglent-style waveform block response.
 
-    Legacy-dialect "C{ch}:WF? DAT2"/"DESC" only (Task 18 deprecation: kept
-    answering until v5.0.0, but the modern-dialect driver capture path no
-    longer sends it -- see build_waveform_preamble/build_waveform_data below).
+    Legacy-dialect "C{ch}:WF? DAT2"/"DESC" only. As of v5.0.0 the modern
+    dialect no longer falls through to this builder (Task 18's back-compat
+    shim was removed on schedule); a modern-dialect read_raw() times out on
+    an unrecognized/legacy waveform read instead, matching real modern
+    hardware -- see build_waveform_preamble/build_waveform_data below for
+    the documented modern path.
     """
     channel = conn._last_waveform_channel or next(iter(conn._waveform_payloads), 1)
     payload = mock_synth.payload_for(conn, channel, include_offset=True)

--- a/scpi_control/power_supply_output.py
+++ b/scpi_control/power_supply_output.py
@@ -5,7 +5,6 @@ Represents a single power supply output with voltage, current, and enable contro
 
 import logging
 import re
-import warnings
 from typing import TYPE_CHECKING, Dict
 
 from scpi_control import exceptions
@@ -244,19 +243,6 @@ class PowerSupplyOutput:
         Raises:
             NotImplementedError: If OVP is not supported by this model
         """
-        if self._psu.model_capability.scpi_variant == "siglent_spd":
-            # QS0503X-E01B p.36 lists the full SPD3303X command set; it has no
-            # protection subsystem, so this command is silently discarded by the
-            # instrument. FutureWarning (not DeprecationWarning) because the latter
-            # is hidden by default outside __main__, and a user who believes OVP is
-            # armed must see this. Capability flips to False and this raises in
-            # v5.0.0 (audit H18).
-            warnings.warn(
-                "SPD3303X has no protection subsystem; this call arms nothing. " "It will raise NotImplementedError in v5.0.0.",
-                FutureWarning,
-                stacklevel=2,
-            )
-
         if not self._psu.model_capability.has_ovp:
             raise NotImplementedError(f"Over-voltage protection not supported on {self._psu.model_capability.model_name}")
 
@@ -291,19 +277,6 @@ class PowerSupplyOutput:
         Raises:
             NotImplementedError: If OCP is not supported by this model
         """
-        if self._psu.model_capability.scpi_variant == "siglent_spd":
-            # QS0503X-E01B p.36 lists the full SPD3303X command set; it has no
-            # protection subsystem, so this command is silently discarded by the
-            # instrument. FutureWarning (not DeprecationWarning) because the latter
-            # is hidden by default outside __main__, and a user who believes OCP is
-            # armed must see this. Capability flips to False and this raises in
-            # v5.0.0 (audit H18).
-            warnings.warn(
-                "SPD3303X has no protection subsystem; this call arms nothing. " "It will raise NotImplementedError in v5.0.0.",
-                FutureWarning,
-                stacklevel=2,
-            )
-
         if not self._psu.model_capability.has_ocp:
             raise NotImplementedError(f"Over-current protection not supported on {self._psu.model_capability.model_name}")
 

--- a/scpi_control/psu_models.py
+++ b/scpi_control/psu_models.py
@@ -64,8 +64,11 @@ PSU_MODEL_REGISTRY = {
             OutputSpec(2, 30.0, 3.0, 90.0, 0.001, 0.001),
             OutputSpec(3, 5.0, 3.0, 15.0, 0.01, 0.001),  # Fixed 5V output
         ],
-        has_ovp=True,
-        has_ocp=True,
+        # QS0503X-E01B p.36 lists the full SPD3303X command set; it has no
+        # protection subsystem, so OVP/OCP calls never armed anything on
+        # real hardware. False as of v5.0.0 (audit H18).
+        has_ovp=False,
+        has_ocp=False,
         has_timer=True,
         has_waveform=True,
         has_tracking=True,
@@ -81,8 +84,11 @@ PSU_MODEL_REGISTRY = {
             OutputSpec(2, 30.0, 3.0, 90.0, 0.001, 0.001),
             OutputSpec(3, 5.0, 3.0, 15.0, 0.01, 0.001),
         ],
-        has_ovp=True,
-        has_ocp=True,
+        # QS0503X-E01B p.36 lists the full SPD3303X command set; it has no
+        # protection subsystem, so OVP/OCP calls never armed anything on
+        # real hardware. False as of v5.0.0 (audit H18).
+        has_ovp=False,
+        has_ocp=False,
         has_timer=True,
         has_waveform=True,
         has_tracking=True,

--- a/tests/test_mock_dialects.py
+++ b/tests/test_mock_dialects.py
@@ -45,6 +45,17 @@ class TestModernResponses:
         with pytest.raises(TimeoutError):
             self.conn.query("TDIV?")
 
+    def test_legacy_waveform_read_times_out_on_modern_scope(self):
+        # v5.0.0: the C<n>:WF? DAT2/DESC back-compat shim (Task 18) is
+        # removed. The modern programming guide documents no such command,
+        # so a modern-dialect instance must no longer serve a legacy
+        # waveform block for it, even when the request is issued by hand
+        # instead of through the driver's (already-correct) modern capture
+        # path -- read_raw() must time out like real modern hardware.
+        self.conn.write("C1:WF? DAT2")
+        with pytest.raises(TimeoutError):
+            self.conn.read_raw()
+
     def test_legacy_write_is_recorded_but_ignored(self):
         # Real scopes silently drop unknown writes; only queries time out
         self.conn.write("TDIV 0.001")

--- a/tests/test_mock_strict_mode.py
+++ b/tests/test_mock_strict_mode.py
@@ -11,9 +11,17 @@ from scpi_control import exceptions
 from scpi_control.connection.mock import MockConnection
 
 
-def test_unmatched_psu_query_returns_empty_by_default():
-    """Default stays lenient in 4.1.0 so existing suites keep working."""
+def test_unmatched_psu_query_raises_by_default():
+    """v5.0.0: strict is now the default, so unmatched queries time out like real hardware."""
     conn = MockConnection(psu_mode=True)
+    conn.connect()
+    with pytest.raises(exceptions.TimeoutError):
+        conn.query("CH1:VOLTAGE?")
+
+
+def test_unmatched_psu_query_returns_empty_when_lenient():
+    """strict=False explicitly restores the pre-5.0.0 lenient "" behavior."""
+    conn = MockConnection(psu_mode=True, strict=False)
     conn.connect()
     assert conn.query("CH1:VOLTAGE?") == ""
 

--- a/tests/test_power_supply.py
+++ b/tests/test_power_supply.py
@@ -20,7 +20,9 @@ class TestPSUModels:
         assert cap.manufacturer == "Siglent"
         assert cap.num_outputs == 3
         assert cap.scpi_variant == "siglent_spd"
-        assert cap.has_ovp is True
+        # SPD3303X has no protection subsystem (QS0503X-E01B p.36) -- audit H18.
+        assert cap.has_ovp is False
+        assert cap.has_ocp is False
         assert cap.has_timer is True
 
     def test_detect_siglent_spd3303x_e(self):
@@ -398,27 +400,32 @@ class TestAdvancedFeatures:
             _ = psu.tracking_mode
 
     def test_ovp_level(self, siglent_psu):
-        """Test OVP (over-voltage protection) level."""
+        """Test OVP (over-voltage protection) level on SPD3303X, which has no
+        protection subsystem (QS0503X-E01B p.36) -- audit H18."""
         psu = siglent_psu
         output = psu.output1
 
-        assert psu.model_capability.has_ovp is True
+        assert psu.model_capability.has_ovp is False
 
-        # Set OVP level
-        output.ovp_level = 25.0
-        # Mock doesn't store this, but should not error
-        assert isinstance(output.ovp_level, float)
+        with pytest.raises(NotImplementedError):
+            output.ovp_level = 25.0
+
+        with pytest.raises(NotImplementedError):
+            _ = output.ovp_level
 
     def test_ocp_level(self, siglent_psu):
-        """Test OCP (over-current protection) level."""
+        """Test OCP (over-current protection) level on SPD3303X, which has no
+        protection subsystem (QS0503X-E01B p.36) -- audit H18."""
         psu = siglent_psu
         output = psu.output1
 
-        assert psu.model_capability.has_ocp is True
+        assert psu.model_capability.has_ocp is False
 
-        # Set OCP level
-        output.ocp_level = 2.5
-        assert isinstance(output.ocp_level, float)
+        with pytest.raises(NotImplementedError):
+            output.ocp_level = 2.5
+
+        with pytest.raises(NotImplementedError):
+            _ = output.ocp_level
 
     def test_ovp_generic_support(self):
         """Test OVP on generic PSU (SCPI-99 standard supports it)."""

--- a/tests/test_spd_protection_warning.py
+++ b/tests/test_spd_protection_warning.py
@@ -1,8 +1,9 @@
 """SPD3303X has no OVP/OCP subsystem (QS0503X-E01B p.36) -- audit H18.
 
-Until v5.0.0 the capability flags stay True for compatibility, but the call must
-not look successful: someone raising voltage on a 12V DUT believing protection is
-armed is the failure this warning exists to prevent.
+As of v5.0.0, `has_ovp`/`has_ocp` are False for the SPD3303X/-E and ovp_level/
+ocp_level raise NotImplementedError instead of silently discarding the command:
+someone raising voltage on a 12V DUT believing protection is armed is the
+failure this guard exists to prevent.
 """
 
 import pytest
@@ -19,11 +20,21 @@ def spd():
     return psu
 
 
-def test_setting_ovp_warns_that_nothing_is_armed(spd):
-    with pytest.warns(FutureWarning, match="no.*protection subsystem"):
+def test_setting_ovp_raises_not_implemented(spd):
+    with pytest.raises(NotImplementedError, match="Over-voltage protection not supported"):
         spd.output1.ovp_level = 12.0
 
 
-def test_setting_ocp_warns_that_nothing_is_armed(spd):
-    with pytest.warns(FutureWarning, match="no.*protection subsystem"):
+def test_getting_ovp_raises_not_implemented(spd):
+    with pytest.raises(NotImplementedError, match="Over-voltage protection not supported"):
+        _ = spd.output1.ovp_level
+
+
+def test_setting_ocp_raises_not_implemented(spd):
+    with pytest.raises(NotImplementedError, match="Over-current protection not supported"):
         spd.output1.ocp_level = 2.5
+
+
+def test_getting_ocp_raises_not_implemented(spd):
+    with pytest.raises(NotImplementedError, match="Over-current protection not supported"):
+        _ = spd.output1.ocp_level


### PR DESCRIPTION
Cuts **v5.0.0** (MAJOR). Bundles the merged web-gateway security boundary (PR #100) with the three breaking changes the 4.1.0 changelog deferred to v5.0.0, and bumps the version.

## Breaking changes

**From the security boundary (PR #100, already on main):**
- Web gateway now requires a bearer token on every `/api/*` request and the WebSocket stream; `/docs` and `/redoc` removed (schema at `/api/openapi.json`, token required); reference files move to a JSON metadata format (`scpi-web references migrate`).

**Landed on this branch — the three 4.1.0-deferred breaks, now due:**
- **SPD3303X/-E OVP/OCP** — `ovp_level`/`ocp_level` raise `NotImplementedError` (the SPD3303X has no protection subsystem; `has_ovp`/`has_ocp` are now `False`). They emitted a `FutureWarning` in 4.1.0.
- **`MockConnection` strict-by-default** — an unmatched PSU/AWG/DAQ query raises `TimeoutError` like real hardware; pass `strict=False` for the old lenient `""`.
- **Modern `WF?` shim removed** — a modern-dialect mock no longer answers the legacy `C<n>:WF?` read; legacy scopes unaffected.

## How it was built
Each break landed subagent-driven with review. Notably, the strict-default flip broke only **1** test — the mock is already faithful enough (from the wire-forms work) that PSU/AWG/DAQ tests don't hit unmatched queries. The OVP/OCP change surfaced an example script that would have broken the smoke test; it was guarded.

## Verification
- Full suite: **1610 passed / 19 skipped**, 0 failed (FutureWarning count dropped as OVP/OCP warnings are gone).
- Version bumped in all three convention files: `pyproject.toml`, `scpi_control/__init__.py` (`__version__`, feeds provenance + GUI About), `CHANGELOG.md` (`[Unreleased]` → `[5.0.0] - 2026-07-24`).
- PyPI summary length 430/512.

## After merge
Release cut by creating the GitHub Release through `gh` (fires `publish.yml` → PyPI as the maintainer, not the bot; the tag also triggers the desktop builds). PyPI publish is irreversible.

Note: `docs/about/changelog.md` (a separate docs-site mirror) has been stale since 3.3.0 — pre-existing drift, not addressed here.
