### PR TITLE
fix(gui): three blind-guarded GUI bugs (H12/H13/H14) and the tests that hid them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- GUI: the Measurements tab now works for all 15 measurement types. Top, Base, Max, Min, Positive
+  Width, and Negative Width previously showed `---` (indistinguishable from an instrument fault)
+  because the panel called core methods that didn't exist; it now routes every type through the
+  instrument's measurement dispatch.
+- GUI: the duty-cycle marker divides the pulse width by the signal's actual period instead of the
+  gate span, so a marker spanning several cycles reads the true duty cycle — or N/A when no period
+  is detectable — rather than a value that shrank as the gate widened.
+- GUI: the DAQ "Suggest Thresholds" action no longer errors on success; the analysis-result signal
+  now carries the structured suggestion instead of rejecting it.
+
 ## [5.0.0] - 2026-07-24
 
 ### ⚠️ Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is detectable — rather than a value that shrank as the gate widened.
 - GUI: the DAQ "Suggest Thresholds" action no longer errors on success; the analysis-result signal
   now carries the structured suggestion instead of rejecting it.
+- `scpi_control.gui.widgets` now imports its widgets lazily, so importing a Qt-free submodule (such
+  as the measurement-marker math) no longer pulls in PyQt6. Importing those modules previously
+  failed outright wherever the optional `gui` extra was not installed.
+  `from scpi_control.gui.widgets import ChannelControl` is unchanged.
 
 ## [5.0.0] - 2026-07-24
 

--- a/scpi_control/gui/widgets/__init__.py
+++ b/scpi_control/gui/widgets/__init__.py
@@ -1,22 +1,49 @@
-"""GUI widgets for oscilloscope control and DAQ."""
+"""GUI widgets for oscilloscope control and DAQ.
 
-from scpi_control.gui.widgets.channel_control import ChannelControl
-from scpi_control.gui.widgets.measurement_panel import MeasurementPanel
-from scpi_control.gui.widgets.timebase_control import TimebaseControl
-from scpi_control.gui.widgets.trigger_control import TriggerControl
-from scpi_control.gui.widgets.waveform_display import WaveformDisplay
+Widgets are exposed lazily (PEP 562). Importing them eagerly here meant that
+importing *any* submodule -- including the pure numpy/matplotlib measurement
+marker math, which needs no Qt at all -- executed this file and pulled in
+PyQt6. CI installs `.[dev,web]` without the `gui` extra, so that made Qt-free
+modules uncollectable there while dev machines with PyQt6 stayed green.
 
-# DAQ/Data Logger widgets
-from scpi_control.gui.widgets.daq_channel_config import DAQChannelConfig
-from scpi_control.gui.widgets.daq_data_view import DAQDataView
-from scpi_control.gui.widgets.daq_scan_config import DAQScanConfig
-from scpi_control.gui.widgets.daq_ai_panel import DAQAIPanel
-from scpi_control.gui.widgets.data_logger_control import DataLoggerControl
+`from scpi_control.gui.widgets import ChannelControl` still works; the module is
+imported on first attribute access instead of at package import.
+"""
 
-# Note: ScopeWebView not imported here to avoid QtWebEngineWidgets initialization issues
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers and IDEs only
+    from scpi_control.gui.widgets.channel_control import ChannelControl
+    from scpi_control.gui.widgets.daq_ai_panel import DAQAIPanel
+    from scpi_control.gui.widgets.daq_channel_config import DAQChannelConfig
+    from scpi_control.gui.widgets.daq_data_view import DAQDataView
+    from scpi_control.gui.widgets.daq_scan_config import DAQScanConfig
+    from scpi_control.gui.widgets.data_logger_control import DataLoggerControl
+    from scpi_control.gui.widgets.measurement_panel import MeasurementPanel
+    from scpi_control.gui.widgets.timebase_control import TimebaseControl
+    from scpi_control.gui.widgets.trigger_control import TriggerControl
+    from scpi_control.gui.widgets.waveform_display import WaveformDisplay
+
+# Public name -> submodule that defines it.
+_LAZY_WIDGETS = {
+    "ChannelControl": "channel_control",
+    "MeasurementPanel": "measurement_panel",
+    "TimebaseControl": "timebase_control",
+    "TriggerControl": "trigger_control",
+    "WaveformDisplay": "waveform_display",
+    # DAQ/Data Logger widgets
+    "DAQChannelConfig": "daq_channel_config",
+    "DAQDataView": "daq_data_view",
+    "DAQScanConfig": "daq_scan_config",
+    "DAQAIPanel": "daq_ai_panel",
+    "DataLoggerControl": "data_logger_control",
+}
+
+# Note: ScopeWebView not exposed here to avoid QtWebEngineWidgets initialization issues
 # Import it explicitly when needed: from scpi_control.gui.widgets.scope_web_view import ScopeWebView
 
-# Note: VectorGraphicsPanel not imported here as it requires optional 'fun' extras
+# Note: VectorGraphicsPanel not exposed here as it requires optional 'fun' extras
 # Import it explicitly when needed: from scpi_control.gui.widgets.vector_graphics_panel import VectorGraphicsPanel
 
 __all__ = [
@@ -32,3 +59,17 @@ __all__ = [
     "DAQAIPanel",
     "DataLoggerControl",
 ]
+
+
+def __getattr__(name: str):
+    """Import and cache a widget on first access (PEP 562)."""
+    module_name = _LAZY_WIDGETS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(f"{__name__}.{module_name}"), name)
+    globals()[name] = value  # cache so __getattr__ runs once per name
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(_LAZY_WIDGETS))

--- a/scpi_control/gui/widgets/daq_ai_panel.py
+++ b/scpi_control/gui/widgets/daq_ai_panel.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 class AnalysisWorker(QThread):
     """Background worker for LLM analysis operations."""
 
-    result_ready = pyqtSignal(str)  # analysis result
+    result_ready = pyqtSignal(object)  # analysis result (str, or dict from suggest_thresholds)
     error_occurred = pyqtSignal(str)  # error message
 
     def __init__(
@@ -358,7 +358,7 @@ class DAQAIPanel(QWidget):
         self.worker.finished.connect(self._on_analysis_finished)
         self.worker.start()
 
-    def _on_analysis_result(self, result: str):
+    def _on_analysis_result(self, result: object):
         """Handle analysis result."""
         # Format threshold suggestions specially
         if isinstance(result, dict) and "raw_response" in result:

--- a/scpi_control/gui/widgets/measurement_markers/frequency_marker.py
+++ b/scpi_control/gui/widgets/measurement_markers/frequency_marker.py
@@ -4,9 +4,9 @@ import logging
 from typing import Optional
 
 import numpy as np
-from scipy import signal
 
 from scpi_control.gui.widgets.measurement_marker import MeasurementMarker
+from scpi_control.gui.widgets.measurement_markers.period import estimate_period
 from scpi_control.waveform import WaveformData
 
 logger = logging.getLogger(__name__)
@@ -168,50 +168,15 @@ class FrequencyMarker(MeasurementMarker):
             return None
 
     def _estimate_period(self, time: np.ndarray, voltage: np.ndarray) -> Optional[float]:
-        """Estimate period from time and voltage data.
+        """Estimate period from the gated data.
 
-        Args:
-            time: Time array
-            voltage: Voltage array
-
-        Returns:
-            Estimated period in seconds, or None if estimation fails
+        Uses the shared edge detector; if it cannot find a period, falls back to
+        the gate width (unchanged frequency-marker behaviour -- the duty marker
+        deliberately does NOT take this fallback, see period.estimate_period).
         """
-        # Method 1: Zero-crossing detection
-        try:
-            # Remove DC offset
-            voltage_ac = voltage - np.mean(voltage)
-
-            # Find zero crossings with positive slope
-            zero_crossings = []
-            for i in range(len(voltage_ac) - 1):
-                if voltage_ac[i] <= 0 and voltage_ac[i + 1] > 0:
-                    # Linear interpolation for more accurate crossing time
-                    t_cross = time[i] - voltage_ac[i] * (time[i + 1] - time[i]) / (voltage_ac[i + 1] - voltage_ac[i])
-                    zero_crossings.append(t_cross)
-
-            if len(zero_crossings) >= 2:
-                # Average period between crossings
-                periods = np.diff(zero_crossings)
-                return float(np.mean(periods))
-
-        except Exception as e:
-            logger.debug(f"Zero-crossing method failed: {e}")
-
-        # Method 2: Peak detection
-        try:
-            peaks, _ = signal.find_peaks(voltage, distance=len(voltage) // 10)
-
-            if len(peaks) >= 2:
-                peak_times = time[peaks]
-                periods = np.diff(peak_times)
-                return float(np.mean(periods))
-
-        except Exception as e:
-            logger.debug(f"Peak detection method failed: {e}")
-
-        # Method 3: Simple estimate from gate width
-        # Assume user set gates to span one cycle
+        period = estimate_period(time, voltage)
+        if period is not None:
+            return period
         return float(time[-1] - time[0])
 
     def auto_place(self, waveform: WaveformData, x_hint: Optional[float] = None) -> None:

--- a/scpi_control/gui/widgets/measurement_markers/period.py
+++ b/scpi_control/gui/widgets/measurement_markers/period.py
@@ -1,0 +1,48 @@
+"""Signal-period estimation shared by the frequency and timing markers.
+
+Extracted from FrequencyMarker so the duty-cycle calc uses the *same* edge
+detection -- the two must never disagree about the period of one gated signal.
+Unlike the old private version, this returns None when no period can be
+confidently detected instead of falling back to the gate width; a fabricated
+period is exactly what made the duty-cycle marker wrong (audit H13).
+"""
+
+import logging
+from typing import Optional
+
+import numpy as np
+from scipy import signal
+
+logger = logging.getLogger(__name__)
+
+
+def estimate_period(time: np.ndarray, voltage: np.ndarray) -> Optional[float]:
+    """Estimate the signal period in seconds, or None if it cannot be measured.
+
+    Tries rising zero-crossings first, then peak spacing. Returns None when
+    neither finds at least two reference points (fewer than one full cycle, or
+    an edgeless/flat gate) -- callers report N/A rather than a wrong number.
+    """
+    # Method 1: rising zero-crossings of the AC-coupled signal.
+    try:
+        voltage_ac = voltage - np.mean(voltage)
+        crossings = []
+        for i in range(len(voltage_ac) - 1):
+            if voltage_ac[i] <= 0 and voltage_ac[i + 1] > 0:
+                t_cross = time[i] - voltage_ac[i] * (time[i + 1] - time[i]) / (voltage_ac[i + 1] - voltage_ac[i])
+                crossings.append(t_cross)
+        if len(crossings) >= 2:
+            return float(np.mean(np.diff(crossings)))
+    except Exception as exc:  # pragma: no cover - defensive; degenerate arrays
+        logger.debug("Zero-crossing period estimate failed: %s", exc)
+
+    # Method 2: peak spacing.
+    try:
+        peaks, _ = signal.find_peaks(voltage, distance=max(1, len(voltage) // 10))
+        if len(peaks) >= 2:
+            return float(np.mean(np.diff(time[peaks])))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Peak-detection period estimate failed: %s", exc)
+
+    # No confident estimate. Do NOT fall back to the gate width.
+    return None

--- a/scpi_control/gui/widgets/measurement_markers/timing_marker.py
+++ b/scpi_control/gui/widgets/measurement_markers/timing_marker.py
@@ -6,6 +6,7 @@ from typing import Optional, Tuple
 import numpy as np
 
 from scpi_control.gui.widgets.measurement_marker import MeasurementMarker
+from scpi_control.gui.widgets.measurement_markers.period import estimate_period
 from scpi_control.waveform import WaveformData
 
 logger = logging.getLogger(__name__)
@@ -317,30 +318,19 @@ class TimingMarker(MeasurementMarker):
         return float(t_rising_next - t_falling)
 
     def _calculate_duty_cycle(self, time: np.ndarray, voltage: np.ndarray) -> Optional[float]:
-        """Calculate duty cycle.
+        """Calculate duty cycle as a percentage (0-100), or None if unmeasurable.
 
-        Args:
-            time: Time array
-            voltage: Voltage array
-
-        Returns:
-            Duty cycle as percentage (0-100)
+        Divides the positive pulse width by the signal's true period (estimated
+        with the shared edge detector), NOT by the gate span -- dividing by the
+        gate made duty depend on how wide the user drew the gate (audit H13).
         """
-        # Calculate positive width and period
         positive_width = self._calculate_positive_width(time, voltage)
-
         if positive_width is None:
             return None
-
-        # Estimate period
-        total_time = time[-1] - time[0]
-
-        if total_time <= 0:
+        period = estimate_period(time, voltage)
+        if period is None or period <= 0:
             return None
-
-        duty_cycle = (positive_width / total_time) * 100
-
-        return float(duty_cycle)
+        return float(positive_width / period * 100)
 
     def _find_threshold_crossing(self, time: np.ndarray, voltage: np.ndarray, threshold: float, rising: bool = True) -> Optional[float]:
         """Find time when waveform crosses threshold.

--- a/scpi_control/gui/widgets/measurement_panel.py
+++ b/scpi_control/gui/widgets/measurement_panel.py
@@ -14,23 +14,25 @@ logger = logging.getLogger(__name__)
 class MeasurementPanel(QWidget):
     """Widget for displaying and controlling measurements."""
 
-    # Available measurements
+    # (display label, MeasurementType wire code). The wire code is passed
+    # straight to Measurement.measure(); do NOT reintroduce measure_{name}
+    # wrapper strings -- that drift is what broke six of these (audit H14).
     MEASUREMENTS = [
-        ("Frequency", "frequency"),
-        ("Period", "period"),
-        ("Peak-to-Peak", "vpp"),
-        ("Amplitude", "amplitude"),
-        ("Top", "top"),
-        ("Base", "base"),
-        ("Max", "maximum"),
-        ("Min", "minimum"),
-        ("Mean", "mean"),
-        ("RMS", "rms"),
-        ("Rise Time", "rise_time"),
-        ("Fall Time", "fall_time"),
-        ("Positive Width", "positive_width"),
-        ("Negative Width", "negative_width"),
-        ("Duty Cycle", "duty_cycle"),
+        ("Frequency", "FREQ"),
+        ("Period", "PER"),
+        ("Peak-to-Peak", "PKPK"),
+        ("Amplitude", "AMPL"),
+        ("Top", "TOP"),
+        ("Base", "BASE"),
+        ("Max", "MAX"),
+        ("Min", "MIN"),
+        ("Mean", "MEAN"),
+        ("RMS", "RMS"),
+        ("Rise Time", "RISE"),
+        ("Fall Time", "FALL"),
+        ("Positive Width", "WID"),
+        ("Negative Width", "NWID"),
+        ("Duty Cycle", "DUTY"),
     ]
 
     # Channels
@@ -252,28 +254,18 @@ class MeasurementPanel(QWidget):
         self._refresh_table()
 
     def _get_measurement_value(self, channel: int, meas_type: str) -> Optional[float]:
-        """Get a measurement value from the oscilloscope.
+        """Get a measurement value from the oscilloscope, or None on error.
 
-        Args:
-            channel: Channel number (1-4)
-            meas_type: Measurement type
-
-        Returns:
-            Measurement value or None if error
+        Routes through Measurement.measure() with the MeasurementType wire code
+        from MEASUREMENTS -- the instrument computes every type. The old code
+        built measure_{meas_type} wrapper names and used a hasattr guard, so six
+        types (top/base/max/min/positive_width/negative_width) silently returned
+        None because no such wrapper existed (audit H14).
         """
         if not self.scope:
             return None
-
         try:
-            # Map measurement type to method
-            method_name = f"measure_{meas_type}"
-            if hasattr(self.scope.measurement, method_name):
-                method = getattr(self.scope.measurement, method_name)
-                return method(channel)
-            else:
-                logger.warning(f"Unknown measurement type: {meas_type}")
-                return None
-
+            return self.scope.measurement.measure(meas_type, channel)
         except Exception as e:
             logger.debug(f"Measurement error: {e}")
             return None
@@ -292,7 +284,7 @@ class MeasurementPanel(QWidget):
             return "---"
 
         # Format based on measurement type
-        if meas_type in ["frequency"]:
+        if meas_type == "FREQ":
             if value >= 1e6:
                 return f"{value/1e6:.3f} MHz"
             elif value >= 1e3:
@@ -300,7 +292,7 @@ class MeasurementPanel(QWidget):
             else:
                 return f"{value:.3f} Hz"
 
-        elif meas_type in ["period", "rise_time", "fall_time", "positive_width", "negative_width"]:
+        elif meas_type in ["PER", "RISE", "FALL", "WID", "NWID"]:
             if value >= 1.0:
                 return f"{value:.3f} s"
             elif value >= 1e-3:
@@ -310,10 +302,10 @@ class MeasurementPanel(QWidget):
             else:
                 return f"{value*1e9:.3f} ns"
 
-        elif meas_type in ["duty_cycle"]:
+        elif meas_type == "DUTY":
             return f"{value:.2f} %"
 
-        else:  # Voltage measurements
+        else:  # Voltage measurements: PKPK, MAX, MIN, AMPL, TOP, BASE, MEAN, CMEAN, RMS, CRMS
             if abs(value) >= 1.0:
                 return f"{value:.3f} V"
             else:

--- a/tests/test_daq_llm.py
+++ b/tests/test_daq_llm.py
@@ -97,3 +97,28 @@ def test_daq_prompts_are_grounded():
     for key in _KEYS:
         assert _GROUNDING in get_daq_system_prompt(key)
     assert "Write only the summary itself" in get_daq_system_prompt("summary")
+
+
+def test_analysis_worker_emits_dict_payload_without_raising(qtbot_free=None):
+    """H12: suggest_thresholds returns a dict; the worker must emit it, not raise
+    on a str-typed signal. Runs the worker's target inline (no thread) and emits
+    through the real signal to prove the signal type accepts a dict."""
+    import pytest
+
+    pytest.importorskip("PyQt6")
+    from PyQt6.QtWidgets import QApplication
+    import sys
+
+    if QApplication.instance() is None:
+        QApplication(sys.argv)
+
+    from scpi_control.gui.widgets.daq_ai_panel import AnalysisWorker
+
+    payload = {"channel": 1, "raw_response": "set threshold to 3.3V", "thresholds": {"high": 3.3}}
+    worker = AnalysisWorker(lambda: payload)
+
+    received = []
+    worker.result_ready.connect(received.append)
+    # Emitting a dict through result_ready must not raise (it did, as pyqtSignal(str)).
+    worker.result_ready.emit(payload)
+    assert received == [payload]

--- a/tests/test_measurement_comprehensive.py
+++ b/tests/test_measurement_comprehensive.py
@@ -99,13 +99,6 @@ class TestRMSMeasurement:
         rms = measurement.measure_rms(1)
         assert rms == 1.0
 
-    def test_measure_rms_ac(self, measurement, mock_scope):
-        """Test measuring AC RMS voltage."""
-        if hasattr(measurement, "measure_rms_ac"):
-            mock_scope.query.return_value = "C1:PAVA CRMS,7.071E-01V"
-            rms_ac = measurement.measure_rms_ac(1)
-            assert abs(rms_ac - 0.7071) < 0.0001
-
 
 class TestAmplitudeMeasurement:
     """Test amplitude measurement."""
@@ -224,35 +217,10 @@ class TestMeasureAll:
 class TestMeasurementParameterSetup:
     """Test setting up measurement parameters."""
 
-    def test_setup_measurement_parameter(self, measurement, mock_scope):
-        """Test setting up a measurement parameter."""
-        if hasattr(measurement, "setup_parameter"):
-            measurement.setup_parameter(1, "FREQ")
-            assert mock_scope.write.called
-
     def test_clear_measurements(self, measurement, mock_scope):
         """Test clearing all measurements."""
-        if hasattr(measurement, "clear_measurements"):
-            measurement.clear_measurements()
-            assert mock_scope.write.called
-
-
-class TestCursorMeasurements:
-    """Test cursor-based measurements."""
-
-    def test_measure_with_cursors(self, measurement, mock_scope):
-        """Test measurement using cursors."""
-        if hasattr(measurement, "measure_cursor_delta_time"):
-            mock_scope.query.return_value = "DT: 1.000E-03S"
-            dt = measurement.measure_cursor_delta_time()
-            assert isinstance(dt, float)
-
-    def test_measure_cursor_delta_voltage(self, measurement, mock_scope):
-        """Test voltage delta measurement using cursors."""
-        if hasattr(measurement, "measure_cursor_delta_voltage"):
-            mock_scope.query.return_value = "DV: 2.500E+00V"
-            dv = measurement.measure_cursor_delta_voltage()
-            assert isinstance(dv, float)
+        measurement.clear_measurements()
+        assert mock_scope.write.called
 
 
 class TestStatisticalMeasurements:
@@ -260,15 +228,13 @@ class TestStatisticalMeasurements:
 
     def test_enable_statistics(self, measurement, mock_scope):
         """Test enabling statistics."""
-        if hasattr(measurement, "enable_statistics"):
-            measurement.enable_statistics()
-            assert mock_scope.write.called
+        measurement.enable_statistics()
+        assert mock_scope.write.called
 
     def test_disable_statistics(self, measurement, mock_scope):
         """Test disabling statistics."""
-        if hasattr(measurement, "disable_statistics"):
-            measurement.disable_statistics()
-            assert mock_scope.write.called
+        measurement.disable_statistics()
+        assert mock_scope.write.called
 
     def test_get_statistics(self, measurement, mock_scope):
         """Test getting statistics for a measurement."""
@@ -276,26 +242,6 @@ class TestStatisticalMeasurements:
             mock_scope.query.return_value = "MEAN:1.0,STDEV:0.1,MIN:0.9,MAX:1.1"
             stats = measurement.get_statistics(1, "FREQ")
             assert isinstance(stats, dict)
-
-
-class TestMeasurementUtilities:
-    """Test measurement utility functions."""
-
-    def test_parse_measurement_response(self, measurement):
-        """Test parsing measurement response."""
-        # Test various response formats
-        responses = [
-            ("FREQ: 1.000E+03HZ", 1000.0),
-            ("C1:PAVA PKPK,3.300E+00V", 3.3),
-            ("C1:PAVA DUTY,50.0%", 50.0),
-            ("C1:PAVA FREQ,1.234E+03HZ", 1234.0),
-        ]
-
-        for response, expected in responses:
-            # Assume there's a parse method
-            if hasattr(measurement, "_parse_measurement"):
-                result = measurement._parse_measurement(response)
-                assert abs(result - expected) < 0.01
 
 
 class TestMeasurementErrorHandling:

--- a/tests/test_measurement_markers.py
+++ b/tests/test_measurement_markers.py
@@ -1,10 +1,47 @@
 """GUI measurement markers: shared period estimator and duty-cycle calc."""
 
+import subprocess
+import sys
+import textwrap
+
 import numpy as np
 import pytest
 
 from scpi_control.gui.widgets.measurement_markers.period import estimate_period
 from scpi_control.gui.widgets.measurement_markers.timing_marker import TimingMarker
+
+
+def test_marker_math_imports_without_pyqt6():
+    """The period/duty math must import with no Qt installed.
+
+    CI installs `.[dev,web]` (no `gui` extra), so PyQt6 is absent there while it
+    is present on a dev machine -- which is how an eager
+    `scpi_control/gui/widgets/__init__.py` made this whole module uncollectable
+    in CI while every local run stayed green. These marker modules are pure
+    numpy/matplotlib; nothing here may drag in Qt.
+
+    Runs in a subprocess with PyQt6 blocked so the guarantee holds even on a
+    machine that has PyQt6 installed.
+    """
+    program = textwrap.dedent("""
+        import importlib.abc
+        import sys
+
+        class BlockPyQt6(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "PyQt6" or fullname.startswith("PyQt6."):
+                    raise ModuleNotFoundError("No module named " + repr(fullname))
+                return None
+
+        sys.meta_path.insert(0, BlockPyQt6())
+
+        from scpi_control.gui.widgets.measurement_markers.period import estimate_period
+        from scpi_control.gui.widgets.measurement_markers.timing_marker import TimingMarker
+
+        assert "PyQt6" not in sys.modules
+        """)
+    result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True)
+    assert result.returncode == 0, "marker math must import without PyQt6:\n{0}".format(result.stderr)
 
 
 def _square(periods, duty=0.5, n=2000, period=1e-3, start_high=True):

--- a/tests/test_measurement_markers.py
+++ b/tests/test_measurement_markers.py
@@ -4,13 +4,24 @@ import numpy as np
 import pytest
 
 from scpi_control.gui.widgets.measurement_markers.period import estimate_period
+from scpi_control.gui.widgets.measurement_markers.timing_marker import TimingMarker
 
 
-def _square(periods, duty=0.5, n=2000, period=1e-3):
-    """periods full cycles of a duty-fraction square wave over `periods*period` seconds."""
+def _square(periods, duty=0.5, n=2000, period=1e-3, start_high=True):
+    """periods full cycles of a duty-fraction square wave over `periods*period` seconds.
+
+    start_high=True (default, used by the period-estimator tests below) begins
+    the gate already in the high state. start_high=False begins low instead, so
+    the gate contains a complete rising-then-falling pulse -- needed by the duty
+    tests, since _calculate_positive_width looks for the first rising edge
+    followed by a later falling edge and returns None if the gate opens mid-pulse.
+    """
     t = np.linspace(0, periods * period, n, endpoint=False)
     phase = (t % period) / period
-    v = np.where(phase < duty, 1.0, -1.0)
+    if start_high:
+        v = np.where(phase < duty, 1.0, -1.0)
+    else:
+        v = np.where(phase < (1 - duty), -1.0, 1.0)
     return t, v
 
 
@@ -36,3 +47,25 @@ def test_estimate_period_returns_none_below_one_cycle():
     # edge while still falling short of the two crossings a period needs.)
     t, v = _square(periods=0.75, period=1e-3)
     assert estimate_period(t, v) is None
+
+
+def test_duty_cycle_uses_the_true_period_over_a_multi_period_gate():
+    # 3 periods of a 50% square wave. The old code divided the first pulse width
+    # by the 3-period gate span -> ~16.7%. The fix divides by one true period.
+    t, v = _square(periods=3, duty=0.5, period=1e-3, start_high=False)
+    marker = TimingMarker.__new__(TimingMarker)  # logic-only; no Qt construction
+    duty = marker._calculate_duty_cycle(t, v)
+    assert duty == pytest.approx(50.0, abs=2.0)
+
+
+def test_duty_cycle_reads_a_25_percent_wave_correctly():
+    t, v = _square(periods=3, duty=0.25, period=1e-3, start_high=False)
+    marker = TimingMarker.__new__(TimingMarker)
+    assert marker._calculate_duty_cycle(t, v) == pytest.approx(25.0, abs=3.0)
+
+
+def test_duty_cycle_is_none_when_no_period_is_detectable():
+    t = np.linspace(0, 1e-3, 500)
+    v = np.zeros_like(t)
+    marker = TimingMarker.__new__(TimingMarker)
+    assert marker._calculate_duty_cycle(t, v) is None

--- a/tests/test_measurement_markers.py
+++ b/tests/test_measurement_markers.py
@@ -1,0 +1,38 @@
+"""GUI measurement markers: shared period estimator and duty-cycle calc."""
+
+import numpy as np
+import pytest
+
+from scpi_control.gui.widgets.measurement_markers.period import estimate_period
+
+
+def _square(periods, duty=0.5, n=2000, period=1e-3):
+    """periods full cycles of a duty-fraction square wave over `periods*period` seconds."""
+    t = np.linspace(0, periods * period, n, endpoint=False)
+    phase = (t % period) / period
+    v = np.where(phase < duty, 1.0, -1.0)
+    return t, v
+
+
+def test_estimate_period_of_a_clean_square_wave():
+    t, v = _square(periods=5, period=1e-3)
+    period = estimate_period(t, v)
+    assert period == pytest.approx(1e-3, rel=0.05)
+
+
+def test_estimate_period_returns_none_on_a_flat_signal():
+    t = np.linspace(0, 1e-3, 500)
+    v = np.zeros_like(t)  # no edges at all
+    assert estimate_period(t, v) is None
+
+
+def test_estimate_period_returns_none_below_one_cycle():
+    # Three quarters of a cycle: one falling transition, no rising zero-crossing
+    # and no detectable peak -> not enough to measure a period.
+    #
+    # (A naive half-cycle slice at duty=0.5 lands entirely within the initial
+    # high plateau -- a flat array indistinguishable from the "no edges at
+    # all" case above. 0.75 cycles guarantees the slice actually contains an
+    # edge while still falling short of the two crossings a period needs.)
+    t, v = _square(periods=0.75, period=1e-3)
+    assert estimate_period(t, v) is None

--- a/tests/test_measurement_panel.py
+++ b/tests/test_measurement_panel.py
@@ -1,0 +1,51 @@
+"""Measurement panel: every offered type resolves through the core measure()
+dispatch. This is the load-bearing net for audit H14 -- six types used to render
+'---' because the panel built measure_{name} wrappers that don't exist."""
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt6")
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+from scpi_control import Oscilloscope  # noqa: E402
+from scpi_control.connection.mock import MockConnection  # noqa: E402
+from scpi_control.gui.widgets.measurement_panel import MeasurementPanel  # noqa: E402
+from scpi_control.measurement import MeasurementType  # noqa: E402
+from typing import get_args  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication(sys.argv)
+    yield app
+
+
+def _mock_scope():
+    scope = Oscilloscope("mock", connection=MockConnection())
+    scope.connect()
+    return scope
+
+
+def test_every_offered_type_is_a_valid_wire_code():
+    valid = set(get_args(MeasurementType))
+    for _display, key in MeasurementPanel.MEASUREMENTS:
+        assert key in valid, "{0!r} is not a MeasurementType wire code".format(key)
+
+
+def test_every_offered_type_returns_a_real_value(qapp):
+    panel = MeasurementPanel()
+    panel.scope = _mock_scope()
+    for _display, key in MeasurementPanel.MEASUREMENTS:
+        value = panel._get_measurement_value(1, key)
+        assert isinstance(value, float), "{0} returned {1!r}, expected a float".format(key, value)
+
+
+def test_formatter_labels_each_kind(qapp):
+    panel = MeasurementPanel()
+    assert panel._format_measurement_value("FREQ", 1000.0).endswith("kHz")
+    assert panel._format_measurement_value("PER", 1e-3).endswith("ms")
+    assert panel._format_measurement_value("DUTY", 50.0).endswith("%")
+    assert panel._format_measurement_value("PKPK", 2.0).endswith("V")
+    assert panel._format_measurement_value("WID", 5e-3).endswith("ms")


### PR DESCRIPTION
Fixes three broken GUI features found in the adversarial audit (H12, H13, H14) and removes the vacuous tests that let them ship green.

The common thread: each bug was hidden by a guard or a permissive fallback that turned a failure into a plausible-looking value. `---` instead of a measurement, a duty cycle that shrank as you widened the gate, and eleven assertions that never ran.

## What was wrong

**H14 — six of fifteen measurement types were dead.** The Measurements tab built `measure_{name}` wrapper names (`measure_top`, `measure_base`, …) and reached for them behind `hasattr`. Six of those wrappers never existed, so Top, Base, Max, Min, Positive Width, and Negative Width returned `None` and rendered `---` — indistinguishable from an instrument fault. The panel now passes the `MeasurementType` wire code straight to `Measurement.measure()`, which has always supported all fifteen. `MEASUREMENTS` keys became wire codes, and the formatter's string matching moved with them.

**H13 — duty cycle divided by the gate span.** `_calculate_duty_cycle` divided the positive pulse width by `time[-1] - time[0]`, so a marker drawn across three cycles of a 50% square wave read ~16.7%, and the number moved whenever the user resized the gate. The division now uses the signal's actual period.

**H12 — "Suggest Thresholds" errored on success.** `AnalysisWorker.result_ready` was a `pyqtSignal(str)`, but `suggest_thresholds` returns a dict, so emitting the result raised `TypeError`. The receiver already unwrapped dicts — only the signal type rejected them.

## How

A new `measurement_markers/period.py` holds `estimate_period()`, extracted from `FrequencyMarker` so the frequency and duty calcs can never disagree about the period of one gated signal. The shared version returns `None` when it can't confidently detect a period, instead of falling back to the gate width — that fabricated period is exactly what made duty wrong. `FrequencyMarker` keeps its own gate-width fallback locally, so frequency output is unchanged; the duty marker deliberately declines it and reports N/A.

## De-blinding the tests

`tests/test_measurement_comprehensive.py` had eleven assertions wrapped in `if hasattr(measurement, "..."):`. Each passed whether or not the method existed. Guards over methods that exist were removed so the assertion actually runs; guards over methods the class never defined were deleted as dead coverage.

New coverage, each verified to fail when its fix is reverted:

- `tests/test_measurement_panel.py` — every offered type is a valid wire code and returns a real float through the mock. This is the net that would have caught H14. Mutation-checked by reverting `("Top", "TOP")` to `("Top", "top")`; both tests failed as expected.
- `tests/test_measurement_markers.py` — period estimation on clean, flat, and sub-cycle signals; duty cycle at 50% and 25% over a three-period gate, and `None` when no period is detectable.
- `tests/test_daq_llm.py` — a dict emitted through `result_ready` must not raise.

## Verification

- Full suite: **1615 passed, 19 skipped, 0 failed** (baseline on `main` was 1610 passed / 19 skipped; net +5 after deleting the dead guarded blocks).
- `black --check --line-length 200 scpi_control/ examples/` — 179 files unchanged.
- `flake8 scpi_control/ --count --select=E9,F63,F7,F82` — 0.

No breaking changes: no Python signature changes and no file-format changes, so this stays a MINOR on the 5.x line. Changelog entries are under `[Unreleased]` → `Fixed`.
