### PR TITLE
test: mark example subprocess runs slow so local loops can skip them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,14 +186,53 @@ multiple worker processes:
 python -m pytest -n auto
 ```
 
-`-n auto` spawns one worker per CPU core; on a multi-core machine this cuts
-full-suite wall time substantially. Prefer `--testmon` for tight edit loops
-where only a handful of tests need to rerun, and `-n auto` when you want the
-whole suite fast (e.g. before committing) — run one or the other per
-invocation rather than combining them. (In local testing with pytest-testmon
-2.2.0 and pytest-xdist 3.8.0, `--testmon -n auto` together did not error and
-testmon's change detection still worked correctly across workers, but this
-combination isn't a primary supported workflow, so keep them separate.)
+`-n auto` spawns one worker per CPU core. Note that more workers is not always
+faster: every worker pays the full import cost of numpy/scipy/matplotlib and
+friends, so on a high-core machine that startup overhead can eat most of the
+gain. Measured on a 32-core Windows box (1616 tests):
+
+| Invocation | Wall clock |
+| ---------- | ---------- |
+| serial     | ~117s      |
+| `-n auto` (32 workers) | ~95s |
+| `-n 8`     | ~69s       |
+
+If `-n auto` disappoints, try a fixed, smaller worker count. Prefer `--testmon`
+for tight edit loops where only a handful of tests need to rerun, and a parallel
+run when you want the whole suite fast (e.g. before committing) — run one or the
+other per invocation rather than combining them. (In local testing with
+pytest-testmon 2.2.0 and pytest-xdist 3.8.0, `--testmon -n auto` together did not
+error and testmon's change detection still worked correctly across workers, but
+this combination isn't a primary supported workflow, so keep them separate.)
+
+### Deselecting the Slow Example Runs
+
+`tests/test_examples_smoke.py` executes each no-hardware example as a real
+subprocess. That is the only guard that catches **API drift** in the published
+examples — a call to a method that no longer exists compiles fine and fails only
+at runtime, so the compile check cannot see it. It is also the slowest thing in
+the suite, and `report_ai_qa.py` does live inference wherever a local Ollama is
+running (~26s there, near-instant everywhere else, since the example exits
+cleanly when no Ollama is reachable).
+
+Those runs are marked `slow`, so you can drop them while iterating:
+
+```bash
+python -m pytest -m "not slow"          # skip the example subprocesses
+python -m pytest -m "not slow" -n 8     # ...and parallelise the rest
+```
+
+On the same 32-core box as the table above, the second form runs 1603 tests in
+~10s, against ~117s for a full serial run — the example subprocesses dominate
+local wall time far more than the remaining 1603 tests combined.
+
+The cheap guards in that file (stale-token scan, compile check, notebook JSON)
+are unmarked and always run.
+
+Deliberately **not** added to `addopts`: CI invokes a bare `pytest` and reads the
+same `pyproject.toml`, so a default `-m "not slow"` would silently strip example
+coverage from CI while looking green locally. Always finish with a full run
+before committing.
 
 ### Writing Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ addopts = [
 markers = [
     "hardware: tests that require actual oscilloscope hardware",
     "gui: tests that require GUI dependencies (PyQt6)",
+    "slow: tests that run examples as subprocesses (deselect with -m 'not slow')",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -8,6 +8,15 @@ examples as subprocesses.
 Limitation: hardware-bound examples (e.g. simple_capture.py, advanced_analysis.py)
 cannot be executed headless, so their fixes are covered by the token scan and the
 compile check, not by running them.
+
+The execution guard is the expensive one -- each example is a real subprocess, and
+report_ai_qa.py additionally does live inference wherever a local Ollama is running.
+It is marked `slow` so tight edit loops can deselect it with `-m "not slow"`; the
+scan/compile guards stay cheap and always run. Do not deselect it by default in
+pyproject `addopts`: CI invokes a bare `pytest` and reads the same config, so that
+would silently strip example coverage from CI. Execution is what catches API drift
+that a compile check cannot -- a call to a method that no longer exists compiles
+perfectly and fails only at runtime.
 """
 
 import importlib.util
@@ -89,6 +98,7 @@ def test_notebook_is_valid_json():
     json.loads(nb.read_text(encoding="utf-8"))
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("filename, module", EXECUTE, ids=[f for f, _ in EXECUTE])
 def test_no_hardware_example_runs(filename, module, tmp_path):
     if not _available(module):


### PR DESCRIPTION
Adds a `slow` marker to the 13 example-execution tests so a tight edit loop can drop them, without weakening what CI checks.

## Why not just delete them

`tests/test_examples_smoke.py` runs each no-hardware example as a real subprocess, and that is the only guard that catches **API drift** in the published examples. The compile check cannot see it: a call to a method that no longer exists compiles perfectly and fails only at runtime — precisely the failure mode of the H14 bug fixed in #102, where the GUI panel called `measure_{name}` wrappers that were never defined. With v5.0.0 having removed the modern-dialect shim, flipped `MockConnection` strict defaults, and made PSU OVP/OCP raise `NotImplementedError`, execution is what proves the examples still work against the current API.

The cost also isn't where it looks. `report_ai_qa.py` accounts for ~26s of it, but only on a machine with a local Ollama running — it does live `llama3.2` inference there and exits cleanly everywhere else, so CI never pays that. It's the single best end-to-end check of the local-LLM tool-calling path, and it can only run on a developer box.

So the problem was never "examples as tests" — it was that every local run paid for the LLM integration test.

## What changed

- `slow` marker registered in `pyproject.toml` (joins `hardware` and `gui`; `--strict-markers` is on).
- `@pytest.mark.slow` on `test_no_hardware_example_runs` only. The cheap guards in the same file — stale-token scan, compile check, notebook JSON validity — stay unmarked and always run.
- CONTRIBUTING gains a section on deselecting them, and its xdist advice is corrected (see below).

Deliberately **not** added to `addopts`. CI invokes a bare `pytest` and reads the same `pyproject.toml`, so a default `-m "not slow"` would silently strip example coverage from CI while every local run looked green. That is the same local/CI config-parity trap that caused the collection failure in #102, and the reasoning is recorded in both the module docstring and CONTRIBUTING so it doesn't get "helpfully" optimised later.

## Measured

On a 32-core Windows box, 1616 tests:

| Invocation | Wall clock | Tests |
| ---------- | ---------- | ----- |
| full serial (unchanged default) | ~117s | 1616 passed, 19 skipped |
| `-m "not slow" -n 8` | **~10s** | 1603 passed, 19 skipped |

The 13 example subprocesses dominate local wall time more than the other 1603 tests combined.

While measuring, the existing `-n auto` recommendation in CONTRIBUTING turned out to be wrong on high-core machines — each worker pays full numpy/scipy/matplotlib import cost, so 32 workers is *slower* than 8:

| Invocation | Wall clock |
| ---------- | ---------- |
| serial | ~117s |
| `-n auto` (32 workers) | ~95s |
| `-n 8` | ~69s |

CONTRIBUTING now carries these numbers and suggests a fixed, smaller worker count when `-n auto` disappoints.

## Verification

- `pytest -m "not slow"` → 31 passed, 13 deselected.
- `pytest -m slow --collect-only` → exactly the 13 example runs.
- Default invocation still collects all 44 tests in that file.
- Full suite unchanged: **1616 passed, 19 skipped, 0 failed**.
- `black --check --line-length 200 scpi_control/ examples/` clean; `flake8` gates return 0.

No user-facing behaviour changes, so no CHANGELOG entry — this is developer tooling only.
