### PR TITLE
docs: sharpen package metadata for discoverability (+ PEP 639 licensing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Licensing metadata migrated to PEP 639: the package now declares
+  `License-Expression: MIT` and ships `License-File: LICENSE` instead of the deprecated
+  `license = { text = "MIT" }` table. **Building from source now requires `setuptools>=77`**
+  (raised from 61); installing a prebuilt wheel is unaffected.
+- PyPI summary, keywords, and classifiers rewritten to lead with the SCPI/test-automation
+  category, and the README now opens with a short pitch instead of a single dense paragraph.
+
 ### Fixed
 
 - GUI: the Measurements tab now works for all 15 measurement types. Top, Base, Max, Min, Positive

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # SCPI Instrument Control
 
-> **📦 Package Renamed!** This project was formerly known as `Siglent-Oscilloscope`. See the [Migration Guide](#migration-guide) below for updating your code.
-
 [![CI](https://github.com/little-did-I-know/SCPI-Instrument-Control/actions/workflows/ci.yml/badge.svg)](https://github.com/little-did-I-know/SCPI-Instrument-Control/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/little-did-I-know/SCPI-Instrument-Control/branch/main/graph/badge.svg)](https://codecov.io/gh/little-did-I-know/SCPI-Instrument-Control)
 [![PyPI version](https://img.shields.io/pypi/v/SCPI-Instrument-Control.svg)](https://pypi.org/project/SCPI-Instrument-Control/)
@@ -14,7 +12,14 @@
 [![GitHub last commit](https://img.shields.io/github/last-commit/little-did-I-know/SCPI-Instrument-Control)](https://github.com/little-did-I-know/SCPI-Instrument-Control/commits/main)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-Support-yellow.svg?style=flat&logo=buy-me-a-coffee)](https://buymeacoffee.com/little.did.i.know)
 
-A universal Python library for controlling SCPI-compatible test equipment via Ethernet/LAN (plus USB, GPIB, and serial through the optional VISA backend). It drives oscilloscopes from Siglent, Tektronix, and LeCroy alongside function generators (AWGs), power supplies, and data-acquisition units through one programmatic API — with a high-performance PyQt6 GUI, a browser-based lab gateway, provenance-stamped waveform files, automated PDF/Markdown test reports with local-LLM analysis, and a realistic mock layer that synthesizes state-coupled waveforms so the whole stack can be developed and demoed without an instrument attached.
+Control SCPI-compatible test equipment from Python — oscilloscopes, function generators (AWGs), power supplies, and data-acquisition units — over Ethernet/LAN, plus USB, GPIB, and serial through the optional VISA backend.
+
+- **One API across vendors.** Siglent, Tektronix, and LeCroy oscilloscopes, auto-detected from `*IDN?`, alongside PSUs and DAQ units.
+- **Develop without hardware.** A realistic mock layer synthesizes state-coupled, trigger-aligned waveforms, so the whole stack runs — and CI passes — with nothing on your bench.
+- **See it live.** A high-performance PyQt6 GUI with interactive measurement markers, plus a browser-based lab gateway.
+- **Keep the evidence.** Provenance-stamped waveform files and automated PDF/Markdown test reports with local-LLM analysis.
+
+> **Formerly `Siglent-Oscilloscope`.** Upgrading from the old package? See the [Migration Guide](#migration-guide).
 
 <p align="center">
   <img src="docs/images/sds824x-hd-cal-square.png" alt="Live screen capture from a Siglent SDS824X HD oscilloscope" width="720">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,19 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+# setuptools>=77 is required for the PEP 639 `license`/`license-files` fields below.
+requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
 version = "5.0.0"
-description = "Universal Python library for SCPI test equipment via Ethernet/LAN, USB, GPIB, or serial. Drives oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies, and DAQ units. Waveform capture with acquisition provenance, raw-data extraction (load_waveform, scpi-extract), FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and synthetic-signal mocks for development without hardware."
+# NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
+# before every release -- the v3.2.0 publish failed on exactly this.
+description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"
-license = { text = "MIT" }
-keywords = ["SCPI", "instrument control", "test equipment", "oscilloscope", "function generator", "AWG", "power supply", "PSU", "siglent", "SDS", "SDG", "SPD", "IEEE 488.2", "waveform", "signal generator", "laboratory", "automation", "measurement", "data acquisition", "lab automation", "PyQt6", "GUI", "FFT", "protocol decoder", "I2C", "SPI", "UART", "visualization", "voltage", "current", "frequency", "waveform generator", "waveform", "test equipment", "lab equipment"]
+license = "MIT"
+license-files = ["LICENSE"]
+keywords = ["SCPI", "instrument control", "test equipment", "test automation", "lab automation", "laboratory", "lab equipment", "measurement", "data acquisition", "DAQ", "oscilloscope", "function generator", "signal generator", "AWG", "arbitrary waveform generator", "power supply", "PSU", "waveform", "IEEE 488.2", "VISA", "GPIB", "siglent", "tektronix", "lecroy", "SDS", "SDG", "SPD", "FFT", "protocol decoder", "mock instruments"]
 authors = [
     {name = "Robin Mumm"}
 ]
@@ -21,6 +25,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "Intended Audience :: Manufacturing",
+    "Intended Audience :: Education",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
@@ -32,9 +37,11 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Interface Engine/Protocol Translator",
+    "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: System :: Hardware :: Hardware Drivers",
     "Topic :: System :: Networking :: Monitoring",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Testing",
     "Environment :: X11 Applications :: Qt",
     "Typing :: Typed",
 ]


### PR DESCRIPTION
Makes the package easier to find, leading with the generic SCPI / test-automation category rather than burying it. Vendor names stay as the high-intent tail.

The GitHub side of this work is **already applied** (repo settings, not code) — see the last section.

## PyPI summary

Rewritten to put the category and transports first, 388/512 chars (down from 430):

> Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached.

Added a comment above the field recording the hard 512-char cap, since the v3.2.0 publish failed on exactly that.

## Keywords and classifiers

Keywords had two literal duplicates — `waveform` and `test equipment` each appeared twice (35 entries, 33 unique). Deduped and retuned to 30: dropped terms that cannot realistically rank on their own (`voltage`, `current`, `frequency`, `GUI`, `visualization`), added `test automation`, `VISA`, `arbitrary waveform generator`, and `mock instruments`. Kept the `SDS`/`SDG`/`SPD` model prefixes — low volume, but very high intent.

Classifiers 20 → 23: `Intended Audience :: Education`, `Topic :: Scientific/Engineering :: Visualization`, `Topic :: Software Development :: Testing`.

Worth calibrating: PyPI relevance is driven mostly by **name + summary**. The summary rewrite is the part that moves the needle; the keyword work is hygiene.

## README opening

The first thing a visitor saw was a package-rename banner, above even the pitch, and the pitch itself was a single 90-word sentence. Now it opens with a one-line hook plus four bullets (one API across vendors / develop without hardware / live GUI and gateway / provenance and reports), and the rename notice sits below it, still linking to the Migration Guide. This is also the PyPI long description, so it benefits both surfaces.

## PEP 639 licensing (adjacent fix)

Not discoverability, but it lives in the same metadata block and it was a latent release-breaker. The build already emitted:

```
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
This deprecation is overdue, please update your project and remove deprecated
calls to avoid build errors in the future.
```

Given a release has already failed once on metadata, leaving that seemed like a bad trade. `license = { text = "MIT" }` becomes `license = "MIT"` + `license-files = ["LICENSE"]`, so the wheel now carries `License-Expression: MIT` and `License-File: LICENSE`.

⚠️ This raises the **build-time** floor to `setuptools>=77` (from 61), which is where those fields landed. Installing a prebuilt wheel is unaffected; only building from sdist needs the newer setuptools, and pip fetches it automatically in an isolated build. The `Test Installation` matrix on 3.9–3.14 is the real check on this.

This is also why no `License :: OSI Approved :: MIT License` classifier was added — under PEP 639 that is the deprecated path, and mixing the two is what triggers the warning.

## Verification

- Wheel builds with **no deprecation warnings** (previously two).
- `twine check` **PASSED**.
- `Metadata-Version: 2.4` renders `Summary`, `License-Expression: MIT`, `License-File: LICENSE`, and the keyword list as intended.
- `pytest -m "not slow" -n 8` → 1603 passed, 19 skipped.

## Already applied to the repo (no merge needed)

| Setting | Value |
| ------- | ----- |
| Topics | `scpi` `instrument-control` `test-automation` `test-equipment` `lab-automation` `laboratory` `measurement` `oscilloscope` `function-generator` `power-supply` `data-acquisition` `waveform` `signal-processing` `electronics` `siglent` `tektronix` `lecroy` `gpib` `pyvisa` `pyqt6` (20/20, the GitHub max) |
| About | 205-char summary of the same pitch |
| Homepage | the GitHub Pages docs site |

The repo previously had **no topics, no description, and no homepage** — an empty sidebar, so it surfaced in no topic browsing at all. `python` was deliberately left out (you would be invisible among millions of repos, and the language is already displayed); `pyvisa` is deliberately in, since "PyVISA alternative" is a real path to this project.
