### PR TITLE
chore(release): 5.1.0 - GUI audit fixes, packaging metadata, PEP 639 licensing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.0] - 2026-07-25
+
 ### Changed
 
 - Licensing metadata migrated to PEP 639: the package now declares

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "5.0.0"
+version = "5.1.0"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "5.0.0"
+__version__ = "5.1.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
Cuts 5.1.0. Mechanical release commit only — version bump in the two sources plus the changelog header rename. No code changes.

## Why MINOR

`[Unreleased]` carried `### Changed` and `### Fixed` and **no `⚠️ Breaking Changes` section**, so this stays on the 5.x line. The GUI work that makes up most of it was scoped as explicitly non-breaking: no Python signature changes, no file-format changes.

The one entry worth a second look is the PEP 639 licensing migration, which raises the **build-time** floor to `setuptools>=77`. That is not a breaking change for consumers — installing a prebuilt wheel is unaffected, and pip fetches the newer setuptools automatically when building an sdist in an isolated build. It is called out explicitly in the changelog entry so anyone using `--no-build-isolation` sees it.

## What ships

**Fixed** — four GUI defects from the adversarial audit:
- Measurements tab works for all 15 types (Top, Base, Max, Min, Positive/Negative Width previously rendered `---`)
- Duty-cycle marker divides by the signal's true period rather than the gate span
- DAQ "Suggest Thresholds" no longer errors on success
- `scpi_control.gui.widgets` imports lazily, so Qt-free submodules import without PyQt6

**Changed** — packaging and discoverability:
- PEP 639 licensing (`License-Expression: MIT`, `License-File: LICENSE`)
- PyPI summary, keywords, and classifiers retuned to lead with the SCPI/test-automation category; README opens with a short pitch

Note that this is the release where the new PyPI metadata actually takes effect — summary, keywords, and classifiers only refresh on publish.

## Verification

- Version consistency: `pyproject.toml` and `scpi_control/__init__.py` both read `5.1.0`.
- PyPI summary 387/512 chars — the check that broke the v3.2.0 publish.
- Changelog: exactly one `## [Unreleased]`, `## [5.1.0] - 2026-07-25` present, sections `Changed` + `Fixed`, 6 entries, no breaking-changes section.
- Full suite: **1616 passed, 19 skipped, 0 failed**.
- `python -m build` produces both artifacts at 5.1.0 with **no deprecation warnings**; `twine check` PASSED on the wheel *and* the sdist.

## After merge

Publishing is triggered by creating the GitHub release (`publish.yml` runs on `release: published` and uses trusted publishing). The tag should be `v5.1.0`, matching the existing convention.

## Follow-up spotted, deliberately not bundled here

Nothing asserts that `pyproject.toml` and `scpi_control/__init__.py` agree on the version — they are bumped by hand and could silently drift. A one-line test would close that. Kept out of this PR so the release commit stays purely mechanical.
