### PR TITLE
test: assert pyproject and __version__ agree

### DIFF
--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,54 @@
+"""The two hand-maintained version strings must agree.
+
+`pyproject.toml`'s `[project] version` and `scpi_control.__version__` are bumped by
+hand in the release commit (see the `chore(release):` commits). Nothing checked that
+they matched, so a missed edit would ship a package whose `__version__` lies: the
+wheel installs as one version while the module reports another, which quietly
+corrupts anything that reports the running version -- bug reports, provenance
+stamps written into saved waveforms, and report metadata.
+
+Deliberately parses `pyproject.toml` rather than reading installed distribution
+metadata: `importlib.metadata` reflects whenever the package was last installed, so
+in an editable checkout it happily returns a stale version and the check would pass
+against the wrong source of truth.
+
+No `hasattr`/`try` guards here on purpose. If this file cannot find the version it
+must FAIL, not skip -- a guard that turns "I could not check" into a green run is
+exactly the blindness this suite has been purging.
+"""
+
+import re
+from pathlib import Path
+
+import scpi_control
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def _pyproject_version():
+    """Return `[project] version` from pyproject.toml.
+
+    Hand-parsed instead of using tomllib: the Python floor is 3.9, tomllib only
+    landed in 3.11, and tomli is not a dependency. The match is scoped to the
+    `[project]` table so a `version =` in some other tool's section cannot be
+    picked up by mistake.
+    """
+    assert PYPROJECT.is_file(), "pyproject.toml not found at {0}".format(PYPROJECT)
+    text = PYPROJECT.read_text(encoding="utf-8")
+    table = re.search(r"^\[project\]\s*$(.*?)^\[", text, re.S | re.M)
+    assert table, "could not locate the [project] table in pyproject.toml"
+    match = re.search(r'^version\s*=\s*"([^"]+)"', table.group(1), re.M)
+    assert match, "could not locate `version` inside the [project] table"
+    return match.group(1)
+
+
+def test_pyproject_and_module_version_agree():
+    pyproject_version = _pyproject_version()
+    assert pyproject_version == scpi_control.__version__, "pyproject.toml says {0!r} but scpi_control.__version__ says {1!r} -- both must be bumped in the release commit".format(pyproject_version, scpi_control.__version__)
+
+
+def test_version_is_well_formed():
+    """A malformed version breaks the sdist/wheel filenames and PyPI ordering."""
+    version = scpi_control.__version__
+    assert re.fullmatch(r"\d+\.\d+\.\d+([.\-+]?\w+)*", version), "{0!r} is not a PEP 440-style version".format(version)


### PR DESCRIPTION
Closes the gap spotted while cutting 5.1.0: `pyproject.toml`'s `[project] version` and `scpi_control.__version__` are bumped **by hand** in the release commit, and nothing verified they agreed.

## Why it matters

A missed edit ships a package whose `__version__` lies — the wheel installs as one version while the module reports another. That silently corrupts everything downstream that reports the running version: bug reports, the provenance stamps written into saved waveforms, and report metadata. It fails no build and no existing test, so it would surface only after release, when the version number is already burned on PyPI.

The 5.1.0 release depended entirely on me remembering to edit both files.

## Two design choices worth stating

**Parses `pyproject.toml`, not installed metadata.** `importlib.metadata.version()` reflects whenever the package was last *installed*, so in an editable checkout it returns a stale value — the test would pass while comparing against the wrong source of truth, which is worse than no test.

**Hand-parses the `[project]` table rather than using `tomllib`.** The Python floor is 3.9, `tomllib` only landed in 3.11, and `tomli` is not a dependency. Adding a dependency for one test is a bad trade. The regex is scoped to the `[project]` table so a `version =` key in some other tool's section can't be picked up by mistake, and every parse step asserts rather than returning a default.

**No `hasattr`/`try` guards.** If the version can't be located the test FAILS rather than skips. A guard that converts "I couldn't check" into a green run is precisely the blindness #102 was about.

## Mutation-checked

Both tests were verified to actually fail, not just pass today:

| Mutation | Result |
| -------- | ------ |
| `__init__.py` drifts to `5.1.1` | `test_pyproject_and_module_version_agree` FAILS — `pyproject.toml says '5.1.0' but scpi_control.__version__ says '5.1.1'` |
| **both** sources set to `five-point-one` | agreement test still PASSES (they agree), `test_version_is_well_formed` FAILS |

The second mutation deliberately changes both files so the two tests are isolated — it proves the well-formedness check is load-bearing on its own rather than riding on the agreement check.

Both files restored afterwards; `pyproject.toml` and `__init__.py` both read `5.1.0` on this branch.

## Verification

- `pytest -m "not slow" -n 8` → 1605 passed, 19 skipped (up 2).
- `flake8 --select=E9,F63,F7,F82` → 0.

No CHANGELOG entry — test-only, no user-facing behaviour change, consistent with how the `slow` marker landed in #103.
