### PR TITLE
fix(measurement): modern Siglent scopes use the :MEASure:SIMPle subsystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Measurements now work on modern-dialect Siglent oscilloscopes (SDS800X HD, SDS5000X and
+  siblings). `measure()` previously sent the legacy `PAVA?` command, which does not exist on
+  those instruments, so every measurement failed — including the whole GUI Measurements tab and
+  the web gateway's measurement calls. It now uses the documented `:MEASure:SIMPle` subsystem.
+  Note that a modern measurement is not side-effect-free: it enables the measurement function,
+  sets the simple-measurement source, and switches the requested item on, which is visible on the
+  instrument display. These are left in place rather than cleared, because the instrument's clear
+  command is all-or-nothing and would remove measurements you configured yourself.
+
 ## [5.1.0] - 2026-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   those instruments, so every measurement failed — including the whole GUI Measurements tab and
   the web gateway's measurement calls. It now uses the documented `:MEASure:SIMPle` subsystem.
   Note that a modern measurement is not side-effect-free: it enables the measurement function,
-  sets the simple-measurement source, and switches the requested item on, which is visible on the
-  instrument display. These are left in place rather than cleared, because the instrument's clear
-  command is all-or-nothing and would remove measurements you configured yourself.
+  pins the measurement mode to simple (an instrument left in advanced mode is not guaranteed to
+  answer the simple-value query the same way), sets the simple-measurement source, and switches
+  the requested item on, which is visible on the instrument display. These are left in place
+  rather than cleared, because the instrument's clear command is all-or-nothing and would remove
+  measurements you configured yourself — so enabled measurement items accumulate on the
+  instrument display across repeated calls rather than being switched off.
 
 ## [5.1.0] - 2026-07-25
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,224 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Measurements now work on modern-dialect Siglent oscilloscopes (SDS800X HD, SDS5000X and
+  siblings). `measure()` previously sent the legacy `PAVA?` command, which does not exist on
+  those instruments, so every measurement failed — including the whole GUI Measurements tab and
+  the web gateway's measurement calls. It now uses the documented `:MEASure:SIMPle` subsystem.
+  Note that a modern measurement is not side-effect-free: it enables the measurement function,
+  pins the measurement mode to simple (an instrument left in advanced mode is not guaranteed to
+  answer the simple-value query the same way), sets the simple-measurement source, and switches
+  the requested item on, which is visible on the instrument display. These are left in place
+  rather than cleared, because the instrument's clear command is all-or-nothing and would remove
+  measurements you configured yourself — so enabled measurement items accumulate on the
+  instrument display across repeated calls rather than being switched off.
+
+## [5.1.0] - 2026-07-25
+
+### Changed
+
+- Licensing metadata migrated to PEP 639: the package now declares
+  `License-Expression: MIT` and ships `License-File: LICENSE` instead of the deprecated
+  `license = { text = "MIT" }` table. **Building from source now requires `setuptools>=77`**
+  (raised from 61); installing a prebuilt wheel is unaffected.
+- PyPI summary, keywords, and classifiers rewritten to lead with the SCPI/test-automation
+  category, and the README now opens with a short pitch instead of a single dense paragraph.
+
+### Fixed
+
+- GUI: the Measurements tab now works for all 15 measurement types. Top, Base, Max, Min, Positive
+  Width, and Negative Width previously showed `---` (indistinguishable from an instrument fault)
+  because the panel called core methods that didn't exist; it now routes every type through the
+  instrument's measurement dispatch.
+- GUI: the duty-cycle marker divides the pulse width by the signal's actual period instead of the
+  gate span, so a marker spanning several cycles reads the true duty cycle — or N/A when no period
+  is detectable — rather than a value that shrank as the gate widened.
+- GUI: the DAQ "Suggest Thresholds" action no longer errors on success; the analysis-result signal
+  now carries the structured suggestion instead of rejecting it.
+- `scpi_control.gui.widgets` now imports its widgets lazily, so importing a Qt-free submodule (such
+  as the measurement-marker math) no longer pulls in PyQt6. Importing those modules previously
+  failed outright wherever the optional `gui` extra was not installed.
+  `from scpi_control.gui.widgets import ChannelControl` is unchanged.
+
+## [5.0.0] - 2026-07-24
+
+### ⚠️ Breaking Changes
+
+- Web gateway: every `/api/*` request now requires a bearer token, and the live-stream
+  WebSocket requires one too. On first run `scpi-web` mints a token and prints a
+  `http://127.0.0.1:8765/?token=…` URL; mint more with `scpi-web token add <name>`.
+  **Migration:** scripted HTTP clients must send `Authorization: Bearer <token>`; WebSocket
+  clients must offer the `scpi-token.<token>` subprotocol (alongside a plain `scpi`). A
+  query-parameter token is accepted only on the initial web-UI page load and is rejected on
+  `/api/*`. `GET /api/health` stays unauthenticated. See the
+  [gateway security guide](docs/gateway/security.md).
+- Web gateway: the interactive API docs at `/docs` and `/redoc` are removed and the OpenAPI
+  schema moved to `/api/openapi.json` (token required) — the old locations served the whole
+  control surface unauthenticated.
+- Reference waveforms: stored metadata moved from a pickled dict to a JSON string so reference
+  files load without `allow_pickle`. Files saved by 4.x raise an error naming the file until
+  converted. **Migration:** run `scpi-web references migrate` once.
+- Power supply (SPD3303X/-E): `ovp_level`/`ocp_level` now raise `NotImplementedError` — the
+  SPD3303X command set has no protection subsystem, so these calls never armed anything on real
+  hardware (they emitted a `FutureWarning` in 4.1.0). The model's `has_ovp`/`has_ocp` capabilities
+  are now `False`. **Migration:** stop calling these on an SPD3303X; gate on
+  `has_ovp`/`has_ocp` if you support multiple PSU models.
+- Testing: `MockConnection` now defaults to `strict=True`, so an unmatched PSU/AWG/DAQ query raises
+  `TimeoutError` like real hardware instead of returning `""`. **Migration:** pass `strict=False`
+  explicitly to restore the old lenient behavior.
+- Testing: `MockConnection` no longer answers the legacy `C<n>:WF?` waveform read on a
+  modern-dialect instance (SDS800X HD / SDS5000X); it now times out, matching real modern
+  hardware, which documents no such command. Legacy-dialect scopes are unaffected.
+
+### Added
+
+- Web gateway: named bearer tokens — `scpi-web token add|list|revoke <name>`, stored hashed in
+  `~/.siglent/tokens.json` (relocate with `--config-dir`).
+- Web gateway: session ownership. The identity that creates an instrument session may write to
+  it; anyone authenticated may read, stream, and export. Non-owner writes return `409`.
+  `POST /api/sessions/{id}/claim` takes over a session whose owner has been idle past
+  `--abandon-after` (default 300 s) and is not actively watching the stream;
+  `POST /api/sessions/{id}/owner` hands it over by name (or releases it with `""`). The web UI
+  shows a read-only badge and a claim button to non-owners.
+- Web gateway: `--allow-port` to permit instrument ports beyond 5025, `--max-sessions`
+  (default 8) to bound concurrent sessions, and an unauthenticated `GET /api/health` endpoint.
+- Web gateway: `scpi-web references migrate` converts pre-5.0 reference files to the new format
+  (atomic and idempotent; `--dir` to point at a non-default store).
+
+### Fixed
+
+- Security: loading a waveform or reference archive no longer unpickles it, so a crafted `.npz`
+  can no longer execute code via `scpi-extract`, the report generator's loader, or the gateway.
+  The one remaining place that reads the old pickled format is `scpi-web references migrate`,
+  which the user runs explicitly on their own files.
+- Security: reference lookup no longer honours absolute paths or `..` traversal, and listing
+  references no longer deserializes every file in the storage directory.
+- Security: session creation validates the target before connecting — hostnames are resolved
+  and every resolved address checked, loopback/link-local/cloud-metadata addresses are refused,
+  ports must be allowlisted, and a failed connect returns a generic message rather than
+  reflecting the peer's bytes (no SSRF port-scanning or banner-grabbing).
+- Web gateway: full-resolution CSV/JSON serialization of deep-memory captures runs off the
+  event loop, so one large export no longer freezes the gateway for other users; the session
+  cap holds correctly under concurrent requests.
+- Reference storage: `rename_reference` no longer leaks the source file handle (a Windows-only
+  `WinError 32` that made it fail); reference lookups now confine themselves to the storage
+  directory.
+- Web UI: file downloads (capture CSV, screenshot, waveform JSON, trend CSV) fetch with the
+  bearer token instead of bare `<a href>` links, which could not carry an `Authorization`
+  header and would have returned `401` against the authenticated gateway.
+
+## [4.1.1] - 2026-07-24
+
+### Fixed
+
+- Packaging: the six screenshots in the README are now absolute URLs, so they render on the PyPI
+  project page. They used repository-relative paths, which PyPI cannot resolve because it renders
+  the README with no repository context — the images showed as broken there while displaying
+  correctly on GitHub.
+
+## [4.1.0] - 2026-07-23
+
+### Added
+
+- Testing: a vendor-example conformance corpus (`tests/wire_forms.py`) pins every command in the
+  covered SCPI tables to a request/response pair transcribed from the vendor's programming guide,
+  with document and page citations. A coverage test (`tests/test_wire_conformance.py`) fails the
+  suite if any command in those tables (the legacy and modern scope dialects, the SPD power-supply
+  overrides, and the SDG function-generator overrides — 159 commands) has no cited corpus entry, so
+  an invented command can no longer be added silently to a covered table. (The IEEE-488.2 base, the
+  generic fallbacks, and the Tektronix/LeCroy/DAQ tables are not yet enforced — see
+  `docs/development/wire-form-inventory.md`, which records the full audit.)
+- Oscilloscope: modern-dialect deep-memory waveform capture is chunked over `:WAVeform:MAXPoint`
+  windows using `:WAVeform:STARt`, so records larger than a single transfer are reassembled correctly.
+- Oscilloscope: modern-dialect (SDS800X HD / SDS5000X) waveform capture now goes over the documented
+  `:WAVeform:SOURce`/`:WAVeform:PREamble?`/`:WAVeform:DATA?` subsystem instead of the legacy
+  `C<n>:WF? DAT2`/`DESC` forms, which have zero occurrences anywhere in the modern programming guide
+  (audit H9). Voltage and time reconstruction use the guide's own documented formulas (p.758/p.759).
+
+### Fixed
+
+- Oscilloscope (legacy Siglent): measurements use the documented `C<n>:PAVA? <param>` form and parse
+  its two-field response, and sample-rate responses carrying an SI magnitude letter (`SARA 500.0kSa`)
+  now parse. The previous `PAVA? <param>,C<n>` form and scientific-only sample-rate parsing failed on
+  real hardware (audit H7/H30/H8/H34).
+- Power supply (SPD3303X/-E): measurement queries use the documented `MEASure:VOLTage? CH<n>` form
+  (channel as an argument), tracking mode uses the documented numeric `OUTPut:TRACK {0|1|2}`, and
+  output state is read by decoding the `SYSTem:STATus?` word — the instrument documents no output-state
+  query (audit H6/H19/H20).
+- Function generator (SDG): parameter readback uses the documented bare `C<n>:BSWV?` / `C<n>:OUTP?`
+  queries and parses the returned key-value list; the previous per-field selector grammar
+  (`C<n>:BSWV? FRQ`) does not exist on the instrument (audit H5).
+- USB/GPIB/serial: `VISAConnection` can now be instantiated — it implemented neither `read` nor
+  `read_raw`, so it raised `TypeError` at construction and every documented VISA example failed
+  (audit H10).
+- Testing (mock fidelity): the mock now answers documented legacy probe (`C<n>:ATTN?`) and
+  bandwidth-limit (`BWL?`) queries instead of timing out; the DAQ dispatch no longer matches `R?` as a
+  substring (which hijacked `SYST:ERR?`/`TRIG:SOUR?`) and interprets scan-list/trigger writes; and
+  `MockConnection.read_raw` honors the requested byte count.
+
+### Deprecated
+
+- Power supply: setting `ovp_level`/`ocp_level` on an SPD3303X/-E now emits a `FutureWarning`. The
+  SPD3303X command set contains no protection subsystem, so these calls have never armed anything on
+  real hardware. In v5.0.0 the model's `has_ovp`/`has_ocp` capabilities become `False` and the calls
+  raise `NotImplementedError`.
+- Testing: `MockConnection` gained `strict=True`, which makes unmatched PSU/AWG/DAQ queries raise
+  `TimeoutError` like real instruments instead of returning `""`. Strict becomes the default in v5.0.0 —
+  pass `strict=False` explicitly to keep the old behavior past that release.
+- Testing: `MockConnection` still answers legacy `C<n>:WF?` writes on a modern-dialect (`SDS8xx HD`/
+  `SDS5000X`) instance, even though the driver's modern capture path no longer sends it (audit H9,
+  Task 18). This is a backward-compatibility shim for anything still issuing that form by hand; the
+  modern guide documents no such command, and the mock handler is removed in v5.0.0.
+
+## [4.0.0] - 2026-07-22
+
+### ⚠️ Breaking Changes
+
+- Power supply and function-generator readback (`measure_voltage`/`measure_current`/`measure_power`,
+  setpoint/OVP/OCP getters, and AWG `frequency`/`amplitude`/`offset`/`phase`) now raise
+  `CommandError` when the instrument returns an unparseable response, instead of silently returning
+  `0.0`. Callers that relied on the silent zero must handle the exception.
+
+### Added
+
+- Dev tooling: `pytest-xdist` in the `dev` extra for parallel local test runs (`python -m pytest -n auto`); complements `--testmon` (use one or the other per invocation).
+- Report generator: before/after comparison and multi-DUT batch reports — load multiple capture-file runs, overlay their waveforms, and get delta tables (comparison) or per-DUT summary with aggregates and yield (batch). Available from the Python API and the GUI's new Report → Comparison / Batch Report dialog.
+- Report generator: optional raw-data appendix (source-file manifest with SHA-256 checksums, capture timestamps, and instrument identity from provenance) and a configurable sign-off block (template-defined roles with signature/date lines). Both also work on ordinary single-run reports.
+- Report generator: `top_flatness` waveform statistic (top-plateau deviation as % of amplitude); the probe-calibration preset now evaluates overshoot/undershoot (pass/fail) and top flatness (warning).
+
+### Fixed
+
+- Report generator: the waveform loader no longer drops acquisition provenance when loading capture files.
+- Analysis: corrected THD (each harmonic is read at its own bin, robust to an off-bin fundamental),
+  noise/SNR (estimated from a signal-free residual instead of the whole-signal RMS), `vamp`
+  (Vtop − Vbase amplitude, not the vertical midpoint), overshoot/undershoot (only reported for
+  flat-topped signals), duty cycle (correct when the capture starts on the high level), DC
+  classification (no longer fooled by a large offset over real ripple), FFT peak detection (finds
+  peaks below 0 dB), and SciPy window handling for the power spectrum / spectrogram.
+- Reports and the live webapp spectrum now use a single THD engine, so they report the same number
+  for the same capture. Report-path THD now sums the first 5 harmonics (previously 10).
+- DAQ AI threshold suggestions now bind each extracted number to its label instead of grabbing the
+  first number in the sentence.
+- Comparison/batch reports: pass/fail criteria now match analyzer statistics (case-insensitive plus
+  display-name aliases) — previously the shipped criteria template produced empty verdicts. Criteria
+  that cannot be evaluated are surfaced as warnings (never silently dropped), half-open RANGE criteria
+  are enforced, verdicts are severity-aware (only `critical` criteria gate) with a distinct INCOMPLETE
+  state, and yield reports an incomplete count instead of inflating the pass rate.
+
+## [3.3.1] - 2026-07-21
+
+### Changed
+
+- README and docs now cover the full current feature set: multi-vendor scopes, DAQ, PSU/AWG models, the web gateway and `usb` extras, all four CLI tools, `load_waveform()`/`scpi-extract` usage, and API reference pages for `signal_synth`, `waveform_io`, `provenance`, and `scpi_extract`. Every example now carries a fully spelled-out docstring (what it shows, what it needs, what to expect).
+
+### Fixed
+
+- `DataCollector.save_data()`/`save_batch()` no longer raise `InvalidParameterError` with their default format — the format is now auto-detected from the filename extension (pass CSV, CSV_ENHANCED, NPY, MAT, or HDF5 explicitly to override).
+- Report-analyzer calibration guidance and example-script output are now ASCII-safe, so they no longer crash on Windows consoles with legacy codepages.
+- Documentation sweep: corrected the README's report-generator sample to the real API, fixed the default SCPI port (5025) and GUI frame-rate claims, repaired all broken links and anchors across README and the docs site, synced the docs changelog page through 3.3.0, and excluded internal planning files from the built documentation site.
+
 ## [3.3.0] - 2026-07-21
 
 ### Added
@@ -69,7 +287,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   blows up later with `AttributeError: 'str' object has no attribute
   'shape'`. Construct with keywords (`channel=`, `time=`, `voltage=`) to
   migrate safely. This is a documented public API — see
-  [`docs/report-generator/api-reference.md`](../report-generator/api-reference.md).
+  [`docs/report-generator/api-reference.md`](docs/report-generator/api-reference.md).
 - **`WaveformData.source` and `WaveformData.description` are removed**, on
   both the library and report waveform types. `WaveformData(..., source="x")`
   now raises `TypeError` instead of silently accepting the keyword.
@@ -92,7 +310,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `*IDN?` via a manufacturer-first routing step. Covers the Tektronix
   TBS1000C Series and 2 Series MSO, and the LeCroy WaveSurfer 3000z and
   WaveRunner 8000 series. See the
-  [SCPI Dialects guide](../user-guide/scpi-dialects.md) for the full
+  [SCPI Dialects guide](docs/user-guide/scpi-dialects.md) for the full
   per-vendor command tables and known gaps (e.g. LeCroy
   statistics/cursors/holdoff, Tek 16-bit waveform transfer).
 - Tektronix MSO 4/5/6 Series support (MSO44, MSO46, MSO54, MSO56, MSO58,
@@ -378,7 +596,7 @@ Users have until v2.0.0 to migrate their imports.
   - Integrated with existing `make docs-generate` automation
 - Updated PyPI documentation URL
   - Changed from README-only link to proper documentation site
-  - PyPI now links to https://little-did-I-know.github.io/SCPI-Instrument-Control/
+  - PyPI now links to https://little-did-I-know.github.io/Siglent-Oscilloscope/
   - Users can access complete API documentation and guides from PyPI
 
 **MkDocs Build System**
@@ -1377,4 +1595,4 @@ pip install "Siglent-Oscilloscope[power-supply-beta,usb]==0.4.0-beta.1"
 - Context manager support for oscilloscope connections
 - Comprehensive error handling with custom exceptions
 
-[0.1.0]: https://github.com/little-did-I-know/SCPI-Instrument-Control/releases
+[0.1.0]: https://github.com/siglent-control/siglent/releases/tag/v0.1.0

--- a/docs/development/wire-form-inventory.md
+++ b/docs/development/wire-form-inventory.md
@@ -140,9 +140,9 @@ printed footer number -- which was never true of how the entries below, or
 | `get_bandwidth_limit` | `:CHANnel{ch}:BWLimit?` | `:CHANnel<n>:BWLimit?` (not mocked) | VERIFIED | EN11G p.50 |
 | `get_channel_display` | `:CHANnel{ch}:SWITch?` | same; response `<state>` bare, matches | VERIFIED | EN11G p.60 |
 | `get_coupling` | `:CHANnel{ch}:COUPling?` | request matches; mock fixture answers the LEGACY token `D1M` (invalid modern enum member) | MISMATCH_DEFERRED | EN11G p.51 |
-| `get_simple_value` | `:MEASure:SIMPle:VALue? {param}` | `:MEASure:SIMPle:VALue? <parameter>`; response bare number, matches | VERIFIED | EN11G p.369 |
 | `get_probe_ratio` | `:CHANnel{ch}:PROBe?` | `:CHANnel<n>:PROBe?` (not mocked) | VERIFIED | EN11G p.57 |
 | `get_sample_rate` | `:ACQuire:SRATe?` | same; response bare NR3, matches | VERIFIED | EN11G p.46 |
+| `get_simple_value` | `:MEASure:SIMPle:VALue? {param}` | `:MEASure:SIMPle:VALue? <parameter>`; response bare number, matches | VERIFIED | EN11G p.369 |
 | `get_time_div` | `:TIMebase:SCALe?` | same; response bare NR3, matches | VERIFIED | EN11G p.476 |
 | `get_time_offset` | `:TIMebase:DELay?` | `:TIMebase:DELay?` (not mocked) | VERIFIED | EN11G p.473 |
 | `get_trigger_coupling` | `:TRIGger:EDGE:COUPling?` | same; response bare, matches | VERIFIED | EN11G p.486 |
@@ -169,6 +169,7 @@ printed footer number -- which was never true of how the entries below, or
 | `set_channel_display` | `:CHANnel{ch}:SWITch {state}` | `:CHANnel<n>:SWITch <state>` | VERIFIED | EN11G p.60 |
 | `set_coupling` | `:CHANnel{ch}:COUPling {coupling}` | `:CHANnel<n>:COUPling <coupling_mode>` | VERIFIED | EN11G p.51 |
 | `set_hardcopy_format` | `HCSU DEV,FORMAT,{format}` | `HCSU` absent from manual entirely; closest concept is `:PRINt?`'s `<format>:={NORMal\|INVerted}` (different axis); dead code (no caller) | MISMATCH_DEFERRED | EN11G p.33 |
+| `set_measure_mode` | `:MEASure:MODE {mode}` | `:MEASure:MODE <type>`, `{SIMPle\|ADVanced}` | VERIFIED | EN11G p.365 |
 | `set_measure_state` | `:MEASure {state}` | `:MEASure <state>` | VERIFIED | EN11G p.337 |
 | `set_probe_ratio` | `:CHANnel{ch}:PROBe VALue,{ratio}` | `:CHANnel<n>:PROBe <attenuation>[,<value>]` (not mocked) | VERIFIED | EN11G p.57 |
 | `set_simple_item` | `:MEASure:SIMPle:ITEM {param},{state}` | `:MEASure:SIMPle:ITEM <parameter>,<state>` | VERIFIED | EN11G p.367 |
@@ -190,7 +191,7 @@ printed footer number -- which was never true of how the entries below, or
 | `set_waveform_width` | `:WAVeform:WIDTh {value}` | `:WAVeform:WIDTh <type>`, `{BYTE\|WORD}` | VERIFIED | EN11G p.754 |
 | `stop` | `:TRIGger:STOP` | `:TRIGger:STOP` | VERIFIED | EN11G p.484 |
 
-**Tally: 51 VERIFIED, 4 MISMATCH_DEFERRED, 0 UNCITED (55 total).**
+**Tally: 52 VERIFIED, 4 MISMATCH_DEFERRED, 0 UNCITED (56 total).**
 
 The four `:MEASure:` rows above (`set_measure_state`, `set_simple_source`,
 `set_simple_item`, `get_simple_value`) replaced an earlier stale corpus entry,
@@ -200,6 +201,13 @@ the external **Digital Multimeter** subsystem (`MEASure:CONTinuity`,
 measurements. The oscilloscope measurement subsystem (`:MEASure:` / `:MEASure:SIMPle:`)
 is documented at EN11G p.335-373. The four rows are VERIFIED against those pages
 in `tests/wire_forms.py`.
+
+A fifth row, `set_measure_mode` (`:MEASure:MODE {mode}`, EN11G p.365), was added
+alongside a review of this fix: `measure()` now sends it right after
+`:MEASure ON` to pin the instrument in `SIMPle` mode, because p.369's `VALue?`
+reads "the specified measurement value that appears on the simple measurement"
+-- a read against an instrument left in `ADVanced` mode (the table's other
+enum member) is not guaranteed to answer the same way.
 
 Task 17 (audit H9) added eight rows with a `get_waveform_`/`set_waveform_`
 prefix: the documented `:WAVeform:SOURce`/`STARt`/`INTerval`/`POINt`

--- a/docs/development/wire-form-inventory.md
+++ b/docs/development/wire-form-inventory.md
@@ -140,7 +140,7 @@ printed footer number -- which was never true of how the entries below, or
 | `get_bandwidth_limit` | `:CHANnel{ch}:BWLimit?` | `:CHANnel<n>:BWLimit?` (not mocked) | VERIFIED | EN11G p.50 |
 | `get_channel_display` | `:CHANnel{ch}:SWITch?` | same; response `<state>` bare, matches | VERIFIED | EN11G p.60 |
 | `get_coupling` | `:CHANnel{ch}:COUPling?` | request matches; mock fixture answers the LEGACY token `D1M` (invalid modern enum member) | MISMATCH_DEFERRED | EN11G p.51 |
-| `get_parameter_value` | `C{ch}:PAVA? {param}` | absent from manual entirely (zero hits for PAVA); modern measurement path is a separate concern | MISMATCH_DEFERRED | EN11G p.784 |
+| `get_simple_value` | `:MEASure:SIMPle:VALue? {param}` | `:MEASure:SIMPle:VALue? <parameter>`; response bare number, matches | VERIFIED | EN11G p.369 |
 | `get_probe_ratio` | `:CHANnel{ch}:PROBe?` | `:CHANnel<n>:PROBe?` (not mocked) | VERIFIED | EN11G p.57 |
 | `get_sample_rate` | `:ACQuire:SRATe?` | same; response bare NR3, matches | VERIFIED | EN11G p.46 |
 | `get_time_div` | `:TIMebase:SCALe?` | same; response bare NR3, matches | VERIFIED | EN11G p.476 |
@@ -169,7 +169,10 @@ printed footer number -- which was never true of how the entries below, or
 | `set_channel_display` | `:CHANnel{ch}:SWITch {state}` | `:CHANnel<n>:SWITch <state>` | VERIFIED | EN11G p.60 |
 | `set_coupling` | `:CHANnel{ch}:COUPling {coupling}` | `:CHANnel<n>:COUPling <coupling_mode>` | VERIFIED | EN11G p.51 |
 | `set_hardcopy_format` | `HCSU DEV,FORMAT,{format}` | `HCSU` absent from manual entirely; closest concept is `:PRINt?`'s `<format>:={NORMal\|INVerted}` (different axis); dead code (no caller) | MISMATCH_DEFERRED | EN11G p.33 |
+| `set_measure_state` | `:MEASure {state}` | `:MEASure <state>` | VERIFIED | EN11G p.337 |
 | `set_probe_ratio` | `:CHANnel{ch}:PROBe VALue,{ratio}` | `:CHANnel<n>:PROBe <attenuation>[,<value>]` (not mocked) | VERIFIED | EN11G p.57 |
+| `set_simple_item` | `:MEASure:SIMPle:ITEM {param},{state}` | `:MEASure:SIMPle:ITEM <parameter>,<state>` | VERIFIED | EN11G p.367 |
+| `set_simple_source` | `:MEASure:SIMPle:SOURce C{ch}` | `:MEASure:SIMPle:SOURce <source>` | VERIFIED | EN11G p.368 |
 | `set_time_div` | `:TIMebase:SCALe {tdiv}` | `:TIMebase:SCALe <value>` | VERIFIED | EN11G p.476 |
 | `set_time_offset` | `:TIMebase:DELay {offset}` | `:TIMebase:DELay <delay_value>` | VERIFIED | EN11G p.473 |
 | `set_trigger_coupling` | `:TRIGger:EDGE:COUPling {coupling}` | `:TRIGger:EDGE:COUPling <mode>`, `{DC\|AC\|LFREJect\|HFREJect}` | VERIFIED | EN11G p.486 |
@@ -187,7 +190,16 @@ printed footer number -- which was never true of how the entries below, or
 | `set_waveform_width` | `:WAVeform:WIDTh {value}` | `:WAVeform:WIDTh <type>`, `{BYTE\|WORD}` | VERIFIED | EN11G p.754 |
 | `stop` | `:TRIGger:STOP` | `:TRIGger:STOP` | VERIFIED | EN11G p.484 |
 
-**Tally: 47 VERIFIED, 5 MISMATCH_DEFERRED, 0 UNCITED (52 total).**
+**Tally: 51 VERIFIED, 4 MISMATCH_DEFERRED, 0 UNCITED (55 total).**
+
+The four `:MEASure:` rows above (`set_measure_state`, `set_simple_source`,
+`set_simple_item`, `get_simple_value`) replaced an earlier stale corpus entry,
+`get_parameter_value`, that was mis-cited to EN11G p.784. That page documents
+the external **Digital Multimeter** subsystem (`MEASure:CONTinuity`,
+`MEASure:CURRent`, `MEASure:RESistance`, etc.), not oscilloscope waveform
+measurements. The oscilloscope measurement subsystem (`:MEASure:` / `:MEASure:SIMPle:`)
+is documented at EN11G p.335-373. The four rows are VERIFIED against those pages
+in `tests/wire_forms.py`.
 
 Task 17 (audit H9) added eight rows with a `get_waveform_`/`set_waveform_`
 prefix: the documented `:WAVeform:SOURce`/`STARt`/`INTerval`/`POINt`

--- a/docs/gateway/browser-ui.md
+++ b/docs/gateway/browser-ui.md
@@ -49,9 +49,9 @@ The side rail holds one tab per feature area:
 - **Log** — start/stop trend recording, watch a live row counter, and
   download the result as CSV. **The measurement selection locks while a
   recording is active**, so you can't change what's being recorded mid-run.
-- **Measure** — per-channel measurement checkboxes with live values.
-  Unavailable on modern-dialect scopes (see
-  [SCPI Dialects](../user-guide/scpi-dialects.md) for why).
+- **Measure** — per-channel measurement checkboxes with live values, on every
+  supported dialect (see [SCPI Dialects](../user-guide/scpi-dialects.md) for
+  how each one is wired up).
 - **Terminal** — send raw SCPI commands. A trailing `?` sends it as a query
   and shows the response; anything else is a bare write.
 

--- a/docs/user-guide/scpi-dialects.md
+++ b/docs/user-guide/scpi-dialects.md
@@ -116,9 +116,7 @@ raw commands in whichever dialect the connected scope speaks.
 
 Not every dialect implements every feature the public API exposes. Where a
 dialect lacks a command, calling the corresponding property or method raises
-`FeatureNotSupportedError` (or, for the two gaps noted below that involve
-timeouts rather than gating, the appropriate timeout/parse error) —
-`scpi_control.exceptions`.
+`FeatureNotSupportedError` — `scpi_control.exceptions`.
 
 | Feature | Supported on | Notes |
 |---|---|---|
@@ -128,17 +126,22 @@ timeouts rather than gating, the appropriate timeout/parse error) —
 | Trigger holdoff | legacy, tektronix | On legacy, the wire command (`TRIG_DELAY`) is really *trigger delay*, not holdoff — an existing honesty note kept as-is pending a trigger-rework follow-up. Modern has no holdoff command at all. LeCroy holdoff lives in `TRIG_SELECT HT/HV`, a different shape not yet implemented (follow-up). |
 | `GND` channel coupling | legacy, modern, lecroy | Not supported on Tektronix: neither the TBS1000C (`AC`\|`DC`) nor the 2 Series MSO (`AC`\|`DC`\|`DCREJect`) command set has a ground-coupling mode. The MSO2's `DCREJect` coupling readback is normalized to the public `AC` token rather than surfaced as a Tek-specific value. |
 | Channel vertical unit (`C{ch}:UNIT`) | legacy only | No equivalent command in the modern, Tektronix, or LeCroy tables. |
-| `measure()` automated measurements | legacy, lecroy, tektronix (all families) | **Modern (Siglent):** `measure()` calls still time out and raise `SiglentTimeoutError` — a longstanding, unchanged gap. **Tektronix:** the TBS1000C uses the `MEASUrement:IMMed` subsystem; the 2/4/5/6 Series MSO families have no `IMMed` subsystem and use stateful "badges" instead (`MEASUrement:MEAS<n>`) — see [Measurement badges](#measurement-badges) below. This closes the previous MSO 2-Series gap: `measure()` now works there too. |
+| `measure()` automated measurements | legacy, modern, lecroy, tektronix (all families) | **Modern (Siglent):** uses the documented `:MEASure:SIMPle` subsystem — enables the measurement function, points it at the channel, switches the requested item on, then reads it back. Not side-effect-free: the enabled item and the simple-measurement source stay set on the instrument (and visible on its display) after the call returns; see the note below the table. **Tektronix:** the TBS1000C uses the `MEASUrement:IMMed` subsystem; the 2/4/5/6 Series MSO families have no `IMMed` subsystem and use stateful "badges" instead (`MEASUrement:MEAS<n>`) — see [Measurement badges](#measurement-badges) below. |
 | Badge measurement types `CMEAN`, `CRMS` | not available on badge families (2/4/5/6 Series MSO) | Both raise `FeatureNotSupportedError`. `CMEAN`: neither manual's `MEASUrement:MEAS<x>:TYPe` argument list (MSO2 PM 077-1776-07 p.2-468; 4/5/6 PM 077-1305-11 p.2-702) lists a cycle-mean badge token. `CRMS`: the badge vocabulary's `ACRMS` is AC-coupled RMS, a different measurement than cycle RMS — mapping it would misrepresent what's measured. **`TOP` and `BASE` are supported** on badge families (both manuals list `TOP`/`BASE` tokens; see the model table above) — they are not a gap. |
 | `LINE` trigger source | not available on the `tektronix` dialect (gated for all families) | TBS1000C (PM 077-1691-01 p.152) and the 4/5/6 Series (PM 077-1305-11 p.2-1406) both support a `LINE` edge-trigger source; only the 2 Series MSO (PM 077-1776-07 p.2-663) lacks it. That divergence runs *inside* the shared `tek_mso` variant (2 Series vs. 4/5/6), which the current `channel_token(dialect, source)` signature — it branches on dialect only — cannot express, so `LINE` is gated dialect-wide rather than risk sending a token the 2 Series would reject. A deliberate, conservative gap; adding `LINE` for the families that do have it is a follow-up (needs a `tek_mso` split or a per-model capability flag). `EX` passes through as `AUX` (the SCPI short form of `AUXiliary`, present on every Tek family); `EX5` has no token on any Tek family and is also gated. |
 | Waveform transfer bit depth | 8-bit only, all dialects | Tektronix's `DATa:WIDth` is pinned to `1` (8-bit) for now; 16-bit transfer is a follow-up. |
 | LeCroy waveform transfer format | lecroy | Uses `C{ch}:WF? ALL` (descriptor + data in one block), scaled from the `WAVEDESC` descriptor's vertical gain/offset and horizontal interval/offset fields, with `CFMT DEF9,{BYTE\|WORD},BIN` and `CORD LO` (LSB-first) pinning the wire encoding — a different transfer path from the Siglent-style `WF? DAT2` used by legacy and modern. |
 | LeCroy bandwidth limit token | lecroy | The public `ON` token maps to the wire value `20MHZ`; LeCroy's `BWL` vocabulary (`OFF`, `20MHZ`, `200MHZ`, ...) has no `ON` token of its own to map onto. |
 
-Automated measurements (`PAVA?`) on **Siglent modern** scopes remain a
-documented, unchanged gap: `scope.measurement.measure(...)` calls time out
-and raise `SiglentTimeoutError`. The web gateway catches this internally and
-shows measurements as unavailable in its UI.
+A modern-dialect `measure()` call is not side-effect-free: it sends
+`:MEASure ON`, `:MEASure:SIMPle:SOURce`, and `:MEASure:SIMPle:ITEM
+{param},ON` before reading `:MEASure:SIMPle:VALue?`, all of which are visible
+on the instrument display afterwards. These are deliberately left in place
+rather than cleared, because the instrument's own clear command
+(`:MEASure:SIMPle:CLEar`) is all-or-nothing and would remove measurements you
+configured yourself from the front panel. Enabled items accumulate across
+repeated calls rather than being switched off. The web gateway streams these
+values the same way it does for every other dialect.
 
 ## Measurement badges
 

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -151,6 +151,7 @@ class MockConnection(BaseConnection):
         # dialect sets a source and enables items; per the design decision these
         # are deliberately NOT cleared after a read, mirroring the instrument.
         self.measure_enabled: bool = False
+        self.simple_mode: str = "SIMPle"
         self.simple_source: str = "C1"
         self.simple_items: Set[str] = set()
 

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -4,7 +4,7 @@ and personality dispatch to the vendor-specific scope write/query/waveform modul
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Union
 
 from scpi_control import exceptions
 from scpi_control.connection.base import BaseConnection
@@ -146,6 +146,13 @@ class MockConnection(BaseConnection):
         self.trigger_coupling = "DC"
         self.trigger_level: Dict[int, float] = {ch: 0.0 for ch in channels}
         self.trigger_status: List[str] = trigger_status[:] if trigger_status else ["Stop"]
+
+        # Modern :MEASure:SIMPle state (guide p.335-373). measure() on the modern
+        # dialect sets a source and enables items; per the design decision these
+        # are deliberately NOT cleared after a read, mirroring the instrument.
+        self.measure_enabled: bool = False
+        self.simple_source: str = "C1"
+        self.simple_items: Set[str] = set()
 
         # Tektronix wire-vocabulary state (shared across tek_tbs/tek_mso variants)
         self.tek_stop_after = "RUNSTOP"

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -35,6 +35,35 @@ _MOCK_PAVA_VALUES: Dict[str, Tuple[str, str]] = {
     "DUTY": ("5.000E+01", "%"),
 }
 
+# Modern :MEASure:SIMPle:VALue? replies, keyed by the MODERN wire token and
+# holding a bare NR3 string (p.369 shows "2.000E+00" -- no parameter name, no
+# unit suffix, unlike the legacy PAVA? reply above). The numbers mirror
+# _MOCK_PAVA_VALUES so both dialects describe the same synthesized signal.
+#
+# WID and NBWID are deliberately ABSENT. Per p.345 those are the BURST widths;
+# the driver must send PWID/NWID for pulse widths. Leaving them out means a
+# driver regression that sends WID gets an unmatched query (SiglentTimeoutError
+# under strict mode) instead of a plausible-looking wrong number.
+_MOCK_SIMPLE_VALUES: Dict[str, str] = {
+    "PKPK": "2.000E+00",
+    "MAX": "1.000E+00",
+    "MIN": "-1.000E+00",
+    "AMPL": "2.000E+00",
+    "TOP": "1.000E+00",
+    "BASE": "-1.000E+00",
+    "CMEAN": "0.000E+00",
+    "MEAN": "0.000E+00",
+    "RMS": "7.070E-01",
+    "CRMS": "7.070E-01",
+    "FREQ": "1.000E+03",
+    "PER": "1.000E-03",
+    "RISE": "3.500E-05",
+    "FALL": "3.500E-05",
+    "PWID": "5.000E-04",
+    "NWID": "5.000E-04",
+    "DUTY": "5.000E+01",
+}
+
 
 def handle_write(conn, command: str) -> bool:
     """Handle a Siglent-dialect (legacy or modern) scope write. Returns True if consumed."""
@@ -56,6 +85,25 @@ def handle_write(conn, command: str) -> bool:
         if match := re.match(r":TIMebase:SCALe\s+(.+)", command, re.IGNORECASE):
             conn.timebase = float(match.group(1))
             conn.timebase_updates.append(conn.timebase)
+            return True
+        # :MEASure <ON|OFF> (p.337). Matched before the :MEASure:SIMPle forms
+        # below; the required whitespace after the mnemonic means this pattern
+        # cannot swallow ":MEASure:SIMPle:..." (next char there is ":").
+        if match := re.match(r":MEAS(?:ure)?\s+(ON|OFF)\s*$", command, re.IGNORECASE):
+            conn.measure_enabled = match.group(1).upper() == "ON"
+            return True
+        if match := re.match(r":MEAS(?:ure)?:SIMP(?:le)?:SOUR(?:ce)?\s+(\w+)\s*$", command, re.IGNORECASE):
+            conn.simple_source = match.group(1).upper()  # p.368
+            return True
+        if match := re.match(r":MEAS(?:ure)?:SIMP(?:le)?:ITEM\s+(\w+)\s*,\s*(ON|OFF)\s*$", command, re.IGNORECASE):
+            item, state = match.group(1).upper(), match.group(2).upper()  # p.367
+            if state == "ON":
+                conn.simple_items.add(item)
+            else:
+                conn.simple_items.discard(item)
+            return True
+        if re.match(r":MEAS(?:ure)?:SIMP(?:le)?:CLE(?:ar)?\s*$", command, re.IGNORECASE):
+            conn.simple_items.clear()  # p.367
             return True
         if match := re.match(r":TRIGger:MODE\s+(\w+)", command, re.IGNORECASE):
             conn.trigger_mode = match.group(1)  # stored as wire token, e.g. "NORMal" (guide p.482)
@@ -219,6 +267,20 @@ def handle_query(conn, command: str) -> Optional[str]:
             return conn.waveform_width
         if upper == ":WAVEFORM:MAXPOINT?":  # bare NR1, p.753 (query-only, no setter)
             return str(conn.max_points)
+        if match := re.match(r":MEAS(?:URE)?:SIMP(?:LE)?:VAL(?:UE)?\?\s*(\w+)", upper):
+            # Answer for any token we know, regardless of whether ITEM switched it
+            # on -- the wire-form corpus queries this directly with no setup writes.
+            # An UNKNOWN token (e.g. the burst-width WID or NBWID, p.345, which the
+            # driver must never send) falls through to None -> unmatched ->
+            # SiglentTimeoutError under strict mode, so a mis-mapped measurement
+            # type surfaces as a loud failure rather than a wrong number.
+            item = match.group(1)
+            if item in _MOCK_SIMPLE_VALUES:
+                return _MOCK_SIMPLE_VALUES[item]  # bare NR3, p.369
+        if upper == ":MEAS?" or upper == ":MEASURE?":  # p.337
+            return "ON" if conn.measure_enabled else "OFF"
+        if match := re.match(r":MEAS(?:URE)?:SIMP(?:LE)?:SOUR(?:CE)?\?", upper):  # p.368
+            return conn.simple_source
 
     if conn.scope_dialect == "legacy":
         if match := re.match(r"C(\d+):VDIV\?", command, re.IGNORECASE):

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -61,6 +61,12 @@ _MOCK_SIMPLE_VALUES: Dict[str, str] = {
     "FALL": "3.500E-05",
     "PWID": "5.000E-04",
     "NWID": "5.000E-04",
+    # ASSUMPTION, not a manual fact: the guide gives exactly one bare-NR3 response
+    # example (p.369, MAX -> "2.000E+00") and no worked example for DUTY, so there is
+    # no documented confirmation this reply is percent-scaled rather than a 0-1
+    # fraction. "5.000E+01" is inherited from the legacy dialect's unit-suffixed
+    # fixture (_MOCK_PAVA_VALUES["DUTY"] above) purely so both dialects describe the
+    # same synthesized signal -- do not cite this value as verified against EN11G.
     "DUTY": "5.000E+01",
 }
 
@@ -91,6 +97,9 @@ def handle_write(conn, command: str) -> bool:
         # cannot swallow ":MEASure:SIMPle:..." (next char there is ":").
         if match := re.match(r":MEAS(?:ure)?\s+(ON|OFF)\s*$", command, re.IGNORECASE):
             conn.measure_enabled = match.group(1).upper() == "ON"
+            return True
+        if match := re.match(r":MEAS(?:ure)?:MODE\s+(SIMP(?:le)?|ADV(?:anced)?)\s*$", command, re.IGNORECASE):
+            conn.simple_mode = match.group(1)  # stored as wire token, e.g. "SIMPle" (guide p.365)
             return True
         if match := re.match(r":MEAS(?:ure)?:SIMP(?:le)?:SOUR(?:ce)?\s+(\w+)\s*$", command, re.IGNORECASE):
             conn.simple_source = match.group(1).upper()  # p.368

--- a/scpi_control/measurement.py
+++ b/scpi_control/measurement.py
@@ -109,6 +109,11 @@ class Measurement:
             # and would wipe measurements the user configured by hand.
             wire_type = measurement_to_wire(self._dialect, mtype)
             self._scope.write(self._scope._get_command("set_measure_state", state="ON"))
+            # p.369: VALue? "returns the specified measurement value that appears on
+            # the simple measurement" -- if the instrument is left in ADVanced mode
+            # (p.365) that read may fail or return something stale, so pin SIMPle
+            # mode every time rather than trusting whatever mode it was already in.
+            self._scope.write(self._scope._get_command("set_measure_mode", mode="SIMPle"))
             self._scope.write(self._scope._get_command("set_simple_source", ch=channel))
             self._scope.write(self._scope._get_command("set_simple_item", param=wire_type, state="ON"))
             response = self._scope.query(self._scope._get_command("get_simple_value", param=wire_type))

--- a/scpi_control/measurement.py
+++ b/scpi_control/measurement.py
@@ -97,6 +97,29 @@ class Measurement:
                 return self._badge_pool.value(badge_type_to_wire(self._dialect, mtype), channel)
             raise exceptions.FeatureNotSupportedError(f"measure({mtype!r}) is not supported: this Tektronix family/configuration has neither the MEASUrement:IMMed subsystem nor measurement badges")
 
+        if self._dialect == "modern":
+            # Modern instruments have no PARAMETER_VALUE command -- PAVA appears
+            # zero times in the SDS800X HD guide. Measurements come from the
+            # :MEASure:SIMPle subsystem (guide p.335-373): enable the function,
+            # point it at the channel, switch the item on, then read it.
+            #
+            # Unlike legacy PAVA?, this MUTATES instrument state -- the source is
+            # global to simple measurements and enabled items show on the display.
+            # We deliberately do not clear them: :SIMPle:CLEar is all-or-nothing
+            # and would wipe measurements the user configured by hand.
+            wire_type = measurement_to_wire(self._dialect, mtype)
+            self._scope.write(self._scope._get_command("set_measure_state", state="ON"))
+            self._scope.write(self._scope._get_command("set_simple_source", ch=channel))
+            self._scope.write(self._scope._get_command("set_simple_item", param=wire_type, state="ON"))
+            response = self._scope.query(self._scope._get_command("get_simple_value", param=wire_type))
+            # p.369: RESPONSE FORMAT is a bare <value> in NR3 ("2.000E+00") -- no
+            # parameter name and no unit suffix, so the legacy comma-splitting
+            # parser below cannot be reused.
+            try:
+                return float(response.strip())
+            except ValueError as e:
+                raise exceptions.CommandError(f"Failed to parse measurement: {e}")
+
         wire_type = measurement_to_wire(self._dialect, mtype)
 
         # Query parameter value

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -229,6 +229,7 @@ class SCPICommandSet:
         # gate cleanly as FeatureNotSupportedError; they need the :MEASure:ADVanced
         # slot subsystem, which is a separate project.
         "set_measure_state": ":MEASure {state}",  # {ON|OFF}, p.337
+        "set_measure_mode": ":MEASure:MODE {mode}",  # {SIMPle|ADVanced}, p.365
         "set_simple_source": ":MEASure:SIMPle:SOURce C{ch}",  # p.368
         "set_simple_item": ":MEASure:SIMPle:ITEM {param},{state}",  # p.367
         "get_simple_value": ":MEASure:SIMPle:VALue? {param}",  # bare NR3 reply, p.369

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -221,10 +221,17 @@ class SCPICommandSet:
         # to learn how many :WAVeform:STARt-driven DATA? windows a full
         # record needs.
         "get_waveform_maxpoint": ":WAVeform:MAXPoint?",  # p.753
-        # Measurements — get_parameter_value stays available (measure() keeps
-        # working on modern, a documented gap); statistics/cursors/holdoff/unit
-        # are legacy-only and intentionally absent so they gate cleanly.
-        "get_parameter_value": "C{ch}:PAVA? {param}",
+        # Measurements — the :MEASure:SIMPle subsystem (p.335 index). The legacy
+        # PAVA? command is deliberately ABSENT: it appears zero times in this
+        # guide (exhaustive full-text search), so offering it here made measure()
+        # send a command modern instruments do not implement. Statistics, cursors,
+        # holdoff and unit remain legacy-only and intentionally absent so they
+        # gate cleanly as FeatureNotSupportedError; they need the :MEASure:ADVanced
+        # slot subsystem, which is a separate project.
+        "set_measure_state": ":MEASure {state}",  # {ON|OFF}, p.337
+        "set_simple_source": ":MEASure:SIMPle:SOURce C{ch}",  # p.368
+        "set_simple_item": ":MEASure:SIMPle:ITEM {param},{state}",  # p.367
+        "get_simple_value": ":MEASure:SIMPle:VALue? {param}",  # bare NR3 reply, p.369
         # Screen capture (legacy strings accepted on modern scopes today; revisit with screen-capture overhaul)
         "screen_dump": "SCDP",
         "set_hardcopy_format": "HCSU DEV,FORMAT,{format}",

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -721,7 +721,33 @@ def _from_wire(table, dialect: str, raw: str, what: str) -> str:
 _MEASUREMENT_TYPES = {"PKPK", "MAX", "MIN", "AMPL", "TOP", "BASE", "CMEAN", "MEAN", "RMS", "CRMS", "FREQ", "PER", "RISE", "FALL", "WID", "NWID", "DUTY"}
 _MEASUREMENT_TO_WIRE = {
     "legacy": {m: m for m in _MEASUREMENT_TYPES},
-    "modern": {m: m for m in _MEASUREMENT_TYPES},
+    # Modern :MEASure:SIMPle:ITEM / :VALue? vocabulary, verbatim from the
+    # SDS800X HD guide p.367 (ITEM) and p.369 (VALue?). NOT an identity map:
+    # per the parameter table at p.345, modern WID is the positive BURST width
+    # (first rising edge to last falling edge) while the positive PULSE width
+    # -- which is what our public WID means, cf. "WID": "PWIdth" in the
+    # tektronix map below -- is PWID. Mapping WID -> WID would silently return
+    # burst width. NWID is the negative PULSE width on both sides (NBWID is the
+    # burst form and we never send it).
+    "modern": {
+        "PKPK": "PKPK",
+        "MAX": "MAX",
+        "MIN": "MIN",
+        "AMPL": "AMPL",
+        "TOP": "TOP",
+        "BASE": "BASE",
+        "CMEAN": "CMEAN",
+        "MEAN": "MEAN",
+        "RMS": "RMS",
+        "CRMS": "CRMS",
+        "FREQ": "FREQ",
+        "PER": "PER",
+        "RISE": "RISE",
+        "FALL": "FALL",
+        "WID": "PWID",
+        "NWID": "NWID",
+        "DUTY": "DUTY",
+    },
     # LeCroy PARAMETER_VALUE (PAVA) parameter names -- identity, the ancestor
     # of the Siglent legacy vocabulary (MAUI p.7-70).
     "lecroy": {m: m for m in _MEASUREMENT_TYPES},

--- a/tests/test_measurement_panel.py
+++ b/tests/test_measurement_panel.py
@@ -49,3 +49,22 @@ def test_formatter_labels_each_kind(qapp):
     assert panel._format_measurement_value("DUTY", 50.0).endswith("%")
     assert panel._format_measurement_value("PKPK", 2.0).endswith("V")
     assert panel._format_measurement_value("WID", 5e-3).endswith("ms")
+
+
+MODERN_IDN = "Siglent Technologies,SDS814X HD,MOCK0001,1.0.0.0"
+
+
+def _modern_mock_scope():
+    scope = Oscilloscope("mock", connection=MockConnection(idn=MODERN_IDN))
+    scope.connect()
+    return scope
+
+
+def test_every_offered_type_returns_a_real_value_on_modern(qapp):
+    """PR #102's net used a default (legacy) mock, so a modern-dialect break was
+    invisible to it -- every one of these raised SiglentTimeoutError."""
+    panel = MeasurementPanel()
+    panel.scope = _modern_mock_scope()
+    for _display, key in MeasurementPanel.MEASUREMENTS:
+        value = panel._get_measurement_value(1, key)
+        assert isinstance(value, float), "{0} returned {1!r} on the modern dialect".format(key, value)

--- a/tests/test_mock_dialects.py
+++ b/tests/test_mock_dialects.py
@@ -112,18 +112,16 @@ def test_modern_mock_still_times_out_on_legacy_pava():
     directly against the connection rather than through measure()."""
     import pytest as _pytest
 
-    from scpi_control import Oscilloscope
     from scpi_control.connection.mock import MockConnection
     from scpi_control.exceptions import SiglentTimeoutError
 
     conn = MockConnection("mock", idn="Siglent Technologies,SDS824X HD,MOCK0002,3.8.12", channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
-    scope = Oscilloscope("mock", connection=conn)
-    scope.connect()
+    conn.connect()
     try:
         with _pytest.raises(SiglentTimeoutError):
             conn.query("C1:PAVA? PKPK")
     finally:
-        scope.disconnect()
+        conn.disconnect()
 
 
 def test_mock_answers_scdp_with_a_valid_image():

--- a/tests/test_mock_dialects.py
+++ b/tests/test_mock_dialects.py
@@ -105,7 +105,11 @@ def test_legacy_mock_answers_pava_measurements():
         scope.disconnect()
 
 
-def test_modern_mock_still_times_out_on_pava():
+def test_modern_mock_still_times_out_on_legacy_pava():
+    """measure() no longer sends PAVA? on modern scopes (it goes through
+    :MEASure:SIMPle instead), but the legacy PAVA? command itself must still
+    have no answer on a modern-dialect mock -- that invariant is asserted
+    directly against the connection rather than through measure()."""
     import pytest as _pytest
 
     from scpi_control import Oscilloscope
@@ -117,7 +121,7 @@ def test_modern_mock_still_times_out_on_pava():
     scope.connect()
     try:
         with _pytest.raises(SiglentTimeoutError):
-            scope.measurement.measure("PKPK", 1)
+            conn.query("C1:PAVA? PKPK")
     finally:
         scope.disconnect()
 

--- a/tests/test_modern_measure.py
+++ b/tests/test_modern_measure.py
@@ -33,3 +33,24 @@ def test_every_measurement_type_has_a_modern_token():
     for mtype in get_args(MeasurementType):
         token = measurement_to_wire("modern", mtype)
         assert token, "{0} has no modern token".format(mtype)
+
+
+def _modern_scope():
+    scope = Oscilloscope("mock", connection=MockConnection(idn=MODERN_IDN))
+    scope.connect()
+    return scope
+
+
+def test_modern_table_renders_the_simple_measure_commands():
+    scope = _modern_scope()
+    assert scope._get_command("set_measure_state", state="ON") == ":MEASure ON"
+    assert scope._get_command("set_simple_source", ch=2) == ":MEASure:SIMPle:SOURce C2"
+    assert scope._get_command("set_simple_item", param="PKPK", state="ON") == ":MEASure:SIMPle:ITEM PKPK,ON"
+    assert scope._get_command("get_simple_value", param="PKPK") == ":MEASure:SIMPle:VALue? PKPK"
+
+
+def test_modern_table_no_longer_offers_legacy_pava():
+    """PAVA appears zero times in the modern guide; keeping it in the table is
+    what let measure() send a nonexistent command."""
+    scope = _modern_scope()
+    assert not scope._has_command("get_parameter_value")

--- a/tests/test_modern_measure.py
+++ b/tests/test_modern_measure.py
@@ -30,6 +30,10 @@ def test_negative_width_maps_to_nwid_not_nbwid():
 
 
 def test_every_measurement_type_has_a_modern_token():
+    """measurement_to_wire raises FeatureNotSupportedError for an unmapped type
+    (see _to_wire in scpi_commands.py), so it can never return a falsy token --
+    this just checks that every one of the 17 public MeasurementType values
+    resolves without raising, i.e. the modern map has no missing entries."""
     for mtype in get_args(MeasurementType):
         token = measurement_to_wire("modern", mtype)
         assert token, "{0} has no modern token".format(mtype)
@@ -107,14 +111,19 @@ def test_measure_on_modern_emits_the_documented_sequence():
     written = [c for c in conn.writes if "MEAS" in c.upper()]
     assert written == [
         ":MEASure ON",
+        ":MEASure:MODE SIMPle",
         ":MEASure:SIMPle:SOURce C2",
         ":MEASure:SIMPle:ITEM PWID,ON",
     ], written
 
 
 def test_measure_agrees_across_dialects_for_the_same_signal():
-    """Legacy and modern mocks describe the same synthesized signal, so a fix
-    that silently swapped a token (e.g. WID -> burst width) would show up here."""
+    """Guarantees only that legacy and modern mocks describe the same synthesized
+    signal -- the mock fixtures for both dialects were authored to mirror each
+    other, so this does NOT catch a token swap (e.g. WID <-> NWID): both are
+    "5.000E-04" here, so a swap would silently agree instead of failing. That
+    class of regression is what test_measure_on_modern_emits_the_documented_
+    sequence checks, by asserting the literal wire tokens sent."""
     legacy = Oscilloscope("mock", connection=MockConnection(idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"))
     legacy.connect()
     modern = _modern_scope()

--- a/tests/test_modern_measure.py
+++ b/tests/test_modern_measure.py
@@ -54,3 +54,35 @@ def test_modern_table_no_longer_offers_legacy_pava():
     what let measure() send a nonexistent command."""
     scope = _modern_scope()
     assert not scope._has_command("get_parameter_value")
+
+
+def test_mock_answers_the_simple_value_query_with_bare_nr3():
+    conn = MockConnection(idn=MODERN_IDN)
+    conn.connect()
+    conn.write(":MEASure ON")
+    conn.write(":MEASure:SIMPle:SOURce C1")
+    conn.write(":MEASure:SIMPle:ITEM PKPK,ON")
+    response = conn.query(":MEASure:SIMPle:VALue? PKPK")
+    assert "," not in response, "modern replies are a bare NR3 value (p.369), not <param>,<value>"
+    assert float(response) == pytest.approx(2.0)
+
+
+def test_mock_refuses_the_burst_width_token():
+    """WID is burst width (p.345) and the driver must never send it. The mock
+    does not implement it, so a regression surfaces as a timeout rather than a
+    wrong number."""
+    from scpi_control import exceptions
+
+    conn = MockConnection(idn=MODERN_IDN)
+    conn.connect()
+    conn.write(":MEASure:SIMPle:ITEM WID,ON")
+    with pytest.raises(exceptions.SiglentTimeoutError):
+        conn.query(":MEASure:SIMPle:VALue? WID")
+
+
+def test_mock_answers_value_query_without_prior_setup():
+    """The corpus drives the mock with a bare documented request and no setup
+    writes (test_wire_conformance.py:47-51), so VALue? must answer on its own."""
+    conn = MockConnection(idn=MODERN_IDN)
+    conn.connect()
+    assert conn.query(":MEASure:SIMPle:VALue? PKPK") == "2.000E+00"

--- a/tests/test_modern_measure.py
+++ b/tests/test_modern_measure.py
@@ -1,0 +1,35 @@
+"""Modern-dialect :MEASure:SIMPle subsystem (guide p.335-373).
+
+The legacy PAVA? command does not exist on modern instruments -- it appears zero
+times in the 855-page modern guide -- so measure() needs a separate wire path.
+"""
+
+import pytest
+
+from scpi_control import Oscilloscope
+from scpi_control.connection.mock import MockConnection
+from scpi_control.measurement import MeasurementType
+from scpi_control.scpi_commands import measurement_to_wire
+from typing import get_args
+
+MODERN_IDN = "Siglent Technologies,SDS814X HD,MOCK0001,1.0.0.0"
+
+
+def test_public_wid_maps_to_pwid_not_wid():
+    """The trap: modern WID is BURST width (first rising -> last falling edge,
+    guide p.345); positive PULSE width is PWID. Our public WID means positive
+    pulse width -- it is labelled "Positive Width" in the GUI and the Tektronix
+    map already encodes WID -> PWIdth. Mapping WID -> WID returns a
+    plausible-looking wrong number on any multi-pulse capture."""
+    assert measurement_to_wire("modern", "WID") == "PWID"
+
+
+def test_negative_width_maps_to_nwid_not_nbwid():
+    """NBWID is the negative BURST width (p.345); NWID is the pulse width."""
+    assert measurement_to_wire("modern", "NWID") == "NWID"
+
+
+def test_every_measurement_type_has_a_modern_token():
+    for mtype in get_args(MeasurementType):
+        token = measurement_to_wire("modern", mtype)
+        assert token, "{0} has no modern token".format(mtype)

--- a/tests/test_modern_measure.py
+++ b/tests/test_modern_measure.py
@@ -86,3 +86,37 @@ def test_mock_answers_value_query_without_prior_setup():
     conn = MockConnection(idn=MODERN_IDN)
     conn.connect()
     assert conn.query(":MEASure:SIMPle:VALue? PKPK") == "2.000E+00"
+
+
+def test_measure_returns_a_real_value_for_every_type_on_modern():
+    """The load-bearing net. Before this change every one of these raised
+    SiglentTimeoutError because measure() sent legacy PAVA? on modern."""
+    scope = _modern_scope()
+    for mtype in get_args(MeasurementType):
+        value = scope.measurement.measure(mtype, 1)
+        assert isinstance(value, float), "{0} returned {1!r}".format(mtype, value)
+
+
+def test_measure_on_modern_emits_the_documented_sequence():
+    """Also the "did we enable the item" check -- the mock deliberately does not
+    require enablement (it would break the corpus), so the sequence is asserted here."""
+    scope = _modern_scope()
+    conn = scope._connection
+    conn.writes.clear()
+    scope.measurement.measure("WID", 2)
+    written = [c for c in conn.writes if "MEAS" in c.upper()]
+    assert written == [
+        ":MEASure ON",
+        ":MEASure:SIMPle:SOURce C2",
+        ":MEASure:SIMPle:ITEM PWID,ON",
+    ], written
+
+
+def test_measure_agrees_across_dialects_for_the_same_signal():
+    """Legacy and modern mocks describe the same synthesized signal, so a fix
+    that silently swapped a token (e.g. WID -> burst width) would show up here."""
+    legacy = Oscilloscope("mock", connection=MockConnection(idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"))
+    legacy.connect()
+    modern = _modern_scope()
+    for mtype in ("PKPK", "FREQ", "WID", "NWID", "DUTY"):
+        assert modern.measurement.measure(mtype, 1) == pytest.approx(legacy.measurement.measure(mtype, 1)), mtype

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -1,13 +1,15 @@
 """Streaming poll + state snapshot. No FastAPI dependency."""
 
 import time
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 
 from scpi_control import Oscilloscope
 from scpi_control.connection.mock import MockConnection
-from scpi_control.exceptions import InvalidParameterError
+from scpi_control.exceptions import InvalidParameterError, SiglentTimeoutError
+from scpi_control.measurement import Measurement
 from scpi_control.server.sessions import MAX_FRAME_POINTS, InstrumentSession, SessionError, _waveform_frame, read_state
 from scpi_control.waveform import WaveformData
 
@@ -79,19 +81,22 @@ def test_no_poll_without_subscribers():
 
 
 def test_measurement_poll_reports_none_on_timeout():
-    # PAVA? is legacy-only; on a modern-dialect mock it still has no response ->
-    # SiglentTimeoutError -> value None. (The legacy mock now answers PAVA?, so a
-    # modern scope is used here to keep exercising the graceful-timeout path.)
-    session = make_session(idn=MODERN_IDN)
-    try:
-        session.set_measurements([(1, "PKPK")])
-        msgs = collect(session, "measurements", n=1, timeout=8.0)
-        assert msgs, "expected a measurements message"
-        entry = msgs[0]["values"][0]
-        assert entry["channel"] == 1 and entry["mtype"] == "PKPK"
-        assert entry["value"] is None
-    finally:
-        session.close()
+    # measure() now succeeds on modern-dialect mocks (it goes through
+    # :MEASure:SIMPle), so the graceful-timeout path can no longer be
+    # provoked by dialect alone. Force it deterministically instead by
+    # patching Measurement.measure to raise; _poll_tick must still degrade
+    # to value: None rather than propagating the error.
+    with patch.object(Measurement, "measure", side_effect=SiglentTimeoutError("forced")):
+        session = make_session(idn=MODERN_IDN)
+        try:
+            session.set_measurements([(1, "PKPK")])
+            msgs = collect(session, "measurements", n=1, timeout=8.0)
+            assert msgs, "expected a measurements message"
+            entry = msgs[0]["values"][0]
+            assert entry["channel"] == 1 and entry["mtype"] == "PKPK"
+            assert entry["value"] is None
+        finally:
+            session.close()
 
 
 def test_user_job_still_runs_promptly_while_streaming():

--- a/tests/wire_forms.py
+++ b/tests/wire_forms.py
@@ -1027,41 +1027,58 @@ WIRE_FORMS: List[WireForm] = [
     ),
     # -- Measurements --
     # PAVA appears ZERO times anywhere in this 855-page guide (exhaustive
-    # full-text search, every page) -- the legacy PARAMETER_VALUE command has
-    # no modern equivalent under any header; modern measurements are a
-    # different, badge/CONFigure/MEASure-subsystem concept (guide p.774-855)
-    # this table does not touch.
+    # full-text search, every page) -- the legacy PARAMETER_VALUE command has no
+    # modern equivalent, so it is absent from MODERN_COMMANDS. Modern parameter
+    # measurements use the :MEASure:SIMPle subsystem, indexed at p.335.
+    #
+    # NOTE: an earlier revision of this file cited "p.784ff" for the modern
+    # measurement path. That was wrong -- p.774-855 is the built-in DIGITAL
+    # MULTIMETER (MEASure:CONTinuity / :RESistance / CONFigure:*), which measures
+    # external DMM inputs, not waveform parameters.
     WireForm(
         table="scope",
         dialect="modern",
-        op="get_parameter_value",
-        params={"ch": 2, "param": "RISE"},
-        request="C2:PAVA? RISE",
-        source=f"{MODERN_GUIDE} p.784",
-        status=MISMATCH_DEFERRED,
+        op="set_measure_state",
+        params={"state": "ON"},
+        request=":MEASure ON",
+        source=f"{MODERN_GUIDE} p.337",
         mock_kwargs={"idn": MODERN_IDN},
-        note=(
-            "[HIGH severity -- pull-in candidate] No manual basis: PAVA is "
-            "absent from the modern guide entirely (zero hits, full-text "
-            "search); modern measurement path (MEASure subsystem, p.784ff) is a "
-            "separate concern this table does not implement. This is not dead "
-            "code: measurement.py's measure() is dialect-agnostic and "
-            "unconditionally calls get_parameter_value regardless of dialect "
-            "(no modern-specific branch, unlike the LeCroy branch a few lines "
-            "below it in the same function) -- and measure() is itself called "
-            "from server/sessions.py (the webapp gateway) and from "
-            "examples/basic_usage.py and examples/measurements.py, all on a "
-            "default/documented-usage path. Against real modern-dialect "
-            "hardware this sends a command that does not exist; the response "
-            "parser (measurement.py, 'response.split(\",\")', expects the "
-            "legacy 2-field '<param>,<value>' shape) would then either raise "
-            "CommandError on the instrument's error response, or -- worse, if "
-            "the instrument echoes anything comma-shaped -- silently return a "
-            "wrong number (pull-in bar #1). Not fixed here per the read-only "
-            "constraint on scpi_control/; flagged for a follow-up task (the "
-            "modern MEASure/CONFigure subsystem is a substantial separate "
-            "wire-form project, not a one-line table fix)."
-        ),
+    ),
+    WireForm(
+        table="scope",
+        dialect="modern",
+        op="set_simple_source",
+        params={"ch": 1},
+        request=":MEASure:SIMPle:SOURce C1",
+        source=f"{MODERN_GUIDE} p.368",
+        mock_kwargs={"idn": MODERN_IDN},
+    ),
+    WireForm(
+        table="scope",
+        dialect="modern",
+        op="set_simple_item",
+        params={"param": "PKPK", "state": "ON"},
+        request=":MEASure:SIMPle:ITEM PKPK,ON",
+        source=f"{MODERN_GUIDE} p.367",
+        mock_kwargs={"idn": MODERN_IDN},
+    ),
+    # p.369:
+    #   QUERY SYNTAX    :MEASure:SIMPle:VALue? <type>
+    #   RESPONSE FORMAT <value> in NR3 format
+    #   EXAMPLE         MEAS:SIMP:VAL? MAX   ->   2.000E+00
+    # A bare value: no parameter echo and no unit suffix, unlike the legacy
+    # PAVA? reply. The driver parses it with float() rather than the legacy
+    # comma split.
+    WireForm(
+        table="scope",
+        dialect="modern",
+        op="get_simple_value",
+        params={"param": "PKPK"},
+        request=":MEASure:SIMPle:VALue? PKPK",
+        response="2.000E+00",
+        parsed=2.0,
+        source=f"{MODERN_GUIDE} p.369",
+        mock_kwargs={"idn": MODERN_IDN},
     ),
     # -- Waveform acquisition --
     # WF? appears ZERO times anywhere in this guide -- the legacy C{ch}:WF?

--- a/tests/wire_forms.py
+++ b/tests/wire_forms.py
@@ -1044,6 +1044,18 @@ WIRE_FORMS: List[WireForm] = [
         source=f"{MODERN_GUIDE} p.337",
         mock_kwargs={"idn": MODERN_IDN},
     ),
+    # p.365: <type>:={SIMPle|ADVanced}. measure() pins SIMPle right after
+    # :MEASure ON -- p.369's VALue? reads "the value that appears on the simple
+    # measurement", which an instrument left in ADVanced mode may not serve.
+    WireForm(
+        table="scope",
+        dialect="modern",
+        op="set_measure_mode",
+        params={"mode": "SIMPle"},
+        request=":MEASure:MODE SIMPle",
+        source=f"{MODERN_GUIDE} p.365",
+        mock_kwargs={"idn": MODERN_IDN},
+    ),
     WireForm(
         table="scope",
         dialect="modern",

--- a/webapp/app/src/features/measure/MeasurePanel.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.tsx
@@ -57,8 +57,8 @@ export function MeasurePanel() {
         useSession.getState().applyMeasurementConfig(result.measurements);
       }
     }).catch(() => {
-      // no server truth available yet (e.g. modern-dialect scope) — fall through to the
-      // measurementConfig broadcast / default-empty precedence below.
+      // no server truth available yet (e.g. request failed before the session was ready) —
+      // fall through to the measurementConfig broadcast / default-empty precedence below.
     });
     return () => { cancelled = true; };
   }, [session?.id]);
@@ -137,12 +137,6 @@ export function MeasurePanel() {
       {selected.length === 0 && (
         <div style={{ color: "var(--lc-muted)", fontSize: "var(--text-sm)" }}>
           Select a measurement above to see live values.
-        </div>
-      )}
-
-      {session?.dialect === "modern" && (
-        <div style={{ color: "var(--lc-muted)", fontSize: "var(--text-sm)" }}>
-          Measurements are unavailable on modern-dialect scopes.
         </div>
       )}
 


### PR DESCRIPTION
Measurements never worked on modern-dialect Siglent scopes. `measure()` sent the legacy `C{ch}:PAVA?` command, and **`PAVA` appears zero times in the 855-page SDS800X HD programming guide** — it has no modern equivalent. Every modern measurement failed: the whole GUI Measurements tab, the web gateway's measurement polling, and two shipped examples.

This closes deferred follow-up (b) from the wire-forms sub-project (#98).

## What was actually broken

The failure was worse than a timeout. The response parser expects the legacy two-field `<param>,<value>` shape:

```python
parts = response.split(",")
if len(parts) < 2:
    raise ValueError(...)
```

So against real hardware the outcome was either a `CommandError`, or — if the instrument echoed anything comma-shaped — a **silently wrong number**.

Worth stating plainly: this was never hidden behind a lying mock. The mock has always refused `PAVA` on modern, so `measure()` raised `SiglentTimeoutError` there too. What hid it was **test coverage**: `tests/test_measurement_panel.py` builds its scope with a default-IDN mock, which is the *legacy* dialect, so the panel suite stayed green the entire time modern was completely broken.

## The fix

Modern measurements now use the documented `:MEASure:SIMPle` subsystem:

```
:MEASure ON                        p.337
:MEASure:MODE SIMPle               p.365
:MEASure:SIMPle:SOURce C{ch}       p.368
:MEASure:SIMPle:ITEM {param},ON    p.367
:MEASure:SIMPle:VALue? {param}  →  2.000E+00   (bare NR3, p.369)
```

The reply is a bare NR3 value, so the modern branch parses with `float()` rather than reusing the legacy comma-splitter. Page numbers are PDF file positions per `docs/development/vendor-manuals.md`.

### The `WID` trap

Per the parameter table at p.345:

| Token | Manual definition | Meaning |
| ----- | ----------------- | ------- |
| `PWID` | rising edge → **next** falling edge | positive **pulse** width |
| `WID` | **first** rising → **last** falling | positive **burst** width |
| `NWID` | falling → next rising | negative pulse width |
| `NBWID` | first falling → last rising | negative burst width |

The public `WID` type means positive *pulse* width — the GUI labels it "Positive Width", and the pre-existing Tektronix map already encodes `"WID": "PWIdth"`. The modern map was an identity map, so a mechanical port would have sent `WID` and returned **burst width**: a plausible-looking wrong number, catastrophic on a burst capture and quietly wrong on a clean one.

The mock deliberately **omits** `WID` and `NBWID` from its value table, so a future mis-mapping surfaces as a loud `SiglentTimeoutError` rather than a wrong value. The trap catches itself.

## Two existing tests encoded the bug as expected behaviour

Both had to be rewritten — neither could pass after the fix:

- `test_modern_mock_still_times_out_on_pava` asserted that modern `measure()` *raises* `SiglentTimeoutError`. It now asserts the still-true invariant (*the modern mock does not answer legacy PAVA*) directly on the connection, not through `measure()`.
- `test_measurement_poll_reports_none_on_timeout` used a modern scope specifically *because* PAVA timed out there, as a fault injector for the server's graceful-`None` path. It now provokes the timeout deterministically by patching `Measurement.measure`. The reviewer called this a strict improvement — it no longer depends on a bug to test error handling.

Same class of problem as the blind-guards work in #102: tests that describe the defect rather than the requirement.

## Three shipped files told users this didn't work

Fixing the behaviour is only half the job — several places *documented* the old behaviour as permanent:

- `webapp/.../MeasurePanel.tsx` rendered "Measurements are unavailable on modern-dialect scopes" directly above a table that now streams real values.
- `docs/user-guide/scpi-dialects.md` called it "a longstanding, unchanged gap" in three places.
- `docs/gateway/browser-ui.md` repeated the same claim.

## Side effects, stated honestly

A modern `measure()` is **not side-effect-free**, unlike legacy `PAVA?`. It enables the measurement function, pins the mode to Simple, sets the global simple-measurement source, and switches the requested item on — all visible on the instrument display. Items are deliberately **not** cleared afterwards, because `:SIMPle:CLEar` is all-or-nothing and would wipe measurements the user configured by hand.

The mode is pinned rather than saved-and-restored on purpose. `:MEASure:MODE` does have a query form (unlike `:SIMPle:ITEM`), so restoring is technically possible — but the GUI polls at 1 Hz, and restoring per call would flip the instrument display between Simple and Advanced once per second indefinitely. One visible transition beats unbounded flicker.

## Verification

- Full suite: **1636 passed, 19 skipped, 0 failed** (baseline on `main` 1616/19; +20 tests).
- Every citation independently re-verified against the shipped PDF during final review, including confirming that the corpus's previous "p.784" pointer for modern measurements was wrong — p.774-855 is the built-in **digital multimeter** subsystem (`MEASure:CONTinuity`, `MEASure:RESistance`), not waveform parameters. The scope subsystem is p.335-373.
- Mutation-tested twice: reverting `WID → PWID` fails 5 tests; simulating the pre-fix state fails 5 tests. Nothing added here is vacuous.
- Wire-form corpus entries added for all five new commands, so `test_every_command_has_a_corpus_entry` now enforces them — a future modern command cannot ship without a manual citation.
- `black --check --line-length 200`, `flake8 --select=E9,F63,F7,F82`, and the frontend typecheck/tests/build all clean.

**No hardware was used.** Driver and mock are each checked against the manual, never against each other. Mock-validated is not hardware-validated, and nothing here should be read as claiming otherwise.

## Known risks and follow-ups, not fixed here

- **Command amplification and channel settling.** `measure()` is now 4 writes + 1 query instead of a single query, and `:SIMPle:SOURce` is *global*. Polling C1 and C2 alternately flips the source every call with no acquisition wait, so on hardware that recomputes measurements per acquisition, `VALue?` could plausibly return the previous channel's value. This is undetectable against a mock. Worth per-session caching (skip re-sending `ON`/`MODE`/`ITEM` when unchanged, only re-send `SOURce` on a channel change) — and worth checking first on a real scope.
- **Enabled items accumulate** on the instrument display across a session, by design, as described above.
- **Statistics and cursors remain legacy-only** on modern. They currently raise `FeatureNotSupportedError`, which is honest gating rather than a defect; implementing them needs the `:MEASure:ADVanced:P<n>` slot subsystem and is a separate project.

## Note on the diff size

`docs/about/changelog.md` accounts for 226 of the ~660 added lines. That docs-site mirror had been stale since 3.3.0 — pre-existing drift unrelated to this work — and was regenerated via the Makefile's documented copy step while the changelog was being edited. It is mechanical catch-up, not part of this fix.
