### PR TITLE
chore(release): 5.2.0 - modern Siglent measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-07-25
+
 ### Fixed
 
 - Measurements now work on modern-dialect Siglent oscilloscopes (SDS800X HD, SDS5000X and

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-07-25
+
 ### Fixed
 
 - Measurements now work on modern-dialect Siglent oscilloscopes (SDS800X HD, SDS5000X and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "5.1.0"
+version = "5.2.0"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "5.1.0"
+__version__ = "5.2.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
Cuts 5.2.0. Mechanical release commit only — version bump plus the changelog header rename. No code changes.

## Why MINOR

`[Unreleased]` carried a single `### Fixed` entry and **no `⚠️ Breaking Changes` section**. The modern-measurement fix changes no Python signatures and no file formats — `measure(mtype, channel) -> float` is untouched; only the wire traffic behind it changes on the modern dialect. That keeps this on the 5.x line per the release-policy shift established at v4.1.0 (honesty/correctness fixes are MINOR).

## What ships

**Measurements now work on modern-dialect Siglent oscilloscopes** (SDS800X HD, SDS5000X and siblings). `measure()` previously sent the legacy `PAVA?` command, which appears zero times in the modern programming guide, so every measurement failed — the whole GUI Measurements tab, the web gateway's measurement polling, and two shipped examples. It now uses the documented `:MEASure:SIMPle` subsystem.

The changelog entry also records, honestly, that a modern measurement is **not side-effect-free**: it enables the measurement function, pins the measurement mode to simple, sets the simple-measurement source, and switches the requested item on — all visible on the instrument display, and deliberately left in place rather than cleared, because the instrument's clear command is all-or-nothing and would wipe measurements the user configured by hand.

## Four files, not three

The usual release commit touches `pyproject.toml`, `scpi_control/__init__.py`, and `CHANGELOG.md`. This one also regenerates `docs/about/changelog.md` via the Makefile's documented copy step.

That docs-site mirror had been stale since 3.3.0 and was brought current in #107. Renaming `[Unreleased]` → `[5.2.0]` without re-copying would have re-introduced the drift immediately, one release after fixing it. Worth folding into the release ritual permanently.

## Verification

- Version consistency: `pyproject.toml` and `scpi_control/__init__.py` both read `5.2.0` — and this is the first release where `tests/test_version_consistency.py` (added in #106) actually enforces that rather than relying on remembering to edit both files.
- `docs/about/changelog.md` verified **byte-identical** to `CHANGELOG.md`.
- PyPI summary 387/512 chars — the check that broke the v3.2.0 publish.
- Changelog structure: exactly one `## [Unreleased]`, `## [5.2.0] - 2026-07-25` present, one `Fixed` entry, no breaking-changes section.
- Full suite: **1636 passed, 19 skipped, 0 failed**.
- `python -m build` produces both artifacts at 5.2.0 with **no deprecation warnings**; `twine check` PASSED on the wheel *and* the sdist.

## After merge

Publishing is triggered by creating the GitHub release (`publish.yml` runs on `release: published` via trusted publishing), tagged `v5.2.0`. The release must be created through `gh release create` rather than by pushing the tag first — a tag push lets `build-executables.yml` create the release as `github-actions[bot]`, and GitHub suppresses workflow triggers for bot-raised events, so `publish.yml` would never fire and nothing would reach PyPI. That is what happened to v4.1.0.

## Known risk carried into this release

`:MEASure:SIMPle:SOURce` is global and `measure()` now sends four writes per call, so alternating-channel polling flips the source with no settling wait. On hardware that recomputes measurements per acquisition, `VALue?` could return the previous channel's value. This is undetectable against a mock and no hardware was available to test it. Documented in #107 with a suggested per-session caching fix; worth verifying first on a real modern scope.
