### PR TITLE
chore(release): 5.3.0 - provenance honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.0] - 2026-07-25
+
 ### Fixed
 
 - Provenance and report output no longer state things the software cannot know. Enhanced CSV
@@ -15,9 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   modification time off as a capture time; AI-generated Key Findings and Recommendations are
   labelled as such in both Markdown and PDF output, so machine-written text is distinguishable
   from engineering judgement in a signed report; manifest file paths render verbatim instead of
-  being italicised and stripped of underscores by the markdown converter; the shipped comparison
-  example no longer stamps synthetic waveforms with a real instrument identity; and `scpi-extract`
-  reports missing provenance without inventing a reason for it.
+  being italicised and stripped of underscores by the markdown converter; the shipped comparison and
+  batch examples no longer stamp synthetic waveforms with a real instrument identity; and
+  `scpi-extract` reports missing provenance without inventing a reason for it.
 
 ## [5.2.0] - 2026-07-25
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.0] - 2026-07-25
+
 ### Fixed
 
 - Provenance and report output no longer state things the software cannot know. Enhanced CSV
@@ -15,9 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   modification time off as a capture time; AI-generated Key Findings and Recommendations are
   labelled as such in both Markdown and PDF output, so machine-written text is distinguishable
   from engineering judgement in a signed report; manifest file paths render verbatim instead of
-  being italicised and stripped of underscores by the markdown converter; the shipped comparison
-  example no longer stamps synthetic waveforms with a real instrument identity; and `scpi-extract`
-  reports missing provenance without inventing a reason for it.
+  being italicised and stripped of underscores by the markdown converter; the shipped comparison and
+  batch examples no longer stamp synthetic waveforms with a real instrument identity; and
+  `scpi-extract` reports missing provenance without inventing a reason for it.
 
 ## [5.2.0] - 2026-07-25
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "5.2.0"
+version = "5.3.0"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "5.2.0"
+__version__ = "5.3.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
Cuts 5.3.0 — the provenance-honesty release. Version bump plus the changelog header rename, with one small accuracy correction described below.

## Why MINOR

`[Unreleased]` carried a single `### Fixed` entry and no `⚠️ Breaking Changes` section. Non-breaking was a hard requirement for this work and was checked adversarially rather than assumed: no Python signature changes, no removed or renamed public names, `TestReport`'s two new fields are genuinely last in the dataclass (so positional construction is unchanged), `to_dict()` only gains keys, and the sole written-file change is a CSV comment line that nothing in the codebase parses.

## What ships

Seven audit findings, all of the same shape — the software asserting provenance facts it does not know:

- Enhanced CSV headers labelled the **save** time as a **capture** time
- The report manifest passed a file's **mtime** off as an acquisition timestamp
- **AI-generated** Key Findings and Recommendations shipped in signed PDFs unlabelled
- Manifest file paths were mangled by a markdown converter, corrupting the identifiers the manifest exists to make verifiable
- Two shipped examples stamped **synthetic** waveforms with a **real** Siglent identity
- `scpi-extract` invented a reason for missing provenance

## One correction to the changelog entry

The entry as written on the feature branch said "the shipped **comparison** example no longer stamps synthetic waveforms with a real instrument identity". That was accurate when written, but the final whole-branch review found the same fabrication in `examples/batch_report.py` and it was fixed too. The entry now reads "the shipped comparison **and batch** examples".

Correcting it here rather than shipping it: an inaccurate changelog in a release whose entire subject is not overstating what the software knows would be a poor look, and it is a two-word fix.

## Verification

- Both version sources read `5.3.0`, enforced by `tests/test_version_consistency.py`.
- `docs/about/changelog.md` regenerated and verified **byte-identical** to `CHANGELOG.md` — the release commit touches four files rather than the usual three, so the docs-site mirror cannot drift again.
- PyPI summary 387/512 chars — the check that broke the v3.2.0 publish.
- Changelog structure: exactly one `## [Unreleased]`, `## [5.3.0] - 2026-07-25` present, one `Fixed` entry, no breaking-changes section, `5.2.0` untouched.
- Full suite: **1657 passed, 19 skipped, 0 failed**.
- `python -m build` produces both artifacts at 5.3.0 with **no deprecation warnings**; `twine check` PASSED on the wheel *and* the sdist.

## After merge

Publishing fires when the GitHub release is created (`publish.yml` runs on `release: published` via trusted publishing), tagged `v5.3.0`. The release must be created with `gh release create --target <full-40-char-sha>` — not by pushing the tag, since a tag push lets `build-executables.yml` create the release as `github-actions[bot]` and GitHub suppresses workflow triggers for bot-raised events, so nothing would reach PyPI. That is what silently happened to v4.1.0. Note the full SHA is required; an abbreviated one is rejected with HTTP 422.
