### PR TITLE
feat(mock): an instrument that can reject bad input and produce imperfect signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The mock instrument can now misbehave the way real hardware does. It keeps a real SCPI error
-  queue behind `SYST:ERR?` (drained by `*CLS`) and rejects out-of-range parameters instead of
-  storing them — a bad value is accepted by the transport, ignored, and reported as
-  `-222,"Data out of range"` on the next query, which is what an instrument actually does.
-  Validation covers the Siglent scope, PSU, AWG and DAQ personalities, plus the Tektronix and
-  LeCroy scope dialects. `reject_if_invalid` gained an optional `max_magnitude` override, since
-  the shared scope-calibrated bound rejected legitimate AWG frequencies. `FunctionGenerator.get_error()`
-  and `DataLogger.get_error()` therefore return real errors against the mock for the first time.
-  Unimplemented commands still time out under `strict=True`, unchanged.
+  queue behind `SYST:ERR?` (drained by `*CLS` and `*RST`) and rejects out-of-range parameters
+  instead of storing them — a bad value is accepted by the transport, ignored, and reported as
+  `-222,"Data out of range (<parameter>)"` on the next query, which is what an instrument
+  actually does. Validation covers the Siglent scope, PSU and AWG personalities, plus the
+  Tektronix and LeCroy scope dialects; DAQ mode gains the `SYST:ERR?` queue itself but has no
+  numeric parameters to validate (its only two writes, `ROUT:SCAN` and `TRIG:SOUR`, are
+  non-numeric). `reject_if_invalid` gained an optional `max_magnitude` override, since the shared
+  scope-calibrated bound rejected legitimate AWG frequencies (and tightened it for AWG
+  percentages/phase, which never legitimately need it), plus an optional `non_negative` bound for
+  parameters whose real-driver validation is `>= 0` rather than `> 0` (trigger holdoff, AWG
+  phase/ramp symmetry, PSU voltage/current). `FunctionGenerator.get_error()` and
+  `PowerSupply.get_error()` go from timing out entirely to answering `SYST:ERR?` for the first
+  time; `DataLogger.get_error()` already answered before this work, but only ever the hardcoded
+  `+0,"No error"` — it can now report a real queued error too. Unimplemented commands still time
+  out under `strict=True`, unchanged.
 - `SignalSpec` gained optional signal impairments — baseline drift, glitches and edge ringing —
   so measurement and analysis code can be exercised against imperfect signals instead of
   mathematically clean ones. All default to off, so existing synthesised output is unchanged.
+  Ringing is continuous across `stream()` chunks, the same way drift already is, rather than
+  resetting at each chunk boundary; it's an edge impairment, meaningful only on signals that
+  actually have edges (`"square"`, or a pulse-like `"ramp"`).
 
 ## [5.3.0] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The mock instrument can now misbehave the way real hardware does. It keeps a real SCPI error
+  queue behind `SYST:ERR?` (drained by `*CLS`) and rejects out-of-range parameters instead of
+  storing them — a bad value is accepted by the transport, ignored, and reported as
+  `-222,"Data out of range"` on the next query, which is what an instrument actually does.
+  Validation covers the Siglent scope, PSU, AWG and DAQ personalities, plus the Tektronix and
+  LeCroy scope dialects. `reject_if_invalid` gained an optional `max_magnitude` override, since
+  the shared scope-calibrated bound rejected legitimate AWG frequencies. `FunctionGenerator.get_error()`
+  and `DataLogger.get_error()` therefore return real errors against the mock for the first time.
+  Unimplemented commands still time out under `strict=True`, unchanged.
+- `SignalSpec` gained optional signal impairments — baseline drift, glitches and edge ringing —
+  so measurement and analysis code can be exercised against imperfect signals instead of
+  mathematically clean ones. All default to off, so existing synthesised output is unchanged.
+
 ## [5.3.0] - 2026-07-25
 
 ### Fixed

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -10,17 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The mock instrument can now misbehave the way real hardware does. It keeps a real SCPI error
-  queue behind `SYST:ERR?` (drained by `*CLS`) and rejects out-of-range parameters instead of
-  storing them — a bad value is accepted by the transport, ignored, and reported as
-  `-222,"Data out of range"` on the next query, which is what an instrument actually does.
-  Validation covers the Siglent scope, PSU, AWG and DAQ personalities, plus the Tektronix and
-  LeCroy scope dialects. `reject_if_invalid` gained an optional `max_magnitude` override, since
-  the shared scope-calibrated bound rejected legitimate AWG frequencies. `FunctionGenerator.get_error()`
-  and `DataLogger.get_error()` therefore return real errors against the mock for the first time.
-  Unimplemented commands still time out under `strict=True`, unchanged.
+  queue behind `SYST:ERR?` (drained by `*CLS` and `*RST`) and rejects out-of-range parameters
+  instead of storing them — a bad value is accepted by the transport, ignored, and reported as
+  `-222,"Data out of range (<parameter>)"` on the next query, which is what an instrument
+  actually does. Validation covers the Siglent scope, PSU and AWG personalities, plus the
+  Tektronix and LeCroy scope dialects; DAQ mode gains the `SYST:ERR?` queue itself but has no
+  numeric parameters to validate (its only two writes, `ROUT:SCAN` and `TRIG:SOUR`, are
+  non-numeric). `reject_if_invalid` gained an optional `max_magnitude` override, since the shared
+  scope-calibrated bound rejected legitimate AWG frequencies (and tightened it for AWG
+  percentages/phase, which never legitimately need it), plus an optional `non_negative` bound for
+  parameters whose real-driver validation is `>= 0` rather than `> 0` (trigger holdoff, AWG
+  phase/ramp symmetry, PSU voltage/current). `FunctionGenerator.get_error()` and
+  `PowerSupply.get_error()` go from timing out entirely to answering `SYST:ERR?` for the first
+  time; `DataLogger.get_error()` already answered before this work, but only ever the hardcoded
+  `+0,"No error"` — it can now report a real queued error too. Unimplemented commands still time
+  out under `strict=True`, unchanged.
 - `SignalSpec` gained optional signal impairments — baseline drift, glitches and edge ringing —
   so measurement and analysis code can be exercised against imperfect signals instead of
   mathematically clean ones. All default to off, so existing synthesised output is unchanged.
+  Ringing is continuous across `stream()` chunks, the same way drift already is, rather than
+  resetting at each chunk boundary; it's an edge impairment, meaningful only on signals that
+  actually have edges (`"square"`, or a pulse-like `"ramp"`).
 
 ## [5.3.0] - 2026-07-25
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The mock instrument can now misbehave the way real hardware does. It keeps a real SCPI error
+  queue behind `SYST:ERR?` (drained by `*CLS`) and rejects out-of-range parameters instead of
+  storing them — a bad value is accepted by the transport, ignored, and reported as
+  `-222,"Data out of range"` on the next query, which is what an instrument actually does.
+  Validation covers the Siglent scope, PSU, AWG and DAQ personalities, plus the Tektronix and
+  LeCroy scope dialects. `reject_if_invalid` gained an optional `max_magnitude` override, since
+  the shared scope-calibrated bound rejected legitimate AWG frequencies. `FunctionGenerator.get_error()`
+  and `DataLogger.get_error()` therefore return real errors against the mock for the first time.
+  Unimplemented commands still time out under `strict=True`, unchanged.
+- `SignalSpec` gained optional signal impairments — baseline drift, glitches and edge ringing —
+  so measurement and analysis code can be exercised against imperfect signals instead of
+  mathematically clean ones. All default to off, so existing synthesised output is unchanged.
+
 ## [5.3.0] - 2026-07-25
 
 ### Fixed

--- a/docs/user-guide/synthetic-signals.md
+++ b/docs/user-guide/synthetic-signals.md
@@ -36,6 +36,59 @@ signal:
 | `duty` | `0.5` | High fraction of a `"square"` period, `0 < duty < 1` (pulse/PWM) |
 | `noise_rms` | `0.0` | Std-dev of additive Gaussian noise laid on top of any kind |
 | `seed` | `None` | `None` for fresh randomness on every call; an `int` for reproducible output |
+| `drift_amplitude` | `0.0` | Volts of slow baseline wander; `0` (the default) turns drift off |
+| `drift_frequency` | `0.1` | Hz of that wander; only used when `drift_amplitude > 0` |
+| `glitch_rate` | `0.0` | Mean glitches per second; `0` (the default) turns glitches off |
+| `glitch_amplitude` | `0.0` | Volts, peak height of a glitch |
+| `ringing_frequency` | `0.0` | Hz of post-edge oscillation; `0` (the default) turns ringing off |
+| `ringing_damping` | `0.0` | Decay rate per second of that oscillation |
+
+The last six fields are impairments: default-off knobs that make a signal
+imperfect the way a real one is, so measurement and analysis code has
+something realistic to face instead of a mathematically clean waveform. All
+six are appended at the end of the dataclass and every one defaults to a
+value that leaves the signal unaffected, so existing code that constructs a
+`SignalSpec` positionally or without these arguments is unaffected.
+
+- **`drift_amplitude`/`drift_frequency`** add slow baseline wander -- a
+  sinusoid at `drift_frequency` Hz, `drift_amplitude` volts of amplitude,
+  derived from absolute time so it (like ringing, below) stays continuous
+  across `stream()` chunks instead of jumping at chunk boundaries.
+- **`glitch_rate`/`glitch_amplitude`** add sparse, isolated spikes -- a
+  Poisson process at `glitch_rate` events per second, each an instantaneous
+  `+/-glitch_amplitude` volt spike on one sample. Glitches draw from their own
+  generator (seeded independently from the base signal/noise), so enabling
+  them never perturbs `noise_rms`'s samples.
+- **`ringing_frequency`/`ringing_damping`** add a damped sinusoid after every
+  edge of a periodic signal -- what a real probe/scope front-end does after a
+  fast transition, and what gives an overshoot/preshoot measurement something
+  genuine to measure. It's an edge impairment, so it is only meaningful on
+  signals that actually have edges (`"square"`, or a pulse-like `"ramp"`) --
+  applying it to `"sine"` or `"dc"` has no effect, since those kinds have no
+  discontinuities for it to trigger on.
+
+```python
+from scpi_control.signal_synth import SignalSpec, synthesize
+
+# A 1kHz square wave with all three impairments: slow thermal-style drift on
+# the baseline, occasional glitches, and probe-style ringing after every edge
+# -- an intentionally imperfect signal for exercising measurement code against
+# something closer to what a real instrument would actually capture.
+messy = SignalSpec(
+    kind="square",
+    frequency=1_000.0,
+    amplitude=1.0,
+    noise_rms=0.02,
+    drift_amplitude=0.05,
+    drift_frequency=0.2,
+    glitch_rate=2.0,
+    glitch_amplitude=0.3,
+    ringing_frequency=20_000.0,
+    ringing_damping=5_000.0,
+    seed=42,
+)
+volts = synthesize(messy, sample_rate=1_000_000.0, n_points=10_000)
+```
 
 `"square"`'s `duty` is the fraction of each period spent high, so a
 `SignalSpec(kind="square", duty=0.2)` is a 20%-duty pulse/PWM waveform, not
@@ -43,8 +96,10 @@ just a symmetric square wave. `"dc"` ignores `amplitude` entirely and always
 outputs `offset`. `"noise"` uses `amplitude` as the Gaussian standard
 deviation rather than a peak value. An invalid `kind` or an out-of-range
 parameter (non-positive `frequency` on a periodic kind, `duty` outside
-`(0, 1)`, negative `noise_rms`) raises `InvalidParameterError` -- no partial
-or silently-clamped signal is ever returned.
+`(0, 1)`, negative `noise_rms`, a negative `drift_amplitude`/`glitch_rate`/
+`glitch_amplitude`/`ringing_frequency`/`ringing_damping`, or a non-positive
+`drift_frequency` while `drift_amplitude > 0`) raises `InvalidParameterError`
+-- no partial or silently-clamped signal is ever returned.
 
 ## Generating Signals Directly
 

--- a/docs/user-guide/synthetic-signals.md
+++ b/docs/user-guide/synthetic-signals.md
@@ -41,7 +41,7 @@ signal:
 | `glitch_rate` | `0.0` | Mean glitches per second; `0` (the default) turns glitches off |
 | `glitch_amplitude` | `0.0` | Volts, peak height of a glitch |
 | `ringing_frequency` | `0.0` | Hz of post-edge oscillation; `0` (the default) turns ringing off |
-| `ringing_damping` | `0.0` | Decay rate per second of that oscillation |
+| `ringing_damping` | `5000.0` | Decay rate per second of that oscillation; only used when `ringing_frequency > 0` |
 
 The last six fields are impairments: default-off knobs that make a signal
 imperfect the way a real one is, so measurement and analysis code has

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -276,10 +276,14 @@ class MockConnection(BaseConnection):
         (trigger holdoff, AWG phase/ramp symmetry, PSU voltage/current). Pass it
         together with `positive=False` (the default `positive=True` already
         excludes negatives, so `non_negative` would be redundant with it).
+
+        `name` is folded into the queued message (M1: it used to be accepted
+        by ~25 call sites and read by nothing, so a caller polling SYST:ERR?
+        could tell a parameter was rejected but never which one).
         """
         bound = self._ABSURD_MAGNITUDE if max_magnitude is None else max_magnitude
         if not math.isfinite(value) or (positive and value <= 0) or (non_negative and value < 0) or abs(value) > bound:
-            self.push_error(-222, "Data out of range")
+            self.push_error(-222, f"Data out of range ({name})")
             return True
         return False
 

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -4,7 +4,7 @@ and personality dispatch to the vendor-specific scope write/query/waveform modul
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from scpi_control import exceptions
 from scpi_control.connection.base import BaseConnection
@@ -175,6 +175,12 @@ class MockConnection(BaseConnection):
                 self.trigger_status = ["SAVE"]
 
         self.custom_responses = custom_responses or {}
+        # SCPI error queue. Real instruments accept a bad command, ignore it, and
+        # queue an error for collection via SYST:ERR?; they do not fail the
+        # transport. Empty queue answers '+0,"No error"', which is exactly what
+        # the old hardcoded stub returned -- so nothing changes until something
+        # actually queues an error.
+        self.error_queue: List[Tuple[int, str]] = []
         self.writes: List[str] = []
         self.queries: List[str] = []
         self.timebase_updates: List[float] = []
@@ -240,6 +246,17 @@ class MockConnection(BaseConnection):
         """Mark the connection as closed."""
         self._connected = False
 
+    def push_error(self, code: int, message: str) -> None:
+        """Queue a SCPI error for later collection via SYST:ERR?."""
+        self.error_queue.append((code, message))
+
+    def _pop_error(self) -> str:
+        """The SYST:ERR? response: oldest queued error, or '+0,"No error"'."""
+        if self.error_queue:
+            code, message = self.error_queue.pop(0)
+            return f'{code:+d},"{message}"'
+        return '+0,"No error"'
+
     def write(self, command: str) -> None:
         """Record the command and update simple internal state."""
         if not self._connected:
@@ -247,6 +264,10 @@ class MockConnection(BaseConnection):
 
         command = command.strip()
         self.writes.append(command)
+
+        if command.strip().upper() == "*CLS":
+            self.error_queue.clear()
+            return
 
         # Power supply commands
         if self.psu_mode:
@@ -486,16 +507,20 @@ class MockConnection(BaseConnection):
             else:
                 return self.idn
 
+        # SYST:ERR? for the three instrument classes that expose get_error()
+        # (psu_scpi_commands.py:70, awg_scpi_commands.py:65,
+        # daq_scpi_commands.py:59). Scopes deliberately have no get_error, so
+        # scope mode falls through to the strict-mode timeout -- adding an
+        # accessor there would quietly undo that gating.
+        if "SYST:ERR?" in upper and (self.psu_mode or self.awg_mode or self.daq_mode):
+            return self._pop_error()
+
         # Data acquisition (DAQ) queries
         if self.daq_mode:
             # Specific queries first -- the old readings matcher used
             # `"R?" in upper`, which is a substring test and swallowed
             # SYST:ERR? and TRIG:SOUR? (both end in "R?") before they ever
             # reached their own handlers (audit M7).
-
-            # Error query
-            if "SYST:ERR?" in upper:
-                return '+0,"No error"'
 
             # Scan list query
             if "ROUT:SCAN?" in upper:

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -479,11 +479,14 @@ class MockConnection(BaseConnection):
             # Phase 0 is legitimate (awg_output.py's own validation allows
             # `0 <= degrees <= 360`), so it is gated on non_negative (>= 0)
             # rather than positive (> 0) -- a negative phase is not a value
-            # the real driver ever allows either (I2).
+            # the real driver ever allows either (I2). max_magnitude=360: a
+            # phase angle never legitimately exceeds 360 degrees, so the
+            # generic 1e6 scope-calibrated bound let through nonsense like
+            # PHAS 999999 (M5).
             if match := re.match(r"C(\d+):BSWV\s+PHSE,([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 phase = float(match.group(2))
-                if self.reject_if_invalid(phase, name="PHSE", positive=False, non_negative=True):
+                if self.reject_if_invalid(phase, name="PHSE", positive=False, non_negative=True, max_magnitude=360):
                     return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["phase"] = phase
@@ -491,7 +494,7 @@ class MockConnection(BaseConnection):
             if match := re.match(r"SOUR(\d+):PHAS\s+([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 phase = float(match.group(2))
-                if self.reject_if_invalid(phase, name="PHAS", positive=False, non_negative=True):
+                if self.reject_if_invalid(phase, name="PHAS", positive=False, non_negative=True, max_magnitude=360):
                     return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["phase"] = phase
@@ -500,11 +503,14 @@ class MockConnection(BaseConnection):
             # Pulse duty cycle: C1:BSWV DUTY,25 (Siglent) or SOUR1:FUNC:PULS:DCYC 25 (generic)
             # awg_output.py's own validation requires `0 < percent < 100`
             # (strictly exclusive), so duty cycle is gated on positivity --
-            # unlike ramp symmetry below, 0% is never allowed either.
+            # unlike ramp symmetry below, 0% is never allowed either. M5:
+            # max_magnitude=100 -- a percentage, unlike frequency, never
+            # legitimately exceeds 100 in normal use, so the generic 1e6
+            # scope-calibrated bound let through nonsense like DUTY 500000.
             if match := re.match(r"C(\d+):BSWV\s+DUTY,([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 duty = float(match.group(2))
-                if self.reject_if_invalid(duty, name="DUTY"):
+                if self.reject_if_invalid(duty, name="DUTY", max_magnitude=100):
                     return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["pulse_duty"] = duty
@@ -512,7 +518,7 @@ class MockConnection(BaseConnection):
             if match := re.match(r"SOUR(\d+):FUNC:PULS:DCYC\s+([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 duty = float(match.group(2))
-                if self.reject_if_invalid(duty, name="FUNC:PULS:DCYC"):
+                if self.reject_if_invalid(duty, name="FUNC:PULS:DCYC", max_magnitude=100):
                     return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["pulse_duty"] = duty
@@ -524,10 +530,12 @@ class MockConnection(BaseConnection):
             # inclusive, unlike duty cycle above), so it is gated on
             # non_negative (>= 0) rather than positive (> 0) -- a negative
             # symmetry is not a value the real driver ever allows either (I2).
+            # max_magnitude=100 for the same percentage-bound reason as duty
+            # cycle above (M5).
             if match := re.match(r"C(\d+):BSWV\s+SYM,([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 symm = float(match.group(2))
-                if self.reject_if_invalid(symm, name="SYM", positive=False, non_negative=True):
+                if self.reject_if_invalid(symm, name="SYM", positive=False, non_negative=True, max_magnitude=100):
                     return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["ramp_symmetry"] = symm
@@ -535,7 +543,7 @@ class MockConnection(BaseConnection):
             if match := re.match(r"SOUR(\d+):FUNC:RAMP:SYMM\s+([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 symm = float(match.group(2))
-                if self.reject_if_invalid(symm, name="FUNC:RAMP:SYMM", positive=False, non_negative=True):
+                if self.reject_if_invalid(symm, name="FUNC:RAMP:SYMM", positive=False, non_negative=True, max_magnitude=100):
                     return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["ramp_symmetry"] = symm

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -259,14 +259,20 @@ class MockConnection(BaseConnection):
     # later without changing any caller.
     _ABSURD_MAGNITUDE = 1e6
 
-    def reject_if_invalid(self, value: float, *, name: str, positive: bool = True) -> bool:
+    def reject_if_invalid(self, value: float, *, name: str, positive: bool = True, max_magnitude: Optional[float] = None) -> bool:
         """Queue -222 and return True when `value` is unusable on any instrument.
 
         Callers skip their assignment when this returns True, so the command is
         accepted by the transport, ignored, and reported on the next SYST:ERR? --
         which is how real hardware behaves for a bad parameter.
+
+        `max_magnitude` overrides `_ABSURD_MAGNITUDE` (default 1e6) for callers
+        whose quantity legitimately exceeds it in normal use -- e.g. AWG
+        frequency, where registered models go up to 120e6 Hz (awg_models.py)
+        and the scope-calibrated 1e6 bound would reject a real value.
         """
-        if not math.isfinite(value) or (positive and value <= 0) or abs(value) > self._ABSURD_MAGNITUDE:
+        bound = self._ABSURD_MAGNITUDE if max_magnitude is None else max_magnitude
+        if not math.isfinite(value) or (positive and value <= 0) or abs(value) > bound:
             self.push_error(-222, "Data out of range")
             return True
         return False
@@ -296,6 +302,11 @@ class MockConnection(BaseConnection):
             if match := re.match(r"(?:CH|SOUR)(\d+):VOLT\s+([\d.]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 voltage = float(match.group(2))
+                # A voltage setpoint of 0.0 (output at rest) is legitimate --
+                # power_supply_output.py's own validation allows
+                # `0 <= volts <= max_voltage` -- so it is not gated on positivity.
+                if self.reject_if_invalid(voltage, name="VOLT", positive=False):
+                    return
                 if ch in self.psu_outputs:
                     self.psu_outputs[ch]["voltage"] = voltage
                 return
@@ -304,6 +315,10 @@ class MockConnection(BaseConnection):
             if match := re.match(r"(?:CH|SOUR)(\d+):CURR\s+([\d.]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 current = float(match.group(2))
+                # A current limit of 0.0 is legitimate for the same reason as
+                # voltage above, so it is not gated on positivity.
+                if self.reject_if_invalid(current, name="CURR", positive=False):
+                    return
                 if ch in self.psu_outputs:
                     self.psu_outputs[ch]["current"] = current
                 return
@@ -342,6 +357,11 @@ class MockConnection(BaseConnection):
             if match := re.match(r"(?:CH|SOUR)(\d+):VOLT:PROT\s+([\d.]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 level = float(match.group(2))
+                # Unlike voltage/current setpoints above, an OVP level of 0V
+                # would trip immediately and is not a usable value, so it is
+                # gated on positivity.
+                if self.reject_if_invalid(level, name="VOLT:PROT"):
+                    return
                 self.psu_ovp_levels[ch] = level
                 return
 
@@ -349,6 +369,10 @@ class MockConnection(BaseConnection):
             if match := re.match(r"(?:CH|SOUR)(\d+):CURR:PROT\s+([\d.]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 level = float(match.group(2))
+                # Same reasoning as OVP: an OCP level of 0A is not usable, so
+                # it is gated on positivity.
+                if self.reject_if_invalid(level, name="CURR:PROT"):
+                    return
                 self.psu_ocp_levels[ch] = level
                 return
 
@@ -369,85 +393,128 @@ class MockConnection(BaseConnection):
                 return
 
             # Frequency: C1:BSWV FRQ,1000 (Siglent) or SOUR1:FREQ 1000 (generic)
+            # awg_output.py's own validation requires `0 < freq_hz`, so
+            # frequency is gated on positivity.
             if match := re.match(r"C(\d+):BSWV\s+FRQ,([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 freq = float(match.group(2))
+                # Registered AWG models go up to 120MHz (awg_models.py), well
+                # above the scope-calibrated 1e6 default, so this uses a
+                # frequency-appropriate bound instead.
+                if self.reject_if_invalid(freq, name="FRQ", max_magnitude=1e9):
+                    return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["frequency"] = freq
                 return
             if match := re.match(r"SOUR(\d+):FREQ\s+([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 freq = float(match.group(2))
+                if self.reject_if_invalid(freq, name="FREQ", max_magnitude=1e9):
+                    return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["frequency"] = freq
                 return
 
             # Amplitude: C1:BSWV AMP,5.0 (Siglent) or SOUR1:VOLT 5.0 (generic)
+            # A 0 or negative Vpp amplitude is not a usable waveform, so it is
+            # gated on positivity, same as scope V/div.
             if match := re.match(r"C(\d+):BSWV\s+AMP,([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 amp = float(match.group(2))
+                if self.reject_if_invalid(amp, name="AMP"):
+                    return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["amplitude"] = amp
                 return
             if match := re.match(r"SOUR(\d+):VOLT\s+([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 amp = float(match.group(2))
+                if self.reject_if_invalid(amp, name="VOLT"):
+                    return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["amplitude"] = amp
                 return
 
             # Offset: C1:BSWV OFST,0.5 (Siglent) or SOUR1:VOLT:OFFS 0.5 (generic)
+            # Offset may legitimately be negative or zero (awg_output.py's own
+            # validation only checks `abs(volts) > max_offset`, never sign),
+            # so it is not gated on positivity.
             if match := re.match(r"C(\d+):BSWV\s+OFST,([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 offset = float(match.group(2))
+                if self.reject_if_invalid(offset, name="OFST", positive=False):
+                    return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["offset"] = offset
                 return
             if match := re.match(r"SOUR(\d+):VOLT:OFFS\s+([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 offset = float(match.group(2))
+                if self.reject_if_invalid(offset, name="VOLT:OFFS", positive=False):
+                    return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["offset"] = offset
                 return
 
             # Phase: C1:BSWV PHSE,90 (Siglent) or SOUR1:PHAS 90 (generic)
+            # Phase 0 is legitimate (awg_output.py's own validation allows
+            # `0 <= degrees <= 360`), so it is not gated on positivity.
             if match := re.match(r"C(\d+):BSWV\s+PHSE,([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 phase = float(match.group(2))
+                if self.reject_if_invalid(phase, name="PHSE", positive=False):
+                    return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["phase"] = phase
                 return
             if match := re.match(r"SOUR(\d+):PHAS\s+([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 phase = float(match.group(2))
+                if self.reject_if_invalid(phase, name="PHAS", positive=False):
+                    return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["phase"] = phase
                 return
 
             # Pulse duty cycle: C1:BSWV DUTY,25 (Siglent) or SOUR1:FUNC:PULS:DCYC 25 (generic)
+            # awg_output.py's own validation requires `0 < percent < 100`
+            # (strictly exclusive), so duty cycle is gated on positivity --
+            # unlike ramp symmetry below, 0% is never allowed either.
             if match := re.match(r"C(\d+):BSWV\s+DUTY,([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 duty = float(match.group(2))
+                if self.reject_if_invalid(duty, name="DUTY"):
+                    return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["pulse_duty"] = duty
                 return
             if match := re.match(r"SOUR(\d+):FUNC:PULS:DCYC\s+([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 duty = float(match.group(2))
+                if self.reject_if_invalid(duty, name="FUNC:PULS:DCYC"):
+                    return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["pulse_duty"] = duty
                 return
 
             # Ramp symmetry: C1:BSWV SYM,50 (Siglent) or SOUR1:FUNC:RAMP:SYMM 50 (generic)
+            # Symmetry 0 (a pure downward sawtooth) is legitimate
+            # (awg_output.py's own validation allows `0 <= percent <= 100`
+            # inclusive, unlike duty cycle above), so it is not gated on
+            # positivity.
             if match := re.match(r"C(\d+):BSWV\s+SYM,([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 symm = float(match.group(2))
+                if self.reject_if_invalid(symm, name="SYM", positive=False):
+                    return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["ramp_symmetry"] = symm
                 return
             if match := re.match(r"SOUR(\d+):FUNC:RAMP:SYMM\s+([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 symm = float(match.group(2))
+                if self.reject_if_invalid(symm, name="FUNC:RAMP:SYMM", positive=False):
+                    return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["ramp_symmetry"] = symm
                 return

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -259,7 +259,7 @@ class MockConnection(BaseConnection):
     # later without changing any caller.
     _ABSURD_MAGNITUDE = 1e6
 
-    def reject_if_invalid(self, value: float, *, name: str, positive: bool = True, max_magnitude: Optional[float] = None) -> bool:
+    def reject_if_invalid(self, value: float, *, name: str, positive: bool = True, non_negative: bool = False, max_magnitude: Optional[float] = None) -> bool:
         """Queue -222 and return True when `value` is unusable on any instrument.
 
         Callers skip their assignment when this returns True, so the command is
@@ -270,9 +270,15 @@ class MockConnection(BaseConnection):
         whose quantity legitimately exceeds it in normal use -- e.g. AWG
         frequency, where registered models go up to 120e6 Hz (awg_models.py)
         and the scope-calibrated 1e6 bound would reject a real value.
+
+        `non_negative=True` rejects a negative value while still accepting zero --
+        for callers whose real-driver validation is `>= 0` rather than `> 0`
+        (trigger holdoff, AWG phase/ramp symmetry, PSU voltage/current). Pass it
+        together with `positive=False` (the default `positive=True` already
+        excludes negatives, so `non_negative` would be redundant with it).
         """
         bound = self._ABSURD_MAGNITUDE if max_magnitude is None else max_magnitude
-        if not math.isfinite(value) or (positive and value <= 0) or abs(value) > bound:
+        if not math.isfinite(value) or (positive and value <= 0) or (non_negative and value < 0) or abs(value) > bound:
             self.push_error(-222, "Data out of range")
             return True
         return False
@@ -299,25 +305,34 @@ class MockConnection(BaseConnection):
         # Power supply commands
         if self.psu_mode:
             # Voltage setting: CH1:VOLT 5.0 (Siglent) or SOUR1:VOLT 5.0 (generic)
-            if match := re.match(r"(?:CH|SOUR)(\d+):VOLT\s+([\d.]+)", command, re.IGNORECASE):
+            # I1: the capture used to be `([\d.]+)`, which cannot match a sign,
+            # an exponent, or non-finite text -- `CH1:CURR 5e-05` matched only
+            # the leading "5" and silently stored 5.0A, a 100000x error with no
+            # error queued. `(.+)` (matching the scope handlers' own convention
+            # elsewhere in this file) hands the full token to float() so
+            # reject_if_invalid actually sees what was sent.
+            if match := re.match(r"(?:CH|SOUR)(\d+):VOLT\s+(.+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 voltage = float(match.group(2))
                 # A voltage setpoint of 0.0 (output at rest) is legitimate --
                 # power_supply_output.py's own validation allows
-                # `0 <= volts <= max_voltage` -- so it is not gated on positivity.
-                if self.reject_if_invalid(voltage, name="VOLT", positive=False):
+                # `0 <= volts <= max_voltage` -- so it is gated on non_negative
+                # (>= 0) rather than positive (> 0): zero is accepted, a
+                # negative setpoint is not (I2).
+                if self.reject_if_invalid(voltage, name="VOLT", positive=False, non_negative=True):
                     return
                 if ch in self.psu_outputs:
                     self.psu_outputs[ch]["voltage"] = voltage
                 return
 
             # Current setting: CH1:CURR 2.0 (Siglent) or SOUR1:CURR 2.0 (generic)
-            if match := re.match(r"(?:CH|SOUR)(\d+):CURR\s+([\d.]+)", command, re.IGNORECASE):
+            if match := re.match(r"(?:CH|SOUR)(\d+):CURR\s+(.+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 current = float(match.group(2))
                 # A current limit of 0.0 is legitimate for the same reason as
-                # voltage above, so it is not gated on positivity.
-                if self.reject_if_invalid(current, name="CURR", positive=False):
+                # voltage above, so it is gated on non_negative rather than
+                # positive (I2).
+                if self.reject_if_invalid(current, name="CURR", positive=False, non_negative=True):
                     return
                 if ch in self.psu_outputs:
                     self.psu_outputs[ch]["current"] = current
@@ -354,7 +369,7 @@ class MockConnection(BaseConnection):
                 return
 
             # OVP setting: CH1:VOLT:PROT 25.0 or SOUR1:VOLT:PROT 25.0
-            if match := re.match(r"(?:CH|SOUR)(\d+):VOLT:PROT\s+([\d.]+)", command, re.IGNORECASE):
+            if match := re.match(r"(?:CH|SOUR)(\d+):VOLT:PROT\s+(.+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 level = float(match.group(2))
                 # Unlike voltage/current setpoints above, an OVP level of 0V
@@ -366,7 +381,7 @@ class MockConnection(BaseConnection):
                 return
 
             # OCP setting: CH1:CURR:PROT 2.5 or SOUR1:CURR:PROT 2.5
-            if match := re.match(r"(?:CH|SOUR)(\d+):CURR:PROT\s+([\d.]+)", command, re.IGNORECASE):
+            if match := re.match(r"(?:CH|SOUR)(\d+):CURR:PROT\s+(.+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 level = float(match.group(2))
                 # Same reasoning as OVP: an OCP level of 0A is not usable, so
@@ -458,11 +473,13 @@ class MockConnection(BaseConnection):
 
             # Phase: C1:BSWV PHSE,90 (Siglent) or SOUR1:PHAS 90 (generic)
             # Phase 0 is legitimate (awg_output.py's own validation allows
-            # `0 <= degrees <= 360`), so it is not gated on positivity.
+            # `0 <= degrees <= 360`), so it is gated on non_negative (>= 0)
+            # rather than positive (> 0) -- a negative phase is not a value
+            # the real driver ever allows either (I2).
             if match := re.match(r"C(\d+):BSWV\s+PHSE,([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 phase = float(match.group(2))
-                if self.reject_if_invalid(phase, name="PHSE", positive=False):
+                if self.reject_if_invalid(phase, name="PHSE", positive=False, non_negative=True):
                     return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["phase"] = phase
@@ -470,7 +487,7 @@ class MockConnection(BaseConnection):
             if match := re.match(r"SOUR(\d+):PHAS\s+([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 phase = float(match.group(2))
-                if self.reject_if_invalid(phase, name="PHAS", positive=False):
+                if self.reject_if_invalid(phase, name="PHAS", positive=False, non_negative=True):
                     return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["phase"] = phase
@@ -500,12 +517,13 @@ class MockConnection(BaseConnection):
             # Ramp symmetry: C1:BSWV SYM,50 (Siglent) or SOUR1:FUNC:RAMP:SYMM 50 (generic)
             # Symmetry 0 (a pure downward sawtooth) is legitimate
             # (awg_output.py's own validation allows `0 <= percent <= 100`
-            # inclusive, unlike duty cycle above), so it is not gated on
-            # positivity.
+            # inclusive, unlike duty cycle above), so it is gated on
+            # non_negative (>= 0) rather than positive (> 0) -- a negative
+            # symmetry is not a value the real driver ever allows either (I2).
             if match := re.match(r"C(\d+):BSWV\s+SYM,([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 symm = float(match.group(2))
-                if self.reject_if_invalid(symm, name="SYM", positive=False):
+                if self.reject_if_invalid(symm, name="SYM", positive=False, non_negative=True):
                     return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["ramp_symmetry"] = symm
@@ -513,7 +531,7 @@ class MockConnection(BaseConnection):
             if match := re.match(r"SOUR(\d+):FUNC:RAMP:SYMM\s+([\d.E+\-]+)", command, re.IGNORECASE):
                 ch = int(match.group(1))
                 symm = float(match.group(2))
-                if self.reject_if_invalid(symm, name="FUNC:RAMP:SYMM", positive=False):
+                if self.reject_if_invalid(symm, name="FUNC:RAMP:SYMM", positive=False, non_negative=True):
                     return
                 if ch in self.awg_channels:
                     self.awg_channels[ch]["ramp_symmetry"] = symm

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -302,7 +302,10 @@ class MockConnection(BaseConnection):
         command = command.strip()
         self.writes.append(command)
 
-        if command.strip().upper() == "*CLS":
+        if command.upper() in ("*CLS", "*RST"):
+            # Real instruments clear the error queue on both *CLS and *RST
+            # (M7); *RST previously fell through unmatched to a silent no-op,
+            # so a caller resetting after an error would still see it queued.
             self.error_queue.clear()
             return
 

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -3,6 +3,7 @@ and personality dispatch to the vendor-specific scope write/query/waveform modul
 
 from __future__ import annotations
 
+import math
 import re
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Tuple, Union
 
@@ -249,6 +250,26 @@ class MockConnection(BaseConnection):
     def push_error(self, code: int, message: str) -> None:
         """Queue a SCPI error for later collection via SYST:ERR?."""
         self.error_queue.append((code, message))
+
+    # Broad plausibility bounds. These are deliberately NOT per-model limits --
+    # they reject what is wrong for any oscilloscope (non-finite, non-positive,
+    # absurd magnitude), which is what catches the failure that actually happens:
+    # a typo'd or unit-confused value. Per-model ranges belong in the model
+    # registry (models.py already carries max_sample_rate) and can tighten this
+    # later without changing any caller.
+    _ABSURD_MAGNITUDE = 1e6
+
+    def reject_if_invalid(self, value: float, *, name: str, positive: bool = True) -> bool:
+        """Queue -222 and return True when `value` is unusable on any instrument.
+
+        Callers skip their assignment when this returns True, so the command is
+        accepted by the transport, ignored, and reported on the next SYST:ERR? --
+        which is how real hardware behaves for a bad parameter.
+        """
+        if not math.isfinite(value) or (positive and value <= 0) or abs(value) > self._ABSURD_MAGNITUDE:
+            self.push_error(-222, "Data out of range")
+            return True
+        return False
 
     def _pop_error(self) -> str:
         """The SYST:ERR? response: oldest queued error, or '+0,"No error"'."""

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -79,17 +79,29 @@ def handle_write(conn, command: str) -> bool:
             return True
         if match := re.match(r":CHANnel(\d+):SCALe\s+(.+)", command, re.IGNORECASE):
             ch = int(match.group(1))
-            conn._voltage_scales[ch] = float(match.group(2))
-            conn.scale_updates.setdefault(ch, []).append(float(match.group(2)))
+            value = float(match.group(2))
+            if conn.reject_if_invalid(value, name="SCALe"):
+                return True  # consumed, ignored, error queued
+            conn._voltage_scales[ch] = value
+            conn.scale_updates.setdefault(ch, []).append(value)
             return True
         if match := re.match(r":CHANnel(\d+):OFFSet\s+(.+)", command, re.IGNORECASE):
-            conn._voltage_offsets[int(match.group(1))] = float(match.group(2))
+            ch = int(match.group(1))
+            value = float(match.group(2))
+            # Offset may legitimately be negative or zero (e.g. p.56 EXAMPLE
+            # "CHAN2:OFFS -3.8E+00"), so it is not gated on positivity.
+            if conn.reject_if_invalid(value, name="OFFSet", positive=False):
+                return True
+            conn._voltage_offsets[ch] = value
             return True
         if match := re.match(r":CHANnel(\d+):COUPling\s+(\w+)", command, re.IGNORECASE):
             conn._channel_coupling[int(match.group(1))] = match.group(2).upper()
             return True
         if match := re.match(r":TIMebase:SCALe\s+(.+)", command, re.IGNORECASE):
-            conn.timebase = float(match.group(1))
+            value = float(match.group(1))
+            if conn.reject_if_invalid(value, name="TIMebase:SCALe"):
+                return True
+            conn.timebase = value
             conn.timebase_updates.append(conn.timebase)
             return True
         # :MEASure <ON|OFF> (p.337). Matched before the :MEASure:SIMPle forms
@@ -166,22 +178,32 @@ def handle_write(conn, command: str) -> bool:
         # mirroring real scopes which silently drop unknown commands
 
     if command.upper().startswith("TDIV "):
-        value = command.split(" ", 1)[1]
+        raw = command.split(" ", 1)[1]
         try:
-            conn.timebase = float(value)
+            value = float(raw)
         except ValueError:
-            conn.timebase = conn.timebase
+            value = conn.timebase
+        else:
+            if conn.reject_if_invalid(value, name="TDIV"):
+                value = conn.timebase
+        conn.timebase = value
         conn.timebase_updates.append(conn.timebase)
         return True
     elif match := re.match(r"C(\d+):VDIV\s+(.+)", command, re.IGNORECASE):
         channel = int(match.group(1))
         value = float(match.group(2))
+        if conn.reject_if_invalid(value, name="VDIV"):
+            return True  # consumed, ignored, error queued
         conn._voltage_scales[channel] = value
         conn.scale_updates.setdefault(channel, []).append(value)
         return True
     elif match := re.match(r"C(\d+):OFST\s+(.+)", command, re.IGNORECASE):
         channel = int(match.group(1))
         value = float(match.group(2))
+        # Offset may legitimately be negative or zero (p.83 EXAMPLE
+        # "C2: OFST -3V"), so it is not gated on positivity.
+        if conn.reject_if_invalid(value, name="OFST", positive=False):
+            return True
         conn._voltage_offsets[channel] = value
         return True
     elif match := re.match(r"C(\d+):TRA\s+(ON|OFF)", command, re.IGNORECASE):

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -146,7 +146,12 @@ def handle_write(conn, command: str) -> bool:
             conn.trigger_source = match.group(1).upper()
             return True
         if match := re.match(r":TRIGger:EDGE:LEVel\s+(.+)", command, re.IGNORECASE):
-            conn.trigger_level[1] = float(match.group(1))
+            value = float(match.group(1))
+            # Trigger level may legitimately be negative or zero (e.g. a signal
+            # centered below/at ground), so it is not gated on positivity.
+            if conn.reject_if_invalid(value, name="TRIGger:EDGE:LEVel", positive=False):
+                return True
+            conn.trigger_level[1] = value
             return True
         if match := re.match(r":TRIGger:EDGE:SLOPe\s+(\w+)", command, re.IGNORECASE):
             conn.trigger_slope = match.group(1)  # wire token, e.g. "RISing" (guide p.494)
@@ -215,7 +220,12 @@ def handle_write(conn, command: str) -> bool:
         return True
     elif match := re.match(r"C(\d+):ATTN\s+(.+)", command, re.IGNORECASE):
         # ATTENUATION (ATTN) -- RC01020-E01C p.22 (task 14, audit L3).
-        conn.probe_ratios[int(match.group(1))] = float(match.group(2))
+        channel = int(match.group(1))
+        value = float(match.group(2))
+        # An attenuation ratio is a magnitude, so it is gated on positivity.
+        if conn.reject_if_invalid(value, name="ATTN"):
+            return True
+        conn.probe_ratios[channel] = value
         return True
     elif match := re.match(r"BWL\s+(C\d+,(?:ON|OFF)(?:,C\d+,(?:ON|OFF))*)", command, re.IGNORECASE):
         # BANDWIDTH_LIMIT (BWL) -- global, comma-separated channel/mode pairs,
@@ -247,7 +257,12 @@ def handle_write(conn, command: str) -> bool:
         return True
     elif match := re.match(r"C(\d+):TRLV\s+(.+)", command, re.IGNORECASE):
         channel = int(match.group(1))
-        conn.trigger_level[channel] = float(match.group(2))
+        value = float(match.group(2))
+        # Trigger level may legitimately be negative or zero, so it is not
+        # gated on positivity.
+        if conn.reject_if_invalid(value, name="TRLV", positive=False):
+            return True
+        conn.trigger_level[channel] = value
         return True
 
     return False

--- a/scpi_control/connection/mock/tektronix.py
+++ b/scpi_control/connection/mock/tektronix.py
@@ -63,26 +63,48 @@ def handle_write(conn, command: str) -> bool:
         return True
     if match := re.match(r"CH(\d+):SCALE\s+(.+)", upper):
         ch = int(match.group(1))
-        conn._voltage_scales[ch] = float(match.group(2))
-        conn.scale_updates.setdefault(ch, []).append(float(match.group(2)))
+        value = float(match.group(2))
+        # A vertical scale is a magnitude (V/div), so it is gated on positivity.
+        if conn.reject_if_invalid(value, name="SCALE"):
+            return True  # consumed, ignored, error queued
+        conn._voltage_scales[ch] = value
+        conn.scale_updates.setdefault(ch, []).append(value)
         return True
     if match := re.match(r"CH(\d+):OFFSET\s+(.+)", upper):
-        conn._voltage_offsets[int(match.group(1))] = float(match.group(2))
+        ch = int(match.group(1))
+        value = float(match.group(2))
+        # Offset may legitimately be negative or zero, so it is not gated on positivity.
+        if conn.reject_if_invalid(value, name="OFFSET", positive=False):
+            return True
+        conn._voltage_offsets[ch] = value
         return True
     if match := re.match(r"CH(\d+):COUPLING\s+(\w+)", upper):
         conn._channel_coupling[int(match.group(1))] = match.group(2)
         return True
     if match := re.match(r"CH(\d+):PROBE:GAIN\s+(.+)", upper):
-        conn.probe_gains[int(match.group(1))] = float(match.group(2))
+        ch = int(match.group(1))
+        value = float(match.group(2))
+        # A probe attenuation/gain factor is a magnitude, so it is gated on positivity.
+        if conn.reject_if_invalid(value, name="PROBE:GAIN"):
+            return True
+        conn.probe_gains[ch] = value
         return True
     if match := re.match(r"CH(\d+):PROBEFUNC:EXTATTEN\s+(.+)", upper):
         # tek_mso spelling for the same probe-gain state (tek_tbs uses PRObe:GAIN above).
-        conn.probe_gains[int(match.group(1))] = float(match.group(2))
+        ch = int(match.group(1))
+        value = float(match.group(2))
+        if conn.reject_if_invalid(value, name="PROBEFUNC:EXTATTEN"):
+            return True
+        conn.probe_gains[ch] = value
         return True
     if match := re.match(r"CH(\d+):BANDWIDTH\s+(\w+)", upper):
         return True  # accepted, not modeled
     if match := re.match(r"HORIZONTAL:SCALE\s+(.+)", upper):
-        conn.timebase = float(match.group(1))
+        value = float(match.group(1))
+        # A timebase is a magnitude, so it is gated on positivity.
+        if conn.reject_if_invalid(value, name="HORIZONTAL:SCALE"):
+            return True
+        conn.timebase = value
         conn.timebase_updates.append(conn.timebase)
         return True
     if re.match(r"HORIZONTAL:DELAY:TIME\s+", upper):
@@ -111,7 +133,13 @@ def handle_write(conn, command: str) -> bool:
         conn.trigger_source = match.group(1)
         return True
     if match := re.match(r"TRIGGER:A:LEVEL:CH(\d+)\s+(.+)", upper):
-        conn.trigger_level[int(match.group(1))] = float(match.group(2))
+        ch = int(match.group(1))
+        value = float(match.group(2))
+        # Trigger level may legitimately be negative or zero, so it is not
+        # gated on positivity.
+        if conn.reject_if_invalid(value, name="TRIGGER:A:LEVEL", positive=False):
+            return True
+        conn.trigger_level[ch] = value
         return True
     if match := re.match(r"TRIGGER:A:EDGE:SLOPE\s+(\w+)", upper):
         conn.trigger_slope = match.group(1)
@@ -120,7 +148,13 @@ def handle_write(conn, command: str) -> bool:
         conn.trigger_coupling = match.group(1)
         return True
     if match := re.match(r"TRIGGER:A:HOLDOFF:TIME\s+(.+)", upper):
-        conn.holdoff_time = float(match.group(1))
+        value = float(match.group(1))
+        # trigger.py's own validation only rejects a NEGATIVE holdoff
+        # (`if time_seconds < 0: raise`), so 0 is legitimate and this is not
+        # gated on positivity.
+        if conn.reject_if_invalid(value, name="TRIGGER:A:HOLDOFF:TIME", positive=False):
+            return True
+        conn.holdoff_time = value
         return True
     if re.match(r"AUTOSET\s+EXECUTE", upper):
         return True

--- a/scpi_control/connection/mock/tektronix.py
+++ b/scpi_control/connection/mock/tektronix.py
@@ -149,10 +149,11 @@ def handle_write(conn, command: str) -> bool:
         return True
     if match := re.match(r"TRIGGER:A:HOLDOFF:TIME\s+(.+)", upper):
         value = float(match.group(1))
-        # trigger.py's own validation only rejects a NEGATIVE holdoff
-        # (`if time_seconds < 0: raise`), so 0 is legitimate and this is not
-        # gated on positivity.
-        if conn.reject_if_invalid(value, name="TRIGGER:A:HOLDOFF:TIME", positive=False):
+        # trigger.py's own validation rejects a NEGATIVE holdoff
+        # (`if time_seconds < 0: raise`), so 0 is legitimate but a negative
+        # value is not -- gated on non_negative (>= 0), not positive (> 0)
+        # (I2: `positive=False` alone let `-5.0` silently through).
+        if conn.reject_if_invalid(value, name="TRIGGER:A:HOLDOFF:TIME", positive=False, non_negative=True):
             return True
         conn.holdoff_time = value
         return True

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -96,6 +96,13 @@ _GENERATORS: Dict[str, Callable[[SignalSpec, np.ndarray, np.random.Generator], n
 
 PERIODIC_KINDS = ("sine", "square", "triangle", "ramp")
 
+# Hard cap on the ringing decay kernel's length in samples, independent of
+# n_points (I3) or sample_rate. This is a backstop against a user-supplied
+# ringing_damping near zero making `5 / damping` samples unboundedly long --
+# not the normal control on cost, which is ringing_damping's own sensible
+# nonzero default (M8).
+_MAX_RINGING_KERNEL_SAMPLES = 200_000
+
 
 def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
     if spec.kind not in _GENERATORS:
@@ -149,34 +156,65 @@ def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 
     _validate(spec, sample_rate, n_points)
     rng = np.random.default_rng(spec.seed)
     t = t0 + np.arange(n_points) / sample_rate
-    samples = _GENERATORS[spec.kind](spec, t, rng) + spec.offset
     if spec.ringing_frequency > 0:
         # A damped sinusoid triggered at each edge. Real probe/scope front-ends
         # ring after a fast transition; this is what gives overshoot/preshoot
-        # measurements something real to measure. Deterministic and edge-local,
-        # so it needs no generator and is automatically continuous across
-        # stream() chunks. Applied to the base signal BEFORE drift and glitches:
-        # ringing is part of the signal's own edge response, not a baseline
-        # wander or an additive event.
-        edges = np.flatnonzero(np.diff(samples))
+        # measurements something real to measure. Applied to the base signal
+        # BEFORE drift and glitches: ringing is part of the signal's own edge
+        # response, not a baseline wander or an additive event.
+        #
+        # I3: this must be a function of ABSOLUTE TIME, like drift, not of the
+        # current buffer alone -- np.diff() cannot see an edge across a
+        # stream() chunk boundary, so an edge landing right at a boundary used
+        # to get no ringing at all, and one near a chunk's end had its ring
+        # truncated. Fixed the same way drift is continuous: render
+        # `decay_len` extra samples BEFORE t0, detect edges (and let their
+        # ringing spill forward) across that whole extended window, then slice
+        # the prepended samples back off. The generator is called exactly
+        # once (over the extended window) rather than once for the plain
+        # buffer and again for the extended one, so a stochastic kind (e.g.
+        # "noise") does not draw from `rng` twice.
+        decay_len = min(_MAX_RINGING_KERNEL_SAMPLES, max(1, int(sample_rate / max(spec.ringing_damping, 1e-9) * 5)))
+        # Built as t0 + (index - decay_len) / sample_rate, NOT (t0 - decay_len /
+        # sample_rate) + index / sample_rate -- the two are mathematically equal
+        # but round differently in float64. With the latter, this chunk's t0
+        # (itself computed elsewhere as start_time + produced / sample_rate) and
+        # this expression's own "t0 - decay_len/sample_rate" partial sum
+        # accumulate rounding error differently than a neighboring chunk's
+        # equivalent sample does, so the same absolute instant can land a few
+        # ULP apart depending on which chunk computed it -- enough to flip which
+        # side of a razor's-edge comparison (e.g. square wave's `< duty`) a
+        # sample falls on, right when frequency and chunk_size divide evenly
+        # (verified: this happened at every chunk boundary in the drift-style
+        # continuity test below until reordered this way).
+        t_ext = t0 + (np.arange(n_points + decay_len) - decay_len) / sample_rate
+        samples_ext = _GENERATORS[spec.kind](spec, t_ext, rng) + spec.offset
+        edges = np.flatnonzero(np.diff(samples_ext))
         if edges.size:
             # 5 time constants of decay, in samples. `max(spec.ringing_damping, 1e-9)`
             # only guards the division against damping == 0 (undamped ringing) --
             # it must NOT clamp small-but-nonzero damping up to some larger floor,
             # or slow decay would be truncated before it actually decays, showing
             # up as a discontinuity where the kernel window ends. `max(1, ...)`
-            # then guards int() truncating to 0 for very heavy damping. Both are
-            # capped by n_points, since the kernel can never need to run longer
-            # than the buffer itself.
-            decay_len = min(n_points, max(1, int(sample_rate / max(spec.ringing_damping, 1e-9) * 5)))
+            # then guards int() truncating to 0 for very heavy damping.
+            # `_MAX_RINGING_KERNEL_SAMPLES` is a defensive backstop, not the
+            # normal control on cost -- M8 gives ringing_damping a sensible
+            # nonzero default so ordinary use never approaches it; it only
+            # bounds the (user-opted-into) case of an explicit near-zero
+            # damping, which would otherwise make the kernel unboundedly long.
+            total = n_points + decay_len
             tail = np.arange(decay_len) / sample_rate
             kernel = np.sin(2 * np.pi * spec.ringing_frequency * tail) * np.exp(-spec.ringing_damping * tail)
-            response = np.zeros(n_points)
+            response = np.zeros(total)
             for edge in edges:
-                step = samples[edge + 1] - samples[edge]
-                end = min(n_points, edge + 1 + decay_len)
+                step = samples_ext[edge + 1] - samples_ext[edge]
+                end = min(total, edge + 1 + decay_len)
                 response[edge + 1 : end] += 0.5 * step * kernel[: end - edge - 1]
-            samples = samples + response
+            samples = samples_ext[decay_len:] + response[decay_len:]
+        else:
+            samples = samples_ext[decay_len:]
+    else:
+        samples = _GENERATORS[spec.kind](spec, t, rng) + spec.offset
     if spec.drift_amplitude > 0:
         # Time-based, NOT a random walk: stream() re-seeds per chunk, so a walk
         # would reset at every chunk boundary and a live view would show sawtooth

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -30,6 +30,12 @@ class SignalSpec:
         duty: High fraction of a "square" period, 0 < duty < 1 (pulse/PWM).
         noise_rms: Std-dev of additive Gaussian noise laid on any kind.
         seed: None for fresh randomness per call; an int for reproducibility.
+        drift_amplitude: Volts of slow baseline wander (0 = off).
+        drift_frequency: Hz of that wander; only used when drift_amplitude > 0.
+        glitch_rate: Mean glitches per second (0 = off).
+        glitch_amplitude: Volts, peak height of a glitch.
+        ringing_frequency: Hz of post-edge oscillation (0 = off).
+        ringing_damping: Decay rate per second of that oscillation.
     """
 
     kind: str = "sine"
@@ -40,6 +46,15 @@ class SignalSpec:
     duty: float = 0.5
     noise_rms: float = 0.0
     seed: Optional[int] = None
+    # Impairments, all default-off. Appended at the END of the dataclass
+    # deliberately: inserting them next to noise_rms, where they read better,
+    # would reorder positional construction and break callers.
+    drift_amplitude: float = 0.0  # volts of slow baseline wander (0 = off)
+    drift_frequency: float = 0.1  # Hz of that wander; only used when drift_amplitude > 0
+    glitch_rate: float = 0.0  # mean glitches per second (0 = off)
+    glitch_amplitude: float = 0.0  # volts, peak height of a glitch
+    ringing_frequency: float = 0.0  # Hz of post-edge oscillation (0 = off)
+    ringing_damping: float = 0.0  # decay rate per second of that oscillation
 
 
 def _cycle_fraction(spec: SignalSpec, t: np.ndarray) -> np.ndarray:
@@ -95,6 +110,16 @@ def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
         raise exceptions.InvalidParameterError(f"duty must be strictly between 0 and 1: {spec.duty}")
     if spec.noise_rms < 0:
         raise exceptions.InvalidParameterError(f"noise_rms must be non-negative: {spec.noise_rms}")
+    if spec.drift_amplitude < 0:
+        raise exceptions.InvalidParameterError(f"drift_amplitude must be non-negative: {spec.drift_amplitude}")
+    if spec.glitch_rate < 0:
+        raise exceptions.InvalidParameterError(f"glitch_rate must be non-negative: {spec.glitch_rate}")
+    if spec.glitch_amplitude < 0:
+        raise exceptions.InvalidParameterError(f"glitch_amplitude must be non-negative: {spec.glitch_amplitude}")
+    if spec.ringing_frequency < 0:
+        raise exceptions.InvalidParameterError(f"ringing_frequency must be non-negative: {spec.ringing_frequency}")
+    if spec.ringing_damping < 0:
+        raise exceptions.InvalidParameterError(f"ringing_damping must be non-negative: {spec.ringing_damping}")
 
 
 def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 0.0) -> np.ndarray:

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -122,6 +122,18 @@ def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
         raise exceptions.InvalidParameterError(f"ringing_damping must be non-negative: {spec.ringing_damping}")
 
 
+def _impairment_rng(seed: Optional[int], stream_index: int) -> np.random.Generator:
+    """An independent, seed-reproducible generator per impairment.
+
+    Drawing impairments from synthesize()'s shared `rng` would make enabling one
+    impairment change another's samples and the base noise, so a test asserting on
+    noise would break merely because drift was switched on.
+    """
+    if seed is None:
+        return np.random.default_rng()
+    return np.random.default_rng([seed, stream_index])
+
+
 def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 0.0) -> np.ndarray:
     """Generate voltage samples for a signal spec.
 
@@ -138,6 +150,23 @@ def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 
     rng = np.random.default_rng(spec.seed)
     t = t0 + np.arange(n_points) / sample_rate
     samples = _GENERATORS[spec.kind](spec, t, rng) + spec.offset
+    if spec.drift_amplitude > 0:
+        # Time-based, NOT a random walk: stream() re-seeds per chunk, so a walk
+        # would reset at every chunk boundary and a live view would show sawtooth
+        # jumps. Deriving drift from absolute time keeps it continuous for free.
+        samples = samples + spec.drift_amplitude * np.sin(2 * np.pi * spec.drift_frequency * t)
+    if spec.glitch_rate > 0 and spec.glitch_amplitude > 0:
+        glitch_rng = _impairment_rng(spec.seed, 1)
+        expected = spec.glitch_rate * n_points / sample_rate
+        count = glitch_rng.poisson(expected)
+        if count:
+            positions = glitch_rng.integers(0, n_points, size=count)
+            signs = glitch_rng.choice(np.array([-1.0, 1.0]), size=count)
+            samples = samples.copy()
+            # np.add.at, NOT samples[positions] += ... -- fancy-index += applies
+            # only ONCE per repeated index, so duplicate glitch positions would be
+            # silently dropped and the glitch rate would come out low.
+            np.add.at(samples, positions, signs * spec.glitch_amplitude)
     if spec.noise_rms > 0:
         samples = samples + rng.normal(0.0, spec.noise_rms, n_points)
     return samples

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -34,8 +34,18 @@ class SignalSpec:
         drift_frequency: Hz of that wander; only used when drift_amplitude > 0.
         glitch_rate: Mean glitches per second (0 = off).
         glitch_amplitude: Volts, peak height of a glitch.
-        ringing_frequency: Hz of post-edge oscillation (0 = off).
-        ringing_damping: Decay rate per second of that oscillation.
+        ringing_frequency: Hz of post-edge oscillation (0 = off). Ringing is
+            an EDGE impairment -- it is only meaningful on signals that have
+            edges to trigger on ("square", or a pulse-like "ramp"). Applying
+            it to "sine" or "dc" has no effect, since those kinds never
+            produce a discontinuity.
+        ringing_damping: Decay rate per second of that oscillation; only used
+            when ringing_frequency > 0. Defaults away from 0 for the same
+            reason drift_frequency does: undamped ringing (decay rate 0)
+            never actually decays, so the kernel would run for the entire
+            buffer on every edge -- quadratic in the number of edges once
+            ringing_frequency is switched on the most natural way, by setting
+            only that field.
     """
 
     kind: str = "sine"
@@ -53,8 +63,8 @@ class SignalSpec:
     drift_frequency: float = 0.1  # Hz of that wander; only used when drift_amplitude > 0
     glitch_rate: float = 0.0  # mean glitches per second (0 = off)
     glitch_amplitude: float = 0.0  # volts, peak height of a glitch
-    ringing_frequency: float = 0.0  # Hz of post-edge oscillation (0 = off)
-    ringing_damping: float = 0.0  # decay rate per second of that oscillation
+    ringing_frequency: float = 0.0  # Hz of post-edge oscillation (0 = off); an edge impairment, meaningful only on "square"/pulse-like "ramp"
+    ringing_damping: float = 5_000.0  # decay rate per second (M8: nonzero default, same reason as drift_frequency -- damping=0 never decays, making the kernel run the whole buffer on every edge)
 
 
 def _cycle_fraction(spec: SignalSpec, t: np.ndarray) -> np.ndarray:

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -119,6 +119,13 @@ def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
         raise exceptions.InvalidParameterError(f"noise_rms must be non-negative: {spec.noise_rms}")
     if spec.drift_amplitude < 0:
         raise exceptions.InvalidParameterError(f"drift_amplitude must be non-negative: {spec.drift_amplitude}")
+    if spec.drift_amplitude > 0 and spec.drift_frequency <= 0:
+        # M3: drift_frequency itself was never validated, so drift_frequency=0.0
+        # (with drift enabled) silently produced NO drift at all -- sin(0*t) is
+        # always 0 -- and a negative value merely inverted phase, both surprising
+        # and undocumented. Only checked when drift is actually enabled: a
+        # disabled drift_frequency default/leftover value is never used.
+        raise exceptions.InvalidParameterError(f"drift_frequency must be positive when drift_amplitude > 0: {spec.drift_frequency}")
     if spec.glitch_rate < 0:
         raise exceptions.InvalidParameterError(f"glitch_rate must be non-negative: {spec.glitch_rate}")
     if spec.glitch_amplitude < 0:

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -150,6 +150,33 @@ def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 
     rng = np.random.default_rng(spec.seed)
     t = t0 + np.arange(n_points) / sample_rate
     samples = _GENERATORS[spec.kind](spec, t, rng) + spec.offset
+    if spec.ringing_frequency > 0:
+        # A damped sinusoid triggered at each edge. Real probe/scope front-ends
+        # ring after a fast transition; this is what gives overshoot/preshoot
+        # measurements something real to measure. Deterministic and edge-local,
+        # so it needs no generator and is automatically continuous across
+        # stream() chunks. Applied to the base signal BEFORE drift and glitches:
+        # ringing is part of the signal's own edge response, not a baseline
+        # wander or an additive event.
+        edges = np.flatnonzero(np.diff(samples))
+        if edges.size:
+            # 5 time constants of decay, in samples. `max(spec.ringing_damping, 1e-9)`
+            # only guards the division against damping == 0 (undamped ringing) --
+            # it must NOT clamp small-but-nonzero damping up to some larger floor,
+            # or slow decay would be truncated before it actually decays, showing
+            # up as a discontinuity where the kernel window ends. `max(1, ...)`
+            # then guards int() truncating to 0 for very heavy damping. Both are
+            # capped by n_points, since the kernel can never need to run longer
+            # than the buffer itself.
+            decay_len = min(n_points, max(1, int(sample_rate / max(spec.ringing_damping, 1e-9) * 5)))
+            tail = np.arange(decay_len) / sample_rate
+            kernel = np.sin(2 * np.pi * spec.ringing_frequency * tail) * np.exp(-spec.ringing_damping * tail)
+            response = np.zeros(n_points)
+            for edge in edges:
+                step = samples[edge + 1] - samples[edge]
+                end = min(n_points, edge + 1 + decay_len)
+                response[edge + 1 : end] += 0.5 * step * kernel[: end - edge - 1]
+            samples = samples + response
     if spec.drift_amplitude > 0:
         # Time-based, NOT a random walk: stream() re-seeds per chunk, so a walk
         # would reset at every chunk boundary and a live view would show sawtooth

--- a/tests/test_mock_error_queue.py
+++ b/tests/test_mock_error_queue.py
@@ -173,3 +173,416 @@ def test_unimplemented_command_still_times_out_rather_than_queueing():
     with pytest.raises(exceptions.SiglentTimeoutError):
         conn.query("C1:NOSUCHQUERY?")
     assert conn.error_queue == [], "a timeout must not also queue an error"
+
+
+# ---------------------------------------------------------------------------
+# Task 4: the queue becomes reachable through the public API (PowerSupply,
+# FunctionGenerator, DataLogger all read SYST:ERR? via get_error()), plus
+# validation for the PSU/AWG/DAQ numeric setters that feed that queue.
+# ---------------------------------------------------------------------------
+
+
+def test_awg_error_is_visible_through_the_public_api():
+    """FunctionGenerator.get_error() reads SYST:ERR?. Before the queue existed it
+    could only ever return '+0,"No error"', so no caller-side handling of a real
+    instrument error was reachable in a test."""
+    from scpi_control.function_generator import FunctionGenerator
+
+    conn = _conn(awg_mode=True)
+    awg = FunctionGenerator("mock", connection=conn)
+    awg.connect()
+
+    conn.push_error(-222, "Data out of range")
+    assert awg.get_error() == '-222,"Data out of range"'
+    assert awg.get_error() == NO_ERROR
+
+
+def test_psu_error_is_visible_through_the_public_api():
+    """PowerSupply.get_error() reads SYST:ERR? and used to time out entirely
+    before Task 2 added the queue -- this is the first test that can exercise
+    it at all."""
+    from scpi_control.power_supply import PowerSupply
+
+    conn = _conn(psu_mode=True)
+    psu = PowerSupply("mock", connection=conn)
+    psu.connect()
+
+    conn.push_error(-222, "Data out of range")
+    assert psu.get_error() == '-222,"Data out of range"'
+    assert psu.get_error() == NO_ERROR
+
+
+def test_daq_error_is_visible_through_the_public_api():
+    """DataLogger.get_error() reads SYST:ERR?. daq_mode already answered
+    SYST:ERR? before Task 2 (it never timed out), but this proves a real
+    queued error -- not just the hardcoded '+0,"No error"' -- now surfaces
+    through the public method."""
+    from scpi_control.data_logger import DataLogger
+
+    conn = _conn(daq_mode=True)
+    daq = DataLogger("mock", connection=conn)
+    daq.connect()
+
+    conn.push_error(-222, "Data out of range")
+    assert daq.get_error() == '-222,"Data out of range"'
+    assert daq.get_error() == NO_ERROR
+
+
+# --- PSU numeric setters ----------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [1e9], ids=["absurd"])
+def test_invalid_psu_voltage_is_rejected_and_queued(value):
+    conn = _conn(psu_mode=True)
+    conn.write("CH1:VOLT {0}".format(value))
+    assert conn.psu_outputs[1]["voltage"] == 0.0, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_zero_psu_voltage_is_accepted_and_queues_nothing():
+    """A PSU voltage setpoint of 0.0 (output at rest) is legitimate and must
+    not be rejected -- power_supply_output.py's own real-driver validation
+    allows `0 <= volts <= max_voltage`."""
+    conn = _conn(psu_mode=True)
+    conn.write("CH1:VOLT 0.0")
+    assert conn.psu_outputs[1]["voltage"] == 0.0
+    assert conn.error_queue == []
+
+
+@pytest.mark.parametrize("value", [1e9], ids=["absurd"])
+def test_invalid_psu_current_is_rejected_and_queued(value):
+    conn = _conn(psu_mode=True)
+    conn.write("CH1:CURR {0}".format(value))
+    assert conn.psu_outputs[1]["current"] == 0.0, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_zero_psu_current_is_accepted_and_queues_nothing():
+    """A PSU current limit of 0.0 is legitimate for the same reason as
+    voltage above and must not be rejected."""
+    conn = _conn(psu_mode=True)
+    conn.write("CH1:CURR 0.0")
+    assert conn.psu_outputs[1]["current"] == 0.0
+    assert conn.error_queue == []
+
+
+@pytest.mark.parametrize("value", [0.0, 1e9], ids=["zero", "absurd"])
+def test_invalid_psu_ovp_is_rejected_and_queued(value):
+    """Unlike voltage/current setpoints, an over-voltage protection level of
+    0V would trip immediately and is not a usable value, so OVP is gated on
+    positivity."""
+    conn = _conn(psu_mode=True)
+    before = conn.psu_ovp_levels[1]
+    conn.write("CH1:VOLT:PROT {0}".format(value))
+    assert conn.psu_ovp_levels[1] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_psu_ovp_is_accepted_and_queues_nothing():
+    conn = _conn(psu_mode=True)
+    conn.write("CH1:VOLT:PROT 25.0")
+    assert conn.psu_ovp_levels[1] == 25.0
+    assert conn.error_queue == []
+
+
+@pytest.mark.parametrize("value", [0.0, 1e9], ids=["zero", "absurd"])
+def test_invalid_psu_ocp_is_rejected_and_queued(value):
+    """Same reasoning as OVP: an over-current protection level of 0A is not
+    a usable value, so OCP is gated on positivity."""
+    conn = _conn(psu_mode=True)
+    before = conn.psu_ocp_levels[1]
+    conn.write("CH1:CURR:PROT {0}".format(value))
+    assert conn.psu_ocp_levels[1] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_psu_ocp_is_accepted_and_queues_nothing():
+    conn = _conn(psu_mode=True)
+    conn.write("CH1:CURR:PROT 2.5")
+    assert conn.psu_ocp_levels[1] == 2.5
+    assert conn.error_queue == []
+
+
+# --- AWG numeric setters -----------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [-1000.0, 0.0], ids=["negative", "zero"])
+def test_invalid_awg_frequency_is_rejected_and_queued(value):
+    """awg_output.py's real-driver validation requires `0 < freq_hz`, so
+    frequency is gated on positivity."""
+    conn = _conn(awg_mode=True)
+    before = conn.awg_channels[1]["frequency"]
+    conn.write("SOUR1:FREQ {0}".format(value))
+    assert conn.awg_channels[1]["frequency"] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_awg_frequency_is_accepted_and_queues_nothing():
+    conn = _conn(awg_mode=True)
+    conn.write("SOUR1:FREQ 2500.0")
+    assert conn.awg_channels[1]["frequency"] == 2500.0
+    assert conn.error_queue == []
+
+
+def test_valid_high_awg_frequency_is_accepted_and_queues_nothing():
+    """The generic _ABSURD_MAGNITUDE bound (1e6) is calibrated for scope V/div
+    and timebase; registered AWG models go up to 120MHz (awg_models.py's
+    SDG2122X ChannelSpec), so frequency must use a wider bound or this rejects
+    a real, in-spec value. This regression was caught by
+    test_function_generator.py::TestAWGOutput::test_frequency_limit_validation
+    (30MHz) failing when the guard was first added with the scope-scaled bound."""
+    conn = _conn(awg_mode=True)
+    conn.write("SOUR1:FREQ 1.2E8")
+    assert conn.awg_channels[1]["frequency"] == 1.2e8
+    assert conn.error_queue == []
+
+
+@pytest.mark.parametrize("value", [-1.0, 0.0], ids=["negative", "zero"])
+def test_invalid_awg_amplitude_is_rejected_and_queued(value):
+    """An amplitude of 0 or negative Vpp is not a usable waveform, so
+    amplitude is gated on positivity, same as scope V/div."""
+    conn = _conn(awg_mode=True)
+    before = conn.awg_channels[1]["amplitude"]
+    conn.write("SOUR1:VOLT {0}".format(value))
+    assert conn.awg_channels[1]["amplitude"] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_awg_amplitude_is_accepted_and_queues_nothing():
+    conn = _conn(awg_mode=True)
+    conn.write("SOUR1:VOLT 3.0")
+    assert conn.awg_channels[1]["amplitude"] == 3.0
+    assert conn.error_queue == []
+
+
+def test_invalid_awg_offset_is_rejected_and_queued():
+    conn = _conn(awg_mode=True)
+    before = conn.awg_channels[1]["offset"]
+    conn.write("SOUR1:VOLT:OFFS {0}".format(1e9))
+    assert conn.awg_channels[1]["offset"] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_negative_awg_offset_is_accepted_and_queues_nothing():
+    """positive=False must be honored -- an AWG DC offset may legitimately be
+    negative (awg_output.py's real-driver validation only checks
+    `abs(volts) > max_offset`, never sign). Getting this backwards would be a
+    worse bug than the one being fixed."""
+    conn = _conn(awg_mode=True)
+    conn.write("SOUR1:VOLT:OFFS -0.5")
+    assert conn.awg_channels[1]["offset"] == -0.5
+    assert conn.error_queue == []
+
+
+def test_invalid_awg_phase_is_rejected_and_queued():
+    conn = _conn(awg_mode=True)
+    before = conn.awg_channels[1]["phase"]
+    conn.write("SOUR1:PHAS {0}".format(1e9))
+    assert conn.awg_channels[1]["phase"] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_zero_awg_phase_is_accepted_and_queues_nothing():
+    """positive=False must be honored -- phase 0 degrees is the default and
+    entirely legitimate (awg_output.py's real-driver validation allows
+    `0 <= degrees <= 360`)."""
+    conn = _conn(awg_mode=True)
+    conn.write("SOUR1:PHAS 0.0")
+    assert conn.awg_channels[1]["phase"] == 0.0
+    assert conn.error_queue == []
+
+
+@pytest.mark.parametrize("value", [-10.0, 0.0], ids=["negative", "zero"])
+def test_invalid_awg_pulse_duty_is_rejected_and_queued(value):
+    """awg_output.py's real-driver validation requires `0 < percent < 100`
+    (strictly exclusive), so duty cycle is gated on positivity -- unlike ramp
+    symmetry below, 0% is not a value the real driver ever allows either."""
+    conn = _conn(awg_mode=True)
+    before = conn.awg_channels[1]["pulse_duty"]
+    conn.write("SOUR1:FUNC:PULS:DCYC {0}".format(value))
+    assert conn.awg_channels[1]["pulse_duty"] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_awg_pulse_duty_is_accepted_and_queues_nothing():
+    conn = _conn(awg_mode=True)
+    conn.write("SOUR1:FUNC:PULS:DCYC 25.0")
+    assert conn.awg_channels[1]["pulse_duty"] == 25.0
+    assert conn.error_queue == []
+
+
+def test_invalid_awg_ramp_symmetry_is_rejected_and_queued():
+    conn = _conn(awg_mode=True)
+    before = conn.awg_channels[1]["ramp_symmetry"]
+    conn.write("SOUR1:FUNC:RAMP:SYMM {0}".format(1e9))
+    assert conn.awg_channels[1]["ramp_symmetry"] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_zero_awg_ramp_symmetry_is_accepted_and_queues_nothing():
+    """positive=False must be honored -- ramp symmetry of 0% (a pure downward
+    sawtooth) is entirely legitimate (awg_output.py's real-driver validation
+    allows `0 <= percent <= 100` inclusive, unlike duty cycle above). Getting
+    this backwards would be a worse bug than the one being fixed."""
+    conn = _conn(awg_mode=True)
+    conn.write("SOUR1:FUNC:RAMP:SYMM 0.0")
+    assert conn.awg_channels[1]["ramp_symmetry"] == 0.0
+    assert conn.error_queue == []
+
+
+# --- Tektronix dialect: same guard, mirrored per the Task 3 review ---------
+
+TEK_IDN = "TEKTRONIX,TBS1102C,MOCK0101,CF:91.1CT FV:1.10"
+
+
+@pytest.mark.parametrize("value", [-5.0, 0.0], ids=["negative", "zero"])
+def test_invalid_tek_channel_scale_is_rejected_and_queued(value):
+    conn = _conn(idn=TEK_IDN)
+    before = conn._voltage_scales.get(1)
+    conn.write("CH1:SCALE {0}".format(value))
+    assert conn._voltage_scales.get(1) == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_tek_channel_scale_is_accepted_and_queues_nothing():
+    conn = _conn(idn=TEK_IDN)
+    conn.write("CH1:SCALE 0.5")
+    assert conn._voltage_scales[1] == 0.5
+    assert conn.error_queue == []
+
+
+def test_invalid_tek_channel_offset_is_rejected_and_queued():
+    conn = _conn(idn=TEK_IDN)
+    before = conn._voltage_offsets.get(1)
+    conn.write("CH1:OFFSET {0}".format(1e9))
+    assert conn._voltage_offsets.get(1) == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_negative_tek_channel_offset_is_accepted_and_queues_nothing():
+    """positive=False must be honored -- channel offset may legitimately be
+    negative. Getting this backwards would be a worse bug than the one being
+    fixed."""
+    conn = _conn(idn=TEK_IDN)
+    conn.write("CH1:OFFSET -1.5")
+    assert conn._voltage_offsets[1] == -1.5
+    assert conn.error_queue == []
+
+
+@pytest.mark.parametrize("value", [-5.0, 0.0], ids=["negative", "zero"])
+def test_invalid_tek_tbs_probe_gain_is_rejected_and_queued(value):
+    """tek_tbs spelling: CH<n>:PROBE:GAIN."""
+    conn = _conn(idn=TEK_IDN)
+    before = conn.probe_gains.get(1)
+    conn.write("CH1:PROBE:GAIN {0}".format(value))
+    assert conn.probe_gains.get(1) == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_tek_tbs_probe_gain_is_accepted_and_queues_nothing():
+    conn = _conn(idn=TEK_IDN)
+    conn.write("CH1:PROBE:GAIN 0.01")
+    assert conn.probe_gains[1] == 0.01
+    assert conn.error_queue == []
+
+
+@pytest.mark.parametrize("value", [-5.0, 0.0], ids=["negative", "zero"])
+def test_invalid_tek_mso_probe_gain_is_rejected_and_queued(value):
+    """tek_mso spelling for the same probe-gain state: CH<n>:PROBEFUNC:EXTATTEN."""
+    conn = _conn(idn=TEK_IDN)
+    before = conn.probe_gains.get(1)
+    conn.write("CH1:PROBEFUNC:EXTATTEN {0}".format(value))
+    assert conn.probe_gains.get(1) == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_tek_mso_probe_gain_is_accepted_and_queues_nothing():
+    conn = _conn(idn=TEK_IDN)
+    conn.write("CH1:PROBEFUNC:EXTATTEN 0.1")
+    assert conn.probe_gains[1] == 0.1
+    assert conn.error_queue == []
+
+
+@pytest.mark.parametrize("value", [-5.0, 0.0], ids=["negative", "zero"])
+def test_invalid_tek_horizontal_scale_is_rejected_and_queued(value):
+    conn = _conn(idn=TEK_IDN)
+    before = conn.timebase
+    conn.write("HORIZONTAL:SCALE {0}".format(value))
+    assert conn.timebase == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_tek_horizontal_scale_is_accepted_and_queues_nothing():
+    conn = _conn(idn=TEK_IDN)
+    conn.write("HORIZONTAL:SCALE 0.001")
+    assert conn.timebase == 0.001
+    assert conn.error_queue == []
+
+
+def test_invalid_tek_trigger_level_is_rejected_and_queued():
+    conn = _conn(idn=TEK_IDN)
+    before = conn.trigger_level.get(1)
+    conn.write("TRIGGER:A:LEVEL:CH1 {0}".format(1e9))
+    assert conn.trigger_level.get(1) == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_negative_tek_trigger_level_is_accepted_and_queues_nothing():
+    """positive=False must be honored -- a legitimately negative trigger
+    level must NOT be rejected. Getting this backwards would be a worse bug
+    than the one being fixed."""
+    conn = _conn(idn=TEK_IDN)
+    conn.write("TRIGGER:A:LEVEL:CH1 -0.5")
+    assert conn.trigger_level[1] == -0.5
+    assert conn.error_queue == []
+
+
+def test_invalid_tek_holdoff_time_is_rejected_and_queued():
+    conn = _conn(idn=TEK_IDN)
+    before = conn.holdoff_time
+    conn.write("TRIGGER:A:HOLDOFF:TIME {0}".format(1e9))
+    assert conn.holdoff_time == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_zero_tek_holdoff_time_is_accepted_and_queues_nothing():
+    """positive=False must be honored -- trigger.py's own real-driver
+    validation only rejects a NEGATIVE holdoff (`if time_seconds < 0: raise`),
+    so 0 is a legitimate holdoff (no extra delay) and must NOT be rejected."""
+    conn = _conn(idn=TEK_IDN)
+    conn.write("TRIGGER:A:HOLDOFF:TIME 0.0")
+    assert conn.holdoff_time == 0.0
+    assert conn.error_queue == []
+
+
+# --- LeCroy dialect: writes delegate entirely to the Siglent legacy handler,
+# which Task 3 already guarded -- these tests prove that guard is actually
+# reached when dispatched through lecroy.handle_write, not just siglent's own
+# dialect. LeCroy's personality module defines no numeric setters of its own.
+
+LECROY_IDN = "LECROY,WAVESURFER3024Z,MOCK0200,8.5.0"
+
+
+def test_invalid_lecroy_voltage_scale_is_rejected_and_queued():
+    conn = _conn(idn=LECROY_IDN)
+    before = conn._voltage_scales.get(1)
+    conn.write("C1:VDIV {0}".format(1e9))
+    assert conn._voltage_scales.get(1) == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_lecroy_voltage_scale_is_accepted_and_queues_nothing():
+    conn = _conn(idn=LECROY_IDN)
+    conn.write("C1:VDIV 0.5")
+    assert conn._voltage_scales[1] == 0.5
+    assert conn.error_queue == []
+
+
+def test_valid_negative_lecroy_trigger_level_is_accepted_and_queues_nothing():
+    """positive=False must be honored through the LeCroy dispatch path too --
+    a legitimately negative trigger level must NOT be rejected. Getting this
+    backwards would be a worse bug than the one being fixed."""
+    conn = _conn(idn=LECROY_IDN)
+    conn.write("C1:TRLV -0.5")
+    assert conn.trigger_level[1] == -0.5
+    assert conn.error_queue == []

--- a/tests/test_mock_error_queue.py
+++ b/tests/test_mock_error_queue.py
@@ -80,7 +80,7 @@ def test_invalid_voltage_scale_is_rejected_and_queued(value):
     assert conn._voltage_scales.get(1) == before, "a rejected command must not change state"
     # Scope mode has no SYST:ERR? accessor (scopes expose no get_error), so assert
     # on the queue attribute directly rather than over the wire.
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (VDIV)")]
 
 
 def test_valid_voltage_scale_is_accepted_and_queues_nothing():
@@ -105,7 +105,7 @@ def test_invalid_probe_attenuation_is_rejected_and_queued(value):
     conn.write("C1:ATTN {0}".format(value))
 
     assert conn.probe_ratios.get(1) == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (ATTN)")]
 
 
 def test_valid_probe_attenuation_is_accepted_and_queues_nothing():
@@ -127,7 +127,7 @@ def test_invalid_legacy_trigger_level_is_rejected_and_queued(value):
     conn.write("C1:TRLV {0}".format(value))
 
     assert conn.trigger_level.get(1) == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (TRLV)")]
 
 
 def test_valid_negative_legacy_trigger_level_is_accepted_and_queues_nothing():
@@ -152,7 +152,7 @@ def test_invalid_modern_trigger_level_is_rejected_and_queued(value):
     conn.write(":TRIGger:EDGE:LEVel {0}".format(value))
 
     assert conn.trigger_level.get(1) == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (TRIGger:EDGE:LEVel)")]
 
 
 def test_valid_negative_modern_trigger_level_is_accepted_and_queues_nothing():
@@ -245,7 +245,7 @@ def test_invalid_psu_voltage_is_rejected_and_queued(value):
     conn = _conn(psu_mode=True)
     conn.write("CH1:VOLT {0}".format(value))
     assert conn.psu_outputs[1]["voltage"] == 0.0, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (VOLT)")]
 
 
 def test_zero_psu_voltage_is_accepted_and_queues_nothing():
@@ -278,7 +278,7 @@ def test_invalid_psu_current_is_rejected_and_queued(value):
     conn = _conn(psu_mode=True)
     conn.write("CH1:CURR {0}".format(value))
     assert conn.psu_outputs[1]["current"] == 0.0, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (CURR)")]
 
 
 def test_zero_psu_current_is_accepted_and_queues_nothing():
@@ -315,7 +315,7 @@ def test_invalid_psu_ovp_is_rejected_and_queued(value):
     before = conn.psu_ovp_levels[1]
     conn.write("CH1:VOLT:PROT {0}".format(value))
     assert conn.psu_ovp_levels[1] == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (VOLT:PROT)")]
 
 
 def test_valid_psu_ovp_is_accepted_and_queues_nothing():
@@ -337,7 +337,7 @@ def test_invalid_psu_ocp_is_rejected_and_queued(value):
     before = conn.psu_ocp_levels[1]
     conn.write("CH1:CURR:PROT {0}".format(value))
     assert conn.psu_ocp_levels[1] == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (CURR:PROT)")]
 
 
 def test_valid_psu_ocp_is_accepted_and_queues_nothing():
@@ -358,7 +358,7 @@ def test_invalid_awg_frequency_is_rejected_and_queued(value):
     before = conn.awg_channels[1]["frequency"]
     conn.write("SOUR1:FREQ {0}".format(value))
     assert conn.awg_channels[1]["frequency"] == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (FREQ)")]
 
 
 def test_valid_awg_frequency_is_accepted_and_queues_nothing():
@@ -389,7 +389,7 @@ def test_invalid_awg_amplitude_is_rejected_and_queued(value):
     before = conn.awg_channels[1]["amplitude"]
     conn.write("SOUR1:VOLT {0}".format(value))
     assert conn.awg_channels[1]["amplitude"] == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (VOLT)")]
 
 
 def test_valid_awg_amplitude_is_accepted_and_queues_nothing():
@@ -404,7 +404,7 @@ def test_invalid_awg_offset_is_rejected_and_queued():
     before = conn.awg_channels[1]["offset"]
     conn.write("SOUR1:VOLT:OFFS {0}".format(1e9))
     assert conn.awg_channels[1]["offset"] == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (VOLT:OFFS)")]
 
 
 def test_valid_negative_awg_offset_is_accepted_and_queues_nothing():
@@ -424,7 +424,7 @@ def test_invalid_awg_phase_is_rejected_and_queued(value):
     before = conn.awg_channels[1]["phase"]
     conn.write("SOUR1:PHAS {0}".format(value))
     assert conn.awg_channels[1]["phase"] == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (PHAS)")]
 
 
 def test_invalid_negative_awg_phase_is_rejected_and_queued():
@@ -437,7 +437,7 @@ def test_invalid_negative_awg_phase_is_rejected_and_queued():
     before = conn.awg_channels[1]["phase"]
     conn.write("SOUR1:PHAS -1000")
     assert conn.awg_channels[1]["phase"] == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (PHAS)")]
 
 
 def test_valid_zero_awg_phase_is_accepted_and_queues_nothing():
@@ -459,7 +459,7 @@ def test_invalid_awg_pulse_duty_is_rejected_and_queued(value):
     before = conn.awg_channels[1]["pulse_duty"]
     conn.write("SOUR1:FUNC:PULS:DCYC {0}".format(value))
     assert conn.awg_channels[1]["pulse_duty"] == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (FUNC:PULS:DCYC)")]
 
 
 def test_valid_awg_pulse_duty_is_accepted_and_queues_nothing():
@@ -475,7 +475,7 @@ def test_invalid_awg_ramp_symmetry_is_rejected_and_queued(value):
     before = conn.awg_channels[1]["ramp_symmetry"]
     conn.write("SOUR1:FUNC:RAMP:SYMM {0}".format(value))
     assert conn.awg_channels[1]["ramp_symmetry"] == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (FUNC:RAMP:SYMM)")]
 
 
 def test_invalid_negative_awg_ramp_symmetry_is_rejected_and_queued():
@@ -488,7 +488,7 @@ def test_invalid_negative_awg_ramp_symmetry_is_rejected_and_queued():
     before = conn.awg_channels[1]["ramp_symmetry"]
     conn.write("SOUR1:FUNC:RAMP:SYMM -50")
     assert conn.awg_channels[1]["ramp_symmetry"] == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (FUNC:RAMP:SYMM)")]
 
 
 def test_valid_zero_awg_ramp_symmetry_is_accepted_and_queues_nothing():
@@ -513,7 +513,7 @@ def test_invalid_tek_channel_scale_is_rejected_and_queued(value):
     before = conn._voltage_scales.get(1)
     conn.write("CH1:SCALE {0}".format(value))
     assert conn._voltage_scales.get(1) == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (SCALE)")]
 
 
 def test_valid_tek_channel_scale_is_accepted_and_queues_nothing():
@@ -528,7 +528,7 @@ def test_invalid_tek_channel_offset_is_rejected_and_queued():
     before = conn._voltage_offsets.get(1)
     conn.write("CH1:OFFSET {0}".format(1e9))
     assert conn._voltage_offsets.get(1) == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (OFFSET)")]
 
 
 def test_valid_negative_tek_channel_offset_is_accepted_and_queues_nothing():
@@ -548,7 +548,7 @@ def test_invalid_tek_tbs_probe_gain_is_rejected_and_queued(value):
     before = conn.probe_gains.get(1)
     conn.write("CH1:PROBE:GAIN {0}".format(value))
     assert conn.probe_gains.get(1) == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (PROBE:GAIN)")]
 
 
 def test_valid_tek_tbs_probe_gain_is_accepted_and_queues_nothing():
@@ -565,7 +565,7 @@ def test_invalid_tek_mso_probe_gain_is_rejected_and_queued(value):
     before = conn.probe_gains.get(1)
     conn.write("CH1:PROBEFUNC:EXTATTEN {0}".format(value))
     assert conn.probe_gains.get(1) == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (PROBEFUNC:EXTATTEN)")]
 
 
 def test_valid_tek_mso_probe_gain_is_accepted_and_queues_nothing():
@@ -581,7 +581,7 @@ def test_invalid_tek_horizontal_scale_is_rejected_and_queued(value):
     before = conn.timebase
     conn.write("HORIZONTAL:SCALE {0}".format(value))
     assert conn.timebase == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (HORIZONTAL:SCALE)")]
 
 
 def test_valid_tek_horizontal_scale_is_accepted_and_queues_nothing():
@@ -596,7 +596,7 @@ def test_invalid_tek_trigger_level_is_rejected_and_queued():
     before = conn.trigger_level.get(1)
     conn.write("TRIGGER:A:LEVEL:CH1 {0}".format(1e9))
     assert conn.trigger_level.get(1) == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (TRIGGER:A:LEVEL)")]
 
 
 def test_valid_negative_tek_trigger_level_is_accepted_and_queues_nothing():
@@ -614,7 +614,7 @@ def test_invalid_tek_holdoff_time_is_rejected_and_queued():
     before = conn.holdoff_time
     conn.write("TRIGGER:A:HOLDOFF:TIME {0}".format(1e9))
     assert conn.holdoff_time == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (TRIGGER:A:HOLDOFF:TIME)")]
 
 
 def test_invalid_negative_tek_holdoff_time_is_rejected_and_queued():
@@ -627,7 +627,7 @@ def test_invalid_negative_tek_holdoff_time_is_rejected_and_queued():
     before = conn.holdoff_time
     conn.write("TRIGGER:A:HOLDOFF:TIME -5.0")
     assert conn.holdoff_time == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (TRIGGER:A:HOLDOFF:TIME)")]
 
 
 def test_valid_zero_tek_holdoff_time_is_accepted_and_queues_nothing():
@@ -653,7 +653,7 @@ def test_invalid_lecroy_voltage_scale_is_rejected_and_queued():
     before = conn._voltage_scales.get(1)
     conn.write("C1:VDIV {0}".format(1e9))
     assert conn._voltage_scales.get(1) == before, "a rejected command must not change state"
-    assert conn.error_queue == [(-222, "Data out of range")]
+    assert conn.error_queue == [(-222, "Data out of range (VDIV)")]
 
 
 def test_valid_lecroy_voltage_scale_is_accepted_and_queues_nothing():

--- a/tests/test_mock_error_queue.py
+++ b/tests/test_mock_error_queue.py
@@ -231,8 +231,17 @@ def test_daq_error_is_visible_through_the_public_api():
 # --- PSU numeric setters ----------------------------------------------------
 
 
-@pytest.mark.parametrize("value", [1e9], ids=["absurd"])
+@pytest.mark.parametrize(
+    "value",
+    [-5.0, 1e9, float("nan"), float("inf")],
+    ids=["negative", "absurd", "nan", "inf"],
+)
 def test_invalid_psu_voltage_is_rejected_and_queued(value):
+    """I1: the capture used to be `([\\d.]+)`, which cannot match a sign, nan,
+    or inf -- these all fell straight through unmatched (no rejection, no
+    state change, but also no error queued -- the guard was never reached at
+    all). Brought up to the same negative/nan/inf coverage as the scope
+    guards (test_invalid_voltage_scale_is_rejected_and_queued)."""
     conn = _conn(psu_mode=True)
     conn.write("CH1:VOLT {0}".format(value))
     assert conn.psu_outputs[1]["voltage"] == 0.0, "a rejected command must not change state"
@@ -249,7 +258,22 @@ def test_zero_psu_voltage_is_accepted_and_queues_nothing():
     assert conn.error_queue == []
 
 
-@pytest.mark.parametrize("value", [1e9], ids=["absurd"])
+def test_psu_voltage_microvolt_setpoint_is_not_corrupted_by_the_regex():
+    """I1 regression: `CH1:VOLT 2e-05` (what `"{0}".format(0.00002)` produces)
+    used to match only the leading "2" under the old `([\\d.]+)` capture, so
+    the mock silently stored 2.0V instead of 20 microvolts -- a 100000x error
+    with nothing queued to reveal it."""
+    conn = _conn(psu_mode=True)
+    conn.write("CH1:VOLT {0}".format(0.00002))
+    assert conn.psu_outputs[1]["voltage"] == 2e-05
+    assert conn.error_queue == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [-5.0, 1e9, float("nan"), float("inf")],
+    ids=["negative", "absurd", "nan", "inf"],
+)
 def test_invalid_psu_current_is_rejected_and_queued(value):
     conn = _conn(psu_mode=True)
     conn.write("CH1:CURR {0}".format(value))
@@ -266,11 +290,27 @@ def test_zero_psu_current_is_accepted_and_queues_nothing():
     assert conn.error_queue == []
 
 
-@pytest.mark.parametrize("value", [0.0, 1e9], ids=["zero", "absurd"])
+def test_psu_current_microamp_setpoint_is_not_corrupted_by_the_regex():
+    """I1 regression: `set_current(0.00005)` emits `CH1:CURR 5e-05`; the old
+    `([\\d.]+)` capture matched only the leading "5" and stored 5.0A -- a
+    100000x error, no error queued. Microamp-level current limits are entirely
+    plausible, so this is reachable through normal public-API use."""
+    conn = _conn(psu_mode=True)
+    conn.write("CH1:CURR {0}".format(0.00005))
+    assert conn.psu_outputs[1]["current"] == 5e-05
+    assert conn.error_queue == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [0.0, -5.0, 1e9, float("nan"), float("inf")],
+    ids=["zero", "negative", "absurd", "nan", "inf"],
+)
 def test_invalid_psu_ovp_is_rejected_and_queued(value):
     """Unlike voltage/current setpoints, an over-voltage protection level of
     0V would trip immediately and is not a usable value, so OVP is gated on
-    positivity."""
+    positivity. Negative/nan/inf coverage added alongside I1's regex widening,
+    which is what makes the guard reachable for these values at all."""
     conn = _conn(psu_mode=True)
     before = conn.psu_ovp_levels[1]
     conn.write("CH1:VOLT:PROT {0}".format(value))
@@ -285,7 +325,11 @@ def test_valid_psu_ovp_is_accepted_and_queues_nothing():
     assert conn.error_queue == []
 
 
-@pytest.mark.parametrize("value", [0.0, 1e9], ids=["zero", "absurd"])
+@pytest.mark.parametrize(
+    "value",
+    [0.0, -5.0, 1e9, float("nan"), float("inf")],
+    ids=["zero", "negative", "absurd", "nan", "inf"],
+)
 def test_invalid_psu_ocp_is_rejected_and_queued(value):
     """Same reasoning as OVP: an over-current protection level of 0A is not
     a usable value, so OCP is gated on positivity."""
@@ -374,10 +418,24 @@ def test_valid_negative_awg_offset_is_accepted_and_queues_nothing():
     assert conn.error_queue == []
 
 
-def test_invalid_awg_phase_is_rejected_and_queued():
+@pytest.mark.parametrize("value", [1e9], ids=["absurd"])
+def test_invalid_awg_phase_is_rejected_and_queued(value):
     conn = _conn(awg_mode=True)
     before = conn.awg_channels[1]["phase"]
-    conn.write("SOUR1:PHAS {0}".format(1e9))
+    conn.write("SOUR1:PHAS {0}".format(value))
+    assert conn.awg_channels[1]["phase"] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_invalid_negative_awg_phase_is_rejected_and_queued():
+    """I2: `SOUR1:PHAS -1000` used to be accepted and stored as -1000.0
+    because `positive=False` alone allows any sign. awg_output.py's
+    real-driver validation is `0 <= degrees <= 360`, so a negative phase must
+    now be rejected via `non_negative=True` while zero (tested below) still
+    passes."""
+    conn = _conn(awg_mode=True)
+    before = conn.awg_channels[1]["phase"]
+    conn.write("SOUR1:PHAS -1000")
     assert conn.awg_channels[1]["phase"] == before, "a rejected command must not change state"
     assert conn.error_queue == [(-222, "Data out of range")]
 
@@ -411,10 +469,24 @@ def test_valid_awg_pulse_duty_is_accepted_and_queues_nothing():
     assert conn.error_queue == []
 
 
-def test_invalid_awg_ramp_symmetry_is_rejected_and_queued():
+@pytest.mark.parametrize("value", [1e9], ids=["absurd"])
+def test_invalid_awg_ramp_symmetry_is_rejected_and_queued(value):
     conn = _conn(awg_mode=True)
     before = conn.awg_channels[1]["ramp_symmetry"]
-    conn.write("SOUR1:FUNC:RAMP:SYMM {0}".format(1e9))
+    conn.write("SOUR1:FUNC:RAMP:SYMM {0}".format(value))
+    assert conn.awg_channels[1]["ramp_symmetry"] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_invalid_negative_awg_ramp_symmetry_is_rejected_and_queued():
+    """I2: `SOUR1:FUNC:RAMP:SYMM -50` used to be accepted and stored as -50.0
+    because `positive=False` alone allows any sign. awg_output.py's
+    real-driver validation is `0 <= percent <= 100`, so a negative symmetry
+    must now be rejected via `non_negative=True` while zero (tested below)
+    still passes."""
+    conn = _conn(awg_mode=True)
+    before = conn.awg_channels[1]["ramp_symmetry"]
+    conn.write("SOUR1:FUNC:RAMP:SYMM -50")
     assert conn.awg_channels[1]["ramp_symmetry"] == before, "a rejected command must not change state"
     assert conn.error_queue == [(-222, "Data out of range")]
 
@@ -541,6 +613,19 @@ def test_invalid_tek_holdoff_time_is_rejected_and_queued():
     conn = _conn(idn=TEK_IDN)
     before = conn.holdoff_time
     conn.write("TRIGGER:A:HOLDOFF:TIME {0}".format(1e9))
+    assert conn.holdoff_time == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_invalid_negative_tek_holdoff_time_is_rejected_and_queued():
+    """I2: `TRIGGER:A:HOLDOFF:TIME -5.0` used to be accepted and stored as
+    -5.0 because `positive=False` alone allows any sign, even though
+    trigger.py's own real-driver validation is `if time_seconds < 0: raise`.
+    Now gated on `non_negative=True` instead: negative is rejected, zero
+    (tested below) still passes."""
+    conn = _conn(idn=TEK_IDN)
+    before = conn.holdoff_time
+    conn.write("TRIGGER:A:HOLDOFF:TIME -5.0")
     assert conn.holdoff_time == before, "a rejected command must not change state"
     assert conn.error_queue == [(-222, "Data out of range")]
 

--- a/tests/test_mock_error_queue.py
+++ b/tests/test_mock_error_queue.py
@@ -8,6 +8,7 @@ perfect health and no caller-side error handling was reachable in tests.
 
 import pytest
 
+from scpi_control import exceptions
 from scpi_control.connection.mock import MockConnection
 
 NO_ERROR = '+0,"No error"'
@@ -63,16 +64,10 @@ def test_scope_mode_still_has_no_error_query():
     absence. Adding a wire-level accessor here would quietly undo that gating, so
     scope mode must keep timing out. The queue itself still works; it just has no
     SCPI accessor, which matches the library's model."""
-    from scpi_control import exceptions
-
     conn = _conn()  # default = scope mode
     with pytest.raises(exceptions.SiglentTimeoutError):
         conn.query("SYST:ERR?")
 
-
-import math
-
-from scpi_control import exceptions
 
 LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
 

--- a/tests/test_mock_error_queue.py
+++ b/tests/test_mock_error_queue.py
@@ -57,3 +57,44 @@ def test_scope_mode_still_has_no_error_query():
     conn = _conn()  # default = scope mode
     with pytest.raises(exceptions.SiglentTimeoutError):
         conn.query("SYST:ERR?")
+
+
+import math
+
+from scpi_control import exceptions
+
+LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [1e9, -5.0, 0.0, float("nan"), float("inf")],
+    ids=["absurd", "negative", "zero", "nan", "inf"],
+)
+def test_invalid_voltage_scale_is_rejected_and_queued(value):
+    conn = _conn(idn=LEGACY_IDN)
+    before = conn._voltage_scales.get(1)
+
+    conn.write("C1:VDIV {0}".format(value))
+
+    assert conn._voltage_scales.get(1) == before, "a rejected command must not change state"
+    # Scope mode has no SYST:ERR? accessor (scopes expose no get_error), so assert
+    # on the queue attribute directly rather than over the wire.
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_voltage_scale_is_accepted_and_queues_nothing():
+    conn = _conn(idn=LEGACY_IDN)
+    conn.write("C1:VDIV 0.5")
+    assert conn._voltage_scales[1] == 0.5
+    assert conn.error_queue == []
+
+
+def test_unimplemented_command_still_times_out_rather_than_queueing():
+    """The strict-mode boundary. An UNIMPLEMENTED command must keep failing
+    loudly -- that is what forces every new command to earn a wire-form corpus
+    entry. Only IMPLEMENTED commands with bad parameters queue an error."""
+    conn = _conn(idn=LEGACY_IDN)
+    with pytest.raises(exceptions.SiglentTimeoutError):
+        conn.query("C1:NOSUCHQUERY?")
+    assert conn.error_queue == [], "a timeout must not also queue an error"

--- a/tests/test_mock_error_queue.py
+++ b/tests/test_mock_error_queue.py
@@ -46,6 +46,17 @@ def test_cls_clears_the_queue():
     assert conn.query("SYST:ERR?") == NO_ERROR
 
 
+def test_rst_also_clears_the_queue():
+    """M7: real instruments clear the error queue on both *CLS and *RST --
+    *RST used to fall through unmatched (a silent no-op), so a caller
+    resetting after an error would still see it queued on the next
+    SYST:ERR?."""
+    conn = _conn(awg_mode=True)
+    conn.push_error(-222, "Data out of range")
+    conn.write("*RST")
+    assert conn.query("SYST:ERR?") == NO_ERROR
+
+
 def test_scope_mode_still_has_no_error_query():
     """Scopes deliberately have no get_error -- scope.get_error() raises
     NotImplementedError and test_scpi_command_tables.py:38 asserts the command's

--- a/tests/test_mock_error_queue.py
+++ b/tests/test_mock_error_queue.py
@@ -90,6 +90,81 @@ def test_valid_voltage_scale_is_accepted_and_queues_nothing():
     assert conn.error_queue == []
 
 
+MODERN_IDN = "Siglent Technologies,SDS824X HD,MOCK0002,3.8.12"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [-5.0, 0.0, float("nan"), float("inf")],
+    ids=["negative", "zero", "nan", "inf"],
+)
+def test_invalid_probe_attenuation_is_rejected_and_queued(value):
+    conn = _conn(idn=LEGACY_IDN)
+    before = conn.probe_ratios.get(1)
+
+    conn.write("C1:ATTN {0}".format(value))
+
+    assert conn.probe_ratios.get(1) == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_probe_attenuation_is_accepted_and_queues_nothing():
+    conn = _conn(idn=LEGACY_IDN)
+    conn.write("C1:ATTN 10")
+    assert conn.probe_ratios[1] == 10.0
+    assert conn.error_queue == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [float("nan"), float("inf")],
+    ids=["nan", "inf"],
+)
+def test_invalid_legacy_trigger_level_is_rejected_and_queued(value):
+    conn = _conn(idn=LEGACY_IDN)
+    before = conn.trigger_level.get(1)
+
+    conn.write("C1:TRLV {0}".format(value))
+
+    assert conn.trigger_level.get(1) == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_negative_legacy_trigger_level_is_accepted_and_queues_nothing():
+    """positive=False must still be honored -- a legitimately negative trigger
+    level must NOT be rejected. Getting this backwards would be a worse bug
+    than the one being fixed."""
+    conn = _conn(idn=LEGACY_IDN)
+    conn.write("C1:TRLV -0.5")
+    assert conn.trigger_level[1] == -0.5
+    assert conn.error_queue == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [float("nan"), float("inf")],
+    ids=["nan", "inf"],
+)
+def test_invalid_modern_trigger_level_is_rejected_and_queued(value):
+    conn = _conn(idn=MODERN_IDN)
+    before = conn.trigger_level.get(1)
+
+    conn.write(":TRIGger:EDGE:LEVel {0}".format(value))
+
+    assert conn.trigger_level.get(1) == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range")]
+
+
+def test_valid_negative_modern_trigger_level_is_accepted_and_queues_nothing():
+    """positive=False must still be honored -- a legitimately negative trigger
+    level must NOT be rejected. Getting this backwards would be a worse bug
+    than the one being fixed."""
+    conn = _conn(idn=MODERN_IDN)
+    conn.write(":TRIGger:EDGE:LEVel -0.5")
+    assert conn.trigger_level[1] == -0.5
+    assert conn.error_queue == []
+
+
 def test_unimplemented_command_still_times_out_rather_than_queueing():
     """The strict-mode boundary. An UNIMPLEMENTED command must keep failing
     loudly -- that is what forces every new command to earn a wire-form corpus

--- a/tests/test_mock_error_queue.py
+++ b/tests/test_mock_error_queue.py
@@ -450,6 +450,17 @@ def test_valid_zero_awg_phase_is_accepted_and_queues_nothing():
     assert conn.error_queue == []
 
 
+def test_awg_phase_above_360_is_rejected_and_queued():
+    """M5: a phase angle never legitimately exceeds 360 degrees, but the
+    generic 1e6 scope-calibrated bound let PHAS 999999 through -- below 1e6,
+    above any usable phase. Now caught by max_magnitude=360."""
+    conn = _conn(awg_mode=True)
+    before = conn.awg_channels[1]["phase"]
+    conn.write("SOUR1:PHAS 999999")
+    assert conn.awg_channels[1]["phase"] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range (PHAS)")]
+
+
 @pytest.mark.parametrize("value", [-10.0, 0.0], ids=["negative", "zero"])
 def test_invalid_awg_pulse_duty_is_rejected_and_queued(value):
     """awg_output.py's real-driver validation requires `0 < percent < 100`
@@ -467,6 +478,17 @@ def test_valid_awg_pulse_duty_is_accepted_and_queues_nothing():
     conn.write("SOUR1:FUNC:PULS:DCYC 25.0")
     assert conn.awg_channels[1]["pulse_duty"] == 25.0
     assert conn.error_queue == []
+
+
+def test_awg_pulse_duty_above_100_is_rejected_and_queued():
+    """M5: a percentage never legitimately exceeds 100, but the generic 1e6
+    scope-calibrated bound let FUNC:PULS:DCYC 500000 through -- below 1e6,
+    nonsense for a duty cycle. Now caught by max_magnitude=100."""
+    conn = _conn(awg_mode=True)
+    before = conn.awg_channels[1]["pulse_duty"]
+    conn.write("SOUR1:FUNC:PULS:DCYC 500000")
+    assert conn.awg_channels[1]["pulse_duty"] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range (FUNC:PULS:DCYC)")]
 
 
 @pytest.mark.parametrize("value", [1e9], ids=["absurd"])
@@ -500,6 +522,17 @@ def test_valid_zero_awg_ramp_symmetry_is_accepted_and_queues_nothing():
     conn.write("SOUR1:FUNC:RAMP:SYMM 0.0")
     assert conn.awg_channels[1]["ramp_symmetry"] == 0.0
     assert conn.error_queue == []
+
+
+def test_awg_ramp_symmetry_above_100_is_rejected_and_queued():
+    """M5: a percentage never legitimately exceeds 100, but the generic 1e6
+    scope-calibrated bound let FUNC:RAMP:SYMM 999999 through -- below 1e6,
+    nonsense for a symmetry percentage. Now caught by max_magnitude=100."""
+    conn = _conn(awg_mode=True)
+    before = conn.awg_channels[1]["ramp_symmetry"]
+    conn.write("SOUR1:FUNC:RAMP:SYMM 999999")
+    assert conn.awg_channels[1]["ramp_symmetry"] == before, "a rejected command must not change state"
+    assert conn.error_queue == [(-222, "Data out of range (FUNC:RAMP:SYMM)")]
 
 
 # --- Tektronix dialect: same guard, mirrored per the Task 3 review ---------

--- a/tests/test_mock_error_queue.py
+++ b/tests/test_mock_error_queue.py
@@ -1,0 +1,59 @@
+"""The mock's SCPI error queue.
+
+Real instruments accept a bad command, ignore it, and queue an error for later
+collection. The mock used to answer '+0,"No error"' unconditionally, so
+FunctionGenerator.get_error() and DataLogger.get_error() could only ever report
+perfect health and no caller-side error handling was reachable in tests.
+"""
+
+import pytest
+
+from scpi_control.connection.mock import MockConnection
+
+NO_ERROR = '+0,"No error"'
+
+
+def _conn(**kwargs):
+    conn = MockConnection(**kwargs)
+    conn.connect()
+    return conn
+
+
+@pytest.mark.parametrize("mode", ["daq_mode", "awg_mode", "psu_mode"])
+def test_empty_queue_reports_no_error(mode):
+    """All three instrument classes that expose get_error() must be able to ask.
+    Only daq_mode answered before -- awg_mode and psu_mode timed out, so
+    FunctionGenerator.get_error() and PowerSupply.get_error() were unusable
+    against the mock entirely."""
+    assert _conn(**{mode: True}).query("SYST:ERR?") == NO_ERROR
+
+
+def test_errors_pop_oldest_first_then_drain_to_no_error():
+    conn = _conn(awg_mode=True)
+    conn.push_error(-222, "Data out of range")
+    conn.push_error(-113, "Undefined header")
+
+    assert conn.query("SYST:ERR?") == '-222,"Data out of range"'
+    assert conn.query("SYST:ERR?") == '-113,"Undefined header"'
+    assert conn.query("SYST:ERR?") == NO_ERROR
+
+
+def test_cls_clears_the_queue():
+    """*CLS is the standard way to clear status; the mock ignored it entirely."""
+    conn = _conn(awg_mode=True)
+    conn.push_error(-222, "Data out of range")
+    conn.write("*CLS")
+    assert conn.query("SYST:ERR?") == NO_ERROR
+
+
+def test_scope_mode_still_has_no_error_query():
+    """Scopes deliberately have no get_error -- scope.get_error() raises
+    NotImplementedError and test_scpi_command_tables.py:38 asserts the command's
+    absence. Adding a wire-level accessor here would quietly undo that gating, so
+    scope mode must keep timing out. The queue itself still works; it just has no
+    SCPI accessor, which matches the library's model."""
+    from scpi_control import exceptions
+
+    conn = _conn()  # default = scope mode
+    with pytest.raises(exceptions.SiglentTimeoutError):
+        conn.query("SYST:ERR?")

--- a/tests/test_signal_impairments.py
+++ b/tests/test_signal_impairments.py
@@ -1,0 +1,50 @@
+"""Signal impairments: drift, glitches and edge ringing.
+
+The mock produced mathematically perfect waveforms, so measurement code had never
+faced an imperfect signal. These impairments are all DEFAULT OFF -- the
+default-off test below is the load-bearing one, because turning them on by
+default would silently change what every existing mock-based test measures.
+"""
+
+import numpy as np
+import pytest
+
+from scpi_control import exceptions
+from scpi_control.signal_synth import SignalSpec, synthesize
+
+RATE = 100_000.0
+N = 4_000
+
+
+def test_new_fields_default_to_off():
+    spec = SignalSpec(kind="sine", frequency=1_000.0)
+    assert spec.drift_amplitude == 0.0
+    assert spec.glitch_rate == 0.0
+    assert spec.ringing_frequency == 0.0
+
+
+def test_default_spec_output_is_unchanged_by_the_new_fields():
+    """The guarantee that keeps this non-breaking: a spec with no impairment
+    arguments must produce exactly what it produced before this sub-project."""
+    spec = SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0, noise_rms=0.01, seed=7)
+    a = synthesize(spec, RATE, N)
+    b = synthesize(spec, RATE, N)
+    np.testing.assert_array_equal(a, b)
+    # A clean sine stays within its amplitude envelope; any impairment leaking in
+    # by default would push it outside.
+    assert np.max(np.abs(a)) < 1.0 + 6 * 0.01
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"drift_amplitude": -1.0},
+        {"glitch_rate": -1.0},
+        {"glitch_amplitude": -1.0},
+        {"ringing_damping": -1.0},
+    ],
+)
+def test_negative_impairment_parameters_are_rejected(kwargs):
+    spec = SignalSpec(kind="sine", frequency=1_000.0, **kwargs)
+    with pytest.raises(exceptions.InvalidParameterError):
+        synthesize(spec, RATE, N)

--- a/tests/test_signal_impairments.py
+++ b/tests/test_signal_impairments.py
@@ -42,9 +42,60 @@ def test_default_spec_output_is_unchanged_by_the_new_fields():
         {"glitch_rate": -1.0},
         {"glitch_amplitude": -1.0},
         {"ringing_damping": -1.0},
+        {"ringing_frequency": -1.0},
     ],
 )
 def test_negative_impairment_parameters_are_rejected(kwargs):
     spec = SignalSpec(kind="sine", frequency=1_000.0, **kwargs)
     with pytest.raises(exceptions.InvalidParameterError):
         synthesize(spec, RATE, N)
+
+
+def test_drift_moves_the_baseline():
+    clean = synthesize(SignalSpec(kind="dc", offset=0.0, seed=1), RATE, N)
+    drifted = synthesize(SignalSpec(kind="dc", offset=0.0, drift_amplitude=0.5, drift_frequency=1.0, seed=1), RATE, N)
+    assert np.max(np.abs(drifted)) > 0.1, "drift should visibly move the baseline"
+    assert np.allclose(clean, 0.0), "the clean control must be flat"
+
+
+def test_drift_is_continuous_across_stream_chunks():
+    """stream() re-seeds per chunk. A random-walk drift would jump at each chunk
+    boundary; a time-based one stays continuous."""
+    from scpi_control.signal_synth import stream
+
+    spec = SignalSpec(kind="dc", offset=0.0, drift_amplitude=0.5, drift_frequency=1.0, seed=3)
+    chunks = []
+    for i, chunk in enumerate(stream(spec, RATE, 1_000)):
+        chunks.append(chunk)
+        if i == 3:
+            break
+    joined = np.concatenate(chunks)
+    steps = np.abs(np.diff(joined))
+    # No sample-to-sample step should dwarf the typical one -- that is what a
+    # per-chunk reset would look like.
+    assert np.max(steps) < 20 * np.median(steps[steps > 0])
+
+
+def test_glitches_raise_the_peak_above_the_clean_amplitude():
+    base = dict(kind="sine", frequency=1_000.0, amplitude=1.0, seed=5)
+    clean = synthesize(SignalSpec(**base), RATE, N)
+    spiky = synthesize(SignalSpec(glitch_rate=500.0, glitch_amplitude=3.0, **base), RATE, N)
+    assert np.max(np.abs(spiky)) > np.max(np.abs(clean)) + 1.0
+
+
+def test_impairments_are_reproducible_under_a_seed():
+    spec = SignalSpec(kind="sine", frequency=1_000.0, glitch_rate=500.0, glitch_amplitude=3.0, drift_amplitude=0.2, seed=11)
+    np.testing.assert_array_equal(synthesize(spec, RATE, N), synthesize(spec, RATE, N))
+
+
+def test_enabling_drift_does_not_change_the_noise_samples():
+    """Impairments draw from their own generators, so switching one on must not
+    perturb another's randomness -- otherwise a test asserting on noise would
+    break merely because drift was enabled."""
+    base = dict(kind="dc", offset=0.0, noise_rms=0.1, seed=13)
+    noisy = synthesize(SignalSpec(**base), RATE, N)
+    noisy_drifted = synthesize(SignalSpec(drift_amplitude=1.0, drift_frequency=0.5, **base), RATE, N)
+    # Removing the (deterministic, time-based) drift must recover the same noise.
+    t = np.arange(N) / RATE
+    recovered = noisy_drifted - 1.0 * np.sin(2 * np.pi * 0.5 * t)
+    np.testing.assert_allclose(recovered, noisy, atol=1e-9)

--- a/tests/test_signal_impairments.py
+++ b/tests/test_signal_impairments.py
@@ -99,3 +99,55 @@ def test_enabling_drift_does_not_change_the_noise_samples():
     t = np.arange(N) / RATE
     recovered = noisy_drifted - 1.0 * np.sin(2 * np.pi * 0.5 * t)
     np.testing.assert_allclose(recovered, noisy, atol=1e-9)
+
+
+def test_default_spec_produces_exactly_the_clean_signal():
+    """The real default-off guarantee. A DC spec at zero offset with no noise must
+    return EXACTLY zeros, so ANY nonzero default impairment -- drift, glitch or
+    ringing, at any magnitude or timescale -- breaks this immediately. The
+    envelope-based test above cannot see a slow drift; this one can."""
+    out = synthesize(SignalSpec(kind="dc", offset=0.0, seed=1), RATE, N)
+    np.testing.assert_array_equal(out, np.zeros(N))
+
+
+def test_glitches_at_colliding_positions_sum_via_add_at_not_overwrite():
+    """np.add.at accumulates every glitch landing on a repeated sample index;
+    fancy-index += would silently keep only the last write to a repeated index,
+    dropping the rest. At the glitch densities used elsewhere in this file,
+    duplicate positions are too rare to tell the two apart (0/200 trials in the
+    Task 6 review). Here n_points is tiny and glitch_rate is deliberately huge --
+    about 100 glitches land on only 20 positions -- so multiple same-sign
+    collisions on one sample are certain. fancy-index += can never push a sample
+    past 1x glitch_amplitude no matter how many glitches land there; np.add.at
+    can and does."""
+    spec = SignalSpec(kind="dc", offset=0.0, glitch_rate=5000.0, glitch_amplitude=1.0, seed=0)
+    out = synthesize(spec, 1000.0, 20)
+    assert np.max(np.abs(out)) >= 2.0, "same-sign glitch collisions should stack past 1x glitch_amplitude"
+
+
+def test_ringing_produces_overshoot_above_the_flat_top():
+    """Exercises the overshoot measurement the audit caught fabricating values for
+    signals without flat tops (M42) -- now there is a signal that genuinely has
+    overshoot to measure."""
+    base = dict(kind="square", frequency=1_000.0, amplitude=1.0, seed=2)
+    clean = synthesize(SignalSpec(**base), RATE, N)
+    rung = synthesize(SignalSpec(ringing_frequency=20_000.0, ringing_damping=5_000.0, **base), RATE, N)
+
+    assert np.max(rung) > np.max(clean) * 1.05, "ringing should overshoot the flat top"
+    # And it must decay: the late part of a held level should be flatter than the
+    # part right after the triggering edge. NOTE: comparing the first vs last 200
+    # samples of the whole 4000-sample array (as originally drafted) does not test
+    # this -- at these parameters the decay window is 5/ringing_damping seconds =
+    # 100 samples, longer than the 50-sample half-period between edges, so
+    # consecutive edges' ringing overlaps into a steady state and the start and
+    # end of the array read as statistically indistinguishable (verified: it
+    # fails, 1.052 vs 1.041). Scoping to one held level (the first one, which
+    # starts from an unrung baseline) isolates the actual decay behaviour.
+    edges = np.flatnonzero(np.diff(clean))
+    held = rung[edges[0] + 1 : edges[1] + 1]
+    assert np.std(held[-20:]) < np.std(held[:20]), "ringing should decay within a held level"
+
+
+def test_ringing_is_off_by_default_for_a_square_wave():
+    clean = synthesize(SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, seed=2), RATE, N)
+    assert np.max(clean) == pytest.approx(1.0)

--- a/tests/test_signal_impairments.py
+++ b/tests/test_signal_impairments.py
@@ -51,6 +51,25 @@ def test_negative_impairment_parameters_are_rejected(kwargs):
         synthesize(spec, RATE, N)
 
 
+@pytest.mark.parametrize("drift_frequency", [0.0, -1.0], ids=["zero", "negative"])
+def test_drift_frequency_must_be_positive_when_drift_is_enabled(drift_frequency):
+    """M3: _validate covered every new field except drift_frequency.
+    drift_amplitude=5.0, drift_frequency=0.0 used to silently produce no drift
+    at all (sin(0*t) == 0), and a negative value merely inverted phase --
+    both surprising and undocumented rather than rejected."""
+    spec = SignalSpec(kind="dc", drift_amplitude=5.0, drift_frequency=drift_frequency)
+    with pytest.raises(exceptions.InvalidParameterError):
+        synthesize(spec, RATE, N)
+
+
+def test_drift_frequency_is_unchecked_while_drift_is_disabled():
+    """drift_amplitude's default (0.0, drift off) must not make an otherwise
+    unrelated drift_frequency value (including the field's own non-positive
+    edge cases) block synthesis."""
+    out = synthesize(SignalSpec(kind="dc", offset=0.0, drift_frequency=0.0, seed=1), RATE, N)
+    np.testing.assert_array_equal(out, np.zeros(N))
+
+
 def test_drift_moves_the_baseline():
     clean = synthesize(SignalSpec(kind="dc", offset=0.0, seed=1), RATE, N)
     drifted = synthesize(SignalSpec(kind="dc", offset=0.0, drift_amplitude=0.5, drift_frequency=1.0, seed=1), RATE, N)

--- a/tests/test_signal_impairments.py
+++ b/tests/test_signal_impairments.py
@@ -198,6 +198,20 @@ def test_ringing_is_off_by_default_for_a_square_wave():
     assert np.max(clean) == pytest.approx(1.0)
 
 
+def test_ringing_damping_defaults_to_nonzero():
+    """M8: the natural way to switch ringing on is setting only
+    ringing_frequency. If ringing_damping stayed at its old default (0.0,
+    undamped), the resulting kernel never decays, so it would run for
+    n_points-1 edges * n_points samples each on a fast square wave --
+    quadratic in n_points (measured, pre-fix: 0.013/0.084/0.402s at n =
+    5k/20k/50k). Same fix as drift_frequency's own nonzero default, and for
+    the same reason."""
+    spec = SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, ringing_frequency=20_000.0, seed=2)
+    assert spec.ringing_damping > 0.0
+    out = synthesize(spec, 1_000_000.0, 50_000)
+    assert np.isfinite(out).all()
+
+
 def test_ringing_is_continuous_across_stream_chunks():
     """I3: the doc comment used to claim ringing was 'automatically continuous
     across stream() chunks'. It wasn't -- np.diff() only sees edges inside the

--- a/tests/test_signal_impairments.py
+++ b/tests/test_signal_impairments.py
@@ -101,6 +101,32 @@ def test_enabling_drift_does_not_change_the_noise_samples():
     np.testing.assert_allclose(recovered, noisy, atol=1e-9)
 
 
+def test_enabling_glitches_does_not_perturb_the_shared_noise_generator():
+    """I4: glitches are the only impairment that draws randomness, via a
+    separate generator (`_impairment_rng(spec.seed, 1)`), so switching them on
+    must not perturb `noise_rms`'s shared `rng` draw. test_enabling_drift_does_
+    not_change_the_noise_samples does not prove this: drift is deterministic
+    and time-based and never touches any generator, so it only proves
+    additivity. If glitches drew from the same `rng` as noise instead (e.g.
+    `glitch_rng = rng`), the noise draw would shift too, and every sample --
+    not just the sparse glitches themselves -- would differ from the
+    non-glitchy spec's output."""
+    base = dict(kind="dc", offset=0.0, noise_rms=0.1, seed=13)
+    noisy = synthesize(SignalSpec(**base), RATE, N)
+    noisy_glitchy = synthesize(SignalSpec(glitch_rate=500.0, glitch_amplitude=3.0, **base), RATE, N)
+    diff = noisy_glitchy - noisy
+    changed = np.flatnonzero(diff)
+    assert changed.size > 0, "glitch_rate=500 over a 4000-sample buffer should land at least one glitch"
+    # A perturbed shared generator would shift every one of the 4000 samples,
+    # not just the handful of sparse glitches -- this bounds "handful".
+    assert changed.size < N // 4, "far more samples changed than glitches could plausibly land on -- the noise generator was perturbed"
+    # Every changed sample must be an exact integer multiple of glitch_amplitude
+    # (one or more glitches landing there) -- not an arbitrarily-shifted noise
+    # value, which is what a perturbed shared generator would produce instead.
+    remainder = diff[changed] / 3.0
+    np.testing.assert_allclose(remainder, np.round(remainder), atol=1e-9)
+
+
 def test_default_spec_produces_exactly_the_clean_signal():
     """The real default-off guarantee. A DC spec at zero offset with no noise must
     return EXACTLY zeros, so ANY nonzero default impairment -- drift, glitch or

--- a/tests/test_signal_impairments.py
+++ b/tests/test_signal_impairments.py
@@ -151,3 +151,29 @@ def test_ringing_produces_overshoot_above_the_flat_top():
 def test_ringing_is_off_by_default_for_a_square_wave():
     clean = synthesize(SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, seed=2), RATE, N)
     assert np.max(clean) == pytest.approx(1.0)
+
+
+def test_ringing_is_continuous_across_stream_chunks():
+    """I3: the doc comment used to claim ringing was 'automatically continuous
+    across stream() chunks'. It wasn't -- np.diff() only sees edges inside the
+    current buffer, so an edge landing at a chunk boundary got no ringing at
+    all, and one near a chunk's end had its ring truncated. Mirrors
+    test_drift_is_continuous_across_stream_chunks, but proves the stronger
+    claim directly: a stream() reconstruction must be bit-identical to a
+    single contiguous synthesize() call, the same way it already is for drift.
+
+    frequency=997.0 (not an exact divisor of chunk_size/sample_rate) is
+    deliberate: at a perfectly round frequency like 1000.0 Hz, some square-wave
+    edges land EXACTLY on a `cycle_fraction == duty` floating-point threshold,
+    and accumulate one ULP of rounding differently depending on whether t was
+    reached via one contiguous arange() or via a chunk's t0 + a smaller
+    arange() -- a pre-existing quantization artifact in the base generator,
+    orthogonal to this chunk-continuity fix (reproduced: it affects the plain
+    square wave with NO ringing involved at all, at frequency=1000.0 exactly).
+    """
+    from scpi_control.signal_synth import stream
+
+    spec = SignalSpec(kind="square", frequency=997.0, amplitude=1.0, ringing_frequency=20_000.0, ringing_damping=5_000.0, seed=2)
+    contiguous = synthesize(spec, RATE, N)
+    streamed = np.concatenate(list(stream(spec, RATE, 1_000, duration=N / RATE)))
+    np.testing.assert_array_equal(streamed, contiguous)


### PR DESCRIPTION
Gives the mock two capabilities it lacked: the ability to **reject bad input** like a real instrument, and the ability to produce **imperfect signals** like a real probe.

The motivation is the standing constraint on this project — there are no physical instruments, so the mock *is* the instrument, and every feature is only as trustworthy as the thing it is validated against. A mock that can only succeed cannot test the code whose job is to notice failure.

## Part A — an instrument that rejects bad input

**A real SCPI error queue.** `SYST:ERR?` was a hardcoded `'+0,"No error"'` stub living inside the DAQ branch. It is now a FIFO queue, drained by `SYST:ERR?` and cleared by `*CLS` and `*RST` (both were previously ignored entirely).

Measured behaviour before this branch:

| Mode | `SYST:ERR?` |
| ---- | ----------- |
| DAQ | `'+0,"No error"'` — permanently |
| AWG | **timed out** |
| PSU | **timed out** |

All three declare `"get_error"` in their command tables and expose a public `get_error()`. So `FunctionGenerator.get_error()` and `PowerSupply.get_error()` **could not be exercised against the mock at all**, and `DataLogger.get_error()` could only ever report health. All three now return real errors.

Scopes deliberately keep timing out: they expose no `get_error`, `Oscilloscope.get_error()` raises `NotImplementedError`, and `oscilloscope.py:297` records that the real hardware query always timed out too. Giving scope mode an accessor would have quietly undone intentional gating, so scope-mode errors are observable through the `error_queue` attribute instead. A test pins that boundary.

**Parameter validation.** Setters stored whatever arrived — 1e9 V/div was accepted. Now a bad value is **accepted by the transport, ignored, and queued** as `-222,"Data out of range (VDIV)"`, because that is what hardware does; nothing raises. Coverage spans the Siglent legacy and modern scope dialects, the PSU/AWG modes, and the Tektronix personality (LeCroy delegates to the Siglent handler and needed no changes; DAQ has no numeric setters, only a channel list and an enum).

**The strict-mode boundary is untouched and explicitly tested:** an *unimplemented* command still raises `SiglentTimeoutError`, which is what forces every new command to earn a wire-form corpus entry. Only *implemented* commands with bad parameters queue errors, and a timeout never queues one.

## Part B — signals that are imperfect

`SignalSpec` gained baseline drift, glitches and edge ringing. Every one defaults to **off**, so existing synthesised output is byte-identical unless asked for — that guarantee is the load-bearing test in the branch, asserting a zero-offset DC spec returns *exactly* zeros, so any nonzero default of any kind at any magnitude breaks it.

Two constraints shaped the implementation:

- **Drift and ringing are functions of absolute time, not random walks.** `stream()` re-seeds per chunk, so anything stateful would reset at chunk boundaries and show sawtooth jumps in a live view. Ringing renders extra samples before `t0` and slices them off to achieve this.
- **Each impairment draws from its own generator**, so enabling one cannot perturb another's randomness or the base noise.

These were chosen to stress code this project has previously found broken: glitches attack peak-based period detection, drift attacks zero-crossing detection — the two strategies inside `estimate_period()` — and ringing gives the overshoot measurement an audit caught fabricating values something real to measure.

## What review caught

The final whole-branch review returned five Important findings. The worst was a silent data-corruption bug, and it is worth describing because of how it hid.

The PSU handlers captured their numeric argument with `([\d.]+)` — a regex that cannot match a sign, an exponent, or non-finite text. `PowerSupply.output1.set_current(0.00005)` emits `CH1:CURR 5e-05`; the regex matched only the leading `5`, and the mock stored **5.0 A — a 100,000× error, silently, through ordinary public-API use.** Microamp current limits are entirely plausible.

It also made the new guards near-vacuous: `-5.0`, `nan` and `inf` all fell through unmatched. **And the tests had been narrowed to fit it** — the PSU parametrize lists used `[1e9]` alone, the one input shape the broken regex could match, while the scope tests covered negative/nan/inf, with nothing recording why. A suite that looked thorough, shaped around a bug.

Also fixed: `reject_if_invalid` could not express "must be ≥ 0", so negative trigger holdoff and negative phase were accepted; ringing was not actually continuous across `stream()` chunks despite a comment claiming it was; the per-impairment-generator decision had no test at all (swapping to the shared generator left all 120 synthesis tests passing); and the six new public fields were missing from the `SignalSpec` documentation table.

## Verification

- Full suite: **1774 passed, 19 skipped, 0 failed** (baseline on `main` 1657/19).
- **CI-parity sweep** with `reportlab` and with `PyQt6` each blocked via a `sys.meta_path` finder — 1776 and 1780 tests collected, zero errors. CI installs `.[dev,web]` without those extras, and a local run can never catch a missing `importorskip` because this machine has them all. This class of bug has shipped from here twice, so the sweep is now a plan step rather than something to remember.
- Every constraint mutation-tested: reverting drift to a random walk, making drift draw from the shared generator, swapping `np.add.at` for fancy-index `+=`, disabling ringing, and flipping impairment defaults.
- `black --check --line-length 200` clean; `flake8 --select=E9,F63,F7,F82` returns 0.

## Known limitations, recorded rather than dropped

- **Square-wave threshold quantisation (pre-existing).** At frequencies landing exactly on a duty boundary — including 1 kHz at 100 kS/s, this project's most common test signal — the base generator's float64 threshold misplaces about four level flips between chunked and contiguous synthesis. Ringing then faithfully rings on each spurious edge, amplifying four samples into ~353. Verified independent of this branch: it reproduces with ringing off, and divergence is zero at off-boundary frequencies with ringing on. Not fixed here because changing the base generator alters synthesised output and would risk this branch's own default-off guarantee — it needs its own task.
- **The error queue is unbounded**, and in scope mode undrainable over the wire (no accessor), so it is cleared only by `*CLS`/`*RST`. Real instruments cap at ~20 entries and push `-350,"Queue overflow"`.
- **Malformed values still raise** out of the transport: `C1:VDIV abc` produces a `ValueError` rather than queueing `-104,"Data type error"`.
- **No `ringing_amplitude` knob** — magnitude is hardcoded at 50% of the step, giving ~90% first-sample overshoot at the tested parameters. A realistic 5–20% overshoot with a visible ring is not currently expressible.

## Non-breaking

MINOR → 5.4.0. New `SignalSpec` fields are appended at the end of the dataclass (mid-class insertion would reorder positional construction). `reject_if_invalid` gained only keyword-only parameters with defaults. An empty error queue returns `'+0,"No error"'`, byte-identical to the old stub. No signature changes, no removed or renamed public names.
