### PR TITLE
chore(release): 5.4.0 - mock fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.0] - 2026-07-26
+
 ### Added
 
 - The mock instrument can now misbehave the way real hardware does. It keeps a real SCPI error

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.0] - 2026-07-26
+
 ### Added
 
 - The mock instrument can now misbehave the way real hardware does. It keeps a real SCPI error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "5.3.0"
+version = "5.4.0"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "5.3.0"
+__version__ = "5.4.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope

--- a/tests/test_server_ownership.py
+++ b/tests/test_server_ownership.py
@@ -1,5 +1,6 @@
 """Session ownership: the creating identity owns the session."""
 
+import threading
 import time
 
 import pytest
@@ -373,6 +374,7 @@ def test_watcher_released_on_abnormal_disconnect(two_users_ws, monkeypatch):
     client.app.state.abandon_after = 0.0
 
     raised = []
+    reached = threading.Event()
 
     def _boom(_scope):
         # Recording the call is inside the same body as the raise, so if a
@@ -381,14 +383,25 @@ def test_watcher_released_on_abnormal_disconnect(two_users_ws, monkeypatch):
         # with it, and the assertion below catches the decay into a
         # duplicate of the clean-close test.
         raised.append(True)
+        reached.set()
         raise RuntimeError("simulated mid-stream failure")
 
     monkeypatch.setattr(stream_module, "read_state", _boom)
     # No receive_json here: the handler crashes before it ever sends a
     # frame, so waiting on one would hang forever waiting for a message
     # that never arrives.
+    #
+    # But we cannot just close immediately either. The handler reaches
+    # read_state via ``session.submit(...)`` onto the session's worker thread
+    # (stream.py:98), so it runs asynchronously relative to the handshake --
+    # closing the socket right away races that dispatch, and the job may never
+    # run. That race made this test fail intermittently in CI on whichever
+    # interpreter happened to lose it (3.10 on one run, 3.11 on the next, each
+    # time passing on the others). Waiting for the helper to actually fire
+    # removes the timing dependency; the timeout keeps a genuine regression
+    # from hanging the suite.
     with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=alice_ws):
-        pass
+        assert reached.wait(timeout=10.0), "handler never reached read_state within 10s"
 
     assert raised, "abnormal path never exercised -- read_state must raise, not return"
 


### PR DESCRIPTION
Cuts 5.4.0 — the mock fidelity release. Version bump plus the changelog header rename; no code changes.

## Why MINOR

`[Unreleased]` carried a single `### Added` section and no `⚠️ Breaking Changes`. Everything in it is additive: new `SignalSpec` fields appended at the end of the dataclass (so positional construction is unchanged), new keyword-only parameters with defaults on `reject_if_invalid`, and an empty error queue that returns `'+0,"No error"'` byte-identical to the stub it replaced.

## What ships

The mock can now **misbehave the way real hardware does** — the point being that this project has no physical instruments, so the mock is the instrument, and a mock that can only succeed cannot test the code whose job is to notice failure.

- A real SCPI error queue behind `SYST:ERR?`, cleared by `*CLS` and `*RST`. `FunctionGenerator.get_error()` and `PowerSupply.get_error()` go from **timing out entirely** to answering; `DataLogger.get_error()` can finally report something other than health.
- Out-of-range parameters are rejected across the Siglent scope, PSU and AWG personalities plus the Tektronix and LeCroy dialects — accepted by the transport, ignored, and queued as `-222`, which is what an instrument actually does. Unimplemented commands still time out, so the wire-form conformance net is untouched.
- `SignalSpec` gained baseline drift, glitches and edge ringing, all default-off, so measurement code can be exercised against imperfect signals instead of mathematically clean ones.

## Verification

- Both version sources read `5.4.0`, enforced by `tests/test_version_consistency.py`.
- `docs/about/changelog.md` regenerated and verified **byte-identical** to `CHANGELOG.md`.
- PyPI summary 387/512 chars — the check that broke the v3.2.0 publish.
- Changelog structure: exactly one `## [Unreleased]`, `## [5.4.0] - 2026-07-26` present, one `Added` section, no breaking-changes section, `5.3.0` untouched.
- Full suite: **1774 passed, 19 skipped, 0 failed**.
- `python -m build` produces both artifacts at 5.4.0 with **no deprecation warnings**; `twine check` PASSED on the wheel *and* the sdist.
- All four touched files confirmed **BOM-free**. Worth stating because the first bump attempt used PowerShell's `Set-Content -Encoding utf8`, which writes a BOM and corrupted `pyproject.toml` for TOML parsers; it was caught, reverted, and redone through Python with explicit encoding.

## Known limitations carried into this release

Recorded in the feature PR rather than dropped, and none blocking:

- A **pre-existing** float64 duty-threshold artifact in the square-wave generator misplaces a few level flips at frequencies landing exactly on a duty boundary — including 1 kHz at 100 kS/s, this project's most common test signal. Ringing then faithfully rings on each spurious edge, amplifying it. Verified independent of the feature work (it reproduces with ringing off, and divergence is zero at off-boundary frequencies). Not fixed here because changing the base generator alters synthesised output and would risk the default-off guarantee.
- The error queue is unbounded, and in scope mode undrainable over the wire — real instruments cap at ~20 entries and push `-350,"Queue overflow"`.
- Malformed values still raise out of the transport (`C1:VDIV abc` → `ValueError`) rather than queueing `-104,"Data type error"`.
- No `ringing_amplitude` knob; magnitude is hardcoded at 50% of the step, giving ~90% first-sample overshoot at the tested parameters.
- `tests/test_server_ownership.py::test_watcher_released_on_abnormal_disconnect` is **flaky** — it lost a race on the Python 3.10 runner during this branch's CI and passed on re-run, having passed on five other interpreter versions in the same run. Pre-existing and unrelated to this work, but worth de-flaking.

## After merge

Publishing fires when the GitHub release is created (`publish.yml` on `release: published`, trusted publishing), tagged `v5.4.0`. Create it with `gh release create --target <full-40-char-sha>` — not by pushing the tag, since a tag push lets `build-executables.yml` create the release as `github-actions[bot]` and GitHub suppresses workflow triggers for bot-raised events, which is how v4.1.0 silently never reached PyPI. The full SHA is required; an abbreviated one is rejected with HTTP 422.
