### PR TITLE
feat(synth): add the chirp, exponential, pulse and multitone signal kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Four new synthetic signal kinds join `sine`/`square`/`triangle`/`ramp`/`dc`/`noise`: `chirp`, a
+  repeating frequency sweep from `frequency` to `end_frequency` over `sweep_time` (linear or, with
+  `sweep_log`, logarithmic), with phase carried across the retrace so the sweep boundary is
+  discontinuity-free — it's also the one kind the mock free-runs rather than trigger-aligns, since
+  a sweep has no stable period; `exponential`, a square wave through an RC network with time
+  constant `tau`, evaluated at its periodic steady state so it's settled from the first cycle
+  rather than over the first few, and split by `duty`; `pulse`, a trapezoid whose width and edge
+  rate are set independently of the period by `pulse_width` and `edge_time` (`edge_time` may be 0
+  for an ideal edge) rather than by `duty`, which `pulse` ignores — `pulse_width` is the
+  50%-to-50% (FWHM) width, matching both instrument convention and the threshold the repo's timing
+  analyzer measures at, so the flat top runs for `pulse_width - edge_time`; and `multitone`, a
+  fundamental plus a coherent harmonic series (`harmonics` gives the relative amplitudes of the
+  2nd, 3rd, ... harmonic), where `amplitude` sets the fundamental rather than the peak of the sum
+  — deliberately not normalized, since normalizing would make THD depend on the harmonic set. The
+  new kinds give the repo's timing, THD and spectrum analyzers a closed-form answer to check
+  against for the first time, rather than only a pure sine, a square, or noise. Non-breaking:
+  every new `SignalSpec` field is optional and appended at the end of the dataclass, so existing
+  specs and positional construction are unaffected.
+
 ## [5.4.0] - 2026-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Control SCPI-compatible test equipment from Python — oscilloscopes, function g
 - **GUI Application**: Modern PyQt6-based graphical interface
 - **Waveform Acquisition**: Capture and download waveform data in multiple formats (.npz, .csv, .mat, .h5)
 - **Acquisition Provenance**: every saved waveform records the instrument, settings, and timestamp that produced it; extract raw data from any saved file with load_waveform() or the scpi-extract CLI
-- **Synthetic Signals & Realistic Mock**: generate parameterized test waveforms (sine/square/triangle/ramp/DC/noise) with `SignalSpec`/`make_waveform`, or `synthesize()`/`stream()` for one-shot arrays and phase-continuous, optionally real-time-paced chunks; develop without hardware against a mock scope that synthesizes state-coupled, trigger-aligned waveforms by default
+- **Synthetic Signals & Realistic Mock**: generate parameterized test waveforms (sine/square/triangle/ramp/DC/noise/chirp/exponential/pulse/multitone) with `SignalSpec`/`make_waveform`, or `synthesize()`/`stream()` for one-shot arrays and phase-continuous, optionally real-time-paced chunks; develop without hardware against a mock scope that synthesizes state-coupled, trigger-aligned waveforms by default
 - **Channel Configuration**: Control voltage scale, coupling, offset, bandwidth
 - **Trigger Settings**: Configure trigger modes, levels, edge detection
 - **Advanced Analysis**: Built-in FFT, SNR, THD, and statistical analysis tools

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ This library provides comprehensive control for SCPI test equipment — oscillos
     - **Protocol Decoding** - Decode I2C, SPI, and UART protocols
     - **Automation** - High-level automation classes for data collection
     - **Data Provenance** - Every capture records the instrument, settings, and timestamp that produced it; read it back with `load_waveform()` or the `scpi-extract` CLI
-    - **Synthetic Signals** - Generate parameterized waveforms (sine, square, triangle, ramp, DC, noise) with no instrument required; mock scopes synthesize state-coupled captures by default
+    - **Synthetic Signals** - Generate parameterized waveforms (sine, square, triangle, ramp, DC, noise, chirp, exponential, pulse, multitone) with no instrument required; mock scopes synthesize state-coupled captures by default
 
 === "GUI Application"
 

--- a/docs/user-guide/synthetic-signals.md
+++ b/docs/user-guide/synthetic-signals.md
@@ -63,14 +63,19 @@ value that leaves the signal unaffected, so existing code that constructs a
 - **`ringing_frequency`/`ringing_damping`** add a damped sinusoid after every
   edge of a periodic signal -- what a real probe/scope front-end does after a
   fast transition, and what gives an overshoot/preshoot measurement something
-  genuine to measure. It's an edge impairment, so it is only meaningful on
-  signals that actually have edges (`"square"` and `"pulse"`, or a pulse-like
-  `"ramp"`) -- applying it to `"sine"` or `"dc"` has no effect, since those
-  kinds have no discontinuities for it to trigger on. It is likewise a
-  genuine no-op on `"chirp"`, `"exponential"`, and `"multitone"`, all three of
-  which are continuous. For `"exponential"` that continuity is by
-  construction: both branch boundaries of the RC charge/discharge evaluate to
-  the same level, so there is never a real edge for the kernel to trigger on.
+  genuine to measure. It's an edge impairment, so it is *physically*
+  meaningful on signals that actually have fast edges (`"square"` and
+  `"pulse"`, or a pulse-like `"ramp"`). On the continuous kinds (`"sine"`,
+  `"chirp"`, `"exponential"`, `"multitone"`) it is **not** a no-op, though:
+  edges are found as any nonzero sample-to-sample change rather than as a
+  discontinuity, so every sample of a continuous signal qualifies and the
+  impairment becomes a derivative-weighted filter. Its magnitude scales with
+  the signal's slew rate -- measurable, but usually far smaller than on a real
+  edge (at `sample_rate=1e6`, `amplitude=1.0`,
+  `ringing_frequency=50_000`: about 0.10 V on `"chirp"`, 0.056 V on
+  `"exponential"`, 0.013 V on `"multitone"` and 0.010 V on `"sine"`, against
+  0.90 V on `"square"`). `"dc"`, whose sample-to-sample differences are all
+  zero, is the only kind ringing genuinely leaves untouched.
 
 ```python
 from scpi_control.signal_synth import SignalSpec, synthesize

--- a/docs/user-guide/synthetic-signals.md
+++ b/docs/user-guide/synthetic-signals.md
@@ -11,7 +11,8 @@ captures.
 
 - **Develop and test without hardware.** Write and exercise capture,
   analysis, and reporting code against realistic waveforms -- sine, square,
-  triangle, ramp, DC, noise -- before an instrument is available.
+  triangle, ramp, DC, noise, chirp, exponential, pulse, multitone -- before
+  an instrument is available.
 - **Reproducible test data.** A seeded `SignalSpec` produces the exact same
   samples every run, which makes it useful for regression tests and
   deterministic examples/demos.
@@ -28,7 +29,7 @@ signal:
 
 | Field | Default | Meaning |
 | --- | --- | --- |
-| `kind` | `"sine"` | `"sine"`, `"square"`, `"triangle"`, `"ramp"`, `"dc"`, or `"noise"` |
+| `kind` | `"sine"` | `"sine"`, `"square"`, `"triangle"`, `"ramp"`, `"dc"`, `"noise"`, `"chirp"`, `"exponential"`, `"pulse"`, or `"multitone"` |
 | `frequency` | `1000.0` | Repetition rate in Hz (periodic kinds only) |
 | `amplitude` | `1.0` | Peak amplitude in volts (Vpp = `2 * amplitude`); for `"noise"`, the standard deviation; ignored for `"dc"` |
 | `offset` | `0.0` | DC offset in volts, added to every kind (`"dc"` outputs exactly this level) |
@@ -63,9 +64,13 @@ value that leaves the signal unaffected, so existing code that constructs a
   edge of a periodic signal -- what a real probe/scope front-end does after a
   fast transition, and what gives an overshoot/preshoot measurement something
   genuine to measure. It's an edge impairment, so it is only meaningful on
-  signals that actually have edges (`"square"`, or a pulse-like `"ramp"`) --
-  applying it to `"sine"` or `"dc"` has no effect, since those kinds have no
-  discontinuities for it to trigger on.
+  signals that actually have edges (`"square"` and `"pulse"`, or a pulse-like
+  `"ramp"`) -- applying it to `"sine"` or `"dc"` has no effect, since those
+  kinds have no discontinuities for it to trigger on. It is likewise a
+  genuine no-op on `"chirp"`, `"exponential"`, and `"multitone"`, all three of
+  which are continuous. For `"exponential"` that continuity is by
+  construction: both branch boundaries of the RC charge/discharge evaluate to
+  the same level, so there is never a real edge for the kernel to trigger on.
 
 ```python
 from scpi_control.signal_synth import SignalSpec, synthesize
@@ -100,6 +105,42 @@ parameter (non-positive `frequency` on a periodic kind, `duty` outside
 `glitch_amplitude`/`ringing_frequency`/`ringing_damping`, or a non-positive
 `drift_frequency` while `drift_amplitude > 0`) raises `InvalidParameterError`
 -- no partial or silently-clamped signal is ever returned.
+
+### Kind-specific parameters
+
+Seven more fields exist purely to parameterize the four newer kinds; each is
+ignored by every other kind, and every default is chosen so
+`SignalSpec(kind=X)` alone works at the default 1 kHz `frequency`:
+
+| Field | Read by | Default | Meaning |
+| --- | --- | --- | --- |
+| `end_frequency` | `"chirp"` | `10_000.0` | Sweep stop frequency in Hz |
+| `sweep_time` | `"chirp"` | `0.01` | Seconds per sweep, after which it retraces |
+| `sweep_log` | `"chirp"` | `False` | Sweep logarithmically (equal time per octave) instead of linearly |
+| `tau` | `"exponential"` | `1e-4` | RC time constant in seconds |
+| `pulse_width` | `"pulse"` | `2e-4` | 50%-to-50% width (FWHM) in seconds |
+| `edge_time` | `"pulse"` | `1e-5` | 0-to-100% transition time in seconds; `0` gives an ideal instantaneous edge |
+| `harmonics` | `"multitone"` | `(0.1, 0.05)` | Relative amplitudes of the 2nd, 3rd, ... harmonic |
+
+Three things are easy to get wrong here:
+
+- **`pulse_width` is the 50%-to-50% width (FWHM)**, not the flat-top
+  duration -- it matches the instrument convention
+  (`SOUR{ch}:FUNC:PULS:WIDT`) and the threshold the repo's timing analyzer
+  measures at. The flat top itself runs for `pulse_width - edge_time`.
+  `"pulse"` also **ignores `duty`** entirely; independence from the period is
+  the whole reason it exists alongside `"square"`, whose only shape control
+  *is* `duty`.
+- **For `"multitone"`, `amplitude` is the fundamental's amplitude, not the
+  peak of the sum.** It is deliberately not normalized against the harmonics,
+  because normalizing would make THD depend on which harmonics are present;
+  as generated, THD is exactly `sqrt(sum(h**2))` for `harmonics = (h2, h3,
+  ...)`.
+- **`"chirp"` retraces every `sweep_time`**, with phase carried across the
+  retrace rather than reset, so there is no discontinuity at a sweep
+  boundary. Because it has no stable period, `"chirp"` is deliberately not in
+  `PERIODIC_KINDS`: it is the one kind the mock free-runs rather than
+  trigger-aligns (see [Trigger alignment](#state-coupling) below).
 
 ## Generating Signals Directly
 
@@ -259,7 +300,10 @@ before an acquisition change what comes back:
   fraction of the window, so consecutive captures visibly shift rather than
   repeating. Each channel aligns to its own trigger level and signal; the
   mock does not model `trigger_source` routing (triggering one channel off
-  another channel's crossing) between channels.
+  another channel's crossing) between channels. `"chirp"` is not in
+  `PERIODIC_KINDS` (it has no stable period), so it always free-runs -- never
+  trigger-aligned, even when the configured trigger level/slope is otherwise
+  attainable.
 
 ### Precedence vs. `waveform_payloads`
 

--- a/examples/synthetic_signals.py
+++ b/examples/synthetic_signals.py
@@ -12,9 +12,11 @@ next capture -- exactly like a real scope.
 
 This example (1) generates a few signal kinds directly and prints basic
 stats, (2) opens a mock oscilloscope session, acquires, then changes TDIV and
-VDIV over SCPI to show the capture's length and clipping respond, and (3)
-saves one synthesized capture and reloads it with load_waveform() to show the
-chain composes.
+VDIV over SCPI to show the capture's length and clipping respond, (3) saves
+one synthesized capture and reloads it with load_waveform() to show the chain
+composes, (4) synthesizes a multitone and compares its measured THD to the
+analytically expected value, and (5) synthesizes a chirp and measures its
+start/end frequency from zero crossings.
 
 Requirements: SCPI-Instrument-Control (core install) -- runs entirely against
 a mock connection, no instrument needed.
@@ -22,6 +24,9 @@ a mock connection, no instrument needed.
 
 from pathlib import Path
 
+import numpy as np
+
+from scpi_control.analysis import FFTAnalyzer
 from scpi_control.connection import MockConnection
 from scpi_control.oscilloscope import Oscilloscope
 from scpi_control.signal_synth import SignalSpec, make_waveform
@@ -104,10 +109,63 @@ def demo_reload() -> None:
     print(f"First 5 samples (V): {loaded.voltage[:5].tolist()}")
 
 
+def demo_multitone() -> None:
+    """Synthesize a multitone and compare its measured THD to the analytic value.
+
+    harmonics gives the relative amplitudes of the 2nd, 3rd, ... harmonic of a
+    coherent series riding on the fundamental, so THD comes out to exactly
+    sqrt(sum(h**2)) -- independent of amplitude, frequency, and phase.
+    """
+    print()
+    print("=== Part 4: multitone -- measured vs. expected THD ===")
+    harmonics = (0.1, 0.05)
+    spec = SignalSpec(kind="multitone", frequency=1_000.0, amplitude=1.0, harmonics=harmonics)
+    waveform = make_waveform(spec, sample_rate=100_000.0, n_points=100_000)
+    measured_thd = FFTAnalyzer.thd_of_waveform(waveform)
+    expected_thd = 100.0 * float(np.sqrt(np.sum(np.square(harmonics))))
+    print(f"multitone: measured THD = {measured_thd:.3f}%  " f"expected THD (100*sqrt(sum(h**2))) = {expected_thd:.3f}%")
+
+
+def _zero_crossing_freq(time_s: np.ndarray, voltage: np.ndarray, from_end: bool) -> float:
+    """Estimate instantaneous frequency from one pair of rising zero crossings.
+
+    Linear interpolation between the two bracketing samples locates each
+    crossing sub-sample; the reciprocal of the gap between one crossing and
+    the next is a local frequency estimate -- accurate near the start or end
+    of a sweep, where the chirp's instantaneous frequency is nearly constant
+    over a single cycle.
+    """
+    rising = np.flatnonzero((voltage[:-1] <= 0.0) & (voltage[1:] > 0.0))
+    pair = rising[-2:] if from_end else rising[:2]
+
+    def _crossing_time(i: int) -> float:
+        t0, t1 = time_s[i], time_s[i + 1]
+        v0, v1 = voltage[i], voltage[i + 1]
+        return float(t0 + (0.0 - v0) * (t1 - t0) / (v1 - v0))
+
+    return 1.0 / (_crossing_time(pair[1]) - _crossing_time(pair[0]))
+
+
+def demo_chirp() -> None:
+    """Synthesize a chirp and measure its start/end frequency from zero crossings."""
+    print()
+    print("=== Part 5: chirp -- measured start/end frequency ===")
+    spec = SignalSpec(kind="chirp")  # defaults: 1 kHz -> 10 kHz over 10 ms, then it retraces
+    sample_rate = 1_000_000.0
+    n_points = int(round(sample_rate * spec.sweep_time))
+    waveform = make_waveform(spec, sample_rate=sample_rate, n_points=n_points)
+    start_freq = _zero_crossing_freq(waveform.time, waveform.voltage, from_end=False)
+    end_freq = _zero_crossing_freq(waveform.time, waveform.voltage, from_end=True)
+    print(f"chirp: configured {spec.frequency:.1f} Hz -> {spec.end_frequency:.1f} Hz over {spec.sweep_time * 1000:.1f} ms")
+    print(f"chirp: measured start = {start_freq:.1f} Hz  measured end = {end_freq:.1f} Hz")
+
+
 def main() -> None:
     demo_make_waveform()
     demo_mock_session()
     demo_reload()
+    demo_multitone()
+    demo_chirp()
 
 
 if __name__ == "__main__":

--- a/scpi_control/connection/mock/synth.py
+++ b/scpi_control/connection/mock/synth.py
@@ -45,7 +45,13 @@ def _trigger_crossing(spec: SignalSpec, level: float, rising: bool) -> Optional[
         return None
     period = 1.0 / spec.frequency
     n = 4096
-    ideal = synthesize(replace(spec, noise_rms=0.0, seed=0), sample_rate=n / period, n_points=n)
+    # Every impairment is stripped, not just the noise: this search is for the
+    # IDEAL crossing, and an impairment that shifts it would shift t0 with it --
+    # trigger alignment would then jitter with the impairment settings instead of
+    # sitting on the signal's own edge. (Ringing moves an exponential's crossing
+    # from 68.85 us to 66.41 us, and re-synthesizing it here costs ~20 ms per
+    # acquisition on the continuous kinds.)
+    ideal = synthesize(replace(spec, noise_rms=0.0, seed=0, ringing_frequency=0.0, drift_amplitude=0.0, glitch_rate=0.0), sample_rate=n / period, n_points=n)
     above = ideal >= level
     # np.roll makes the comparison periodic: a crossing at the period boundary
     # (e.g. a zero-phase sine rising through 0 at t=0/t=P) is not missed.

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -193,6 +193,38 @@ def _pulse(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndar
     return np.where(within < spec.edge_time, rise, np.where(within < spec.pulse_width, high, np.where(within < spec.pulse_width + spec.edge_time, fall, low)))
 
 
+def _chirp_phase(spec: SignalSpec, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+    """Phase accumulated from the start of a sweep to `x` seconds into it."""
+    f0 = spec.frequency
+    f1 = spec.end_frequency
+    span = spec.sweep_time
+    if spec.sweep_log:
+        ratio = f1 / f0
+        if ratio == 1.0:
+            # The limit of the log form as f1 -> f0: a constant-frequency tone.
+            # Taken here rather than raising, because log(1) == 0 would divide by
+            # zero on a spec that is degenerate but perfectly sane.
+            return 2.0 * np.pi * f0 * x
+        return 2.0 * np.pi * f0 * span / np.log(ratio) * (np.power(ratio, x / span) - 1.0)
+    return 2.0 * np.pi * (f0 * x + (f1 - f0) * x * x / (2.0 * span))
+
+
+def _chirp(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    """A repeating frequency sweep, with phase accumulated across retraces.
+
+    Phase is n * PHI(sweep_time) + PHI(position within this sweep), not merely
+    the latter: resetting phase at each retrace would put a step discontinuity
+    every sweep_time, which the ringing impairment would then treat as a real
+    edge. np.floor (not int truncation) gives the sweep index, because t is
+    routinely negative -- the mock free-runs from a negative t0 and ringing
+    renders samples before t0.
+    """
+    sweep = np.floor(t / spec.sweep_time)
+    within = t - sweep * spec.sweep_time
+    phase = sweep * _chirp_phase(spec, spec.sweep_time) + _chirp_phase(spec, within)
+    return spec.amplitude * np.sin(phase + spec.phase)
+
+
 _GENERATORS: Dict[str, Callable[[SignalSpec, np.ndarray, np.random.Generator], np.ndarray]] = {
     "sine": _sine,
     "square": _square,
@@ -203,6 +235,7 @@ _GENERATORS: Dict[str, Callable[[SignalSpec, np.ndarray, np.random.Generator], n
     "multitone": _multitone,
     "exponential": _exponential,
     "pulse": _pulse,
+    "chirp": _chirp,
 }
 
 PERIODIC_KINDS = ("sine", "square", "triangle", "ramp", "multitone", "exponential", "pulse")
@@ -243,6 +276,16 @@ def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
             raise exceptions.InvalidParameterError(f"pulse_width (50%-to-50%) must exceed edge_time, or the pulse never reaches its top: {spec.pulse_width} <= {spec.edge_time}")
         if spec.pulse_width + spec.edge_time > 1.0 / spec.frequency:
             raise exceptions.InvalidParameterError(f"the trapezoid must fit in one period: pulse_width + edge_time = {spec.pulse_width + spec.edge_time} > {1.0 / spec.frequency}")
+    if spec.kind == "chirp":
+        # chirp is deliberately outside PERIODIC_KINDS (no stable period, so the
+        # mock must free-run it rather than align it to a trigger), which means
+        # the shared positive-frequency check above does not cover it.
+        if spec.frequency <= 0:
+            raise exceptions.InvalidParameterError(f"frequency must be positive for 'chirp': {spec.frequency}")
+        if spec.end_frequency <= 0:
+            raise exceptions.InvalidParameterError(f"end_frequency must be positive for 'chirp': {spec.end_frequency}")
+        if spec.sweep_time <= 0:
+            raise exceptions.InvalidParameterError(f"sweep_time must be positive for 'chirp': {spec.sweep_time}")
     if spec.noise_rms < 0:
         raise exceptions.InvalidParameterError(f"noise_rms must be non-negative: {spec.noise_rms}")
     if spec.drift_amplitude < 0:

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -36,10 +36,14 @@ class SignalSpec:
         glitch_rate: Mean glitches per second (0 = off).
         glitch_amplitude: Volts, peak height of a glitch.
         ringing_frequency: Hz of post-edge oscillation (0 = off). Ringing is
-            an EDGE impairment -- it is only meaningful on signals that have
-            edges to trigger on ("square", or a pulse-like "ramp"). Applying
-            it to "sine" or "dc" has no effect, since those kinds never
-            produce a discontinuity.
+            an EDGE impairment: it is PHYSICALLY meaningful on kinds with fast
+            edges ("square", "pulse", or a pulse-like "ramp"). It is not,
+            however, a no-op elsewhere -- edges are found as any nonzero
+            sample-to-sample change, not only as a discontinuity, so on a
+            continuous kind ("sine", "chirp", "exponential", "multitone") it
+            acts as a derivative-weighted filter whose magnitude scales with
+            the signal's slew rate: measurable, but usually small. Only "dc",
+            whose sample-to-sample differences are all zero, is a true no-op.
         ringing_damping: Decay rate per second of that oscillation; only used
             when ringing_frequency > 0. Defaults away from 0 for the same
             reason drift_frequency does: undamped ringing (decay rate 0)
@@ -78,7 +82,7 @@ class SignalSpec:
     drift_frequency: float = 0.1  # Hz of that wander; only used when drift_amplitude > 0
     glitch_rate: float = 0.0  # mean glitches per second (0 = off)
     glitch_amplitude: float = 0.0  # volts, peak height of a glitch
-    ringing_frequency: float = 0.0  # Hz of post-edge oscillation (0 = off); an edge impairment, meaningful only on "square"/pulse-like "ramp"
+    ringing_frequency: float = 0.0  # Hz of post-edge oscillation (0 = off); an edge impairment -- physically meaningful on "square"/"pulse"; on continuous kinds a small derivative filter, not a no-op
     ringing_damping: float = 5_000.0  # decay rate per second (M8: nonzero default, same reason as drift_frequency -- damping=0 never decays, making the kernel run the whole buffer on every edge)
     # Kind-specific parameters, appended at the END for the same reason the
     # impairments above were: inserting them beside the fields they read best
@@ -153,7 +157,10 @@ def _exponential(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> n
 
     Both branch boundaries evaluate to the same level (the high branch at t_high
     equals low_start; the low branch at t_low equals high_start), so the result
-    is continuous everywhere -- ringing is a genuine no-op on this kind.
+    is continuous everywhere -- there is no jump for a probe's edge response to
+    key on. (Not the same as ringing being a no-op here: it keys on any
+    sample-to-sample change, so it still filters this kind slightly. See
+    SignalSpec.ringing_frequency.)
     """
     period = 1.0 / spec.frequency
     t_high = spec.duty * period
@@ -368,6 +375,11 @@ def synthesize(spec: SignalSpec, sample_rate: float, n_points: int, t0: float = 
         # continuity test below until reordered this way).
         t_ext = t0 + (np.arange(n_points + decay_len) - decay_len) / sample_rate
         samples_ext = _GENERATORS[spec.kind](spec, t_ext, rng) + spec.offset
+        # ANY nonzero sample-to-sample change is an edge here, not just a
+        # discontinuity: on a continuous kind every sample qualifies, so this
+        # becomes a derivative-weighted filter rather than a no-op. That is
+        # defensible as a band-limited edge response and is documented as such
+        # on SignalSpec.ringing_frequency -- it is not a special case to strip.
         edges = np.flatnonzero(np.diff(samples_ext))
         if edges.size:
             # 5 time constants of decay, in samples. `max(spec.ringing_damping, 1e-9)`

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -282,8 +282,17 @@ def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
         except TypeError:
             raise exceptions.InvalidParameterError(f"harmonics must be a sequence of relative amplitudes: {spec.harmonics!r}") from None
         for order, relative in enumerate(relatives, start=2):
-            if not np.isfinite(relative) or relative < 0:
-                raise exceptions.InvalidParameterError(f"harmonics[{order - 2}] (harmonic order {order}) must be a non-negative finite number: {relative}")
+            # The guard has to cover the ELEMENT test too, not just list(): on a
+            # non-numeric element np.isfinite raises a raw "ufunc 'isfinite' not
+            # supported" TypeError, and on a complex one the `>= 0` does --
+            # either would escape this module's contract that every bad
+            # parameter surfaces as InvalidParameterError.
+            try:
+                acceptable = bool(np.isfinite(relative)) and relative >= 0
+            except TypeError:
+                acceptable = False
+            if not acceptable:
+                raise exceptions.InvalidParameterError(f"harmonics[{order - 2}] (harmonic order {order}) must be a non-negative finite number: {relative!r}")
     if spec.kind == "pulse":
         if not np.isfinite(spec.edge_time) or spec.edge_time < 0:
             raise exceptions.InvalidParameterError(f"edge_time must be a non-negative, finite number: {spec.edge_time}")

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -140,6 +140,39 @@ def _multitone(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.
     return spec.amplitude * samples
 
 
+def _exponential(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    """A square wave through an RC network, at its PERIODIC STEADY STATE.
+
+    Solved in closed form rather than integrated forward: stream() re-enters
+    synthesize() per chunk with a new t0, so anything that had to settle in over
+    the first few cycles would restart its settling at every chunk boundary.
+    Requiring the trace to repeat exactly gives two linear equations in the two
+    phase-start levels; `duty` splits the period, the waveform charges toward
+    +amplitude and discharges toward -amplitude with time constant `tau`.
+
+    Both branch boundaries evaluate to the same level (the high branch at t_high
+    equals low_start; the low branch at t_low equals high_start), so the result
+    is continuous everywhere -- ringing is a genuine no-op on this kind.
+    """
+    period = 1.0 / spec.frequency
+    t_high = spec.duty * period
+    t_low = period - t_high
+    a = np.exp(-t_high / spec.tau)
+    b = np.exp(-t_low / spec.tau)
+    # expm1 form throughout: the algebraic result is (2b - 1 - ab)/(1 - ab), but
+    # as tau grows both numerator and denominator become differences of
+    # near-equal numbers and lose every significant digit -- at tau=1e12 the
+    # naive form divides by zero. -expm1(-period/tau) IS 1 - a*b, computed
+    # accurately.
+    denom = -np.expm1(-period / spec.tau)
+    high_start = spec.amplitude * (np.expm1(-t_low / spec.tau) - b * np.expm1(-t_high / spec.tau)) / denom
+    low_start = spec.amplitude * (a * np.expm1(-t_low / spec.tau) - np.expm1(-t_high / spec.tau)) / denom
+    within = _cycle_fraction(spec, t) * period
+    rising = within < t_high
+    decay = np.exp(-np.where(rising, within, within - t_high) / spec.tau)
+    return np.where(rising, spec.amplitude + (high_start - spec.amplitude) * decay, -spec.amplitude + (low_start + spec.amplitude) * decay)
+
+
 _GENERATORS: Dict[str, Callable[[SignalSpec, np.ndarray, np.random.Generator], np.ndarray]] = {
     "sine": _sine,
     "square": _square,
@@ -148,9 +181,10 @@ _GENERATORS: Dict[str, Callable[[SignalSpec, np.ndarray, np.random.Generator], n
     "dc": _dc,
     "noise": _noise,
     "multitone": _multitone,
+    "exponential": _exponential,
 }
 
-PERIODIC_KINDS = ("sine", "square", "triangle", "ramp", "multitone")
+PERIODIC_KINDS = ("sine", "square", "triangle", "ramp", "multitone", "exponential")
 
 # Hard cap on the ringing decay kernel's length in samples, independent of
 # n_points (I3) or sample_rate. This is a backstop against a user-supplied
@@ -169,8 +203,10 @@ def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
         raise exceptions.InvalidParameterError(f"n_points must be at least 1: {n_points}")
     if spec.kind in PERIODIC_KINDS and spec.frequency <= 0:
         raise exceptions.InvalidParameterError(f"frequency must be positive for {spec.kind!r}: {spec.frequency}")
-    if spec.kind == "square" and not 0.0 < spec.duty < 1.0:
+    if spec.kind in ("square", "exponential") and not 0.0 < spec.duty < 1.0:
         raise exceptions.InvalidParameterError(f"duty must be strictly between 0 and 1: {spec.duty}")
+    if spec.kind == "exponential" and spec.tau <= 0:
+        raise exceptions.InvalidParameterError(f"tau must be positive for 'exponential': {spec.tau}")
     if spec.kind == "multitone":
         try:
             relatives = list(spec.harmonics)

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -20,7 +20,8 @@ class SignalSpec:
     """Parameters of one synthetic signal.
 
     Attributes:
-        kind: One of "sine", "square", "triangle", "ramp", "dc", "noise".
+        kind: One of "sine", "square", "triangle", "ramp", "dc", "noise",
+            "chirp", "exponential", "pulse", "multitone".
         frequency: Repetition rate in Hz (periodic kinds only).
         amplitude: Peak amplitude in volts (Vpp = 2*amplitude); for "noise",
             the standard deviation. Ignored for "dc".

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -8,7 +8,7 @@ docs and tests; the mock coupling and code-conversion layers are kind-agnostic.
 
 import time
 from dataclasses import dataclass, replace
-from typing import Callable, Dict, Iterator, Optional
+from typing import Callable, Dict, Iterator, Optional, Tuple, Union
 
 import numpy as np
 
@@ -46,6 +46,20 @@ class SignalSpec:
             buffer on every edge -- quadratic in the number of edges once
             ringing_frequency is switched on the most natural way, by setting
             only that field.
+        end_frequency: "chirp" sweep stop frequency in Hz.
+        sweep_time: "chirp" seconds per sweep, after which it retraces.
+        sweep_log: "chirp" sweeps logarithmically rather than linearly.
+        tau: "exponential" RC time constant in seconds.
+        pulse_width: "pulse" 50%-to-50% width in seconds (FWHM), matching the
+            instrument convention and the threshold the repo's timing analyzer
+            measures at. The flat top therefore runs for pulse_width -
+            edge_time. "pulse" ignores `duty`.
+        edge_time: "pulse" 0-to-100% transition time in seconds; 0 gives an
+            ideal instantaneous edge.
+        harmonics: "multitone" relative amplitudes of the 2nd, 3rd, ...
+            harmonic. `amplitude` is the FUNDAMENTAL's amplitude, so the peak
+            of the sum is higher; that is deliberate, since normalizing would
+            make the THD of a multitone depend on its harmonic set.
     """
 
     kind: str = "sine"
@@ -65,6 +79,21 @@ class SignalSpec:
     glitch_amplitude: float = 0.0  # volts, peak height of a glitch
     ringing_frequency: float = 0.0  # Hz of post-edge oscillation (0 = off); an edge impairment, meaningful only on "square"/pulse-like "ramp"
     ringing_damping: float = 5_000.0  # decay rate per second (M8: nonzero default, same reason as drift_frequency -- damping=0 never decays, making the kernel run the whole buffer on every edge)
+    # Kind-specific parameters, appended at the END for the same reason the
+    # impairments above were: inserting them beside the fields they read best
+    # next to would reorder positional construction and break callers. Every
+    # default is chosen so SignalSpec(kind=X) alone yields a sensible signal at
+    # the default 1 kHz frequency, the property the original six kinds have.
+    end_frequency: float = 10_000.0  # "chirp": sweep stop frequency, Hz
+    sweep_time: float = 0.01  # "chirp": seconds per sweep, then it retraces
+    sweep_log: bool = False  # "chirp": log rather than linear sweep
+    tau: float = 1e-4  # "exponential": RC time constant, s (5 tau per half period at 1 kHz)
+    pulse_width: float = 2e-4  # "pulse": 50%-to-50% width, s (20% duty at 1 kHz)
+    edge_time: float = 1e-5  # "pulse": 0->100% transition time, s
+    harmonics: Tuple[float, ...] = (
+        0.1,
+        0.05,
+    )  # "multitone": relative amplitudes of the 2nd, 3rd, ... harmonic; non-empty by default so SignalSpec(kind="multitone") is not a bit-identical duplicate of "sine"
 
 
 def _cycle_fraction(spec: SignalSpec, t: np.ndarray) -> np.ndarray:

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -173,6 +173,26 @@ def _exponential(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> n
     return np.where(rising, spec.amplitude + (high_start - spec.amplitude) * decay, -spec.amplitude + (low_start + spec.amplitude) * decay)
 
 
+def _pulse(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    """A trapezoid whose width and edge rate are independent of the period.
+
+    That independence is the whole reason this kind exists alongside "square",
+    whose only shape control is `duty` -- which this kind therefore ignores.
+    `pulse_width` is the 50%-to-50% width: the 50% level sits at the midpoint of
+    each linear ramp, so the crossings land at edge_time/2 and
+    pulse_width + edge_time/2, exactly pulse_width apart.
+    """
+    within = _cycle_fraction(spec, t) / spec.frequency
+    high = spec.amplitude
+    low = -spec.amplitude
+    if spec.edge_time <= 0:
+        return np.where(within < spec.pulse_width, high, low)
+    span = high - low
+    rise = low + span * (within / spec.edge_time)
+    fall = high - span * ((within - spec.pulse_width) / spec.edge_time)
+    return np.where(within < spec.edge_time, rise, np.where(within < spec.pulse_width, high, np.where(within < spec.pulse_width + spec.edge_time, fall, low)))
+
+
 _GENERATORS: Dict[str, Callable[[SignalSpec, np.ndarray, np.random.Generator], np.ndarray]] = {
     "sine": _sine,
     "square": _square,
@@ -182,9 +202,10 @@ _GENERATORS: Dict[str, Callable[[SignalSpec, np.ndarray, np.random.Generator], n
     "noise": _noise,
     "multitone": _multitone,
     "exponential": _exponential,
+    "pulse": _pulse,
 }
 
-PERIODIC_KINDS = ("sine", "square", "triangle", "ramp", "multitone", "exponential")
+PERIODIC_KINDS = ("sine", "square", "triangle", "ramp", "multitone", "exponential", "pulse")
 
 # Hard cap on the ringing decay kernel's length in samples, independent of
 # n_points (I3) or sample_rate. This is a backstop against a user-supplied
@@ -215,6 +236,13 @@ def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
         for order, relative in enumerate(relatives, start=2):
             if not np.isfinite(relative) or relative < 0:
                 raise exceptions.InvalidParameterError(f"harmonics[{order - 2}] (harmonic order {order}) must be a non-negative finite number: {relative}")
+    if spec.kind == "pulse":
+        if spec.edge_time < 0:
+            raise exceptions.InvalidParameterError(f"edge_time must be non-negative: {spec.edge_time}")
+        if spec.pulse_width <= spec.edge_time:
+            raise exceptions.InvalidParameterError(f"pulse_width (50%-to-50%) must exceed edge_time, or the pulse never reaches its top: {spec.pulse_width} <= {spec.edge_time}")
+        if spec.pulse_width + spec.edge_time > 1.0 / spec.frequency:
+            raise exceptions.InvalidParameterError(f"the trapezoid must fit in one period: pulse_width + edge_time = {spec.pulse_width + spec.edge_time} > {1.0 / spec.frequency}")
     if spec.noise_rms < 0:
         raise exceptions.InvalidParameterError(f"noise_rms must be non-negative: {spec.noise_rms}")
     if spec.drift_amplitude < 0:

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -124,6 +124,22 @@ def _noise(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndar
     return rng.normal(0.0, spec.amplitude, t.shape)
 
 
+def _multitone(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    """A fundamental plus a coherent harmonic series -- a distorted sine.
+
+    Harmonic k rides at k*theta, so its phase advances with the fundamental's
+    rather than drifting against it. That makes THD exactly sqrt(sum(h**2)),
+    independent of amplitude, frequency and phase, which is the whole point:
+    it gives the repo's THD code a signal with a known correct answer.
+    """
+    theta = 2.0 * np.pi * spec.frequency * t + spec.phase
+    samples = np.sin(theta)
+    for order, relative in enumerate(spec.harmonics, start=2):
+        if relative:
+            samples = samples + relative * np.sin(order * theta)
+    return spec.amplitude * samples
+
+
 _GENERATORS: Dict[str, Callable[[SignalSpec, np.ndarray, np.random.Generator], np.ndarray]] = {
     "sine": _sine,
     "square": _square,
@@ -131,9 +147,10 @@ _GENERATORS: Dict[str, Callable[[SignalSpec, np.ndarray, np.random.Generator], n
     "ramp": _ramp,
     "dc": _dc,
     "noise": _noise,
+    "multitone": _multitone,
 }
 
-PERIODIC_KINDS = ("sine", "square", "triangle", "ramp")
+PERIODIC_KINDS = ("sine", "square", "triangle", "ramp", "multitone")
 
 # Hard cap on the ringing decay kernel's length in samples, independent of
 # n_points (I3) or sample_rate. This is a backstop against a user-supplied
@@ -154,6 +171,14 @@ def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
         raise exceptions.InvalidParameterError(f"frequency must be positive for {spec.kind!r}: {spec.frequency}")
     if spec.kind == "square" and not 0.0 < spec.duty < 1.0:
         raise exceptions.InvalidParameterError(f"duty must be strictly between 0 and 1: {spec.duty}")
+    if spec.kind == "multitone":
+        try:
+            relatives = list(spec.harmonics)
+        except TypeError:
+            raise exceptions.InvalidParameterError(f"harmonics must be a sequence of relative amplitudes: {spec.harmonics!r}") from None
+        for order, relative in enumerate(relatives, start=2):
+            if not np.isfinite(relative) or relative < 0:
+                raise exceptions.InvalidParameterError(f"harmonics[{order - 2}] (harmonic order {order}) must be a non-negative finite number: {relative}")
     if spec.noise_rms < 0:
         raise exceptions.InvalidParameterError(f"noise_rms must be non-negative: {spec.noise_rms}")
     if spec.drift_amplitude < 0:

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -267,8 +267,15 @@ def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
         raise exceptions.InvalidParameterError(f"frequency must be positive for {spec.kind!r}: {spec.frequency}")
     if spec.kind in ("square", "exponential") and not 0.0 < spec.duty < 1.0:
         raise exceptions.InvalidParameterError(f"duty must be strictly between 0 and 1: {spec.duty}")
-    if spec.kind == "exponential" and spec.tau <= 0:
-        raise exceptions.InvalidParameterError(f"tau must be positive for 'exponential': {spec.tau}")
+    # np.isfinite on every kind-specific scalar below, not just a sign check: nan
+    # passes BOTH sides of an ordering comparison, so `tau <= 0` and
+    # `pulse_width <= edge_time` silently let it through -- and a nan pulse_width
+    # is the worst of them, since it yields a finite but wrong waveform with no
+    # tell-tale in the output. tau=inf passes `tau <= 0` too, and produces an
+    # all-nan trace plus a RuntimeWarning, though the documented tau -> inf limit
+    # is the DC average amplitude*(2*duty - 1).
+    if spec.kind == "exponential" and not (np.isfinite(spec.tau) and spec.tau > 0):
+        raise exceptions.InvalidParameterError(f"tau must be a positive, finite number for 'exponential': {spec.tau}")
     if spec.kind == "multitone":
         try:
             relatives = list(spec.harmonics)
@@ -278,8 +285,10 @@ def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
             if not np.isfinite(relative) or relative < 0:
                 raise exceptions.InvalidParameterError(f"harmonics[{order - 2}] (harmonic order {order}) must be a non-negative finite number: {relative}")
     if spec.kind == "pulse":
-        if spec.edge_time < 0:
-            raise exceptions.InvalidParameterError(f"edge_time must be non-negative: {spec.edge_time}")
+        if not np.isfinite(spec.edge_time) or spec.edge_time < 0:
+            raise exceptions.InvalidParameterError(f"edge_time must be a non-negative, finite number: {spec.edge_time}")
+        if not np.isfinite(spec.pulse_width):
+            raise exceptions.InvalidParameterError(f"pulse_width must be a finite number: {spec.pulse_width}")
         if spec.pulse_width <= spec.edge_time:
             raise exceptions.InvalidParameterError(f"pulse_width (50%-to-50%) must exceed edge_time, or the pulse never reaches its top: {spec.pulse_width} <= {spec.edge_time}")
         if spec.pulse_width + spec.edge_time > 1.0 / spec.frequency:
@@ -290,10 +299,10 @@ def _validate(spec: SignalSpec, sample_rate: float, n_points: int) -> None:
         # the shared positive-frequency check above does not cover it.
         if spec.frequency <= 0:
             raise exceptions.InvalidParameterError(f"frequency must be positive for 'chirp': {spec.frequency}")
-        if spec.end_frequency <= 0:
-            raise exceptions.InvalidParameterError(f"end_frequency must be positive for 'chirp': {spec.end_frequency}")
-        if spec.sweep_time <= 0:
-            raise exceptions.InvalidParameterError(f"sweep_time must be positive for 'chirp': {spec.sweep_time}")
+        if not (np.isfinite(spec.end_frequency) and spec.end_frequency > 0):
+            raise exceptions.InvalidParameterError(f"end_frequency must be a positive, finite number for 'chirp': {spec.end_frequency}")
+        if not (np.isfinite(spec.sweep_time) and spec.sweep_time > 0):
+            raise exceptions.InvalidParameterError(f"sweep_time must be a positive, finite number for 'chirp': {spec.sweep_time}")
     if spec.noise_rms < 0:
         raise exceptions.InvalidParameterError(f"noise_rms must be non-negative: {spec.noise_rms}")
     if spec.drift_amplitude < 0:

--- a/tests/test_known_answer_analysis.py
+++ b/tests/test_known_answer_analysis.py
@@ -26,31 +26,37 @@ def test_rc_step_rise_time_is_tau_times_ln_nine():
 
     tau is 1/50th of the high phase here, so the plateau reaches amplitude to
     within e**-50 and the only error left is the sampling grid: the analyzer
-    walks outward in whole samples, so it can be off by one at each end."""
+    walks outward in whole samples, so it can be off by one at each end -- which
+    bounds the error at [0, 2*DT), and it measures 1.28*DT here."""
     tau = 1e-5
     waveform = make_waveform(SignalSpec(kind="exponential", frequency=1_000.0, tau=tau), RATE, 20_000)
     stats = WaveformAnalyzer.calculate_timing_stats(waveform)
-    assert stats["rise_time"] == pytest.approx(tau * np.log(9.0), abs=3 * DT)
+    assert stats["rise_time"] == pytest.approx(tau * np.log(9.0), abs=2 * DT)
 
 
 def test_a_barely_settled_rc_reads_low_by_its_plateau_deficit():
     """The same measurement on a signal that does NOT fully settle, pinned to
     the deviation that causes rather than hidden behind a loose tolerance.
 
-    At the default tau (Th/tau = 5) the plateau only reaches 0.98661 of
-    amplitude. The analyzer's 10%/90% thresholds are relative to the MEASURED
-    range, so they sit at +/-0.78929 instead of +/-0.8, and the measured rise
-    time works out to 2.1392*tau -- 2.64% below the ideal ln(9). Deriving it
-    exactly is what makes this a known-answer test rather than a fudge factor:
+    At the default tau (Th/tau = 5) the plateau only reaches 0.9866142981514304
+    of amplitude. The analyzer's 10%/90% thresholds are relative to the MEASURED
+    range, so they sit at +/-0.7892914385211444 instead of +/-0.8, and the
+    measured rise time works out to 2.13909902*tau -- 2.65% below the ideal
+    ln(9). Deriving it exactly is what makes this a known-answer test rather
+    than a fudge factor:
 
-        v(t) = 1 - 1.98661 * exp(-t/tau)
-        v = -0.78929 at t = 0.10461 * tau
-        v = +0.78929 at t = 2.24377 * tau
+        v(t) = 1 - 1.9866142981514304 * exp(-t/tau)
+        v = -0.7892914385211444 at t = 0.10461213 * tau
+        v = +0.7892914385211444 at t = 2.24371116 * tau
+
+    Tolerance is the sampling grid, not slack: DT is tau/1000 here, and the
+    analyzer's outward whole-sample walk lands on 2.14*tau, 4.2e-4 relative
+    away from the derivation.
     """
     tau = 1e-4
     waveform = make_waveform(SignalSpec(kind="exponential", frequency=1_000.0, tau=tau), RATE, 20_000)
     stats = WaveformAnalyzer.calculate_timing_stats(waveform)
-    assert stats["rise_time"] == pytest.approx(2.1392 * tau, rel=0.01)
+    assert stats["rise_time"] == pytest.approx(2.13910 * tau, rel=1e-3)
 
 
 def test_pulse_timing_stats_match_the_spec_exactly():
@@ -93,5 +99,14 @@ def test_chirp_energy_stays_inside_its_swept_band():
     waveform = make_waveform(spec, 200_000.0, 200_000)  # 1 s = 100 whole sweeps
     peaks = WaveformAnalyzer.calculate_spectrum(waveform)["dominant_peaks"]
     assert peaks
+    # The band is the exact sweep, plus one FFT bin. A linear chirp's spectrum
+    # is near-rectangular over [frequency, end_frequency] with Fresnel ripple
+    # on a scale of sqrt(sweep rate) = sqrt(6 kHz / 10 ms) = 775 Hz. That ripple
+    # does spill past each endpoint, but attenuated; its LARGEST maxima -- the
+    # Fresnel overshoot -- sit ~0.7*sqrt(rate) INSIDE the band, which is exactly
+    # where the top-5 peaks land (2600 Hz and 7400 Hz, 600 Hz inside each end).
+    # So nothing wider than the 1 Hz bin (1 s of samples) is derivable, and the
+    # +/-10% this test used to allow was undeclared slack.
+    bin_hz = waveform.sample_rate / len(waveform.voltage)
     for frequency_hz, _relative in peaks:
-        assert spec.frequency * 0.9 <= frequency_hz <= spec.end_frequency * 1.1
+        assert spec.frequency - bin_hz <= frequency_hz <= spec.end_frequency + bin_hz

--- a/tests/test_known_answer_analysis.py
+++ b/tests/test_known_answer_analysis.py
@@ -1,0 +1,97 @@
+"""Analysis code checked against signals whose correct answer is known on paper.
+
+Before the chirp/exponential/pulse/multitone kinds existed, these analyzers could
+only be pointed at a pure sine, a square, or noise -- none of which has an
+interesting closed-form rise time, pulse width, or THD. Every expected value
+below is derived analytically and every tolerance is justified by sampling
+resolution or a stated systematic effect.
+
+If one of these fails, an analyzer is wrong. Widening a tolerance to make it pass
+defeats the entire purpose of the file.
+"""
+
+import numpy as np
+import pytest
+
+from scpi_control.analysis import FFTAnalyzer
+from scpi_control.report_generator.utils.waveform_analyzer import WaveformAnalyzer
+from scpi_control.signal_synth import SignalSpec, make_waveform
+
+RATE = 10_000_000.0  # 0.1 us per sample: fine enough that sampling error is not the dominant term
+DT = 1.0 / RATE
+
+
+def test_rc_step_rise_time_is_tau_times_ln_nine():
+    """10%-to-90% of an exponential settles in tau*ln(9) = 2.1972*tau.
+
+    tau is 1/50th of the high phase here, so the plateau reaches amplitude to
+    within e**-50 and the only error left is the sampling grid: the analyzer
+    walks outward in whole samples, so it can be off by one at each end."""
+    tau = 1e-5
+    waveform = make_waveform(SignalSpec(kind="exponential", frequency=1_000.0, tau=tau), RATE, 20_000)
+    stats = WaveformAnalyzer.calculate_timing_stats(waveform)
+    assert stats["rise_time"] == pytest.approx(tau * np.log(9.0), abs=3 * DT)
+
+
+def test_a_barely_settled_rc_reads_low_by_its_plateau_deficit():
+    """The same measurement on a signal that does NOT fully settle, pinned to
+    the deviation that causes rather than hidden behind a loose tolerance.
+
+    At the default tau (Th/tau = 5) the plateau only reaches 0.98661 of
+    amplitude. The analyzer's 10%/90% thresholds are relative to the MEASURED
+    range, so they sit at +/-0.78929 instead of +/-0.8, and the measured rise
+    time works out to 2.1392*tau -- 2.64% below the ideal ln(9). Deriving it
+    exactly is what makes this a known-answer test rather than a fudge factor:
+
+        v(t) = 1 - 1.98661 * exp(-t/tau)
+        v = -0.78929 at t = 0.10461 * tau
+        v = +0.78929 at t = 2.24377 * tau
+    """
+    tau = 1e-4
+    waveform = make_waveform(SignalSpec(kind="exponential", frequency=1_000.0, tau=tau), RATE, 20_000)
+    stats = WaveformAnalyzer.calculate_timing_stats(waveform)
+    assert stats["rise_time"] == pytest.approx(2.1392 * tau, rel=0.01)
+
+
+def test_pulse_timing_stats_match_the_spec_exactly():
+    """A trapezoid's measured values follow from its geometry with no systematic
+    error at all: the 50% crossings sit at the ramp midpoints (so the measured
+    width IS pulse_width), and 10%-to-90% of a linear ramp is 0.8*edge_time.
+    Tolerance is two sample periods of grid error."""
+    spec = SignalSpec(kind="pulse", frequency=1_000.0, pulse_width=2e-4, edge_time=1e-5)
+    stats = WaveformAnalyzer.calculate_timing_stats(make_waveform(spec, RATE, 20_000))
+    assert stats["pulse_width"] == pytest.approx(spec.pulse_width, abs=2 * DT)
+    assert stats["rise_time"] == pytest.approx(0.8 * spec.edge_time, abs=2 * DT)
+    assert stats["fall_time"] == pytest.approx(0.8 * spec.edge_time, abs=2 * DT)
+    assert stats["duty_cycle"] == pytest.approx(spec.pulse_width * spec.frequency * 100.0, abs=0.5)
+
+
+@pytest.mark.parametrize("harmonics", [(0.1, 0.05), (0.2,), (0.05, 0.05, 0.05)])
+def test_multitone_thd_matches_the_harmonic_rss(harmonics):
+    """THD is 100*sqrt(sum(h**2)) by construction -- independent of amplitude,
+    frequency and phase, because harmonic k rides at k*theta.
+
+    Sampled over a whole number of cycles so the hanning window's leakage stays
+    inside the +/-2-bin RSS the analyzer sums over; 2% covers what leaks past it."""
+    rate, n, freq = 100_000.0, 100_000, 1_000.0  # 1 s, 1000 whole cycles, 1 Hz bins
+    spec = SignalSpec(kind="multitone", frequency=freq, amplitude=2.0, harmonics=harmonics)
+    waveform = make_waveform(spec, rate, n)
+    expected = 100.0 * np.sqrt(sum(h * h for h in harmonics))
+    assert WaveformAnalyzer.calculate_thd(waveform) == pytest.approx(expected, rel=0.02)
+    assert FFTAnalyzer.thd_of_waveform(waveform) == pytest.approx(expected, rel=0.02)
+
+
+def test_a_pure_sine_has_almost_no_thd():
+    """The control for the test above: the same code path on a signal whose
+    known answer is zero."""
+    waveform = make_waveform(SignalSpec(kind="sine", frequency=1_000.0, amplitude=2.0), 100_000.0, 100_000)
+    assert WaveformAnalyzer.calculate_thd(waveform) < 0.5
+
+
+def test_chirp_energy_stays_inside_its_swept_band():
+    spec = SignalSpec(kind="chirp", frequency=2_000.0, end_frequency=8_000.0, sweep_time=0.01)
+    waveform = make_waveform(spec, 200_000.0, 200_000)  # 1 s = 100 whole sweeps
+    peaks = WaveformAnalyzer.calculate_spectrum(waveform)["dominant_peaks"]
+    assert peaks
+    for frequency_hz, _relative in peaks:
+        assert spec.frequency * 0.9 <= frequency_hz <= spec.end_frequency * 1.1

--- a/tests/test_mock_synthesis.py
+++ b/tests/test_mock_synthesis.py
@@ -1,5 +1,7 @@
 """State-coupled mock waveform synthesis: all vendor personalities, trigger alignment, and server mock sessions."""
 
+from dataclasses import replace
+
 import numpy as np
 import pytest
 
@@ -271,3 +273,38 @@ def test_new_kinds_still_couple_to_volts_per_division():
     # Wider V/div, same signal: still ~1 V peak in volts, but the mock had to
     # encode it at half the code density -- so the trace is coarser, not smaller.
     assert np.max(coarse.voltage) == pytest.approx(1.0, abs=0.15)
+
+
+@pytest.mark.parametrize(
+    "impairment",
+    [
+        {"ringing_frequency": 50_000.0},
+        {"drift_amplitude": 0.5, "drift_frequency": 200.0},
+        {"glitch_rate": 50_000.0, "glitch_amplitude": 2.0, "seed": 3},
+    ],
+    ids=["ringing", "drift", "glitch"],
+)
+def test_trigger_search_ignores_the_impairments(impairment):
+    """The search is for the IDEAL crossing, so every impairment is stripped from
+    it -- an impairment that moved the crossing would move t0 with it, and the
+    alignment would track the impairment settings rather than the signal's own
+    edge. Discriminating: with the impairments left in (noise and seed alone
+    stripped, as before), this exponential's ideal 68.85 us crossing moves to
+    66.41 us with ringing, 64.70 us with drift and 10.25 us with glitches."""
+    from scpi_control.connection.mock.synth import _trigger_crossing
+
+    clean = SignalSpec(kind="exponential", frequency=1_000.0, amplitude=1.0, tau=1e-4, noise_rms=0.0)
+    impaired = replace(clean, **impairment)
+    assert _trigger_crossing(impaired, 0.0, True) == _trigger_crossing(clean, 0.0, True)
+
+
+def test_a_ringing_trigger_aligned_kind_still_displays_stably():
+    """The behavioural half: a trigger-aligned kind with ringing switched on
+    still lands on the same t0 every acquisition, so the trace does not walk."""
+    spec = SignalSpec(kind="exponential", frequency=1_000.0, amplitude=1.0, tau=1e-4, noise_rms=0.0, ringing_frequency=50_000.0)
+    scope, _ = _scope(signals={1: spec})
+    scope.write("C1:TRLV 0.0")
+    first = scope.get_waveform(1, provenance=False)
+    second = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    np.testing.assert_array_equal(first.voltage, second.voltage)

--- a/tests/test_mock_synthesis.py
+++ b/tests/test_mock_synthesis.py
@@ -222,3 +222,52 @@ def test_server_mock_connection_synthesizes():
     scope.disconnect()
     assert len(data.voltage) >= 1_000  # real trace, not the old 256-byte ramp
     assert np.ptp(data.voltage) > 1.0  # default CH1 square, ~2 Vpp
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        SignalSpec(kind="pulse", frequency=1_000.0, amplitude=1.0, pulse_width=2e-4, edge_time=1e-5),
+        SignalSpec(kind="exponential", frequency=1_000.0, amplitude=1.0, tau=1e-4),
+        SignalSpec(kind="multitone", frequency=1_000.0, amplitude=1.0),
+        SignalSpec(kind="chirp", frequency=1_000.0, end_frequency=5_000.0, sweep_time=1e-3),
+    ],
+    ids=["pulse", "exponential", "multitone", "chirp"],
+)
+def test_new_kinds_capture_through_a_mock_scope(spec):
+    scope, _ = _scope(signals={1: spec})
+    data = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    assert len(data.voltage) == 14_000
+    # int8 codes at 25 per division against the mock's 1 V/div default: a 1 V
+    # amplitude signal survives the volts -> codes -> volts round trip.
+    assert np.max(data.voltage) == pytest.approx(1.0, abs=0.1)
+    assert np.min(data.voltage) == pytest.approx(-1.0, abs=0.1)
+
+
+def test_periodic_kinds_are_trigger_aligned_and_chirp_free_runs():
+    """The one behavioural consequence of the PERIODIC_KINDS classification:
+    a kind with a stable period gets the same trigger-aligned t0 on every
+    acquisition, so two captures of a noiseless signal are identical, while
+    chirp free-runs and drifts between acquisitions."""
+    scope, _ = _scope(signals={1: SignalSpec(kind="pulse", frequency=1_000.0, pulse_width=2e-4, edge_time=1e-5)})
+    first = scope.get_waveform(1, provenance=False)
+    second = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    np.testing.assert_array_equal(first.voltage, second.voltage)
+
+    scope, _ = _scope(signals={1: SignalSpec(kind="chirp", frequency=1_000.0, end_frequency=5_000.0, sweep_time=1e-3)})
+    first = scope.get_waveform(1, provenance=False)
+    second = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    assert not np.array_equal(first.voltage, second.voltage)
+
+
+def test_new_kinds_still_couple_to_volts_per_division():
+    scope, _ = _scope(signals={1: SignalSpec(kind="multitone", frequency=1_000.0, amplitude=1.0)})
+    scope.write("C1:VDIV 2.0")
+    coarse = scope.get_waveform(1, provenance=False)
+    scope.disconnect()
+    # Wider V/div, same signal: still ~1 V peak in volts, but the mock had to
+    # encode it at half the code density -- so the trace is coarser, not smaller.
+    assert np.max(coarse.voltage) == pytest.approx(1.0, abs=0.15)

--- a/tests/test_signal_kinds.py
+++ b/tests/test_signal_kinds.py
@@ -62,3 +62,57 @@ def test_the_new_fields_are_appended_and_do_not_move_the_existing_ones():
         "ringing_damping",
     ]
     assert names[14:] == ["end_frequency", "sweep_time", "sweep_log", "tau", "pulse_width", "edge_time", "harmonics"]
+
+
+def _bin_amplitudes(samples, rate):
+    """Single-sided amplitude per FFT bin. Only valid for an integer number of
+    cycles in the buffer, which every caller below arranges -- otherwise leakage
+    spreads a tone across neighbouring bins and the ratios stop being exact."""
+    return np.abs(np.fft.rfft(samples)) * 2.0 / len(samples)
+
+
+def test_multitone_bin_amplitudes_match_the_harmonics_tuple():
+    rate, n, freq = 100_000.0, 100_000, 1_000.0  # 1 s of a 1 kHz tone -> 1 Hz bins, 1000 whole cycles
+    harmonics = (0.25, 0.125, 0.0625)
+    spec = SignalSpec(kind="multitone", frequency=freq, amplitude=2.0, harmonics=harmonics)
+    mag = _bin_amplitudes(synthesize(spec, rate, n), rate)
+    bin_hz = rate / n
+    assert mag[int(freq / bin_hz)] == pytest.approx(2.0, rel=1e-6)
+    for order, relative in enumerate(harmonics, start=2):
+        assert mag[int(order * freq / bin_hz)] == pytest.approx(2.0 * relative, rel=1e-6)
+
+
+def test_multitone_amplitude_is_the_fundamentals_not_the_peaks():
+    """Documented, and load-bearing for THD: normalizing the sum to `amplitude`
+    would make a multitone's THD depend on its harmonic set."""
+    spec = SignalSpec(kind="multitone", frequency=1_000.0, amplitude=1.0, harmonics=(0.5,))
+    samples = synthesize(spec, RATE, 2_000)
+    assert np.max(samples) > 1.0
+
+
+def test_multitone_with_no_harmonics_is_a_sine():
+    plain = synthesize(SignalSpec(kind="sine", frequency=1_000.0), RATE, 2_000)
+    empty = synthesize(SignalSpec(kind="multitone", frequency=1_000.0, harmonics=()), RATE, 2_000)
+    np.testing.assert_allclose(empty, plain, atol=1e-15)
+
+
+def test_multitone_is_periodic_and_triggerable_in_the_mock():
+    assert "multitone" in PERIODIC_KINDS
+
+
+@pytest.mark.parametrize(
+    "harmonics",
+    [
+        (-0.1,),  # negative relative amplitude
+        (0.1, float("nan")),  # non-finite
+        (0.1, float("inf")),
+    ],
+)
+def test_multitone_rejects_bad_harmonics(harmonics):
+    with pytest.raises(exceptions.InvalidParameterError):
+        synthesize(SignalSpec(kind="multitone", frequency=1_000.0, harmonics=harmonics), RATE, 100)
+
+
+def test_multitone_rejects_a_non_sequence_harmonics():
+    with pytest.raises(exceptions.InvalidParameterError):
+        synthesize(SignalSpec(kind="multitone", frequency=1_000.0, harmonics=0.1), RATE, 100)

--- a/tests/test_signal_kinds.py
+++ b/tests/test_signal_kinds.py
@@ -175,3 +175,69 @@ def test_exponential_is_periodic_and_triggerable_in_the_mock():
 def test_exponential_rejects_bad_parameters(kwargs):
     with pytest.raises(exceptions.InvalidParameterError):
         synthesize(SignalSpec(kind="exponential", frequency=1_000.0, **kwargs), RATE, 100)
+
+
+def _fwhm_seconds(samples, rate):
+    """50%-to-50% width of the first pulse, the same threshold the repo's timing
+    analyzer uses."""
+    mid = (samples.max() + samples.min()) / 2.0
+    above = samples >= mid
+    rising = np.flatnonzero(~above[:-1] & above[1:])
+    falling = np.flatnonzero(above[:-1] & ~above[1:])
+    falling = falling[falling > rising[0]]
+    return (falling[0] - rising[0]) / rate
+
+
+def test_pulse_width_is_the_50_percent_width():
+    """pulse_width is FWHM, not top duration: it matches SOUR{ch}:FUNC:PULS:WIDT
+    and the threshold calculate_timing_stats() measures at, so the flat top runs
+    for pulse_width - edge_time."""
+    spec = SignalSpec(kind="pulse", frequency=1_000.0, pulse_width=2e-4, edge_time=1e-5)
+    samples = synthesize(spec, RATE, 2_000)
+    assert _fwhm_seconds(samples, RATE) == pytest.approx(2e-4, abs=2.0 / RATE)
+
+
+def test_pulse_plateaus_sit_at_plus_and_minus_amplitude():
+    spec = SignalSpec(kind="pulse", frequency=1_000.0, amplitude=3.0, pulse_width=2e-4, edge_time=1e-5)
+    samples = synthesize(spec, RATE, 2_000)
+    assert samples.max() == pytest.approx(3.0)
+    assert samples.min() == pytest.approx(-3.0)
+
+
+def test_pulse_edge_time_sets_the_transition_rate():
+    slow = synthesize(SignalSpec(kind="pulse", frequency=1_000.0, pulse_width=2e-4, edge_time=5e-5), RATE, 2_000)
+    fast = synthesize(SignalSpec(kind="pulse", frequency=1_000.0, pulse_width=2e-4, edge_time=1e-6), RATE, 2_000)
+    assert np.max(np.abs(np.diff(slow))) < np.max(np.abs(np.diff(fast)))
+
+
+def test_pulse_accepts_a_zero_edge_time():
+    """An ideal instantaneous edge is legal, and must not divide by zero."""
+    spec = SignalSpec(kind="pulse", frequency=1_000.0, pulse_width=2e-4, edge_time=0.0)
+    samples = synthesize(spec, RATE, 2_000)
+    assert np.all(np.isfinite(samples))
+    assert set(np.unique(np.round(samples, 9))) == {-1.0, 1.0}
+    assert _fwhm_seconds(samples, RATE) == pytest.approx(2e-4, abs=2.0 / RATE)
+
+
+def test_pulse_ignores_duty():
+    wide = synthesize(SignalSpec(kind="pulse", frequency=1_000.0, duty=0.9), RATE, 2_000)
+    narrow = synthesize(SignalSpec(kind="pulse", frequency=1_000.0, duty=0.1), RATE, 2_000)
+    np.testing.assert_array_equal(wide, narrow)
+
+
+def test_pulse_is_periodic_and_triggerable_in_the_mock():
+    assert "pulse" in PERIODIC_KINDS
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"edge_time": -1e-6},  # negative edge
+        {"pulse_width": 1e-6, "edge_time": 1e-5},  # width below the edge time
+        {"pulse_width": 0.0, "edge_time": 0.0},  # zero width
+        {"pulse_width": 9e-4, "edge_time": 2e-4},  # trapezoid longer than the 1 ms period
+    ],
+)
+def test_pulse_rejects_a_trapezoid_that_cannot_exist(kwargs):
+    with pytest.raises(exceptions.InvalidParameterError):
+        synthesize(SignalSpec(kind="pulse", frequency=1_000.0, **kwargs), RATE, 100)

--- a/tests/test_signal_kinds.py
+++ b/tests/test_signal_kinds.py
@@ -241,3 +241,82 @@ def test_pulse_is_periodic_and_triggerable_in_the_mock():
 def test_pulse_rejects_a_trapezoid_that_cannot_exist(kwargs):
     with pytest.raises(exceptions.InvalidParameterError):
         synthesize(SignalSpec(kind="pulse", frequency=1_000.0, **kwargs), RATE, 100)
+
+
+def _zero_crossings(samples):
+    return np.count_nonzero(np.diff(np.signbit(samples)))
+
+
+def test_chirp_frequency_rises_across_a_sweep():
+    span = 0.01
+    spec = SignalSpec(kind="chirp", frequency=1_000.0, end_frequency=10_000.0, sweep_time=span)
+    samples = synthesize(spec, RATE, int(RATE * span))
+    half = len(samples) // 2
+    # First half averages ~3.25 kHz, second half ~7.75 kHz.
+    assert _zero_crossings(samples[half:]) > 2 * _zero_crossings(samples[:half])
+
+
+def test_chirp_phase_is_continuous_across_a_sweep_retrace():
+    """The reason phase accumulates (n * PHI(sweep_time) + PHI(within)) instead
+    of resetting each sweep. A reset would put a step of order the amplitude at
+    every sweep_time -- and the ringing impairment would then treat it as a real
+    edge."""
+    spec = SignalSpec(kind="chirp", frequency=1_000.0, end_frequency=5_000.0, sweep_time=1e-3)
+    samples = synthesize(spec, RATE, 3_000)  # three full sweeps
+    steepest = 2 * np.pi * 5_000.0 * 1.0 / RATE  # the fastest legitimate slope, per sample
+    assert np.max(np.abs(np.diff(samples))) < 1.5 * steepest
+
+
+def test_a_log_sweep_spends_equal_time_per_octave():
+    span = 0.02
+    spec = SignalSpec(kind="chirp", frequency=1_000.0, end_frequency=4_000.0, sweep_time=span, sweep_log=True)
+    samples = synthesize(spec, RATE, int(RATE * span))
+    half = len(samples) // 2
+    # Two octaves over 20 ms: 1->2 kHz in the first half, 2->4 kHz in the second.
+    # At double the frequency throughout, the second half has twice the crossings.
+    assert _zero_crossings(samples[half:]) == pytest.approx(2 * _zero_crossings(samples[:half]), rel=0.05)
+
+
+def test_a_log_sweep_with_equal_endpoints_degenerates_to_a_sine():
+    """The limit of the log form as end_frequency -> frequency. Taken here rather
+    than raising, because log(1) == 0 would otherwise divide by zero on a spec
+    that is degenerate but perfectly sane."""
+    spec = SignalSpec(kind="chirp", frequency=1_000.0, end_frequency=1_000.0, sweep_time=1e-3, sweep_log=True)
+    chirped = synthesize(spec, RATE, 3_000)
+    plain = synthesize(SignalSpec(kind="sine", frequency=1_000.0), RATE, 3_000)
+    np.testing.assert_allclose(chirped, plain, atol=1e-9)
+
+
+def test_chirp_handles_negative_times():
+    """t is routinely negative: the mock free-runs from a negative t0 and the
+    ringing impairment renders samples before t0. np.floor (not int truncation)
+    is what makes the sweep index correct there."""
+    spec = SignalSpec(kind="chirp", frequency=1_000.0, end_frequency=5_000.0, sweep_time=1e-3)
+    samples = synthesize(spec, RATE, 4_000, t0=-2e-3)
+    assert np.all(np.isfinite(samples))
+    steepest = 2 * np.pi * 5_000.0 * 1.0 / RATE
+    assert np.max(np.abs(np.diff(samples))) < 1.5 * steepest
+
+
+def test_chirp_is_not_treated_as_periodic():
+    """It has no stable period, so the mock must free-run rather than try to
+    align it to a trigger level."""
+    assert "chirp" not in PERIODIC_KINDS
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"frequency": 0.0},
+        {"frequency": -1_000.0},
+        {"end_frequency": 0.0},
+        {"end_frequency": -5_000.0},
+        {"sweep_time": 0.0},
+        {"sweep_time": -1e-3},
+    ],
+)
+def test_chirp_rejects_bad_parameters(kwargs):
+    params = {"kind": "chirp", "frequency": 1_000.0, "end_frequency": 5_000.0, "sweep_time": 1e-3}
+    params.update(kwargs)
+    with pytest.raises(exceptions.InvalidParameterError):
+        synthesize(SignalSpec(**params), RATE, 100)

--- a/tests/test_signal_kinds.py
+++ b/tests/test_signal_kinds.py
@@ -320,3 +320,29 @@ def test_chirp_rejects_bad_parameters(kwargs):
     params.update(kwargs)
     with pytest.raises(exceptions.InvalidParameterError):
         synthesize(SignalSpec(**params), RATE, 100)
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        SignalSpec(kind="chirp", frequency=1_000.0, end_frequency=9_000.0, sweep_time=1e-3),
+        SignalSpec(kind="exponential", frequency=1_000.0, tau=1e-4),
+        SignalSpec(kind="pulse", frequency=1_000.0, pulse_width=2e-4, edge_time=1e-5),
+        SignalSpec(kind="multitone", frequency=1_000.0),
+        # The ringing path renders samples before t0 and dispatches the generator
+        # over an extended window (signal_synth.py:208), a second call site the
+        # plain path never exercises.
+        SignalSpec(kind="pulse", frequency=1_000.0, pulse_width=2e-4, edge_time=1e-5, ringing_frequency=50_000.0),
+    ],
+    ids=["chirp", "exponential", "pulse", "multitone", "pulse+ringing"],
+)
+def test_streamed_chunks_reassemble_into_one_synthesize_call(spec):
+    """Not asserted bitwise: stream() computes each chunk's t0 as
+    produced/sample_rate and synthesize() then adds arange(n)/sample_rate, which
+    rounds a hair differently from one arange over the whole span. Those
+    differences are ~1e-16; a phase reset, a settling restart, or a truncated
+    ring would each be of order the amplitude, so 1e-9 separates them cleanly."""
+    chunk, chunks = 512, 8
+    streamed = np.concatenate(list(itertools.islice(stream(spec, RATE, chunk), chunks)))
+    whole = synthesize(spec, RATE, chunk * chunks)
+    np.testing.assert_allclose(streamed, whole, rtol=0, atol=1e-9)

--- a/tests/test_signal_kinds.py
+++ b/tests/test_signal_kinds.py
@@ -1,0 +1,64 @@
+"""The four kind-specific generators: chirp, exponential, pulse, multitone.
+
+Each is a closed-form function of the absolute time array, because stream()
+re-enters synthesize() per chunk with a new t0 and the ringing impairment renders
+samples before t0. A generator that carried state across a call, or that reset a
+phase at a boundary, would show up as a discontinuity -- which is what
+test_streamed_chunks_reassemble_into_one_synthesize_call exists to catch.
+"""
+
+import dataclasses
+import itertools
+
+import numpy as np
+import pytest
+
+from scpi_control import exceptions
+from scpi_control.signal_synth import PERIODIC_KINDS, SignalSpec, stream, synthesize
+
+RATE = 1_000_000.0
+
+
+def test_kind_parameter_fields_default_to_the_documented_values():
+    spec = SignalSpec()
+    assert spec.end_frequency == 10_000.0
+    assert spec.sweep_time == 0.01
+    assert spec.sweep_log is False
+    assert spec.tau == 1e-4
+    assert spec.pulse_width == 2e-4
+    assert spec.edge_time == 1e-5
+    assert spec.harmonics == (0.1, 0.05)
+
+
+def test_the_new_fields_are_appended_and_do_not_move_the_existing_ones():
+    """The non-breaking guarantee: positional construction of every pre-existing
+    field must still bind to the same field. Inserting a new field mid-class --
+    where several of them read better -- would silently re-map every positional
+    caller."""
+    spec = SignalSpec("square", 500.0, 2.0, 0.5, 0.1, 0.25, 0.01, 3)
+    assert spec.kind == "square"
+    assert spec.frequency == 500.0
+    assert spec.amplitude == 2.0
+    assert spec.offset == 0.5
+    assert spec.phase == 0.1
+    assert spec.duty == 0.25
+    assert spec.noise_rms == 0.01
+    assert spec.seed == 3
+    names = [f.name for f in dataclasses.fields(SignalSpec)]
+    assert names[:14] == [
+        "kind",
+        "frequency",
+        "amplitude",
+        "offset",
+        "phase",
+        "duty",
+        "noise_rms",
+        "seed",
+        "drift_amplitude",
+        "drift_frequency",
+        "glitch_rate",
+        "glitch_amplitude",
+        "ringing_frequency",
+        "ringing_damping",
+    ]
+    assert names[14:] == ["end_frequency", "sweep_time", "sweep_log", "tau", "pulse_width", "edge_time", "harmonics"]

--- a/tests/test_signal_kinds.py
+++ b/tests/test_signal_kinds.py
@@ -161,8 +161,10 @@ def test_a_very_slow_rc_stays_finite():
 
 def test_exponential_is_continuous_at_its_phase_boundaries():
     """Both branch boundaries evaluate to the same level by construction, so the
-    trace has no jump anywhere -- which is why ringing is a documented no-op on
-    this kind."""
+    trace has no jump anywhere -- there is no real edge for a probe's edge
+    response to key on. (That is NOT the same as ringing being a no-op here:
+    ringing keys on any sample-to-sample change, so it still filters this kind
+    slightly. Only "dc" is a true no-op.)"""
     samples = synthesize(SignalSpec(kind="exponential", frequency=1_000.0, tau=1e-4), RATE, 3_000)
     assert np.max(np.abs(np.diff(samples))) < 0.05
 
@@ -382,3 +384,35 @@ def test_the_reassemble_check_actually_detects_a_chunk_relative_state_bug(monkey
     with pytest.raises(AssertionError):
         np.testing.assert_allclose(streamed, whole, rtol=0, atol=1e-9)
     assert np.max(np.abs(streamed - whole)) > 0.1  # order the amplitude, not float noise
+
+
+@pytest.mark.parametrize(
+    "kwargs, floor",
+    [
+        ({"kind": "chirp", "end_frequency": 10_000.0, "sweep_time": 0.01}, 5e-2),
+        ({"kind": "exponential", "tau": 1e-4}, 2e-2),
+        ({"kind": "multitone"}, 5e-3),
+        ({"kind": "sine"}, 5e-3),
+    ],
+    ids=["chirp", "exponential", "multitone", "sine"],
+)
+def test_ringing_is_not_a_no_op_on_a_continuous_kind(kwargs, floor):
+    """Pins the corrected documentation. Ringing was described as a no-op on
+    every continuous kind; it is not. Edges are found as ANY nonzero
+    sample-to-sample change, not as a discontinuity, so on a continuous signal
+    every sample qualifies and the impairment acts as a derivative-weighted
+    filter. Floors are ~half the measured deviation at these settings (chirp
+    1.04e-1 V, exponential 5.60e-2, multitone 1.33e-2, sine 9.85e-3 -- square,
+    which has real edges, is 8.95e-1)."""
+    plain = SignalSpec(frequency=1_000.0, amplitude=1.0, **kwargs)
+    ringing = dataclasses.replace(plain, ringing_frequency=50_000.0)
+    deviation = np.max(np.abs(synthesize(ringing, RATE, 5_000) - synthesize(plain, RATE, 5_000)))
+    assert deviation > floor
+
+
+def test_ringing_is_a_true_no_op_only_on_dc():
+    """The one kind whose sample-to-sample differences are all zero, so no
+    sample is ever detected as an edge."""
+    plain = SignalSpec(kind="dc", offset=0.5)
+    ringing = dataclasses.replace(plain, ringing_frequency=50_000.0)
+    np.testing.assert_array_equal(synthesize(ringing, RATE, 5_000), synthesize(plain, RATE, 5_000))

--- a/tests/test_signal_kinds.py
+++ b/tests/test_signal_kinds.py
@@ -440,3 +440,13 @@ def test_non_finite_kind_parameters_are_rejected(kind, field, value):
     spec = dataclasses.replace(SignalSpec(kind=kind, frequency=1_000.0), **{field: value})
     with pytest.raises(exceptions.InvalidParameterError):
         synthesize(spec, RATE, 100)
+
+
+@pytest.mark.parametrize("harmonics", [("a",), (0.1, None), ([0.1],), (1j,)], ids=["str", "None", "list", "complex"])
+def test_multitone_rejects_a_non_numeric_harmonic(harmonics):
+    """The module's contract is that every bad parameter raises
+    InvalidParameterError. A non-numeric element used to escape as a raw
+    TypeError ("ufunc 'isfinite' not supported for the input types"), because
+    the guard wrapped only the list() call and not the element test."""
+    with pytest.raises(exceptions.InvalidParameterError):
+        synthesize(SignalSpec(kind="multitone", frequency=1_000.0, harmonics=harmonics), RATE, 100)

--- a/tests/test_signal_kinds.py
+++ b/tests/test_signal_kinds.py
@@ -116,3 +116,62 @@ def test_multitone_rejects_bad_harmonics(harmonics):
 def test_multitone_rejects_a_non_sequence_harmonics():
     with pytest.raises(exceptions.InvalidParameterError):
         synthesize(SignalSpec(kind="multitone", frequency=1_000.0, harmonics=0.1), RATE, 100)
+
+
+def test_exponential_is_periodic_from_the_very_first_cycle():
+    """What the closed-form steady-state solve buys. An implementation that
+    started at 0 (or at -amplitude) and settled in over a few cycles would fail
+    this -- and would also restart its settling at every stream() chunk."""
+    spec = SignalSpec(kind="exponential", frequency=1_000.0, tau=1e-4)
+    samples = synthesize(spec, RATE, 3_000)  # 1000 samples per period at 1 MSa/s
+    np.testing.assert_allclose(samples[:1_000], samples[1_000:2_000], atol=1e-12)
+    np.testing.assert_allclose(samples[:1_000], samples[2_000:3_000], atol=1e-12)
+
+
+def test_a_very_fast_rc_approaches_an_ideal_square():
+    fast = synthesize(SignalSpec(kind="exponential", frequency=1_000.0, tau=1e-9), RATE, 2_000)
+    ideal = synthesize(SignalSpec(kind="square", frequency=1_000.0), RATE, 2_000)
+    # Not identical: at the first sample of each phase the RC still sits at its
+    # pre-transition level while the ideal square has already switched, so the
+    # two differ by 2*amplitude at exactly one sample per edge (4 edges here).
+    assert np.mean(np.abs(fast - ideal)) < 0.01
+
+
+def test_a_very_slow_rc_settles_to_the_duty_weighted_average():
+    """tau -> inf limit: the RC cannot follow the square at all and sits at its
+    DC average, amplitude * (2*duty - 1)."""
+    spec = SignalSpec(kind="exponential", frequency=1_000.0, amplitude=1.0, duty=0.25, tau=10.0)
+    samples = synthesize(spec, RATE, 1_000)
+    assert samples.mean() == pytest.approx(-0.5, abs=1e-3)
+
+
+def test_a_symmetric_exponential_is_antisymmetric_about_zero():
+    spec = SignalSpec(kind="exponential", frequency=1_000.0, duty=0.5, tau=1e-4)
+    samples = synthesize(spec, RATE, 1_000)
+    assert samples.max() == pytest.approx(-samples.min(), rel=1e-9)
+
+
+def test_a_very_slow_rc_stays_finite():
+    """Guards the expm1 form. Written naively as (2b - 1 - ab)/(1 - ab), a large
+    tau makes the denominator a difference of near-equal numbers: it loses every
+    significant digit and eventually divides by zero."""
+    samples = synthesize(SignalSpec(kind="exponential", frequency=1_000.0, tau=1e12), RATE, 1_000)
+    assert np.all(np.isfinite(samples))
+
+
+def test_exponential_is_continuous_at_its_phase_boundaries():
+    """Both branch boundaries evaluate to the same level by construction, so the
+    trace has no jump anywhere -- which is why ringing is a documented no-op on
+    this kind."""
+    samples = synthesize(SignalSpec(kind="exponential", frequency=1_000.0, tau=1e-4), RATE, 3_000)
+    assert np.max(np.abs(np.diff(samples))) < 0.05
+
+
+def test_exponential_is_periodic_and_triggerable_in_the_mock():
+    assert "exponential" in PERIODIC_KINDS
+
+
+@pytest.mark.parametrize("kwargs", [{"tau": 0.0}, {"tau": -1e-4}, {"duty": 0.0}, {"duty": 1.0}, {"duty": 1.5}])
+def test_exponential_rejects_bad_parameters(kwargs):
+    with pytest.raises(exceptions.InvalidParameterError):
+        synthesize(SignalSpec(kind="exponential", frequency=1_000.0, **kwargs), RATE, 100)

--- a/tests/test_signal_kinds.py
+++ b/tests/test_signal_kinds.py
@@ -416,3 +416,27 @@ def test_ringing_is_a_true_no_op_only_on_dc():
     plain = SignalSpec(kind="dc", offset=0.5)
     ringing = dataclasses.replace(plain, ringing_frequency=50_000.0)
     np.testing.assert_array_equal(synthesize(ringing, RATE, 5_000), synthesize(plain, RATE, 5_000))
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")], ids=["nan", "inf", "-inf"])
+@pytest.mark.parametrize(
+    "kind, field",
+    [
+        ("chirp", "end_frequency"),
+        ("chirp", "sweep_time"),
+        ("exponential", "tau"),
+        ("pulse", "pulse_width"),
+        ("pulse", "edge_time"),
+    ],
+)
+def test_non_finite_kind_parameters_are_rejected(kind, field, value):
+    """A bare sign check does not catch a non-finite value: nan is False on BOTH
+    sides of every ordering comparison, so `tau <= 0` and
+    `pulse_width <= edge_time` used to pass it straight through. pulse_width=nan
+    was the worst of them -- it produced a finite but silently wrong waveform,
+    with no nan in the output to give it away -- and tau=inf produced an all-nan
+    trace plus a RuntimeWarning, where the documented tau -> inf limit is the DC
+    average amplitude*(2*duty - 1)."""
+    spec = dataclasses.replace(SignalSpec(kind=kind, frequency=1_000.0), **{field: value})
+    with pytest.raises(exceptions.InvalidParameterError):
+        synthesize(spec, RATE, 100)

--- a/tests/test_signal_kinds.py
+++ b/tests/test_signal_kinds.py
@@ -13,7 +13,7 @@ import itertools
 import numpy as np
 import pytest
 
-from scpi_control import exceptions
+from scpi_control import exceptions, signal_synth
 from scpi_control.signal_synth import PERIODIC_KINDS, SignalSpec, stream, synthesize
 
 RATE = 1_000_000.0
@@ -260,10 +260,16 @@ def test_chirp_phase_is_continuous_across_a_sweep_retrace():
     """The reason phase accumulates (n * PHI(sweep_time) + PHI(within)) instead
     of resetting each sweep. A reset would put a step of order the amplitude at
     every sweep_time -- and the ringing impairment would then treat it as a real
-    edge."""
-    spec = SignalSpec(kind="chirp", frequency=1_000.0, end_frequency=5_000.0, sweep_time=1e-3)
+    edge.
+
+    5_300 rather than a round 5_000 on purpose: cycles per sweep is
+    T*(f0+f1)/2, which for 5_000 comes out an exact 3.0 -- the accumulated
+    phase term would then be congruent to zero mod 2*pi and dropping it
+    entirely would change nothing, so the test would pass against the very
+    bug it exists to catch. At 5_300 it is 3.15, leaving a 0.94 rad step."""
+    spec = SignalSpec(kind="chirp", frequency=1_000.0, end_frequency=5_300.0, sweep_time=1e-3)
     samples = synthesize(spec, RATE, 3_000)  # three full sweeps
-    steepest = 2 * np.pi * 5_000.0 * 1.0 / RATE  # the fastest legitimate slope, per sample
+    steepest = 2 * np.pi * 5_300.0 * 1.0 / RATE  # the fastest legitimate slope, per sample
     assert np.max(np.abs(np.diff(samples))) < 1.5 * steepest
 
 
@@ -346,3 +352,33 @@ def test_streamed_chunks_reassemble_into_one_synthesize_call(spec):
     streamed = np.concatenate(list(itertools.islice(stream(spec, RATE, chunk), chunks)))
     whole = synthesize(spec, RATE, chunk * chunks)
     np.testing.assert_allclose(streamed, whole, rtol=0, atol=1e-9)
+
+
+def test_the_reassemble_check_actually_detects_a_chunk_relative_state_bug(monkeypatch):
+    """A self-test of test_streamed_chunks_reassemble_into_one_synthesize_call:
+    asserts the detector detects. A pure-formula bug in a generator (e.g. an
+    algebraically wrong phase term) is still a function of the absolute time
+    array, so stream() and synthesize() agree on it regardless -- that class of
+    bug is caught elsewhere (see the sweep-retrace continuity test above), not
+    here. What this check exists to catch is a generator that depends on
+    something other than absolute time -- sample index, chunk-local origin, or
+    carried state -- which only shows up when a signal is split across chunk
+    boundaries. This plants exactly that bug (phase measured from the start of
+    the call instead of from the absolute sweep origin) and confirms it makes
+    the reassemble comparison fail by an amount of order the amplitude, not
+    float noise."""
+
+    def chunk_relative_chirp(spec, t, rng):
+        sweep = np.floor(t / spec.sweep_time)
+        within = t - t[0]  # bug: relative to this call's start, not the sweep origin
+        phase = sweep * signal_synth._chirp_phase(spec, spec.sweep_time) + signal_synth._chirp_phase(spec, within)
+        return spec.amplitude * np.sin(phase + spec.phase)
+
+    monkeypatch.setitem(signal_synth._GENERATORS, "chirp", chunk_relative_chirp)
+    spec = SignalSpec(kind="chirp", frequency=1_000.0, end_frequency=9_000.0, sweep_time=1e-3)
+    chunk, chunks = 512, 8
+    streamed = np.concatenate(list(itertools.islice(stream(spec, RATE, chunk), chunks)))
+    whole = synthesize(spec, RATE, chunk * chunks)
+    with pytest.raises(AssertionError):
+        np.testing.assert_allclose(streamed, whole, rtol=0, atol=1e-9)
+    assert np.max(np.abs(streamed - whole)) > 0.1  # order the amplitude, not float noise


### PR DESCRIPTION
Adds four signal kinds to `scpi_control/signal_synth.py` — `chirp`, `exponential`, `pulse` and `multitone` — joining the existing `sine`/`square`/`triangle`/`ramp`/`dc`/`noise`. The kinds are the enabler; the payoff is that the repo's timing, THD and spectrum analyzers can now be checked against answers derived analytically instead of against a pure sine, a square, or noise.

Non-breaking: every new `SignalSpec` field is optional, defaulted, and appended at the end of the dataclass, so existing specs behave identically and positional construction is unaffected. MINOR bump at release (5.5.0).

## The kinds

- **`chirp`** — a repeating frequency sweep from `frequency` to `end_frequency` over `sweep_time`, linear or logarithmic (`sweep_log`). Phase is carried **across** the retrace rather than reset, so a sweep boundary introduces no discontinuity. It is the one kind the mock free-runs rather than trigger-aligns, because it has no stable period — deliberately absent from `PERIODIC_KINDS`.
- **`exponential`** — a square wave through an RC network with time constant `tau`, solved in closed form at its **periodic steady state**, so it is settled from the very first cycle rather than over the first few. Splits the period by `duty`. The `expm1` formulation is load-bearing: the algebraic form loses all precision as `tau` grows and divides by zero at large `tau`.
- **`pulse`** — a trapezoid whose width and edge rate are independent of the period, unlike `square` whose only shape control is `duty` (which `pulse` ignores). `pulse_width` is the 50%-to-50% (FWHM) width, matching the instrument convention (`SOUR{ch}:FUNC:PULS:WIDT`) and the threshold the repo's timing analyzer measures at, so the flat top runs for `pulse_width - edge_time`. `edge_time` may be 0 for an ideal edge.
- **`multitone`** — a fundamental plus a coherent harmonic series (`harmonics` gives the relative amplitudes of the 2nd, 3rd, … harmonic). `amplitude` is the fundamental's, not the peak of the sum — deliberately not normalized, because normalizing would make THD depend on the harmonic set.

Every generator is a closed-form function of the absolute time array, because `stream()` re-enters `synthesize()` per chunk with a fresh `t0` and the ringing impairment renders samples before `t0`. `tests/test_signal_kinds.py` pins that: chunked and unchunked synthesis must agree to 1e-9, and a committed self-test monkeypatches a genuinely chunk-relative generator to prove the check detects one.

## Known-answer tests

`tests/test_known_answer_analysis.py` points the existing analyzers at signals whose correct answer is derivable on paper:

| Signal | Under test | Expected |
| ------ | ---------- | -------- |
| `exponential`, `tau = Th/50` | `calculate_timing_stats()["rise_time"]` | `ln(9)·tau` |
| `exponential`, `tau = Th/5` | same | `2.13910·tau` (the derived plateau-deficit deviation) |
| `pulse` | `pulse_width` / `rise_time` / `duty_cycle` | `pulse_width` / `0.8·edge_time` / `pulse_width·frequency·100` |
| `multitone` | `calculate_thd()`, `FFTAnalyzer.thd_of_waveform()` | `100·sqrt(Σh²)` |
| `chirp` | `calculate_spectrum()["dominant_peaks"]` | inside the swept band ±1 FFT bin |

All passed on the first run — **no analyzer bug was found**. No tolerance was widened and no expected value was back-fitted; each bound is justified by sampling-grid error or a stated systematic effect.

## Mock

`scpi_control/connection/mock/synth.py` needed no change to support the new kinds — it gates trigger alignment purely on `PERIODIC_KINDS` membership, which the three periodic kinds join and `chirp` does not. `_DEFAULT_SPECS` is untouched, so what a default mock channel emits is unchanged.

One fix did land there: `_trigger_crossing` re-synthesizes 4096 points to locate the *ideal* trigger crossing, but left the impairments enabled — so drift, glitches and ringing each moved the crossing (68.85 µs → 66.41 / 64.70 / 10.25 µs) and ringing cost ~21 ms per acquisition. It now zeroes them alongside the noise it already stripped.

## Documentation correction

The v5.4.0 docs described ringing as having "no effect" on kinds without edges. That is false: ringing detects edges as `np.flatnonzero(np.diff(samples))` — any nonzero sample-to-sample change — so on a continuous signal every sample qualifies and the impairment acts as a derivative-weighted filter. Measured max |with − without| at 1 MSa/s, 1 V amplitude, 50 kHz ringing: chirp 1.04e-1 V, exponential 5.60e-2 V, multitone 1.33e-2 V, sine 9.85e-3 V, square 8.95e-1 V. Only `dc` is a genuine no-op.

The **behaviour is unchanged** — it shipped in 5.4.0 and is defensible as a band-limited edge response. Only the text was wrong, and it is now accurate in `signal_synth.py`, the user guide, and two new tests that pin the measured values.

## Also in this PR

- `np.isfinite` guards on the five new scalar parameters. `pulse_width=nan` previously passed validation and produced a finite but silently wrong waveform — the only case with no `nan` tell-tale in the output.
- `harmonics` with a non-numeric element now raises `InvalidParameterError` instead of escaping as a raw `TypeError`.
- Stale kind enumerations updated in `README.md`, `docs/index.md`, the `SignalSpec.kind` docstring, and `docs/user-guide/synthetic-signals.md`; `examples/synthetic_signals.py` gained multitone-THD and chirp-sweep walkthroughs.

## Verification

- Full suite **1866 passed, 19 skipped, 0 failed**.
- `black --check --line-length 200 scpi_control/ examples/` clean; `flake8 --select=E9,F63,F7,F82` = 0; `--select=F401` clean on `signal_synth.py`.
- CI-extras parity: re-run with PyQt6, reportlab and h5py blocked via a `sys.meta_path` finder — 0 import errors, both new test files passing. CI installs `.[dev,web]` only, and this class of bug has shipped twice before.
