### PR TITLE
fix(automation): repair three silent failures in the capture path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `save_waveform` now accepts `npz` and `h5` as aliases for `NPY` and `HDF5`. `npz` is
+  `start_continuous_capture`'s default, so an overnight run using default arguments previously
+  raised on every save and wrote nothing; four shipped examples were broken the same way. The
+  same spellings were already valid as file *extensions* via auto-detect — that inconsistency is
+  what produced the bug.
+- `batch_capture` now parses the SI unit strings its own docstring documents (`'1us'`, `'500mV'`),
+  via the new `scpi_control.units.parse_si_value`. Previously the documented example raised
+  `TypeError` and discarded every capture already taken. Numeric scales keep working unchanged.
+- `capture_single` now polls `acquisition_status()` instead of sleeping a fixed 0.5 s, with a
+  timeout derived from the current timebase and a new optional `max_wait`. On a slow timebase it
+  previously returned the *previous* acquisition, which `batch_capture` then recorded under the
+  new config's label — wrong data, correctly formatted, no warning. A timed-out capture now
+  appears in `batch_capture`'s results as an entry with empty `waveforms` and an `error` field,
+  rather than aborting the run or holding stale data.
+- `capture_single` no longer clobbers a user-configured `NORM` trigger mode. It previously always
+  armed a single-shot acquisition regardless of trigger mode; it now leaves `NORM` alone and waits
+  for the next natural trigger, matching what `TriggerWaitCollector.wait_for_trigger` already did,
+  and continues to arm a single shot in every other mode as before.
+- `parse_si_value` scales by shifting the decimal exponent rather than multiplying by a float, so
+  `'10us'` is exactly `1e-05`. The multiply-based approach produced `9.999999999999999e-06`, which
+  reached the instrument as `TDIV 9.999999999999999e-06` instead of `TDIV 1e-05`.
+
 ## [5.5.0] - 2026-07-26
 
 ### Added

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `save_waveform` now accepts `npz` and `h5` as aliases for `NPY` and `HDF5`. `npz` is
+  `start_continuous_capture`'s default, so an overnight run using default arguments previously
+  raised on every save and wrote nothing; four shipped examples were broken the same way. The
+  same spellings were already valid as file *extensions* via auto-detect — that inconsistency is
+  what produced the bug.
+- `batch_capture` now parses the SI unit strings its own docstring documents (`'1us'`, `'500mV'`),
+  via the new `scpi_control.units.parse_si_value`. Previously the documented example raised
+  `TypeError` and discarded every capture already taken. Numeric scales keep working unchanged.
+- `capture_single` now polls `acquisition_status()` instead of sleeping a fixed 0.5 s, with a
+  timeout derived from the current timebase and a new optional `max_wait`. On a slow timebase it
+  previously returned the *previous* acquisition, which `batch_capture` then recorded under the
+  new config's label — wrong data, correctly formatted, no warning. A timed-out capture now
+  appears in `batch_capture`'s results as an entry with empty `waveforms` and an `error` field,
+  rather than aborting the run or holding stale data.
+- `capture_single` no longer clobbers a user-configured `NORM` trigger mode. It previously always
+  armed a single-shot acquisition regardless of trigger mode; it now leaves `NORM` alone and waits
+  for the next natural trigger, matching what `TriggerWaitCollector.wait_for_trigger` already did,
+  and continues to arm a single shot in every other mode as before.
+- `parse_si_value` scales by shifting the decimal exponent rather than multiplying by a float, so
+  `'10us'` is exactly `1e-05`. The multiply-based approach produced `9.999999999999999e-06`, which
+  reached the instrument as `TDIV 9.999999999999999e-06` instead of `TDIV 1e-05`.
+
 ## [5.5.0] - 2026-07-26
 
 ### Added

--- a/scpi_control/automation.py
+++ b/scpi_control/automation.py
@@ -46,7 +46,7 @@ import numpy as np
 
 from scpi_control import Oscilloscope
 from scpi_control.connection import BaseConnection
-from scpi_control.exceptions import SiglentError, SiglentTimeoutError
+from scpi_control.exceptions import InvalidParameterError, SiglentError, SiglentTimeoutError
 from scpi_control.units import parse_si_value
 from scpi_control.waveform import WaveformData
 
@@ -160,13 +160,15 @@ class DataCollector:
         Args:
             channels: List of channel numbers to capture (e.g., [1, 2, 3])
             auto_setup: If True, run auto-setup before capture
-            max_wait: Seconds to wait for the acquisition to complete. None
-                (default) derives a budget from the current timebase.
+            max_wait: Seconds to wait for the acquisition to complete. Must be
+                positive. None (default) derives a budget from the current
+                timebase.
 
         Returns:
             Dictionary mapping channel number to WaveformData object
 
         Raises:
+            InvalidParameterError: If max_wait is not positive.
             SiglentTimeoutError: If the acquisition does not complete in time.
                 Reading anyway would return the PREVIOUS acquisition, which is
                 what this replaced.
@@ -178,6 +180,13 @@ class DataCollector:
         """
         if not self._connected:
             raise SiglentError(f"Not connected to oscilloscope at {self.scope.host}:{self.scope.port}")
+
+        # Checked explicitly, because the failure is otherwise misattributed: a
+        # zero or negative budget skips the poll loop without a single status
+        # read and raises "last status: unknown", which reads like an
+        # instrument fault rather than the bad argument it is.
+        if max_wait is not None and max_wait <= 0:
+            raise InvalidParameterError(f"max_wait must be a positive number of seconds, not {max_wait!r}")
 
         if auto_setup:
             self.scope.auto_setup()
@@ -273,8 +282,12 @@ class DataCollector:
         total = len(configs) * triggers_per_config
         current = 0
 
-        # Execute batch capture
-        for config in configs:
+        # Execute batch capture. Enumerated rather than looked up with
+        # configs.index(config): parsing makes duplicate configs genuinely
+        # possible -- ['1us', '1000ns'] used to yield two distinct raw-string
+        # dicts and now both parse to {'timebase': 1e-06} -- and index() would
+        # then report "Config 1/2" twice.
+        for config_index, config in enumerate(configs):
             # Apply configuration
             if "timebase" in config:
                 if hasattr(self.scope, "set_timebase"):
@@ -298,7 +311,7 @@ class DataCollector:
                 current += 1
 
                 if progress_callback:
-                    status = f"Config {configs.index(config)+1}/{len(configs)}, Trigger {trigger_num+1}/{triggers_per_config}"
+                    status = f"Config {config_index+1}/{len(configs)}, Trigger {trigger_num+1}/{triggers_per_config}"
                     progress_callback(current, total, status)
 
                 entry = {

--- a/scpi_control/automation.py
+++ b/scpi_control/automation.py
@@ -148,6 +148,14 @@ class DataCollector:
     def capture_single(self, channels: List[int], auto_setup: bool = False, max_wait: Optional[float] = None) -> Dict[int, WaveformData]:
         """Capture waveforms from specified channels.
 
+        If the scope is already in NORM trigger mode, this waits for the next
+        natural trigger instead of arming a single acquisition -- the user's
+        configured mode is left running rather than being overwritten. In any
+        other mode (including the default) it arms a single acquisition as
+        before. Previously this method always forced a single-shot regardless
+        of mode; a NORM-mode caller upgrading past this change will see
+        capture_single wait for a real trigger instead of forcing one.
+
         Args:
             channels: List of channel numbers to capture (e.g., [1, 2, 3])
             auto_setup: If True, run auto-setup before capture
@@ -181,6 +189,13 @@ class DataCollector:
             # Mirrors wait_for_trigger: NORMAL mode is already free-running and
             # re-arms itself, so arming a SINGLE here would stomp the user's
             # NORM setting and _wait_for_acquisition would never see it.
+            #
+            # Ordering is load-bearing, not cosmetic: trigger_single() writes
+            # TRIG_MODE SINGLE to the scope, which overwrites the very mode
+            # _wait_for_acquisition needs to read to pick its done-states. The
+            # mode must be checked BEFORE this call, not just before the poll
+            # -- moving this inside/after trigger_single() silently reproduces
+            # the bug this guard exists to prevent.
             self.scope.trigger_single()
         self._wait_for_acquisition(self._acquisition_timeout() if max_wait is None else max_wait)
 

--- a/scpi_control/automation.py
+++ b/scpi_control/automation.py
@@ -46,10 +46,18 @@ import numpy as np
 
 from scpi_control import Oscilloscope
 from scpi_control.connection import BaseConnection
-from scpi_control.exceptions import SiglentError
+from scpi_control.exceptions import SiglentError, SiglentTimeoutError
 from scpi_control.waveform import WaveformData
 
 logger = logging.getLogger(__name__)
+
+# Acquisition polling. 14 divisions is one full sweep (matching
+# connection/mock/synth.py's DIVISIONS); x5 covers trigger wait plus transfer;
+# the floor keeps a fast timebase from getting an unusably small budget.
+_ACQUISITION_POLL_INTERVAL = 0.1
+_MIN_ACQUISITION_TIMEOUT = 2.0
+_SWEEP_DIVISIONS = 14
+_ACQUISITION_TIMEOUT_FACTOR = 5
 
 
 class DataCollector:
@@ -103,15 +111,56 @@ class DataCollector:
         self.disconnect()
         return False
 
-    def capture_single(self, channels: List[int], auto_setup: bool = False) -> Dict[int, WaveformData]:
+    def _acquisition_timeout(self) -> float:
+        """Budget for one acquisition, derived from the current timebase.
+
+        Reading the timebase is best-effort: falling back to the floor is better
+        than failing a capture because a diagnostic query did.
+        """
+        try:
+            timebase = float(self.scope.timebase)
+        except Exception:
+            # Deliberately broad: this is a best-effort diagnostic read, and any
+            # failure of it (timeout, unsupported query, a dialect that returns
+            # something unparseable) should degrade to the floor rather than
+            # abort a capture that would otherwise have worked.
+            return _MIN_ACQUISITION_TIMEOUT
+        return max(_MIN_ACQUISITION_TIMEOUT, _SWEEP_DIVISIONS * timebase * _ACQUISITION_TIMEOUT_FACTOR)
+
+    def _wait_for_acquisition(self, max_wait: float) -> None:
+        """Poll until the acquisition completes, mirroring wait_for_trigger.
+
+        The NORM branch is load-bearing: in NORMAL mode the scope re-arms after
+        every trigger and never reports STOP, so a `while status != "STOP"` loop
+        would always time out. TriggerWaitCollector.wait_for_trigger already
+        learned this; this is the same rule, not a second opinion.
+        """
+        done_states = {"TRIGD", "STOP"} if self.scope.trigger.mode == "NORM" else {"STOP"}
+        start_time = time.time()
+        status = ""
+        while (time.time() - start_time) < max_wait:
+            status = self.scope.acquisition_status()
+            if status in done_states:
+                return
+            time.sleep(_ACQUISITION_POLL_INTERVAL)
+        raise SiglentTimeoutError(f"Acquisition did not complete within {max_wait:.2f} s (last status: {status or 'unknown'})")
+
+    def capture_single(self, channels: List[int], auto_setup: bool = False, max_wait: Optional[float] = None) -> Dict[int, WaveformData]:
         """Capture waveforms from specified channels.
 
         Args:
             channels: List of channel numbers to capture (e.g., [1, 2, 3])
             auto_setup: If True, run auto-setup before capture
+            max_wait: Seconds to wait for the acquisition to complete. None
+                (default) derives a budget from the current timebase.
 
         Returns:
             Dictionary mapping channel number to WaveformData object
+
+        Raises:
+            SiglentTimeoutError: If the acquisition does not complete in time.
+                Reading anyway would return the PREVIOUS acquisition, which is
+                what this replaced.
 
         Example:
             >>> data = collector.capture_single([1, 2])
@@ -123,11 +172,17 @@ class DataCollector:
 
         if auto_setup:
             self.scope.auto_setup()
-            time.sleep(1)  # Wait for auto-setup to complete
+            # Unlike the trigger wait below, this genuinely is an
+            # unknown-duration sleep: auto-setup reports no status the library
+            # can poll, so there is nothing to wait ON.
+            time.sleep(1)
 
-        # Trigger single acquisition
-        self.scope.trigger_single()
-        time.sleep(0.5)  # Wait for trigger
+        if self.scope.trigger.mode != "NORM":
+            # Mirrors wait_for_trigger: NORMAL mode is already free-running and
+            # re-arms itself, so arming a SINGLE here would stomp the user's
+            # NORM setting and _wait_for_acquisition would never see it.
+            self.scope.trigger_single()
+        self._wait_for_acquisition(self._acquisition_timeout() if max_wait is None else max_wait)
 
         # Capture waveforms
         waveforms = {}

--- a/scpi_control/automation.py
+++ b/scpi_control/automation.py
@@ -47,6 +47,7 @@ import numpy as np
 from scpi_control import Oscilloscope
 from scpi_control.connection import BaseConnection
 from scpi_control.exceptions import SiglentError, SiglentTimeoutError
+from scpi_control.units import parse_si_value
 from scpi_control.waveform import WaveformData
 
 logger = logging.getLogger(__name__)
@@ -252,7 +253,9 @@ class DataCollector:
         configs = []
         if timebase_scales:
             for tb in timebase_scales:
-                configs.append({"timebase": tb})
+                # Parsed HERE, not at apply time, so an unparseable scale fails
+                # before any capture is taken rather than part-way through a run.
+                configs.append({"timebase": parse_si_value(tb, "timebase scale")})
         else:
             configs.append({})
 
@@ -262,7 +265,7 @@ class DataCollector:
                 for ch, scales in voltage_scales.items():
                     for scale in scales:
                         new_config = config.copy()
-                        new_config[f"ch{ch}_vdiv"] = scale
+                        new_config[f"ch{ch}_vdiv"] = parse_si_value(scale, f"channel {ch} voltage scale")
                         new_configs.append(new_config)
             if new_configs:
                 configs = new_configs
@@ -298,16 +301,23 @@ class DataCollector:
                     status = f"Config {configs.index(config)+1}/{len(configs)}, Trigger {trigger_num+1}/{triggers_per_config}"
                     progress_callback(current, total, status)
 
-                waveforms = self.capture_single(channels)
-
-                results.append(
-                    {
-                        "timestamp": datetime.now().isoformat(),
-                        "config": config.copy(),
-                        "waveforms": waveforms,
-                        "trigger_num": trigger_num,
-                    }
-                )
+                entry = {
+                    "timestamp": datetime.now().isoformat(),
+                    "config": config.copy(),
+                    "waveforms": {},
+                    "trigger_num": trigger_num,
+                }
+                try:
+                    entry["waveforms"] = self.capture_single(channels)
+                except SiglentTimeoutError as exc:
+                    # Record the failure and carry on. Raising would discard every
+                    # capture already taken; returning the stale waveform is what
+                    # this replaced. An "error" key appears ONLY on failed entries,
+                    # so consumers reading config/waveforms/trigger_num are
+                    # unaffected.
+                    logger.warning(f"Capture timed out for config {config}: {exc}")
+                    entry["error"] = str(exc)
+                results.append(entry)
 
         logger.info(f"Batch capture complete: {len(results)} captures")
         return results

--- a/scpi_control/units.py
+++ b/scpi_control/units.py
@@ -12,26 +12,33 @@ them would make one of the two wrong.
 """
 
 import re
+from decimal import Decimal, InvalidOperation
 from typing import Union
 
 from scpi_control import exceptions
 
+# Decimal EXPONENTS, not float multipliers. Multiplying by a float scale is not
+# correctly rounded -- float("10") * 1e-6 is 9.999999999999999e-06, while the
+# literal 10e-6 is 1e-05 -- and the difference reaches the wire, because the
+# parsed value is formatted straight into a SCPI command. Shifting the decimal
+# exponent and converting once gives the canonical float.
+#
 # Case-SENSITIVE on purpose: "m" is milli, "M" is mega. A case-insensitive table
 # turns a 1 mV scale into a 1 MV scale with no error at all. "K" is accepted
 # alongside "k" because instrument front panels commonly print it that way;
 # there is no conflicting lower-case meaning to lose.
-_PREFIXES = {
-    "f": 1e-15,
-    "p": 1e-12,
-    "n": 1e-9,
-    "u": 1e-6,
-    "µ": 1e-6,  # U+00B5 MICRO SIGN
-    "μ": 1e-6,  # U+03BC GREEK SMALL LETTER MU -- both appear in the wild
-    "m": 1e-3,
-    "k": 1e3,
-    "K": 1e3,
-    "M": 1e6,
-    "G": 1e9,
+_PREFIX_EXPONENTS = {
+    "f": -15,
+    "p": -12,
+    "n": -9,
+    "u": -6,
+    "µ": -6,  # U+00B5 MICRO SIGN
+    "μ": -6,  # U+03BC GREEK SMALL LETTER MU -- both appear in the wild
+    "m": -3,
+    "k": 3,
+    "K": 3,
+    "M": 6,
+    "G": 9,
 }
 
 # Leading number (with optional sign and exponent), then optional whitespace,
@@ -62,7 +69,9 @@ def parse_si_value(value: Union[str, float], quantity: str) -> float:
     whole suffix is treated as a unit and ignored ("2.5V" -> 2.5). Units are not
     validated, so "1x" parses to 1.0 -- validating them would mean maintaining a
     list of every unit an instrument might print, for no benefit to any caller.
-    A bare prefix is still a prefix: "1m" is 1e-3, not 1 metre.
+    A bare prefix is still a prefix: "1m" is 1e-3, not 1 metre. The returned
+    float is the same one a decimal literal with that exponent would produce
+    (e.g. "10us" -> 1e-05, not 9.999999999999999e-06).
     """
     # bool before int: bool subclasses int, so True would otherwise sail through
     # as 1.0 and hide whatever mistake produced it.
@@ -76,5 +85,12 @@ def parse_si_value(value: Union[str, float], quantity: str) -> float:
     if not match:
         raise exceptions.InvalidParameterError(f"Could not parse {quantity} from {value!r}. Expected a number with an optional SI prefix and unit, e.g. '1us', '500mV', '2.5V' or 1e-06.")
     number, suffix = match.group(1), match.group(2)
-    scale = _PREFIXES.get(suffix[0], 1.0) if suffix else 1.0
-    return float(number) * scale
+    exponent = _PREFIX_EXPONENTS.get(suffix[0]) if suffix else None
+    if exponent is None:
+        return float(number)
+    try:
+        # Decimal handles a number that ALREADY carries an exponent -- "1e6m" is
+        # 1e3, where naive string composition would build the invalid "1e6e-3".
+        return float(Decimal(number).scaleb(exponent))
+    except InvalidOperation:
+        raise exceptions.InvalidParameterError(f"Could not scale {quantity} from {value!r}: the value is out of range.") from None

--- a/scpi_control/units.py
+++ b/scpi_control/units.py
@@ -12,7 +12,7 @@ them would make one of the two wrong.
 """
 
 import re
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal, InvalidOperation, Overflow
 from typing import Union
 
 from scpi_control import exceptions
@@ -61,14 +61,19 @@ def parse_si_value(value: Union[str, float], quantity: str) -> float:
         The value in base SI units.
 
     Raises:
-        exceptions.InvalidParameterError: If no leading number can be found, or
-            the value is not a string or number.
+        exceptions.InvalidParameterError: If no leading number can be found, if
+            the value is not a string or number, or if the suffix contains
+            digits or numeric punctuation (a thousands separator or a stray
+            character would otherwise silently truncate the number).
 
     The suffix rule: if its FIRST character is a known prefix, that prefix is
     applied and the rest is ignored as a unit ("500mV" -> 0.5). Otherwise the
     whole suffix is treated as a unit and ignored ("2.5V" -> 2.5). Units are not
     validated, so "1x" parses to 1.0 -- validating them would mean maintaining a
     list of every unit an instrument might print, for no benefit to any caller.
+    A suffix carrying digits or numeric punctuation is rejected, though: that
+    means part of the NUMBER was swallowed ("1,000us"), which loses information,
+    whereas an unknown unit loses none.
     A bare prefix is still a prefix: "1m" is 1e-3, not 1 metre. The returned
     float is the same one a decimal literal with that exponent would produce
     (e.g. "10us" -> 1e-05, not 9.999999999999999e-06).
@@ -85,6 +90,15 @@ def parse_si_value(value: Union[str, float], quantity: str) -> float:
     if not match:
         raise exceptions.InvalidParameterError(f"Could not parse {quantity} from {value!r}. Expected a number with an optional SI prefix and unit, e.g. '1us', '500mV', '2.5V' or 1e-06.")
     number, suffix = match.group(1), match.group(2)
+    if suffix and re.search(r"[\d,_.]", suffix):
+        # Units are deliberately unvalidated ("1x" is 1.0) because validating
+        # them would mean listing every unit an instrument might print. But a
+        # suffix containing DIGITS or numeric punctuation means part of the
+        # NUMBER was swallowed, not that an unknown unit was supplied --
+        # "1,000us" would otherwise parse to 1.0 and set a timebase 1000x off,
+        # silently. Unknown units discard nothing; a dropped numeric remainder
+        # discards everything after it.
+        raise exceptions.InvalidParameterError(f"Could not parse {quantity} from {value!r}: unexpected characters after the number.")
     exponent = _PREFIX_EXPONENTS.get(suffix[0]) if suffix else None
     if exponent is None:
         return float(number)
@@ -92,5 +106,8 @@ def parse_si_value(value: Union[str, float], quantity: str) -> float:
         # Decimal handles a number that ALREADY carries an exponent -- "1e6m" is
         # 1e3, where naive string composition would build the invalid "1e6e-3".
         return float(Decimal(number).scaleb(exponent))
-    except InvalidOperation:
+    except (InvalidOperation, Overflow):
+        # Overflow is NOT a subclass of InvalidOperation: scaleb raises it when
+        # the shifted exponent passes the context's Emax ("1e999995G"), so
+        # catching InvalidOperation alone let a raw decimal error escape.
         raise exceptions.InvalidParameterError(f"Could not scale {quantity} from {value!r}: the value is out of range.") from None

--- a/scpi_control/units.py
+++ b/scpi_control/units.py
@@ -1,0 +1,80 @@
+"""Parse human-written SI quantity strings into floats.
+
+`batch_capture` documents its scales as strings ("1us", "500mV") and its own
+example copies them verbatim, but applied them unparsed -- so the documented
+call raised TypeError. This module is that parser.
+
+Deliberately separate from `waveform._SI_MAGNITUDES`, which decodes magnitude
+letters in legacy Siglent *instrument responses* (K/M/G, upper case, no small
+prefixes -- RC01020-E01C p.117). This one parses *user input*, where "m" is
+milli and "M" is mega. Two grammars that happen to share three letters; merging
+them would make one of the two wrong.
+"""
+
+import re
+from typing import Union
+
+from scpi_control import exceptions
+
+# Case-SENSITIVE on purpose: "m" is milli, "M" is mega. A case-insensitive table
+# turns a 1 mV scale into a 1 MV scale with no error at all. "K" is accepted
+# alongside "k" because instrument front panels commonly print it that way;
+# there is no conflicting lower-case meaning to lose.
+_PREFIXES = {
+    "f": 1e-15,
+    "p": 1e-12,
+    "n": 1e-9,
+    "u": 1e-6,
+    "µ": 1e-6,  # U+00B5 MICRO SIGN
+    "μ": 1e-6,  # U+03BC GREEK SMALL LETTER MU -- both appear in the wild
+    "m": 1e-3,
+    "k": 1e3,
+    "K": 1e3,
+    "M": 1e6,
+    "G": 1e9,
+}
+
+# Leading number (with optional sign and exponent), then optional whitespace,
+# then whatever suffix remains. The suffix is NOT anchored to a known unit --
+# see the module note on why units are unvalidated.
+_QUANTITY = re.compile(r"^\s*([+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?)\s*(\S*)\s*$")
+
+
+def parse_si_value(value: Union[str, float], quantity: str) -> float:
+    """Convert an SI quantity string (or a plain number) to a float.
+
+    Args:
+        value: "1us", "500mV", "2.5V", "1e-6", or an int/float, which is
+            returned unchanged. Accepting numbers is what keeps callers that
+            already pass floats working.
+        quantity: Human-readable name of what is being parsed, used in the
+            error message (e.g. "timebase scale").
+
+    Returns:
+        The value in base SI units.
+
+    Raises:
+        exceptions.InvalidParameterError: If no leading number can be found, or
+            the value is not a string or number.
+
+    The suffix rule: if its FIRST character is a known prefix, that prefix is
+    applied and the rest is ignored as a unit ("500mV" -> 0.5). Otherwise the
+    whole suffix is treated as a unit and ignored ("2.5V" -> 2.5). Units are not
+    validated, so "1x" parses to 1.0 -- validating them would mean maintaining a
+    list of every unit an instrument might print, for no benefit to any caller.
+    A bare prefix is still a prefix: "1m" is 1e-3, not 1 metre.
+    """
+    # bool before int: bool subclasses int, so True would otherwise sail through
+    # as 1.0 and hide whatever mistake produced it.
+    if isinstance(value, bool):
+        raise exceptions.InvalidParameterError(f"{quantity} must be a number or an SI string, not a bool: {value!r}")
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        raise exceptions.InvalidParameterError(f"{quantity} must be a number or an SI string: {value!r}")
+    match = _QUANTITY.match(value)
+    if not match:
+        raise exceptions.InvalidParameterError(f"Could not parse {quantity} from {value!r}. Expected a number with an optional SI prefix and unit, e.g. '1us', '500mV', '2.5V' or 1e-06.")
+    number, suffix = match.group(1), match.group(2)
+    scale = _PREFIXES.get(suffix[0], 1.0) if suffix else 1.0
+    return float(number) * scale

--- a/scpi_control/waveform.py
+++ b/scpi_control/waveform.py
@@ -34,6 +34,13 @@ WAVEFORM_CODE_CENTER = 0  # Center code value for signed integer ADC data
 # quantity ever needs this, case must be preserved upstream first.
 _SI_MAGNITUDES = {"G": 1e9, "M": 1e6, "K": 1e3}
 
+# User-facing spellings that mean an existing canonical format. These are the
+# same mappings save_waveform's auto-detect branch already applies to file
+# EXTENSIONS (.npz -> NPY, .h5 -> HDF5); without them the identical spelling was
+# valid as an extension and rejected as an argument, which is exactly how
+# start_continuous_capture shipped with a default format that always raised.
+_FORMAT_ALIASES = {"NPZ": "NPY", "H5": "HDF5"}
+
 
 def _to_float_with_magnitude(numeric_part: str) -> float:
     """Parse an NR3 value that may carry a trailing SI magnitude letter.
@@ -373,7 +380,7 @@ class Waveform:
             format = format_map.get(ext, "CSV")
             logger.debug(f"Auto-detected format: {format} from extension {ext}")
 
-        format = format.upper()
+        format = _FORMAT_ALIASES.get(format.upper(), format.upper())
 
         if format == "CSV":
             self._save_csv(waveform, filename, include_metadata=False, metadata=metadata, bare=bare)

--- a/tests/test_automation_capture.py
+++ b/tests/test_automation_capture.py
@@ -9,6 +9,7 @@ the new config's label -- wrong data, correctly formatted, no warning.
 FakeTime is used throughout so the timeout tests cost no wall-clock time.
 """
 
+import numpy as np
 import pytest
 
 from scpi_control import exceptions
@@ -184,6 +185,65 @@ def test_a_timed_out_capture_becomes_a_visible_failed_entry(monkeypatch):
         assert "error" in entry
         assert entry["config"]
     # Nothing already captured is lost, and no entry claims a waveform it lacks.
+
+
+def test_start_continuous_capture_writes_files_with_its_default_format(monkeypatch, tmp_path):
+    """The regression that actually shipped, pinned at the caller level.
+
+    start_continuous_capture's default file_format is 'npz', which was valid as
+    a filename EXTENSION and rejected as a format ARGUMENT, so every save raised
+    -- swallowed by the loop's broad except, leaving an empty output directory
+    and a log line. The alias fix is covered at unit level; this covers the path
+    that failed, including the filename/extension interaction, end to end.
+    """
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime(step=0.01))
+    dc, _ = _collector()
+    try:
+        returned = dc.start_continuous_capture(channels=[1], duration=0.1, interval=0.02, output_dir=tmp_path)
+    finally:
+        dc.disconnect()
+
+    written = sorted(tmp_path.glob("*.npz"))
+    assert written, "the default file_format must produce files, not a silently empty directory"
+    assert returned == [], "with output_dir set, captures go to disk rather than the returned list"
+    # Loading proves a real npz was written, not an empty or mis-formatted file.
+    with np.load(str(written[0])) as archive:
+        assert len(archive["voltage"]) > 0
+
+
+def test_capture_single_rejects_a_non_positive_max_wait(monkeypatch):
+    """max_wait=0 skipped the poll loop without a single status read and raised
+    'last status: unknown', which reads like an instrument fault rather than the
+    bad argument it is."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, conn = _collector()
+    try:
+        for bad in (0, -1.0):
+            with pytest.raises(exceptions.InvalidParameterError) as excinfo:
+                dc.capture_single([1], max_wait=bad)
+            assert repr(bad) in str(excinfo.value)
+        assert conn.waveform_requests == []
+    finally:
+        dc.disconnect()
+
+
+def test_duplicate_configs_are_numbered_by_position_not_by_value(monkeypatch):
+    """'1us' and '1000ns' are the same timebase, so after parsing both configs
+    are the identical dict {'timebase': 1e-06}. configs.index(config) matched
+    the first one for both and reported 'Config 1/2' twice."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector()
+    statuses = []
+    try:
+        dc.batch_capture(
+            channels=[1],
+            timebase_scales=["1us", "1000ns"],
+            triggers_per_config=1,
+            progress_callback=lambda current, total, status: statuses.append(status),
+        )
+    finally:
+        dc.disconnect()
+    assert [s.split(",")[0] for s in statuses] == ["Config 1/2", "Config 2/2"]
 
 
 def test_successful_entries_carry_no_error_key(monkeypatch):

--- a/tests/test_automation_capture.py
+++ b/tests/test_automation_capture.py
@@ -1,0 +1,95 @@
+"""capture_single must wait for the acquisition, not for a fixed 0.5 seconds.
+
+It armed a single acquisition then slept a flat 0.5 s and read whatever was
+there, while TriggerWaitCollector.wait_for_trigger in the same file polls
+acquisition_status() correctly. On a slow timebase the read landed before the
+sweep finished, so batch_capture recorded the PREVIOUS config's waveform under
+the new config's label -- wrong data, correctly formatted, no warning.
+
+FakeTime is used throughout so the timeout tests cost no wall-clock time.
+"""
+
+import pytest
+
+from scpi_control import exceptions
+from scpi_control.automation import DataCollector
+from scpi_control.connection.mock import MockConnection
+from tests.test_automation import FakeTime
+
+
+def _collector(**kwargs):
+    conn = MockConnection(channel_states={1: True, 2: False}, sample_rate=1_000.0, timebase=1e-3, **kwargs)
+    dc = DataCollector("mock", connection=conn)
+    dc.connect()
+    return dc, conn
+
+
+def test_capture_single_waits_for_the_acquisition_to_finish(monkeypatch):
+    """Three statuses queued: the poll must consume the two busy ones before
+    reading. A fixed sleep would read immediately, at status 'Trig'd'."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, conn = _collector(trigger_status=["Trig'd", "Trig'd", "Stop"])
+    try:
+        waveforms = dc.capture_single([1])
+    finally:
+        dc.disconnect()
+    assert list(waveforms.keys()) == [1]
+    # The queue is drained down to its final repeating element, proving the loop
+    # polled rather than slept.
+    assert conn.trigger_status == ["Stop"]
+
+
+def test_capture_single_times_out_instead_of_reading_stale_data(monkeypatch):
+    """A status that never reaches STOP must raise, not return the previous
+    acquisition. A long queue is required: TRIG_MODE SINGLE resets a
+    single-element queue to ['Ready', 'Stop'] (mock/siglent.py:131-133)."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector(trigger_status=["Trig'd"] * 200)
+    try:
+        with pytest.raises(exceptions.SiglentTimeoutError) as excinfo:
+            dc.capture_single([1], max_wait=1.0)
+    finally:
+        dc.disconnect()
+    message = str(excinfo.value)
+    # acquisition_status() normalizes across dialects, so the last status is the
+    # canonical "TRIGD" token, not the mock's raw "Trig'd".
+    assert "TRIGD" in message
+    assert "1.00" in message
+
+
+def test_normal_trigger_mode_completes_on_trigd(monkeypatch):
+    """In NORM the scope re-arms after every trigger and never reports STOP, so
+    a naive `while status != 'STOP'` loop always times out. wait_for_trigger
+    already carries this branch; capture_single must too."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, conn = _collector(trigger_status=["Ready", "Ready", "Trig'd", "Trig'd"])
+    dc.scope.trigger.mode = "NORM"
+    try:
+        waveforms = dc.capture_single([1], max_wait=5.0)
+    finally:
+        dc.disconnect()
+    assert list(waveforms.keys()) == [1]
+
+
+def test_an_explicit_max_wait_is_honoured(monkeypatch):
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector(trigger_status=["Trig'd"] * 200)
+    try:
+        with pytest.raises(exceptions.SiglentTimeoutError) as excinfo:
+            dc.capture_single([1], max_wait=0.5)
+    finally:
+        dc.disconnect()
+    assert "0.5" in str(excinfo.value)
+
+
+def test_the_default_timeout_scales_with_the_timebase(monkeypatch):
+    """A 100 ms/div sweep takes 1.4 s; a 2 s floor alone would time out on it."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector()
+    try:
+        dc.scope.timebase = 0.1
+        assert dc._acquisition_timeout() == pytest.approx(14 * 0.1 * 5)
+        dc.scope.timebase = 1e-6
+        assert dc._acquisition_timeout() == pytest.approx(2.0)  # floor
+    finally:
+        dc.disconnect()

--- a/tests/test_automation_capture.py
+++ b/tests/test_automation_capture.py
@@ -122,3 +122,81 @@ def test_default_mode_is_armed_single_shot(monkeypatch):
     finally:
         dc.disconnect()
     assert any("TRIG_MODE SINGLE" in w.upper() for w in conn.writes)
+
+
+def test_batch_capture_accepts_its_own_documented_string_scales(monkeypatch):
+    """The docstring documents timebase_scales=['1us','10us'] and
+    voltage_scales={1:['1V','2V']} and its example copies them verbatim -- then
+    the apply path passed them to set_scale() unparsed and raised TypeError,
+    losing every capture taken so far."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, conn = _collector()
+    try:
+        results = dc.batch_capture(
+            channels=[1],
+            timebase_scales=["1us", "10us"],
+            voltage_scales={1: ["1V", "500mV"]},
+            triggers_per_config=1,
+        )
+    finally:
+        dc.disconnect()
+    assert len(results) == 4
+    # pytest.approx: parse_si_value("10us") is 10 * 1e-6, which is
+    # 9.999999999999999e-06 in IEEE 754 binary64 -- not bit-identical to the
+    # 1e-5 literal even though both mean "10 microseconds". test_units.py
+    # uses the same tolerance for the identical reason.
+    assert conn.timebase_updates == pytest.approx([1e-6, 1e-6, 1e-5, 1e-5])
+    assert conn.scale_updates[1] == [1.0, 0.5, 1.0, 0.5]
+
+
+def test_batch_capture_still_accepts_numeric_scales(monkeypatch):
+    """Purely additive: callers already passing floats keep working."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, conn = _collector()
+    try:
+        results = dc.batch_capture(channels=[1], timebase_scales=[1e-3], voltage_scales={1: [0.5]}, triggers_per_config=1)
+    finally:
+        dc.disconnect()
+    assert len(results) == 1
+    assert conn.timebase_updates == [1e-3]
+
+
+def test_batch_capture_rejects_an_unparseable_scale_before_capturing(monkeypatch):
+    """Fail on the argument, not 40 captures in."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, conn = _collector()
+    try:
+        with pytest.raises(exceptions.InvalidParameterError):
+            dc.batch_capture(channels=[1], timebase_scales=["banana"], triggers_per_config=1)
+        assert conn.waveform_requests == []
+    finally:
+        dc.disconnect()
+
+
+def test_a_timed_out_capture_becomes_a_visible_failed_entry(monkeypatch):
+    """The run continues and the failure is in the returned data, not only in a
+    log line. Previously the slot held the PREVIOUS config's waveform."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector(trigger_status=["Trig'd"] * 500)
+    try:
+        results = dc.batch_capture(channels=[1], timebase_scales=["1us", "10us"], triggers_per_config=1)
+    finally:
+        dc.disconnect()
+    assert len(results) == 2, "the run must continue past a timeout"
+    for entry in results:
+        assert entry["waveforms"] == {}
+        assert "error" in entry
+        assert entry["config"]
+    # Nothing already captured is lost, and no entry claims a waveform it lacks.
+
+
+def test_successful_entries_carry_no_error_key(monkeypatch):
+    """Existing consumers reading config/waveforms/trigger_num are unaffected."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector()
+    try:
+        results = dc.batch_capture(channels=[1], timebase_scales=["1us"], triggers_per_config=1)
+    finally:
+        dc.disconnect()
+    assert results and "error" not in results[0]
+    assert results[0]["waveforms"]

--- a/tests/test_automation_capture.py
+++ b/tests/test_automation_capture.py
@@ -141,11 +141,7 @@ def test_batch_capture_accepts_its_own_documented_string_scales(monkeypatch):
     finally:
         dc.disconnect()
     assert len(results) == 4
-    # pytest.approx: parse_si_value("10us") is 10 * 1e-6, which is
-    # 9.999999999999999e-06 in IEEE 754 binary64 -- not bit-identical to the
-    # 1e-5 literal even though both mean "10 microseconds". test_units.py
-    # uses the same tolerance for the identical reason.
-    assert conn.timebase_updates == pytest.approx([1e-6, 1e-6, 1e-5, 1e-5])
+    assert conn.timebase_updates == [1e-6, 1e-6, 1e-5, 1e-5]
     assert conn.scale_updates[1] == [1.0, 0.5, 1.0, 0.5]
 
 

--- a/tests/test_automation_capture.py
+++ b/tests/test_automation_capture.py
@@ -93,3 +93,32 @@ def test_the_default_timeout_scales_with_the_timebase(monkeypatch):
         assert dc._acquisition_timeout() == pytest.approx(2.0)  # floor
     finally:
         dc.disconnect()
+
+
+def test_norm_mode_is_not_re_armed(monkeypatch):
+    """capture_single must not force a single-shot when the scope is already in
+    NORM: doing so would stomp the user's configured mode (and, incidentally,
+    defeat _wait_for_acquisition's own NORM branch, since it reads the mode
+    after this write). Pinned via the raw commands sent to the mock rather
+    than behaviour alone, so removing the guard fails this test even though
+    the capture still completes."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, conn = _collector(trigger_status=["Ready", "Ready", "Trig'd", "Trig'd"])
+    dc.scope.trigger.mode = "NORM"
+    try:
+        dc.capture_single([1], max_wait=5.0)
+    finally:
+        dc.disconnect()
+    assert not any("TRIG_MODE SINGLE" in w.upper() for w in conn.writes)
+
+
+def test_default_mode_is_armed_single_shot(monkeypatch):
+    """Companion to the NORM test above: in the default (non-NORM) mode,
+    capture_single must still arm a single acquisition as before."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, conn = _collector(trigger_status=["Trig'd", "Trig'd", "Stop"])
+    try:
+        dc.capture_single([1])
+    finally:
+        dc.disconnect()
+    assert any("TRIG_MODE SINGLE" in w.upper() for w in conn.writes)

--- a/tests/test_automation_save.py
+++ b/tests/test_automation_save.py
@@ -12,7 +12,6 @@ import pytest
 
 from scpi_control.automation import DataCollector
 from scpi_control.connection.mock import MockConnection
-from scpi_control.exceptions import InvalidParameterError
 from scpi_control.waveform import WaveformData
 
 
@@ -82,17 +81,19 @@ def test_save_data_explicit_npy_format_works(tmp_path):
         assert "voltage" in npz
 
 
-def test_save_data_explicit_lowercase_npz_still_raises(tmp_path):
-    """Pin the contract: save_waveform only accepts the exact tokens it upper-cases
-    to CSV/CSV_ENHANCED/NPY/MAT/HDF5. An explicit format="npz" is not one of them
-    and must still raise -- only the *default* (None) auto-detects."""
+def test_save_data_explicit_lowercase_npz_now_succeeds(tmp_path):
+    """save_waveform now maps the alias "NPZ" -> "NPY" (same as its extension
+    auto-detect already did for .npz), so an explicit format="npz" passed
+    through DataCollector.save_data succeeds instead of raising."""
     mock_connection = MockConnection(channel_states={1: True}, sample_rate=1_000.0, timebase=1e-3)
     collector = DataCollector("mock", connection=mock_connection)
     waveforms = {1: _make_waveform(1)}
     filename = str(tmp_path / "measurement.npz")
 
-    with pytest.raises(InvalidParameterError):
-        collector.save_data(waveforms, filename, format="npz")
+    collector.save_data(waveforms, filename, format="npz")
+
+    saved_path = tmp_path / "measurement_ch1.npz"
+    assert saved_path.exists()
 
 
 def test_save_batch_default_format_smoke(tmp_path):

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -39,7 +39,12 @@ EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
 # real instrument identity onto synthetic report/waveform provenance). The
 # narrower `="SDS1104X-E"` matches only the kwarg-assignment shape the M1 fixes
 # actually removed (model="SDS1104X-E", equipment_model="SDS1104X-E").
-FORBIDDEN = ["Siglent-Oscilloscope", ".time_interval", 'format="NPZ"', '="SDS1104X-E"']
+# NOTE: 'format="NPZ"' used to live here, banning the one spelling someone had
+# been bitten by. The ban was a case-fold away from useless -- lowercase
+# format="npz" failed identically and sailed through -- and NPZ is now a valid
+# alias for NPY anyway. tests/test_save_format_aliases.py covers the real
+# regression instead.
+FORBIDDEN = ["Siglent-Oscilloscope", ".time_interval", '="SDS1104X-E"']
 
 # (filename, module-that-must-import-or-skip). Only examples that run to
 # completion headless with no instrument belong here. report_generation_example.py's

--- a/tests/test_save_format_aliases.py
+++ b/tests/test_save_format_aliases.py
@@ -1,0 +1,59 @@
+"""Every format name the docs promise must actually save.
+
+save_waveform accepted CSV/CSV_ENHANCED/NPY/MAT/HDF5 but the docstrings around
+it -- and four shipped examples -- use 'npz' and 'h5', which raised. 'npz' was
+also start_continuous_capture's DEFAULT, so an overnight run with default
+arguments wrote nothing and only logged it.
+
+Note the asymmetry that caused this: save_waveform's own auto-detect branch maps
+.npz -> NPY and .h5 -> HDF5, so the same spelling was valid as a file extension
+and invalid as an argument.
+"""
+
+import numpy as np
+import pytest
+
+from scpi_control import exceptions
+from scpi_control.waveform import Waveform, WaveformData
+
+
+@pytest.fixture
+def waveform():
+    return WaveformData(time=np.arange(10) / 1e3, voltage=np.zeros(10), channel=1, sample_rate=1e3)
+
+
+@pytest.fixture
+def manager():
+    return Waveform.__new__(Waveform)
+
+
+@pytest.mark.parametrize("fmt", ["npz", "NPZ", "npy", "NPY", "csv", "CSV", "csv_enhanced", "mat", "MAT"])
+def test_documented_format_names_save(manager, waveform, tmp_path, fmt):
+    target = tmp_path / "capture.out"
+    manager.save_waveform(waveform, str(target), format=fmt)
+    assert list(tmp_path.iterdir()), f"format={fmt!r} wrote no file"
+
+
+@pytest.mark.parametrize("fmt", ["h5", "H5", "hdf5", "HDF5"])
+def test_hdf5_format_names_save(manager, waveform, tmp_path, fmt):
+    pytest.importorskip("h5py")  # CI installs .[dev,web] only -- no h5py
+    target = tmp_path / "capture.out"
+    manager.save_waveform(waveform, str(target), format=fmt)
+    assert list(tmp_path.iterdir()), f"format={fmt!r} wrote no file"
+
+
+def test_an_unknown_format_still_raises_and_lists_the_canonical_names(manager, waveform, tmp_path):
+    """The aliases must not turn the guard into a no-op."""
+    with pytest.raises(exceptions.InvalidParameterError) as excinfo:
+        manager.save_waveform(waveform, str(tmp_path / "x.out"), format="parquet")
+    assert "CSV, CSV_ENHANCED, NPY, MAT, HDF5" in str(excinfo.value)
+
+
+def test_the_alias_and_the_extension_agree(manager, waveform, tmp_path):
+    """An explicit format and the auto-detected one must resolve identically for
+    the same spelling -- the inconsistency that produced this bug."""
+    explicit = tmp_path / "explicit.npz"
+    detected = tmp_path / "detected.npz"
+    manager.save_waveform(waveform, str(explicit), format="npz")
+    manager.save_waveform(waveform, str(detected), format=None)
+    assert explicit.exists() and detected.exists()

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,80 @@
+"""Parsing human-written SI quantity strings.
+
+batch_capture documents its scales as strings ('1us', '500mV') and its example
+copies those verbatim, but the apply path never parsed them -- the documented
+call raised TypeError. These tests pin the parser that fixes it, including the
+one rule that is easy to get backwards: 'm' is milli, 'M' is mega.
+"""
+
+import pytest
+
+from scpi_control import exceptions
+from scpi_control.units import parse_si_value
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("1us", 1e-6),
+        ("500mV", 0.5),
+        ("2.5V", 2.5),
+        ("1e-6", 1e-6),
+        ("100 ns", 1e-7),
+        ("1s", 1.0),
+        ("1M", 1e6),
+        ("1m", 1e-3),
+        ("1k", 1e3),
+        ("1K", 1e3),
+        ("1G", 1e9),
+        ("1p", 1e-12),
+        ("1MHz", 1e6),
+        ("1Hz", 1.0),
+        ("-2.5mV", -2.5e-3),
+        ("+1u", 1e-6),
+        ("  1us  ", 1e-6),
+        ("1µs", 1e-6),
+        ("1μs", 1e-6),
+    ],
+)
+def test_parses_si_strings(text, expected):
+    assert parse_si_value(text, "test quantity") == pytest.approx(expected)
+
+
+def test_milli_and_mega_are_distinguished_by_case():
+    """The load-bearing pair. A case-insensitive parser silently turns a 1 mV
+    scale into a 1 MV scale -- nine orders of magnitude, no error."""
+    assert parse_si_value("1m", "scale") == pytest.approx(1e-3)
+    assert parse_si_value("1M", "scale") == pytest.approx(1e6)
+
+
+@pytest.mark.parametrize("value,expected", [(1e-6, 1e-6), (0.5, 0.5), (2, 2.0), (-3, -3.0)])
+def test_numbers_pass_through_untouched(value, expected):
+    """What makes this change purely additive: callers already passing floats
+    keep working, so batch_capture accepts both spellings."""
+    result = parse_si_value(value, "scale")
+    assert isinstance(result, float)
+    assert result == pytest.approx(expected)
+
+
+def test_an_unknown_unit_is_accepted_not_guessed_at():
+    """Units are deliberately unvalidated: the first suffix character is checked
+    against the prefix table and everything else is treated as a unit. Rejecting
+    unknown units would mean maintaining a list of every unit an instrument
+    might use."""
+    assert parse_si_value("1x", "scale") == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "abc", "mV", None, [], True, False])
+def test_rejects_values_with_no_usable_number(bad):
+    """True/False are rejected on purpose despite bool subclassing int -- reading
+    True as 1.0 would silently accept a caller's mistake."""
+    with pytest.raises(exceptions.InvalidParameterError):
+        parse_si_value(bad, "test quantity")
+
+
+def test_the_error_names_the_quantity_and_the_value():
+    with pytest.raises(exceptions.InvalidParameterError) as excinfo:
+        parse_si_value("wat", "timebase scale")
+    message = str(excinfo.value)
+    assert "timebase scale" in message
+    assert "wat" in message

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -78,3 +78,30 @@ def test_the_error_names_the_quantity_and_the_value():
     message = str(excinfo.value)
     assert "timebase scale" in message
     assert "wat" in message
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("10us", 1e-5),
+        ("100ns", 1e-7),
+        ("10mV", 1e-2),
+        ("100us", 1e-4),
+        ("1e6m", 1e3),
+    ],
+)
+def test_parsed_values_are_canonical_floats(text, expected):
+    """Exact equality, NOT pytest.approx -- that is the whole point.
+
+    parse_si_value used to compute float(number) * scale, and float
+    multiplication is not correctly rounded the way parsing a decimal literal
+    is: float("10") * 1e-6 is 9.999999999999999e-06 while 10e-6 is 1e-05. The
+    parsed value is formatted straight into a SCPI command, so the difference
+    reached the wire as "TDIV 9.999999999999999e-06".
+    """
+    assert parse_si_value(text, "scale") == expected
+
+
+def test_a_parsed_scale_formats_to_a_canonical_scpi_value():
+    """The wire-level consequence, pinned directly."""
+    assert "{0}".format(parse_si_value("10us", "timebase scale")) == "1e-05"

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -72,6 +72,29 @@ def test_rejects_values_with_no_usable_number(bad):
         parse_si_value(bad, "test quantity")
 
 
+@pytest.mark.parametrize("bad", ["1,000us", "1_000", "1..5", "5 000"])
+def test_rejects_a_suffix_that_swallowed_part_of_the_number(bad):
+    """The counterpart to the unvalidated-unit rule above, and the same
+    silent-wrong-value class this parser exists to eliminate.
+
+    The regex captures a leading number and treats the rest as a unit, so
+    '1,000us' -- an operator writing 1 ms -- parsed to 1.0 and set a timebase
+    1000x off, recorded under the label '1.0' so nothing downstream could tell.
+    An unknown unit discards nothing; a dropped numeric remainder discards
+    everything after it.
+    """
+    with pytest.raises(exceptions.InvalidParameterError):
+        parse_si_value(bad, "timebase scale")
+
+
+def test_an_exponent_beyond_the_decimal_range_is_a_parameter_error():
+    """Decimal.scaleb raises Overflow, which is NOT a subclass of
+    InvalidOperation, so the original guard let a raw decimal exception escape
+    a module that promises InvalidParameterError for every bad input."""
+    with pytest.raises(exceptions.InvalidParameterError):
+        parse_si_value("1e999995G", "scale")
+
+
 def test_the_error_names_the_quantity_and_the_value():
     with pytest.raises(exceptions.InvalidParameterError) as excinfo:
         parse_si_value("wat", "timebase scale")


### PR DESCRIPTION
Fixes three shipped features in the automation path that failed **silently** — the worst kind, because each produced a plausible-looking result while doing the wrong thing. All three come from the 2026-07-22 adversarial audit (findings H2, H3, H4), and all three were re-verified against current `main` before any code was written.

Non-breaking: one new optional parameter, one new module, widened input. MINOR bump at release.

## What was broken

**Saves were rejected, including the documented default.** `save_waveform` accepted `CSV`/`CSV_ENHANCED`/`NPY`/`MAT`/`HDF5`, but `npz` and `h5` — two of the four names `start_continuous_capture`'s docstring lists, one of them its **default** — raised `InvalidParameterError`. An overnight run with default arguments wrote nothing. Four shipped examples (`simple_capture.py`, `batch_capture.py`, `continuous_capture.py`, `trigger_based_capture.py`) were broken the same way.

The tell: `save_waveform`'s own auto-detect branch already mapped `.npz → NPY` and `.h5 → HDF5`. The identical spelling was valid as a file extension and rejected as an argument. The fix applies that same mapping to the explicit argument.

**`batch_capture` crashed on its own documented example.** It types its scales as SI strings, documents `['1us','10us']` and `{1:['1V','2V']}`, repeats them in its example — then passed them to `set_scale()` unparsed. The documented call raised `TypeError` and discarded every capture already taken. Now parsed by a new `scpi_control/units.py`; numeric scales keep working unchanged.

**`capture_single` read before the sweep finished.** It armed a single acquisition, slept a flat 0.5 s, and read whatever was there — while `TriggerWaitCollector.wait_for_trigger`, 400 lines below in the same file, polled `acquisition_status()` correctly. On a slow timebase the read landed early, so `batch_capture` recorded the **previous** config's waveform under the new config's label. Wrong data, correctly formatted, no warning.

## What changed

- **`scpi_control/units.py`** (new) — `parse_si_value` accepts `'1us'`, `'500mV'`, `'2.5V'`, `'1e-6'` and plain numbers. Case-sensitive prefixes (`m` is milli, `M` is mega — a case-insensitive table turns a 1 mV scale into a 1 MV scale with no error). Scales by shifting the **decimal exponent** via `Decimal.scaleb` rather than multiplying by a float, so `'10us'` is exactly `1e-05`; the multiply version produced `9.999999999999999e-06`, which reached the instrument as `TDIV 9.999999999999999e-06`.
- **`capture_single`** polls `acquisition_status()` with a timebase-derived timeout and a new optional `max_wait`. A timed-out capture becomes a visible failed entry in `batch_capture`'s results (empty `waveforms` + an `error` field) rather than aborting the run or holding stale data.
- **NORM trigger mode is no longer clobbered.** `capture_single` previously always armed a single shot regardless of mode; it now leaves a user-configured `NORM` alone and waits for the next natural trigger, matching what `wait_for_trigger` already did. This is a deliberate behaviour change and is disclosed in the docstring, not buried.

## Notes on the process

Two audit findings did **not** survive contact with the code, which is why re-verification came first:

- **H1 was already fixed** — `analysis.py` now maps `hanning → hann` for SciPy, and both spectrum functions return tuples. Dropped from scope rather than "fixed" a second time.
- **A prior partial fix had codified the remaining bug.** `tests/test_automation_save.py` carried a test whose docstring read *"Pin the contract: … an explicit `format='npz'` … must still raise"*. That earlier change fixed `save_data`/`save_batch` defaults but missed that `start_continuous_capture` passes its format explicitly — so its "contract" left the documented default permanently broken. Reversed deliberately.

Review also caught two things worth naming, both fixed here:

- The parser **silently truncated malformed numeric input**: `'1,000us'` → `1.0`. An operator writing a thousands separator would have set a timebase 1000× off, recorded under the label `1.0` so nothing downstream could detect it — the exact silent-wrong-value class this PR exists to eliminate, reappearing inside the fix. Now rejected, while keeping units deliberately unvalidated (`'1x'` is still `1.0`, because an unknown *unit* discards no information whereas a swallowed *numeric remainder* discards everything after it).
- The spec-mandated **end-to-end test was missing** — every caller-level test passed `output_dir=None`, skipping the save branch entirely, so the actual failure path executed in no test. Added, and it asserts on a written file rather than absence of an exception, which matters because a broad `except Exception` in the capture loop swallows save errors. That swallowing is why this bug stayed invisible.

## Verification

- Full suite **1941 passed, 19 skipped, 0 failed**.
- `black --check --line-length 200 scpi_control/ examples/` clean; `flake8 --select=E9,F63,F7,F82` = 0; `--select=F401` shows only a pre-existing unused `struct` import in `waveform.py` (on `main`, deliberately not touched here).
- CI-extras parity: re-run with PyQt6, reportlab and h5py blocked — 0 import errors, HDF5 cases skipping correctly. CI installs `.[dev,web]` only, and this class of bug has shipped twice before.

## Deliberately not in this PR

A circuit breaker for a `batch_capture` run where nothing ever triggers (bounded and visible today, and strictly better than `main`'s abort-and-discard); `KeyboardInterrupt` handling in that loop; `'1e999995'` with no SI prefix returning `inf`; the unvalidated `max_wait` on `wait_for_trigger`; and the broad `except Exception` around the per-capture save.
