### PR TITLE
fix(docs): use an absolute URL for the README screenshot so PyPI renders it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The oscilloscope screenshot at the top of the README no longer fails to load on the PyPI
+  project page. It used a repository-relative path, which GitHub resolves against the repo but
+  PyPI cannot — PyPI renders the README as a standalone document with no repo context, so the
+  image silently broke there while looking fine on GitHub. It now uses an absolute raw URL. Note
+  that PyPI project pages are immutable per release, so the fix appears from the next release
+  onward; already-published pages keep the broken image.
+
 ## [5.5.0] - 2026-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ Control SCPI-compatible test equipment from Python — oscilloscopes, function g
 > **Formerly `Siglent-Oscilloscope`.** Upgrading from the old package? See the [Migration Guide](#migration-guide).
 
 <p align="center">
-  <img src="docs/images/sds824x-hd-cal-square.png" alt="Live screen capture from a Siglent SDS824X HD oscilloscope" width="720">
+  <!-- Absolute raw URL, not a repo-relative path: PyPI renders this README as a
+       standalone document with no repo context, so a relative src has nothing to
+       resolve against and the image silently fails to load there. -->
+  <img src="https://raw.githubusercontent.com/little-did-I-know/SCPI-Instrument-Control/main/docs/images/sds824x-hd-cal-square.png" alt="Live screen capture from a Siglent SDS824X HD oscilloscope" width="720">
   <br>
   <em>A live screen capture pulled over LAN from a Siglent SDS824X&nbsp;HD (its 1&nbsp;kHz calibration square wave), via <code>scope.screen_capture.get_screenshot_pil()</code>.</em>
 </p>

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The oscilloscope screenshot at the top of the README no longer fails to load on the PyPI
+  project page. It used a repository-relative path, which GitHub resolves against the repo but
+  PyPI cannot — PyPI renders the README as a standalone document with no repo context, so the
+  image silently broke there while looking fine on GitHub. It now uses an absolute raw URL. Note
+  that PyPI project pages are immutable per release, so the fix appears from the next release
+  onward; already-published pages keep the broken image.
+
 ## [5.5.0] - 2026-07-26
 
 ### Added


### PR DESCRIPTION
The oscilloscope screenshot at the top of the README doesn't render on the PyPI project page.

## Cause

The `<img>` used a repository-relative path:

```html
<img src="docs/images/sds824x-hd-cal-square.png" ...>
```

GitHub resolves that against the repo. PyPI renders the README as a standalone document with no repo context, so a relative `src` has nothing to resolve against and the image silently fails. Everything else at the top of the README survives because the badges are already absolute shields.io URLs — which is why only the screenshot was affected.

The file itself is present and git-tracked, so this was never broken on GitHub.

## Fix

An absolute raw URL, verified to resolve before committing (`HTTP 200`, `image/png`, 21,732 bytes):

```
https://raw.githubusercontent.com/little-did-I-know/SCPI-Instrument-Control/main/docs/images/sds824x-hd-cal-square.png
```

A comment above the tag records why it must stay absolute, so it doesn't get "tidied" back into a relative path.

## Two things worth knowing

**PyPI project pages are immutable per release.** This does not repair the 5.5.0 page — the screenshot appears from the next release onward.

**13 relative *links* in the README have the same problem** (`CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE`, `examples/`, `docs/gateway/security.md`, and others). They 404 on PyPI for the identical reason. They're deliberately left alone here: making them absolute would fix PyPI but means anyone reading the README on a fork or PR branch gets links pointing back at upstream `main` rather than their own copy. Worth deciding separately rather than bundling into an image fix.

## Verification

- The raw URL resolves (HTTP 200, correct content type and size).
- No relative `<img>` tags remain in the README.
- `docs/about/changelog.md` re-synced to `CHANGELOG.md` and confirmed byte-identical — the two are hand-maintained mirrors and nothing in the suite enforces that.
- No tests run: this changes no code, and the only test mentioning the README does so in a comment, not by reading the file.
