### PR TITLE
chore(release): 5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.0] - 2026-07-26
+
 ### Fixed
 
 - `save_waveform` now accepts `npz` and `h5` as aliases for `NPY` and `HDF5`. `npz` is

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.0] - 2026-07-26
+
 ### Fixed
 
 - `save_waveform` now accepts `npz` and `h5` as aliases for `NPY` and `HDF5`. `npz` is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "5.5.0"
+version = "5.6.0"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "5.5.0"
+__version__ = "5.6.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
Cuts 5.6.0. MINOR — the release is entirely fixes plus one new internal module (`scpi_control.units`), with one new optional parameter. Nothing broke: no renames, no removed names, no required-parameter changes.

## Contents

Six `### Fixed` entries, from PR #115 (five) and PR #116 (one).

**Three silent failures in the automation capture path** (#115) — all from the 2026-07-22 adversarial audit, all re-verified against `main` before any code was written:

- `save_waveform` rejected `npz` and `h5`, two of the four format names its own docstrings list — one of them `start_continuous_capture`'s **default**. An overnight run with default arguments wrote nothing, and four shipped examples were broken the same way. The same spellings were already valid as file *extensions* via auto-detect, which is what produced the inconsistency.
- `batch_capture` raised `TypeError` on the SI-string scales its own docstring documents and its example copies verbatim, discarding every capture already taken. Now parsed by the new `scpi_control/units.py`.
- `capture_single` slept a flat 0.5 s instead of polling `acquisition_status()`, so on a slow timebase it returned the **previous** acquisition — which `batch_capture` then recorded under the new config's label. Wrong data, correctly formatted, no warning.

Plus two changes that came out of reviewing those: `capture_single` no longer clobbers a user-configured `NORM` trigger mode (disclosed in its docstring, not buried), and `parse_si_value` scales by shifting the decimal exponent so `'10us'` is exactly `1e-05` rather than reaching the instrument as `TDIV 9.999999999999999e-06`.

**One documentation fix** (#116) — the README screenshot used a repository-relative path, so it silently failed to load on PyPI while rendering fine on GitHub. Now an absolute raw URL, matching what the README's other six images already did.

## Release mechanics

- `pyproject.toml` and `scpi_control/__init__.py` bumped 5.5.0 → 5.6.0 (both hand-maintained; `tests/test_version_consistency.py` enforces they agree)
- `## [5.6.0] - 2026-07-26` header inserted under `## [Unreleased]`
- `docs/about/changelog.md` re-synced to `CHANGELOG.md` — byte-identical hand-maintained mirrors that nothing in the suite enforces, so this is a manual step every release
- PyPI summary re-checked at **387 characters**, inside the hard 512 cap that failed the v3.2.0 publish

## Verification

- Full suite **1941 passed, 19 skipped, 0 failed**
- `black --check --line-length 200 scpi_control/ examples/` clean (180 files); `flake8 --select=E9,F63,F7,F82` = 0

## Note

The README screenshot fix takes effect on **this** release's PyPI page. The 5.5.0 page keeps the broken image — PyPI project pages are immutable per release.

After merge: tag `v5.6.0` and publish the GitHub release, which triggers the build/PyPI/docs workflow.
