### PR TITLE
fix(automation): stop the capture loop swallowing save failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `start_continuous_capture` no longer hides save failures. Saving sat inside the capture loop's
+  broad `except`, which logs and continues, so a rejected `file_format` or an unwritable
+  `output_dir` failed identically on every iteration for the run's entire duration while the
+  function returned an empty list — an overnight run producing an empty directory and no signal
+  at all. This is what kept the `npz` default (fixed in 5.6.0) invisible for so long. Saves now
+  have their own handler: if the *first* save fails and no file has been written, the run stops
+  immediately with a `SiglentError` naming the format and chaining the underlying cause, because
+  that is configuration rather than a transient fault and every later attempt would fail the same
+  way. Once one file has landed the configuration is proven, so later failures are counted,
+  logged, and summarised at the end without aborting a long unattended run.
+
+### Changed
+
+- `start_continuous_capture` with `output_dir` set now returns per-capture metadata instead of an
+  empty list. Entries carry `timestamp`, `elapsed_time`, `capture_num` and the `files` written,
+  omitting the bulky waveform arrays (those are on disk). Previously the function returned `[]`
+  whether it had written ten thousand files or none, so a caller had no way to tell what happened.
+  In-memory mode (no `output_dir`) is unchanged and still returns the `waveforms`.
+
 ## [5.6.0] - 2026-07-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   immediately with a `SiglentError` naming the format and chaining the underlying cause, because
   that is configuration rather than a transient fault and every later attempt would fail the same
   way. Once one file has landed the configuration is proven, so later failures are counted,
-  logged, and summarised at the end without aborting a long unattended run.
+  logged, and summarised at the end without aborting a long unattended run. The raised error keeps
+  its original type when it is already a library exception, so a caller catching
+  `InvalidParameterError` still catches it. A run that writes nothing because no save was ever
+  *attempted* — every capture yielding no waveforms, from disabled channels or a failing
+  `acquire()` — now ends with a warning too; that is the same empty-directory symptom reached by a
+  different route, and it was equally silent.
 
 ### Changed
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `start_continuous_capture` no longer hides save failures. Saving sat inside the capture loop's
+  broad `except`, which logs and continues, so a rejected `file_format` or an unwritable
+  `output_dir` failed identically on every iteration for the run's entire duration while the
+  function returned an empty list — an overnight run producing an empty directory and no signal
+  at all. This is what kept the `npz` default (fixed in 5.6.0) invisible for so long. Saves now
+  have their own handler: if the *first* save fails and no file has been written, the run stops
+  immediately with a `SiglentError` naming the format and chaining the underlying cause, because
+  that is configuration rather than a transient fault and every later attempt would fail the same
+  way. Once one file has landed the configuration is proven, so later failures are counted,
+  logged, and summarised at the end without aborting a long unattended run.
+
+### Changed
+
+- `start_continuous_capture` with `output_dir` set now returns per-capture metadata instead of an
+  empty list. Entries carry `timestamp`, `elapsed_time`, `capture_num` and the `files` written,
+  omitting the bulky waveform arrays (those are on disk). Previously the function returned `[]`
+  whether it had written ten thousand files or none, so a caller had no way to tell what happened.
+  In-memory mode (no `output_dir`) is unchanged and still returns the `waveforms`.
+
 ## [5.6.0] - 2026-07-26
 
 ### Fixed

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -18,7 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   immediately with a `SiglentError` naming the format and chaining the underlying cause, because
   that is configuration rather than a transient fault and every later attempt would fail the same
   way. Once one file has landed the configuration is proven, so later failures are counted,
-  logged, and summarised at the end without aborting a long unattended run.
+  logged, and summarised at the end without aborting a long unattended run. The raised error keeps
+  its original type when it is already a library exception, so a caller catching
+  `InvalidParameterError` still catches it. A run that writes nothing because no save was ever
+  *attempted* — every capture yielding no waveforms, from disabled channels or a failing
+  `acquire()` — now ends with a warning too; that is the same empty-directory symptom reached by a
+  different route, and it was equally silent.
 
 ### Changed
 

--- a/scpi_control/automation.py
+++ b/scpi_control/automation.py
@@ -355,7 +355,21 @@ class DataCollector:
             progress_callback: Optional callback function(captures_done, status)
 
         Returns:
-            List of capture dictionaries (or empty list if output_dir is specified)
+            List of capture dictionaries. Without ``output_dir`` each entry
+            carries the captured ``waveforms``; with ``output_dir`` the bulky
+            arrays are omitted (they are on disk) and each entry instead lists
+            the ``files`` written, so a caller can still tell how many captures
+            happened and where they went.
+
+        Raises:
+            SiglentError: If the very first save fails and no file was written.
+                That means the run is misconfigured -- a rejected ``file_format``,
+                an unwritable ``output_dir``, a missing optional dependency --
+                and every later attempt would fail identically, so an unattended
+                run is stopped immediately rather than writing nothing for its
+                full duration. Once one file has landed the configuration is
+                proven, and later save failures are counted and logged without
+                aborting the run.
 
         Example:
             >>> # Capture for 60 seconds, save to files
@@ -378,6 +392,9 @@ class DataCollector:
         results = []
         start_time = time.time()
         capture_count = 0
+        files_written = 0
+        save_failures = 0
+        fatal_save_error = None
 
         # Set to AUTO trigger mode for continuous acquisition
         self.scope.trigger.mode = "AUTO"
@@ -409,9 +426,39 @@ class DataCollector:
                 # Save to file or memory
                 if output_dir:
                     timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+                    saved_paths = []
                     for ch, waveform in waveforms.items():
                         filename = output_path / f"ch{ch}_{timestamp_str}.{file_format}"
-                        self.scope.waveform.save_waveform(waveform, str(filename), format=file_format)
+                        try:
+                            self.scope.waveform.save_waveform(waveform, str(filename), format=file_format)
+                        except Exception as exc:
+                            # Saves get their own handler rather than falling through to
+                            # the loop's broad one. That handler logs and CONTINUES, so a
+                            # rejected file_format used to fail identically on every
+                            # iteration for the whole duration while the function returned
+                            # an empty list -- an overnight run producing an empty
+                            # directory and no signal at all. That is how the npz default
+                            # stayed broken (see the 5.6.0 changelog).
+                            save_failures += 1
+                            logger.error(f"Failed to save channel {ch} to {filename}: {exc}")
+                            if files_written == 0:
+                                # Nothing has ever been written, so this is configuration,
+                                # not a transient hiccup, and every later attempt fails the
+                                # same way. Stop now. Once one file has landed the
+                                # configuration is proven and later failures are tolerated.
+                                fatal_save_error = exc
+                                break
+                            continue
+                        files_written += 1
+                        saved_paths.append(str(filename))
+                    # Metadata without the arrays -- they are on disk. This mode used to
+                    # append nothing at all, so a caller could not tell how many captures
+                    # happened, where they went, or whether any had failed.
+                    saved_record = {key: value for key, value in capture_data.items() if key != "waveforms"}
+                    saved_record["files"] = saved_paths
+                    results.append(saved_record)
+                    if fatal_save_error is not None:
+                        break
                     logger.debug(f"Saved capture {capture_count}")
                 else:
                     results.append(capture_data)
@@ -432,6 +479,13 @@ class DataCollector:
                 break
             except Exception as e:
                 logger.error(f"Error during continuous capture: {e}")
+
+        if fatal_save_error is not None:
+            raise SiglentError(
+                f"Continuous capture aborted after {capture_count} capture(s): the first save failed and no file was written. Check output_dir and file_format={file_format!r}."
+            ) from fatal_save_error
+        if save_failures:
+            logger.warning(f"Continuous capture: {save_failures} save(s) failed, {files_written} file(s) written")
 
         logger.info(f"Continuous capture complete: {capture_count} captures over {duration}s")
         return results

--- a/scpi_control/automation.py
+++ b/scpi_control/automation.py
@@ -446,6 +446,12 @@ class DataCollector:
                                 # not a transient hiccup, and every later attempt fails the
                                 # same way. Stop now. Once one file has landed the
                                 # configuration is proven and later failures are tolerated.
+                                #
+                                # This abandons any remaining channels in THIS capture, which
+                                # is deliberate: a rejected format or an unwritable directory
+                                # is channel-independent, so ch2 would fail exactly as ch1
+                                # just did. (The reverse order is tolerated -- if ch1 wrote
+                                # and ch2 failed, the configuration is already proven.)
                                 fatal_save_error = exc
                                 break
                             continue
@@ -481,11 +487,22 @@ class DataCollector:
                 logger.error(f"Error during continuous capture: {e}")
 
         if fatal_save_error is not None:
-            raise SiglentError(
-                f"Continuous capture aborted after {capture_count} capture(s): the first save failed and no file was written. Check output_dir and file_format={file_format!r}."
-            ) from fatal_save_error
+            message = f"Continuous capture aborted after {capture_count} capture(s): no file was written. Check output_dir and file_format={file_format!r}."
+            # Preserve the original type when it is already one of ours -- wrapping an
+            # InvalidParameterError in a plain SiglentError would stop a caller that
+            # catches the specific type from catching it at all.
+            if isinstance(fatal_save_error, SiglentError):
+                raise type(fatal_save_error)(f"{message} ({fatal_save_error})") from fatal_save_error
+            raise SiglentError(message) from fatal_save_error
         if save_failures:
             logger.warning(f"Continuous capture: {save_failures} save(s) failed, {files_written} file(s) written")
+        elif output_dir and files_written == 0:
+            # No save was even ATTEMPTED -- every capture yielded no waveforms, because
+            # the channels are disabled or acquire() failed each time (both handled by
+            # the inner handler above, which logs and continues). Without this the run
+            # ends silently against an empty directory: the same symptom the save
+            # handler fixes, reached by a different route.
+            logger.warning(f"Continuous capture wrote no files: {capture_count} capture(s) produced no waveforms to save. Check that the requested channels are enabled.")
 
         logger.info(f"Continuous capture complete: {capture_count} captures over {duration}s")
         return results

--- a/tests/test_automation_capture.py
+++ b/tests/test_automation_capture.py
@@ -205,7 +205,11 @@ def test_start_continuous_capture_writes_files_with_its_default_format(monkeypat
 
     written = sorted(tmp_path.glob("*.npz"))
     assert written, "the default file_format must produce files, not a silently empty directory"
-    assert returned == [], "with output_dir set, captures go to disk rather than the returned list"
+    # output_dir mode used to return [] unconditionally; it now returns metadata
+    # without the bulky arrays, so a caller can see what happened and where.
+    assert returned, "output_dir mode must report what it captured"
+    assert "waveforms" not in returned[0], "the arrays are on disk, not in the return value"
+    assert returned[0]["files"], "each entry must name the files it wrote"
     # Loading proves a real npz was written, not an empty or mis-formatted file.
     with np.load(str(written[0])) as archive:
         assert len(archive["voltage"]) > 0
@@ -256,3 +260,69 @@ def test_successful_entries_carry_no_error_key(monkeypatch):
         dc.disconnect()
     assert results and "error" not in results[0]
     assert results[0]["waveforms"]
+
+
+def test_a_doomed_save_configuration_fails_fast_instead_of_writing_nothing(monkeypatch, tmp_path):
+    """The defect this replaced: a rejected file_format failed identically on
+    every iteration for the run's whole duration, each failure swallowed by the
+    loop's broad except, and the function returned an empty list. An overnight
+    run produced an empty directory and no signal at all.
+
+    'parquet' is not a supported format, so the FIRST save raises and nothing is
+    ever written -- configuration, not a transient hiccup."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime(step=0.01))
+    # A dedicated subdirectory, not tmp_path itself: a conftest fixture puts a
+    # 'fake-home' directory in tmp_path, so tmp_path is never empty.
+    output_dir = tmp_path / "captures"
+    dc, _ = _collector()
+    try:
+        with pytest.raises(exceptions.SiglentError) as excinfo:
+            dc.start_continuous_capture(channels=[1], duration=10.0, interval=0.02, output_dir=output_dir, file_format="parquet")
+    finally:
+        dc.disconnect()
+
+    message = str(excinfo.value)
+    assert "parquet" in message, "the error must name the format that was rejected"
+    assert "no file was written" in message
+    assert sorted(output_dir.iterdir()) == [], "nothing should have been written"
+    # The cause is chained rather than discarded, so the underlying reason survives.
+    assert isinstance(excinfo.value.__cause__, exceptions.InvalidParameterError)
+
+
+def test_a_later_save_failure_is_counted_without_aborting_the_run(monkeypatch, tmp_path):
+    """Once one file has landed the configuration is proven, so a transient
+    failure must not throw away a long unattended run."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime(step=0.01))
+    dc, _ = _collector()
+    real_save = dc.scope.waveform.save_waveform
+    calls = {"n": 0}
+
+    def flaky_save(waveform, filename, format=None, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:  # first one succeeds, proving the configuration
+            raise OSError("transient disk hiccup")
+        return real_save(waveform, filename, format=format, **kwargs)
+
+    monkeypatch.setattr(dc.scope.waveform, "save_waveform", flaky_save)
+    try:
+        returned = dc.start_continuous_capture(channels=[1], duration=0.1, interval=0.02, output_dir=tmp_path)
+    finally:
+        dc.disconnect()
+
+    assert calls["n"] > 2, "the run must continue past the failed save"
+    assert len(returned) > 1, "captures after the failure must still be reported"
+    assert sorted(tmp_path.glob("*.npz")), "the successful saves must still be on disk"
+
+
+def test_in_memory_mode_still_returns_the_waveforms(monkeypatch):
+    """Without output_dir nothing changed: the arrays come back in the result."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime(step=0.01))
+    dc, _ = _collector()
+    try:
+        returned = dc.start_continuous_capture(channels=[1], duration=0.1, interval=0.02, output_dir=None)
+    finally:
+        dc.disconnect()
+
+    assert returned
+    assert "waveforms" in returned[0]
+    assert "files" not in returned[0]

--- a/tests/test_automation_capture.py
+++ b/tests/test_automation_capture.py
@@ -305,7 +305,7 @@ def test_a_later_save_failure_is_counted_without_aborting_the_run(monkeypatch, t
 
     monkeypatch.setattr(dc.scope.waveform, "save_waveform", flaky_save)
     try:
-        returned = dc.start_continuous_capture(channels=[1], duration=0.1, interval=0.02, output_dir=tmp_path)
+        returned = dc.start_continuous_capture(channels=[1], duration=0.2, interval=0.02, output_dir=tmp_path)
     finally:
         dc.disconnect()
 
@@ -326,3 +326,37 @@ def test_in_memory_mode_still_returns_the_waveforms(monkeypatch):
     assert returned
     assert "waveforms" in returned[0]
     assert "files" not in returned[0]
+
+
+def test_a_run_that_saves_nothing_at_all_still_says_so(caplog, tmp_path):
+    """The other route to an empty output directory: no save ever FAILS because
+    no save is ever attempted. Every capture yields no waveforms (the channel is
+    disabled, or acquire() raises and the inner handler logs and continues), so
+    the save counters stay at zero and nothing would otherwise signal it."""
+    import logging
+
+    conn = MockConnection(channel_states={1: False}, sample_rate=1_000.0, timebase=1e-3)
+    dc = DataCollector("mock", connection=conn)
+    dc.connect()
+    try:
+        with caplog.at_level(logging.WARNING, logger="scpi_control.automation"):
+            returned = dc.start_continuous_capture(channels=[1], duration=0.05, interval=0.01, output_dir=tmp_path / "captures")
+    finally:
+        dc.disconnect()
+
+    assert returned, "captures still happened, they just produced nothing to save"
+    assert all(entry["files"] == [] for entry in returned)
+    assert any("wrote no files" in record.message for record in caplog.records), "a run that writes nothing must say so"
+
+
+def test_the_fatal_error_keeps_its_original_exception_type(tmp_path):
+    """A caller catching InvalidParameterError must still catch it. Wrapping in a
+    plain SiglentError would flatten the type and silently break that."""
+    conn = MockConnection(channel_states={1: True}, sample_rate=1_000.0, timebase=1e-3)
+    dc = DataCollector("mock", connection=conn)
+    dc.connect()
+    try:
+        with pytest.raises(exceptions.InvalidParameterError):
+            dc.start_continuous_capture(channels=[1], duration=0.05, interval=0.01, output_dir=tmp_path / "captures", file_format="parquet")
+    finally:
+        dc.disconnect()


### PR DESCRIPTION
`start_continuous_capture` hid save failures completely. This is the mechanism that kept the `npz` default (fixed in 5.6.0) invisible for as long as it was.

## The defect

Saving sat inside the capture loop's `try`, whose handler logs and **continues the loop**:

```python
if output_dir:
    for ch, waveform in waveforms.items():
        self.scope.waveform.save_waveform(waveform, str(filename), format=file_format)
...
except Exception as e:
    logger.error(f"Error during continuous capture: {e}")
```

So a rejected `file_format` or an unwritable `output_dir` failed identically on every iteration for the run's entire duration, and the function returned an empty list. An overnight run produced an empty directory, an empty return value, and one log line per failure buried in thousands.

The mutation check while building this made the scale concrete — with fail-fast disabled, a short test run logged:

```
Continuous capture: 250 save(s) failed, 0 file(s) written
```

That is what the old code did silently.

## What changed

**Saves get their own handler.** If a save fails and no file has ever been written, the run stops immediately with the original exception's type preserved and the cause chained. That case is configuration — a rejected format, an unwritable directory, a missing optional dependency — so every later attempt would fail identically and an unattended run should not burn its full duration writing nothing.

Once one file has landed the configuration is proven, so later failures are counted, logged, and summarised at the end without aborting a long run. A transient disk hiccup no longer throws away eight hours of captures.

**`output_dir` mode now returns per-capture metadata** instead of `[]` — `timestamp`, `elapsed_time`, `capture_num`, and the `files` written, omitting the bulky arrays since those are on disk. Previously the function returned `[]` whether it had written ten thousand files or none. In-memory mode is unchanged and still returns the `waveforms`.

## From review

An independent review found a hole in the first version and it's fixed here: **a run can write nothing without any save ever failing**, because if every capture yields no waveforms (disabled channels, or `acquire()` raising each time, both handled by an inner handler that logs and continues) the save loop never executes. Counters stay at zero, no fatal, no summary — the same empty-directory symptom reached by a different route, equally silent. That now ends with its own warning.

Three smaller items from the same review: the raised error keeps its original type (wrapping an `InvalidParameterError` in a plain `SiglentError` would stop a caller catching the specific type), the multi-channel asymmetry in the fatal path is now documented at the guard, and a test whose timing margin was exactly zero got widened.

## Verification

- `tests/test_automation_capture.py`, `test_automation.py`, `test_automation_save.py`, `test_examples_smoke.py` — all pass.
- Both new behaviours mutation-checked: disabling fail-fast makes the doomed-configuration test fail; removing the no-files warning makes its test fail.
- `black --check --line-length 200 scpi_control/ examples/` clean; `flake8 --select=E9,F63,F7,F82` = 0.
- The review independently swept examples, docs, README, tests, GUI, server and the report generator for consumers of the return value: every `output_dir` call site discards it, and the only code indexing `result["waveforms"]` is on the in-memory path, which is unchanged.

## Note on the return-value change

`[]` becoming non-empty in `output_dir` mode is a behaviour change, filed under `### Changed`. No caller in the repo depends on the empty list, but it is worth knowing about rather than discovering.
