### PR TITLE
feat(automation): add a consecutive-failure circuit breaker to batch_capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `batch_capture` gained a circuit breaker: `max_consecutive_failures` (default 3) stops a run
+  after that many back-to-back capture timeouts, counted across configurations and reset by any
+  success. This guards the common unattended failure — a trigger level the signal never crosses —
+  which otherwise times out on every single capture: at a 70 s timeout and 100 triggers per
+  configuration, that is hours of waiting to collect nothing, previously surfaced only as one log
+  line per failure. Everything gathered before the breaker trips is still returned, with the
+  failed entries carrying their `error` field, and a warning names the reason and the shortfall.
+  Note this changes the default behaviour of a run whose captures all time out: it now stops early
+  instead of attempting every planned capture. Pass `max_consecutive_failures=None` to restore the
+  old behaviour; a run with genuinely sparse triggers should raise `max_wait` instead.
+
+### Fixed
+
+- `batch_capture` no longer discards the whole run when interrupted. It had no `KeyboardInterrupt`
+  handler, so an operator stopping a run they could see was doomed lost every capture already
+  taken. It now keeps and returns them, matching what `start_continuous_capture` already did.
+
 ## [5.6.0] - 2026-07-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `batch_capture` no longer discards the whole run when interrupted. It had no `KeyboardInterrupt`
-  handler, so an operator stopping a run they could see was doomed lost every capture already
-  taken. It now keeps and returns them, matching what `start_continuous_capture` already did.
+- `batch_capture` no longer discards the whole run when interrupted or when the instrument stops
+  answering. It had no `KeyboardInterrupt` handler at all, so an operator stopping a run they could
+  see was doomed lost every capture already taken; it now keeps and returns them, matching what
+  `start_continuous_capture` already did. The guard covers the whole per-configuration body rather
+  than only the capture, because the gap between configurations — two socket writes plus the settle
+  delay — is exactly where an impatient operator tends to press Ctrl-C.
+- `batch_capture` now records any `SiglentError` as a failed entry, not just `SiglentTimeoutError`.
+  A dropped link mid-run previously propagated and discarded every capture already taken, which is
+  the precise loss the failed-entry path exists to prevent. Connection failures count toward the
+  circuit breaker as well — an instrument that has stopped answering is exactly what it is for. A
+  failure while *applying* a configuration stops the run and returns what was collected.
 
 ## [5.6.0] - 2026-07-26
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `batch_capture` gained a circuit breaker: `max_consecutive_failures` (default 3) stops a run
+  after that many back-to-back capture timeouts, counted across configurations and reset by any
+  success. This guards the common unattended failure — a trigger level the signal never crosses —
+  which otherwise times out on every single capture: at a 70 s timeout and 100 triggers per
+  configuration, that is hours of waiting to collect nothing, previously surfaced only as one log
+  line per failure. Everything gathered before the breaker trips is still returned, with the
+  failed entries carrying their `error` field, and a warning names the reason and the shortfall.
+  Note this changes the default behaviour of a run whose captures all time out: it now stops early
+  instead of attempting every planned capture. Pass `max_consecutive_failures=None` to restore the
+  old behaviour; a run with genuinely sparse triggers should raise `max_wait` instead.
+
+### Fixed
+
+- `batch_capture` no longer discards the whole run when interrupted. It had no `KeyboardInterrupt`
+  handler, so an operator stopping a run they could see was doomed lost every capture already
+  taken. It now keeps and returns them, matching what `start_continuous_capture` already did.
+
 ## [5.6.0] - 2026-07-26
 
 ### Fixed

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -22,9 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `batch_capture` no longer discards the whole run when interrupted. It had no `KeyboardInterrupt`
-  handler, so an operator stopping a run they could see was doomed lost every capture already
-  taken. It now keeps and returns them, matching what `start_continuous_capture` already did.
+- `batch_capture` no longer discards the whole run when interrupted or when the instrument stops
+  answering. It had no `KeyboardInterrupt` handler at all, so an operator stopping a run they could
+  see was doomed lost every capture already taken; it now keeps and returns them, matching what
+  `start_continuous_capture` already did. The guard covers the whole per-configuration body rather
+  than only the capture, because the gap between configurations — two socket writes plus the settle
+  delay — is exactly where an impatient operator tends to press Ctrl-C.
+- `batch_capture` now records any `SiglentError` as a failed entry, not just `SiglentTimeoutError`.
+  A dropped link mid-run previously propagated and discarded every capture already taken, which is
+  the precise loss the failed-entry path exists to prevent. Connection failures count toward the
+  circuit breaker as well — an instrument that has stopped answering is exactly what it is for. A
+  failure while *applying* a configuration stops the run and returns what was collected.
 
 ## [5.6.0] - 2026-07-26
 

--- a/scpi_control/automation.py
+++ b/scpi_control/automation.py
@@ -231,6 +231,7 @@ class DataCollector:
         voltage_scales: Optional[Dict[int, List[str]]] = None,
         triggers_per_config: int = 1,
         progress_callback: Optional[Callable[[int, int, str], None]] = None,
+        max_consecutive_failures: Optional[int] = 3,
     ) -> List[Dict[str, Any]]:
         """Capture multiple waveforms with different configurations.
 
@@ -241,9 +242,25 @@ class DataCollector:
                            (e.g., {1: ['1V', '2V'], 2: ['500mV', '1V']})
             triggers_per_config: Number of captures per configuration
             progress_callback: Optional callback function(current, total, status)
+            max_consecutive_failures: Stop the run after this many back-to-back
+                capture timeouts, counted ACROSS configurations and reset by any
+                success. Guards the common unattended failure -- a trigger level
+                set where the signal never crosses it -- which otherwise times
+                out on every capture for the whole run: at a 70 s timeout and
+                100 triggers per configuration that is hours of waiting to
+                collect nothing. Pass None to disable the breaker entirely; a
+                run with genuinely sparse triggers should raise `max_wait`
+                rather than rely on repeated timeouts.
 
         Returns:
-            List of dictionaries containing waveforms and configuration metadata
+            List of dictionaries containing waveforms and configuration metadata.
+            When the breaker trips (or the run is interrupted) everything gathered
+            so far is still returned -- failed entries carry an ``error`` field --
+            rather than being discarded.
+
+        Raises:
+            InvalidParameterError: If a scale cannot be parsed, or
+                ``max_consecutive_failures`` is not None and not at least 1.
 
         Example:
             >>> results = collector.batch_capture(
@@ -255,8 +272,12 @@ class DataCollector:
         """
         if not self._connected:
             raise SiglentError(f"Not connected to oscilloscope at {self.scope.host}:{self.scope.port}")
+        if max_consecutive_failures is not None and max_consecutive_failures < 1:
+            raise InvalidParameterError(f"max_consecutive_failures must be at least 1, or None to disable the breaker: {max_consecutive_failures}")
 
         results = []
+        consecutive_failures = 0
+        stop_reason = None
 
         # Build configuration list
         configs = []
@@ -322,6 +343,11 @@ class DataCollector:
                 }
                 try:
                     entry["waveforms"] = self.capture_single(channels)
+                    # Any success proves the setup can still trigger, so the breaker
+                    # counts CONSECUTIVE failures rather than total ones -- an
+                    # occasional miss in a long run is not the same as a run that
+                    # cannot trigger at all.
+                    consecutive_failures = 0
                 except SiglentTimeoutError as exc:
                     # Record the failure and carry on. Raising would discard every
                     # capture already taken; returning the stale waveform is what
@@ -330,8 +356,26 @@ class DataCollector:
                     # unaffected.
                     logger.warning(f"Capture timed out for config {config}: {exc}")
                     entry["error"] = str(exc)
+                    consecutive_failures += 1
+                except KeyboardInterrupt:
+                    # Keep what was collected. Without this an operator aborting a
+                    # run they can see is doomed loses every capture already taken.
+                    logger.info("Batch capture interrupted by user")
+                    stop_reason = "interrupted by user"
+                    break
                 results.append(entry)
 
+                if max_consecutive_failures is not None and consecutive_failures >= max_consecutive_failures:
+                    stop_reason = f"{consecutive_failures} consecutive capture timeouts"
+                    break
+
+            if stop_reason is not None:
+                break
+
+        if stop_reason is not None:
+            # Not silent: the collected results come back, the failed entries carry
+            # their own `error`, and the caller is told the run was cut short.
+            logger.warning(f"Batch capture stopped early ({stop_reason}) after {len(results)} of {total} planned captures. Check the trigger level and max_wait if captures are timing out.")
         logger.info(f"Batch capture complete: {len(results)} captures")
         return results
 

--- a/scpi_control/automation.py
+++ b/scpi_control/automation.py
@@ -270,10 +270,13 @@ class DataCollector:
             ... )
             >>> print(f"Collected {len(results)} captures")
         """
-        if not self._connected:
-            raise SiglentError(f"Not connected to oscilloscope at {self.scope.host}:{self.scope.port}")
+        # Arguments are validated before the connection check: a bad argument is a
+        # bad argument whether or not an instrument happens to be attached, and
+        # reporting it only when connected makes it look like a connection problem.
         if max_consecutive_failures is not None and max_consecutive_failures < 1:
             raise InvalidParameterError(f"max_consecutive_failures must be at least 1, or None to disable the breaker: {max_consecutive_failures}")
+        if not self._connected:
+            raise SiglentError(f"Not connected to oscilloscope at {self.scope.host}:{self.scope.port}")
 
         results = []
         consecutive_failures = 0
@@ -309,73 +312,91 @@ class DataCollector:
         # dicts and now both parse to {'timebase': 1e-06} -- and index() would
         # then report "Config 1/2" twice.
         for config_index, config in enumerate(configs):
-            # Apply configuration
-            if "timebase" in config:
-                if hasattr(self.scope, "set_timebase"):
-                    self.scope.set_timebase(config["timebase"])
-                else:
-                    self.scope.timebase = config["timebase"]
-                logger.info(f"Set timebase to {config['timebase']}")
+            # The WHOLE per-config body is guarded, not just the capture. Ctrl-C
+            # lands wherever the operator happens to press it, and the gap between
+            # configs -- two socket writes plus the settle sleep below -- is exactly
+            # where an impatient operator watching a doomed run tends to hit it.
+            # Guarding only the capture would discard the whole run for a keypress
+            # one statement earlier, which is the loss this exists to prevent.
+            try:
+                # Apply configuration
+                if "timebase" in config:
+                    if hasattr(self.scope, "set_timebase"):
+                        self.scope.set_timebase(config["timebase"])
+                    else:
+                        self.scope.timebase = config["timebase"]
+                    logger.info(f"Set timebase to {config['timebase']}")
 
-            for ch, scale in [(int(k[2]), v) for k, v in config.items() if k.startswith("ch") and k.endswith("_vdiv")]:
-                channel = getattr(self.scope, f"channel{ch}")
-                if hasattr(channel, "set_scale"):
-                    channel.set_scale(scale)
-                else:
-                    channel.voltage_scale = scale
-                logger.info(f"Set channel {ch} scale to {scale}")
+                for ch, scale in [(int(k[2]), v) for k, v in config.items() if k.startswith("ch") and k.endswith("_vdiv")]:
+                    channel = getattr(self.scope, f"channel{ch}")
+                    if hasattr(channel, "set_scale"):
+                        channel.set_scale(scale)
+                    else:
+                        channel.voltage_scale = scale
+                    logger.info(f"Set channel {ch} scale to {scale}")
 
-            time.sleep(0.2)  # Allow settings to settle
+                time.sleep(0.2)  # Allow settings to settle
 
-            # Capture multiple triggers with this configuration
-            for trigger_num in range(triggers_per_config):
-                current += 1
+                # Capture multiple triggers with this configuration
+                for trigger_num in range(triggers_per_config):
+                    current += 1
 
-                if progress_callback:
-                    status = f"Config {config_index+1}/{len(configs)}, Trigger {trigger_num+1}/{triggers_per_config}"
-                    progress_callback(current, total, status)
+                    if progress_callback:
+                        status = f"Config {config_index+1}/{len(configs)}, Trigger {trigger_num+1}/{triggers_per_config}"
+                        progress_callback(current, total, status)
 
-                entry = {
-                    "timestamp": datetime.now().isoformat(),
-                    "config": config.copy(),
-                    "waveforms": {},
-                    "trigger_num": trigger_num,
-                }
-                try:
-                    entry["waveforms"] = self.capture_single(channels)
-                    # Any success proves the setup can still trigger, so the breaker
-                    # counts CONSECUTIVE failures rather than total ones -- an
-                    # occasional miss in a long run is not the same as a run that
-                    # cannot trigger at all.
-                    consecutive_failures = 0
-                except SiglentTimeoutError as exc:
-                    # Record the failure and carry on. Raising would discard every
-                    # capture already taken; returning the stale waveform is what
-                    # this replaced. An "error" key appears ONLY on failed entries,
-                    # so consumers reading config/waveforms/trigger_num are
-                    # unaffected.
-                    logger.warning(f"Capture timed out for config {config}: {exc}")
-                    entry["error"] = str(exc)
-                    consecutive_failures += 1
-                except KeyboardInterrupt:
-                    # Keep what was collected. Without this an operator aborting a
-                    # run they can see is doomed loses every capture already taken.
-                    logger.info("Batch capture interrupted by user")
-                    stop_reason = "interrupted by user"
-                    break
-                results.append(entry)
+                    entry = {
+                        "timestamp": datetime.now().isoformat(),
+                        "config": config.copy(),
+                        "waveforms": {},
+                        "trigger_num": trigger_num,
+                    }
+                    try:
+                        entry["waveforms"] = self.capture_single(channels)
+                        # Any success proves the setup can still trigger, so the breaker
+                        # counts CONSECUTIVE failures rather than total ones -- an
+                        # occasional miss in a long run is not the same as a run that
+                        # cannot trigger at all.
+                        consecutive_failures = 0
+                    except SiglentError as exc:
+                        # SiglentError, not just SiglentTimeoutError: a dropped link is
+                        # the other likely unattended failure, and letting it propagate
+                        # would discard every capture already taken -- precisely the loss
+                        # this whole path exists to prevent. A scope that stopped
+                        # answering is also exactly what a breaker is for, so it counts.
+                        # Record and carry on; an "error" key appears ONLY on failed
+                        # entries, so consumers reading config/waveforms/trigger_num are
+                        # unaffected.
+                        logger.warning(f"Capture failed for config {config}: {exc}")
+                        entry["error"] = str(exc)
+                        consecutive_failures += 1
+                    results.append(entry)
 
-                if max_consecutive_failures is not None and consecutive_failures >= max_consecutive_failures:
-                    stop_reason = f"{consecutive_failures} consecutive capture timeouts"
-                    break
+                    if max_consecutive_failures is not None and consecutive_failures >= max_consecutive_failures:
+                        stop_reason = f"{consecutive_failures} consecutive capture failures"
+                        break
+
+            except KeyboardInterrupt:
+                # Keep what was collected. Without this an operator aborting a run
+                # they can see is doomed loses every capture already taken.
+                logger.info("Batch capture interrupted by user")
+                stop_reason = "interrupted by user"
+            except SiglentError as exc:
+                # Applying the configuration failed -- the instrument stopped
+                # answering between captures. Stop, but return what was collected.
+                logger.error(f"Batch capture stopped: applying configuration {config} failed: {exc}")
+                stop_reason = f"instrument error while applying a configuration: {exc}"
 
             if stop_reason is not None:
                 break
 
         if stop_reason is not None:
             # Not silent: the collected results come back, the failed entries carry
-            # their own `error`, and the caller is told the run was cut short.
-            logger.warning(f"Batch capture stopped early ({stop_reason}) after {len(results)} of {total} planned captures. Check the trigger level and max_wait if captures are timing out.")
+            # their own `error`, and the caller is told the run was cut short. ERROR
+            # rather than WARNING because a truncated batch is a result the caller
+            # will otherwise mistake for a complete one -- `len(results)` is the only
+            # other signal, and save_batch reports it without any hint of a shortfall.
+            logger.error(f"Batch capture stopped early ({stop_reason}) after {len(results)} of {total} planned captures. Check the trigger level and max_wait if captures are timing out.")
         logger.info(f"Batch capture complete: {len(results)} captures")
         return results
 

--- a/tests/test_automation_capture.py
+++ b/tests/test_automation_capture.py
@@ -256,3 +256,124 @@ def test_successful_entries_carry_no_error_key(monkeypatch):
         dc.disconnect()
     assert results and "error" not in results[0]
     assert results[0]["waveforms"]
+
+
+def test_the_breaker_stops_a_run_that_cannot_trigger(monkeypatch):
+    """The unattended failure this guards: a trigger level the signal never
+    crosses times out on EVERY capture. At a 70 s timeout and 100 triggers per
+    config that is hours of waiting to collect nothing, previously surfaced only
+    as one log line per failure."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector(trigger_status=["Trig'd"] * 5000)
+    try:
+        results = dc.batch_capture(
+            channels=[1],
+            timebase_scales=["1us", "10us", "100us"],
+            triggers_per_config=10,
+            max_consecutive_failures=3,
+        )
+    finally:
+        dc.disconnect()
+
+    assert len(results) == 3, "the run must stop at the third consecutive timeout, not after all 30"
+    assert all("error" in entry for entry in results)
+    # Everything gathered is still returned rather than discarded.
+    assert results[0]["config"]
+
+
+def test_a_success_resets_the_breaker(monkeypatch):
+    """Consecutive, not cumulative: an occasional miss in a long run is not the
+    same as a run that cannot trigger at all, and must not stop it."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector()
+    real_capture = dc.capture_single
+    calls = {"n": 0}
+
+    def flaky_capture(channels, **kwargs):
+        calls["n"] += 1
+        if calls["n"] % 2 == 0:  # every other capture times out
+            raise exceptions.SiglentTimeoutError("no trigger")
+        return real_capture(channels, **kwargs)
+
+    monkeypatch.setattr(dc, "capture_single", flaky_capture)
+    try:
+        results = dc.batch_capture(channels=[1], timebase_scales=["1us"], triggers_per_config=8, max_consecutive_failures=3)
+    finally:
+        dc.disconnect()
+
+    assert len(results) == 8, "alternating failures never reach 3 in a row, so the run completes"
+    assert sum("error" in entry for entry in results) == 4
+
+
+def test_the_breaker_counts_across_configuration_boundaries(monkeypatch):
+    """triggers_per_config=1 would never trip a per-config breaker, which is why
+    the count crosses configurations rather than resetting at each one."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector(trigger_status=["Trig'd"] * 5000)
+    try:
+        results = dc.batch_capture(channels=[1], timebase_scales=["1us", "10us", "100us", "1ms"], triggers_per_config=1, max_consecutive_failures=2)
+    finally:
+        dc.disconnect()
+
+    assert len(results) == 2, "two configs of one trigger each must trip a threshold of 2"
+
+
+def test_the_breaker_can_be_disabled(monkeypatch):
+    """A run with genuinely sparse triggers can opt out."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector(trigger_status=["Trig'd"] * 5000)
+    try:
+        results = dc.batch_capture(channels=[1], timebase_scales=["1us"], triggers_per_config=5, max_consecutive_failures=None)
+    finally:
+        dc.disconnect()
+
+    assert len(results) == 5, "with the breaker disabled every planned capture is attempted"
+    assert all("error" in entry for entry in results)
+
+
+def test_the_breaker_defaults_on(monkeypatch):
+    """The run worth protecting is the one where nobody thought to pass the
+    parameter, so the default must not be None."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector(trigger_status=["Trig'd"] * 5000)
+    try:
+        results = dc.batch_capture(channels=[1], timebase_scales=["1us"], triggers_per_config=50)
+    finally:
+        dc.disconnect()
+
+    assert len(results) < 50, "the default breaker must cut a doomed run short"
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_an_invalid_breaker_threshold_is_rejected(bad):
+    dc, _ = _collector()
+    try:
+        with pytest.raises(exceptions.InvalidParameterError):
+            dc.batch_capture(channels=[1], timebase_scales=["1us"], max_consecutive_failures=bad)
+    finally:
+        dc.disconnect()
+
+
+def test_an_interrupted_run_keeps_what_it_collected(monkeypatch):
+    """Ctrl-C on a run the operator can see is doomed must not throw away the
+    captures already taken. start_continuous_capture already behaved this way;
+    batch_capture had no handler at all, so the whole run was lost."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector()
+    real_capture = dc.capture_single
+    calls = {"n": 0}
+
+    def interrupt_on_third(channels, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise KeyboardInterrupt
+        return real_capture(channels, **kwargs)
+
+    monkeypatch.setattr(dc, "capture_single", interrupt_on_third)
+    try:
+        results = dc.batch_capture(channels=[1], timebase_scales=["1us"], triggers_per_config=10)
+    finally:
+        dc.disconnect()
+
+    assert len(results) == 2, "the two completed captures must survive the interrupt"
+    assert all(entry["waveforms"] for entry in results)

--- a/tests/test_automation_capture.py
+++ b/tests/test_automation_capture.py
@@ -341,7 +341,8 @@ def test_the_breaker_defaults_on(monkeypatch):
     finally:
         dc.disconnect()
 
-    assert len(results) < 50, "the default breaker must cut a doomed run short"
+    assert len(results) == 3, "the default threshold is 3, so a doomed run stops at the third failure"
+    assert all("error" in entry for entry in results)
 
 
 @pytest.mark.parametrize("bad", [0, -1])
@@ -377,3 +378,82 @@ def test_an_interrupted_run_keeps_what_it_collected(monkeypatch):
 
     assert len(results) == 2, "the two completed captures must survive the interrupt"
     assert all(entry["waveforms"] for entry in results)
+    # Note on this test's failure mode: without the handler the KeyboardInterrupt
+    # escapes into pytest, which aborts the whole SESSION ("!!! KeyboardInterrupt
+    # !!!") rather than reporting one red test. If the handler is ever removed the
+    # signal is a dead suite, not a failing test -- worth knowing before hunting it.
+
+
+def test_a_dropped_connection_mid_run_does_not_discard_the_captures(monkeypatch):
+    """A dropped link is the other likely unattended failure. Catching only
+    SiglentTimeoutError let it propagate and discard every capture already taken
+    -- the exact loss the error-entry path exists to prevent. It counts toward
+    the breaker too: a scope that stopped answering is what a breaker is for."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector()
+    real_capture = dc.capture_single
+    calls = {"n": 0}
+
+    def drop_after_two(channels, **kwargs):
+        calls["n"] += 1
+        if calls["n"] > 2:
+            raise exceptions.SiglentConnectionError("connection reset by peer")
+        return real_capture(channels, **kwargs)
+
+    monkeypatch.setattr(dc, "capture_single", drop_after_two)
+    try:
+        results = dc.batch_capture(channels=[1], timebase_scales=["1us"], triggers_per_config=20, max_consecutive_failures=3)
+    finally:
+        dc.disconnect()
+
+    assert len(results) == 5, "two successes, then three failures trip the breaker"
+    assert all(entry["waveforms"] for entry in results[:2])
+    assert all("error" in entry for entry in results[2:])
+
+
+def test_an_interrupt_between_configs_also_keeps_the_captures(monkeypatch):
+    """The window the first version missed: Ctrl-C during the config-apply block
+    (set_timebase / set_scale / the settle sleep) rather than during a capture.
+    Guarding only the capture discarded the whole run for a keypress one
+    statement earlier."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector()
+    real_set = dc.scope.set_timebase
+    calls = {"n": 0}
+
+    def interrupt_on_second_config(value):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise KeyboardInterrupt
+        return real_set(value)
+
+    monkeypatch.setattr(dc.scope, "set_timebase", interrupt_on_second_config)
+    try:
+        results = dc.batch_capture(channels=[1], timebase_scales=["1us", "10us"], triggers_per_config=2)
+    finally:
+        dc.disconnect()
+
+    assert len(results) == 2, "the first config's captures must survive an interrupt in the second's setup"
+
+
+def test_an_instrument_error_while_applying_a_config_keeps_the_captures(monkeypatch):
+    """Same window, non-interrupt cause: the scope stops answering between
+    configs. Previously this propagated and discarded the run."""
+    monkeypatch.setattr("scpi_control.automation.time", FakeTime())
+    dc, _ = _collector()
+    real_set = dc.scope.set_timebase
+    calls = {"n": 0}
+
+    def die_on_second_config(value):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise exceptions.SiglentConnectionError("scope stopped answering")
+        return real_set(value)
+
+    monkeypatch.setattr(dc.scope, "set_timebase", die_on_second_config)
+    try:
+        results = dc.batch_capture(channels=[1], timebase_scales=["1us", "10us"], triggers_per_config=2)
+    finally:
+        dc.disconnect()
+
+    assert len(results) == 2, "the first config's captures must survive the instrument dying"


### PR DESCRIPTION
`batch_capture` records a timed-out capture as a failed entry and carries on — right for an occasional miss, wrong for a run that cannot trigger at all. A trigger level the signal never crosses times out on *every* capture: at a 70 s timeout and `triggers_per_config=100`, hours of waiting to collect nothing, surfaced only as one log line per failure.

## The breaker

`max_consecutive_failures` (default **3**) stops the run after that many back-to-back capture failures, counted **across configurations** and **reset by any success**.

Both of those matter. Per-config counting was considered and rejected: with `triggers_per_config=100` a single config *is* two hours, and with `triggers_per_config=1` a per-config counter can never trip at all. And counting consecutively rather than cumulatively means an occasional miss in a long run doesn't accumulate into a false trip.

On trip the run stops and **returns everything collected** — the failed entries already carry their `error` field — with an ERROR-level log naming the reason and the shortfall. Raising would reintroduce exactly the data loss 5.6.0 fixed.

`max_consecutive_failures=None` disables it. The default is deliberately on: the run worth protecting is the one where nobody thought to pass the parameter. A run with genuinely sparse triggers should raise `max_wait` instead.

## Loss of the run on interrupt and on a dropped link

Two related holes, both closed here:

- **`KeyboardInterrupt`** — `batch_capture` had no handler, so an operator stopping a run they could see was doomed lost every capture already taken. The guard covers the **whole per-configuration body**, not just the capture: the gap between configurations (two socket writes plus the settle delay) is exactly where an impatient operator tends to press Ctrl-C, and guarding only the capture would discard the run for a keypress one statement earlier.
- **`SiglentError`** — only `SiglentTimeoutError` was caught, so a dropped link mid-run propagated and discarded everything, which is the precise loss the failed-entry path exists to prevent. Connection failures now record as failed entries and count toward the breaker; an instrument that has stopped answering is what a breaker is for. A failure while *applying* a configuration stops the run and returns what was collected.

## From review

An independent review found both of the above scoping gaps in my first version — the `KeyboardInterrupt` handler wrapping only `capture_single`, and the handler catching only `SiglentTimeoutError`. It also caught a weak test: `test_the_breaker_defaults_on` asserted only `len(results) < 50`, which passes at 0, 1 and 49 and so pinned the default being non-`None` and nothing about it being 3. Now `== 3`.

Argument validation also moved ahead of the connection check — a bad `max_consecutive_failures` is a bad argument whether or not an instrument is attached, and reporting it only when connected made it look like a connection problem.

## Verification

- `tests/test_automation_capture.py`, `test_automation.py`, `test_automation_save.py` — 35 passed.
- Both breaker behaviours mutation-checked: disabling the trip condition fails 3 tests; removing the success-reset fails the reset test.
- `black --check --line-length 200 scpi_control/ examples/` clean; `flake8 --select=E9,F63,F7,F82` = 0.
- Behaviour-change sweep: no internal callers. The only callers are `examples/batch_capture.py` and its doc copy, neither passing the parameter — they now stop early on a doomed run, which is the intent. No documentation asserts the old "attempts every planned capture" behaviour.

## Note

This changes the default behaviour of a run whose captures all fail: it stops early instead of attempting everything. That is the point, but it is a default change rather than a purely additive one, and the changelog says so.

One known limitation, recorded rather than hidden: a trip is visible through `len(results)`, the per-entry `error` fields, and the ERROR log, but there is no structured "this run was truncated" flag in the return value. `save_batch` will report the shorter count without further comment.
