### PR TITLE
feat(mock): drive a mock scope from a mock AWG, through an optional RC device model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shortfall. Note this changes the default behaviour of a run whose captures all fail: it now stops
   early instead of attempting every planned capture. Pass `max_consecutive_failures=None` to
   restore the old behaviour; a run with genuinely sparse triggers should raise `max_wait` instead.
+- A mock AWG's output can now be captured by a mock oscilloscope: wire
+  `AwgLoopback(awg_connection, awg_channel=1)` into the scope's `signals=`, and a SCPI write to the
+  AWG changes the next capture. Previously the mock AWG was a write-only surface — you could set a
+  waveform and read it back, but nothing in the system responded to its output, which made it
+  untestable end to end without hardware. `MockConnection`'s `signals=` now accepts a callable
+  returning a `SignalSpec` as well as a static one, evaluated at every acquisition; this is a
+  general extension point, not AWG-specific, so any dynamic signal source works the same way.
+  `scpi_control.dut.RCLowPass` is a new first-order RC low-pass usable as a device under test
+  between the two instruments, or on any array on its own, using exact zero-order-hold
+  discretisation; the mock applies it with a lead-in rendered before the capture window so a
+  capture has no settling transient at its head. Two conversions are worth knowing, because
+  getting them wrong produces plausible-looking output: AWG amplitude is peak-to-peak and is
+  halved into `SignalSpec`'s peak amplitude, and phase is degrees and becomes radians — an output
+  that is off reads flat. `ARB` is captured as a sine with a logged warning, since the mock stores
+  no arbitrary sample data, and extreme duty values are clamped rather than raising. Non-breaking:
+  a static `SignalSpec` in `signals=` behaves exactly as before.
 
 ### Changed
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -19,6 +19,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shortfall. Note this changes the default behaviour of a run whose captures all fail: it now stops
   early instead of attempting every planned capture. Pass `max_consecutive_failures=None` to
   restore the old behaviour; a run with genuinely sparse triggers should raise `max_wait` instead.
+- A mock AWG's output can now be captured by a mock oscilloscope: wire
+  `AwgLoopback(awg_connection, awg_channel=1)` into the scope's `signals=`, and a SCPI write to the
+  AWG changes the next capture. Previously the mock AWG was a write-only surface — you could set a
+  waveform and read it back, but nothing in the system responded to its output, which made it
+  untestable end to end without hardware. `MockConnection`'s `signals=` now accepts a callable
+  returning a `SignalSpec` as well as a static one, evaluated at every acquisition; this is a
+  general extension point, not AWG-specific, so any dynamic signal source works the same way.
+  `scpi_control.dut.RCLowPass` is a new first-order RC low-pass usable as a device under test
+  between the two instruments, or on any array on its own, using exact zero-order-hold
+  discretisation; the mock applies it with a lead-in rendered before the capture window so a
+  capture has no settling transient at its head. Two conversions are worth knowing, because
+  getting them wrong produces plausible-looking output: AWG amplitude is peak-to-peak and is
+  halved into `SignalSpec`'s peak amplitude, and phase is degrees and becomes radians — an output
+  that is off reads flat. `ARB` is captured as a sine with a logged warning, since the mock stores
+  no arbitrary sample data, and extreme duty values are clamped rather than raising. Non-breaking:
+  a static `SignalSpec` in `signals=` behaves exactly as before.
 
 ### Changed
 

--- a/docs/user-guide/synthetic-signals.md
+++ b/docs/user-guide/synthetic-signals.md
@@ -335,6 +335,94 @@ Mock sessions created through the web gateway now default to
 points long (14 divisions x 1 ms/div timebase) instead of the fixed 256-byte
 explicit ramp payloads earlier sessions served.
 
+## AWG to Scope Loopback
+
+Every example so far has one mock instrument synthesizing from its own state.
+`AwgLoopback` (`scpi_control.connection.mock.loopback`) patches a second mock
+instrument's state into that synthesis, so a mock scope can capture whatever a
+mock AWG is currently outputting -- two separate `MockConnection` objects, one
+virtual cable between them:
+
+```python
+from scpi_control.connection import MockConnection
+from scpi_control.connection.mock.loopback import AwgLoopback
+from scpi_control.dut import RCLowPass
+from scpi_control.oscilloscope import Oscilloscope
+
+awg = MockConnection("mock", awg_mode=True)
+scope_conn = MockConnection("mock", signals={1: AwgLoopback(awg, awg_channel=1, dut=RCLowPass(cutoff_hz=2_000))})
+scope = Oscilloscope("mock", connection=scope_conn)
+```
+
+### `signals=` as a callable
+
+`signals={channel: ...}` now accepts a callable that returns a `SignalSpec`,
+not just a static `SignalSpec` instance -- and unlike a static spec, which is
+read once, a callable is invoked at **every acquisition**. That is what makes
+the loopback live: `AwgLoopback` is such a callable, and each call re-reads
+the AWG connection's current channel state, so a `C1:BSWV` write on the AWG
+changes the very next scope capture. This is a general extension point, not
+specific to AWGs -- anything with a `() -> SignalSpec` signature works.
+
+### Function mapping
+
+`AwgLoopback` translates the AWG channel's live state into a `SignalSpec` on
+every call:
+
+| AWG `WVTP` | `SignalSpec.kind` |
+| --- | --- |
+| `SINE` | `sine` |
+| `SQUARE` | `square` |
+| `NOISE` | `noise` |
+| `DC` | `dc` |
+| `PULSE` | `pulse` |
+| `RAMP` | `triangle` if symmetry is within 1% of 50, otherwise `ramp` |
+| `ARB` | `sine`, with a logged warning (the mock stores no arbitrary sample data) |
+
+Two unit conversions happen on the way in, because the AWG and `SignalSpec`
+don't speak the same units for the same quantity:
+
+- **Amplitude.** An AWG's `AMP` is peak-to-peak; `SignalSpec.amplitude` is
+  peak. `AwgLoopback` halves it, so an AWG set to 2.0 Vpp arrives as a 2.0 V
+  peak-to-peak capture, not 4.0.
+- **Phase.** An AWG's `PHSE` is in degrees; `SignalSpec.phase` is in radians.
+  `AwgLoopback` converts.
+
+An output with `enabled=False` reads flat -- like a disconnected input, not a
+zero-amplitude waveform at some frequency.
+
+### Duty is clamped, not validated
+
+`SignalSpec` requires strictly `0 < duty < 1` and raises `InvalidParameterError`
+outside that range, but a real AWG accepts `DUTY,0` and `DUTY,100` without
+complaint. `AwgLoopback` clamps the converted duty into `SignalSpec`'s legal
+range instead of propagating the AWG's value verbatim, because a mock
+instrument should not raise where a real one would simply output something
+(a very narrow pulse, or one at the opposite rail) and keep going.
+
+### The DUT: `RCLowPass`
+
+`AwgLoopback` accepts an optional `dut=` -- a device model sitting between
+the AWG and the scope, exactly where a real device under test would
+physically sit. That's why the DUT lives on the loopback rather than on the
+scope's `MockConnection`: it belongs to the cable run connecting the two
+instruments, not to either instrument itself.
+
+`scpi_control.dut.RCLowPass(cutoff_hz=...)` is a first-order RC low-pass. It
+is stateful -- unlike every generator in `signal_synth`, which is closed-form
+specifically so consecutive captures and streamed chunks join seamlessly --
+so filtering a bare capture would start from `y = 0` and put a settling
+transient at the head of every acquisition. To avoid that, the filter is
+applied to a lead-in rendered *before* the capture window and then discarded,
+the same fix `signal_synth`'s ringing impairment uses for the same reason: a
+capture is in steady state from its very first sample, with no transient at
+the head.
+
+**Known simplification:** trigger alignment (see [State
+coupling](#state-coupling) above) searches for the trigger-level crossing on
+the *unfiltered* signal, so where a capture triggers does not depend on the
+DUT's filter state -- only the sample values within the window do.
+
 ## Extensibility
 
 Signal kinds live in a small dispatch table (`kind -> generator function`)
@@ -350,3 +438,5 @@ generator function, a table entry, and matching docs/tests -- no changes to
 - `examples/synthetic_signals.py` for a runnable, hardware-free walkthrough
   of `make_waveform()`, a mock session reacting to SCPI writes, and the
   save/reload round trip
+- `examples/awg_scope_loopback.py` for a runnable walkthrough of the AWG to
+  scope loopback, including the `RCLowPass` DUT

--- a/docs/user-guide/synthetic-signals.md
+++ b/docs/user-guide/synthetic-signals.md
@@ -389,8 +389,13 @@ don't speak the same units for the same quantity:
   peak: Gaussian noise has no true peak, so `AwgLoopback` maps the AWG's `AMP`
   on the usual convention that a quoted peak-to-peak is the +/-3 sigma span
   (99.7% of samples), i.e. `sigma = Vpp / 6`. An AWG set to 2.0 Vpp of noise
-  therefore arrives as a sigma = 0.333 V trace, whose measured peak-to-peak is
-  approximately -- but, being random, never exactly -- 2.0 V.
+  therefore arrives as a sigma = 0.333 V trace, and only sigma is fixed by that
+  mapping -- the measured peak-to-peak of an actual capture is not scattered
+  around 2.0 V but systematically above it, because the extreme of N Gaussian
+  samples grows with N rather than converging on the +/-3 sigma convention used
+  to set sigma. A 14,000-sample capture's expected extreme is about 7.9 sigma,
+  i.e. roughly 2.3 to 2.8 V peak-to-peak for this 2.0 Vpp request, and larger
+  still for a longer capture.
 - **Phase.** An AWG's `PHSE` is in degrees; `SignalSpec.phase` is in radians.
   `AwgLoopback` converts.
 

--- a/docs/user-guide/synthetic-signals.md
+++ b/docs/user-guide/synthetic-signals.md
@@ -376,7 +376,7 @@ every call:
 | `NOISE` | `noise` |
 | `DC` | `dc` |
 | `PULSE` | `pulse` |
-| `RAMP` | `triangle` if symmetry is within 1% of 50, otherwise `ramp` |
+| `RAMP` | `triangle` if symmetry is within 1 percentage point of 50 (i.e. 49 to 51), otherwise `ramp` |
 | `ARB` | `sine`, with a logged warning (the mock stores no arbitrary sample data) |
 
 Two unit conversions happen on the way in, because the AWG and `SignalSpec`
@@ -384,7 +384,13 @@ don't speak the same units for the same quantity:
 
 - **Amplitude.** An AWG's `AMP` is peak-to-peak; `SignalSpec.amplitude` is
   peak. `AwgLoopback` halves it, so an AWG set to 2.0 Vpp arrives as a 2.0 V
-  peak-to-peak capture, not 4.0.
+  peak-to-peak capture, not 4.0. **`NOISE` is the exception**, because
+  `SignalSpec.amplitude` is a standard deviation for that kind rather than a
+  peak: Gaussian noise has no true peak, so `AwgLoopback` maps the AWG's `AMP`
+  on the usual convention that a quoted peak-to-peak is the +/-3 sigma span
+  (99.7% of samples), i.e. `sigma = Vpp / 6`. An AWG set to 2.0 Vpp of noise
+  therefore arrives as a sigma = 0.333 V trace, whose measured peak-to-peak is
+  approximately -- but, being random, never exactly -- 2.0 V.
 - **Phase.** An AWG's `PHSE` is in degrees; `SignalSpec.phase` is in radians.
   `AwgLoopback` converts.
 

--- a/docs/user-guide/synthetic-signals.md
+++ b/docs/user-guide/synthetic-signals.md
@@ -423,6 +423,16 @@ coupling](#state-coupling) above) searches for the trigger-level crossing on
 the *unfiltered* signal, so where a capture triggers does not depend on the
 DUT's filter state -- only the sample values within the window do.
 
+**Quantization caveat:** every mock capture is quantized to int8 codes at 25
+codes/division (see [State coupling](#state-coupling) above), so a voltage
+difference smaller than one code -- 0.04 V at the default 1 V/div -- cannot
+be resolved in a capture, no matter how gently the DUT is filtering. A
+comparison that leans on fine amplitude detail (e.g. a raw sample-to-sample
+step height at a gentle cutoff) will end up measuring the code grid rather
+than the filter. Either widen the effect until it clears one code, or measure
+a time-domain property such as rise time instead, which isn't limited by the
+code grid -- see `examples/awg_scope_loopback.py`, which does exactly that.
+
 ## Extensibility
 
 Signal kinds live in a small dispatch table (`kind -> generator function`)

--- a/docs/user-guide/synthetic-signals.md
+++ b/docs/user-guide/synthetic-signals.md
@@ -429,10 +429,15 @@ coupling](#state-coupling) above) searches for the trigger-level crossing on
 the *unfiltered* signal, so where a capture triggers does not depend on the
 DUT's filter state -- only the sample values within the window do.
 
-**Quantization caveat:** every mock capture is quantized to int8 codes at 25
-codes/division (see [State coupling](#state-coupling) above), so a voltage
-difference smaller than one code -- 0.04 V at the default 1 V/div -- cannot
-be resolved in a capture, no matter how gently the DUT is filtering. A
+**Quantization caveat:** a legacy-dialect mock capture is quantized to int8
+codes at 25 codes/division (see [State coupling](#state-coupling) above), so a
+voltage difference smaller than one code -- 0.04 V at the default 1 V/div --
+cannot be resolved in a capture, no matter how gently the DUT is filtering. The
+modern dialect's `:WAVeform:WIDTh WORD` path is 256x finer (6400 codes/division,
+0.15625 mV/LSB), and since both paths share the same synthesis it is the WORD
+grid, not int8, that the filter's lead-in depth is sized against
+(`dut._WARMUP_TIME_CONSTANTS`, 12 time constants: `e^-12` leaves under 0.05 WORD
+LSB un-settled at the head of the window). A
 comparison that leans on fine amplitude detail (e.g. a raw sample-to-sample
 step height at a gentle cutoff) will end up measuring the code grid rather
 than the filter. Either widen the effect until it clears one code, or measure

--- a/examples/awg_scope_loopback.py
+++ b/examples/awg_scope_loopback.py
@@ -1,0 +1,109 @@
+"""AWG-to-scope loopback: a mock function generator's live state drives what a
+mock oscilloscope captures, optionally through an RC device-under-test model.
+
+scpi_control.connection.mock.loopback.AwgLoopback is a callable suitable for
+MockConnection(signals={...}): it reads a separate mock AWG connection's
+current channel state every time the scope acquires, so a SCPI write on the
+AWG changes the very next scope capture -- two mock instruments joined by one
+virtual cable. An optional scpi_control.dut.RCLowPass sits on that cable,
+standing in for a device under test between the two instruments and rounding
+the edges of whatever the AWG outputs.
+
+This example (1) opens a mock AWG and a mock scope wired together with
+AwgLoopback and prints the captured peak-to-peak of a sine, (2) switches the
+AWG to a square wave with a plain SCPI write and prints the new peak-to-peak,
+then (3) adds an RCLowPass DUT and prints how much it reduces the steepest
+sample-to-sample step, i.e. how much it rounds the square wave's edges.
+
+Requirements: SCPI-Instrument-Control (core install) -- runs entirely against
+mock connections, no instrument needed.
+"""
+
+import numpy as np
+
+from scpi_control.connection import MockConnection
+from scpi_control.connection.mock.loopback import AwgLoopback
+from scpi_control.dut import RCLowPass
+from scpi_control.oscilloscope import Oscilloscope
+
+SAMPLE_RATE = 1_000_000.0
+TIMEBASE = 1e-3
+
+
+def _make_awg() -> MockConnection:
+    """A mock AWG, output enabled at 2.0 Vpp / 1 kHz sine."""
+    awg = MockConnection("mock", awg_mode=True)
+    awg.connect()
+    awg.write("C1:BSWV FRQ,1000")
+    awg.write("C1:BSWV AMP,2.0")
+    awg.write("C1:OUTP ON")
+    return awg
+
+
+def _make_scope(source) -> Oscilloscope:
+    """A mock scope whose channel 1 synthesizes from `source` (an AwgLoopback)."""
+    conn = MockConnection(
+        "mock",
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=SAMPLE_RATE,
+        timebase=TIMEBASE,
+        signals={1: source},
+    )
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    return scope
+
+
+def _vpp(voltage) -> float:
+    return float(voltage.max() - voltage.min())
+
+
+def demo_live_loopback() -> MockConnection:
+    """Capture a sine, switch the AWG to a square over SCPI, capture again."""
+    print("=== Part 1: the scope captures whatever the AWG is currently outputting ===")
+    awg = _make_awg()
+    scope = _make_scope(AwgLoopback(awg, awg_channel=1))
+    try:
+        sine = scope.get_waveform(1, provenance=False)
+        print(f"AWG set to SINE, 2.0 Vpp: scope captures Vpp={_vpp(sine.voltage):.3f} V")
+
+        awg.write("C1:BSWV WVTP,SQUARE")
+        square = scope.get_waveform(1, provenance=False)
+        print(f"AWG switched to SQUARE via 'C1:BSWV WVTP,SQUARE': scope captures Vpp={_vpp(square.voltage):.3f} V")
+    finally:
+        scope.disconnect()
+    return awg
+
+
+def demo_dut(awg: MockConnection) -> None:
+    """Add an RCLowPass DUT between the (now square-wave) AWG and the scope."""
+    print()
+    print("=== Part 2: an RCLowPass DUT rounds the square wave's edges ===")
+    sharp_scope = _make_scope(AwgLoopback(awg))
+    soft_scope = _make_scope(AwgLoopback(awg, dut=RCLowPass(cutoff_hz=2_000.0)))
+    try:
+        sharp = sharp_scope.get_waveform(1, provenance=False)
+        soft = soft_scope.get_waveform(1, provenance=False)
+    finally:
+        sharp_scope.disconnect()
+        soft_scope.disconnect()
+
+    sharp_step = float(np.max(np.abs(np.diff(sharp.voltage))))
+    soft_step = float(np.max(np.abs(np.diff(soft.voltage))))
+    reduction_pct = 100.0 * (1.0 - soft_step / sharp_step)
+    print(f"Max sample-to-sample step with no DUT: {sharp_step:.4f} V")
+    print(f"Max sample-to-sample step with RCLowPass(cutoff_hz=2000): {soft_step:.4f} V")
+    print(f"The DUT reduced the steepest step by {reduction_pct:.1f} percent -- the edges are visibly rounded")
+
+
+def main() -> None:
+    awg = demo_live_loopback()
+    try:
+        demo_dut(awg)
+    finally:
+        awg.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/awg_scope_loopback.py
+++ b/examples/awg_scope_loopback.py
@@ -12,8 +12,13 @@ the edges of whatever the AWG outputs.
 This example (1) opens a mock AWG and a mock scope wired together with
 AwgLoopback and prints the captured peak-to-peak of a sine, (2) switches the
 AWG to a square wave with a plain SCPI write and prints the new peak-to-peak,
-then (3) adds an RCLowPass DUT and prints how much it reduces the steepest
-sample-to-sample step, i.e. how much it rounds the square wave's edges.
+then (3) adds an RCLowPass DUT and prints the 10%-90% rise time of the
+square wave's rising edge with and without the DUT, to show how much it
+rounds the edge. Rise time is used rather than a raw sample-to-sample step
+because the mock's int8 code quantization (25 codes/division, see
+docs/user-guide/synthetic-signals.md) would dominate a step-height
+comparison at a gentle cutoff; a 10%-90% time span is many samples wide and
+is not limited by the code grid.
 
 Requirements: SCPI-Instrument-Control (core install) -- runs entirely against
 mock connections, no instrument needed.
@@ -59,6 +64,41 @@ def _vpp(voltage) -> float:
     return float(voltage.max() - voltage.min())
 
 
+def _rising_crossing(time_s: np.ndarray, voltage: np.ndarray, level: float, start_index: int = 0):
+    """Sub-sample time of the first rising crossing of `level` at/after `start_index`.
+
+    Linear interpolation between the two bracketing samples locates the
+    crossing between samples, not just to the nearest one. Returns
+    (crossing_time, index_of_the_sample_just_before_the_crossing).
+    """
+    candidates = np.flatnonzero((voltage[start_index:-1] < level) & (voltage[start_index + 1 :] >= level))
+    if candidates.size == 0:
+        raise ValueError(f"no rising crossing of {level} found at or after index {start_index}")
+    i = start_index + int(candidates[0])
+    t0, t1 = time_s[i], time_s[i + 1]
+    v0, v1 = voltage[i], voltage[i + 1]
+    crossing_time = float(t0 + (level - v0) * (t1 - t0) / (v1 - v0))
+    return crossing_time, i
+
+
+def _rise_time_10_90_us(waveform) -> float:
+    """10%-90% rise time (microseconds) of the first rising transition.
+
+    The 10% and 90% levels are relative to the trace's own min/max, so this
+    works the same way whether or not a DUT has rounded the edge. Unlike a
+    raw sample-to-sample step, a rise time spans many samples and is not
+    limited by the mock's int8 code quantization.
+    """
+    voltage = waveform.voltage
+    time_s = waveform.time
+    lo, hi = float(voltage.min()), float(voltage.max())
+    v10 = lo + 0.10 * (hi - lo)
+    v90 = lo + 0.90 * (hi - lo)
+    t10, i10 = _rising_crossing(time_s, voltage, v10)
+    t90, _ = _rising_crossing(time_s, voltage, v90, start_index=i10)
+    return (t90 - t10) * 1e6
+
+
 def demo_live_loopback() -> MockConnection:
     """Capture a sine, switch the AWG to a square over SCPI, capture again."""
     print("=== Part 1: the scope captures whatever the AWG is currently outputting ===")
@@ -89,12 +129,11 @@ def demo_dut(awg: MockConnection) -> None:
         sharp_scope.disconnect()
         soft_scope.disconnect()
 
-    sharp_step = float(np.max(np.abs(np.diff(sharp.voltage))))
-    soft_step = float(np.max(np.abs(np.diff(soft.voltage))))
-    reduction_pct = 100.0 * (1.0 - soft_step / sharp_step)
-    print(f"Max sample-to-sample step with no DUT: {sharp_step:.4f} V")
-    print(f"Max sample-to-sample step with RCLowPass(cutoff_hz=2000): {soft_step:.4f} V")
-    print(f"The DUT reduced the steepest step by {reduction_pct:.1f} percent -- the edges are visibly rounded")
+    sharp_rise_us = _rise_time_10_90_us(sharp)
+    soft_rise_us = _rise_time_10_90_us(soft)
+    print(f"10-90 percent rise time with no DUT: {sharp_rise_us:.3f} us (an ideal edge, a fraction of one sample)")
+    print(f"10-90 percent rise time with RCLowPass(cutoff_hz=2000): {soft_rise_us:.1f} us")
+    print("The DUT stretched the rising edge from a fraction of a microsecond to roughly " f"{soft_rise_us:.0f} us -- the edge is visibly rounded")
 
 
 def main() -> None:

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import math
 import re
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from scpi_control import exceptions
 from scpi_control.connection.base import BaseConnection
@@ -53,7 +53,7 @@ class MockConnection(BaseConnection):
         voltage_scales: Optional[Dict[int, float]] = None,
         voltage_offsets: Optional[Dict[int, float]] = None,
         waveform_payloads: Optional[Dict[int, bytes]] = None,
-        signals: Optional[Dict[int, "SignalSpec"]] = None,
+        signals: Optional[Dict[int, Union["SignalSpec", Callable[[], "SignalSpec"]]]] = None,
         sample_rate: float = 1_000.0,
         timebase: float = 1e-3,
         trigger_status: Optional[List[str]] = None,
@@ -91,7 +91,7 @@ class MockConnection(BaseConnection):
         # Explicit payloads only; channels without one get state-coupled synthesis
         # (connection/mock/synth.py). The old fixed 4-byte default is gone.
         self._waveform_payloads: Dict[int, bytes] = dict(waveform_payloads) if waveform_payloads else {}
-        self._signals: Dict[int, "SignalSpec"] = dict(signals) if signals else {}
+        self._signals: Dict[int, Union["SignalSpec", Callable[[], "SignalSpec"]]] = dict(signals) if signals else {}
         self._acquisition_counts: Dict[int, int] = {}
         self._channel_coupling: Dict[int, str] = {ch: "D1M" for ch in channels}
         # Legacy scope probe attenuation / bandwidth-limit state (Task 14,

--- a/scpi_control/connection/mock/loopback.py
+++ b/scpi_control/connection/mock/loopback.py
@@ -26,8 +26,18 @@ _FUNCTION_KINDS = {
     "PULSE": "pulse",
 }
 
-# Percent either side of 50 that still counts as a triangle rather than a sawtooth.
+# Percentage points either side of 50 that still count as a triangle rather than
+# a sawtooth (so 49..51, not 49.5..50.5).
 _RAMP_SYMMETRY_TOLERANCE = 1.0
+
+# Peak-to-peak volts per standard deviation, for NOISE only. Gaussian noise has
+# no true peak, so a source's quoted peak-to-peak is a CONVENTION: the one taken
+# here is the +/-3 sigma span, which contains 99.7% of samples. That makes
+# sigma = Vpp / 6. The factor is a choice, not arithmetic -- a vendor quoting
+# +/-2 sigma or a crest factor would want a different divisor -- so it is named
+# rather than inlined. Nothing else in this file uses it: every other kind's
+# `AMP` really is a peak-to-peak of a bounded waveform, and halves exactly.
+_NOISE_SIGMAS_PER_PEAK_TO_PEAK = 6.0
 
 # SignalSpec requires 0 < duty < 1; an AWG happily accepts 0 and 100.
 _MIN_DUTY = 0.01
@@ -67,8 +77,7 @@ class AwgLoopback:
     def _spec_from(self, state: Dict[str, Any]) -> SignalSpec:
         function = str(state.get("function", "SINE")).upper()
         frequency = float(state.get("frequency", 1000.0)) or 1000.0
-        # SDG `AMP` is peak-to-peak (PG02-E05B p.29); SignalSpec.amplitude is peak.
-        amplitude = float(state.get("amplitude", 1.0)) / 2.0
+        peak_to_peak = float(state.get("amplitude", 1.0))
         offset = float(state.get("offset", 0.0))
         phase = math.radians(float(state.get("phase", 0.0)))
         duty = min(_MAX_DUTY, max(_MIN_DUTY, float(state.get("pulse_duty", 50.0)) / 100.0))
@@ -83,6 +92,16 @@ class AwgLoopback:
             kind = "sine"
         else:
             kind = _FUNCTION_KINDS.get(function, "sine")
+
+        if kind == "noise":
+            # SignalSpec.amplitude is the standard DEVIATION for "noise", not a
+            # peak (see signal_synth.SignalSpec's docstring), so the plain
+            # halving below would be a unit error: it would hand sigma a peak
+            # value and produce a trace roughly 3.8x the requested Vpp.
+            amplitude = peak_to_peak / _NOISE_SIGMAS_PER_PEAK_TO_PEAK
+        else:
+            # SDG `AMP` is peak-to-peak (PG02-E05B p.29); SignalSpec.amplitude is peak.
+            amplitude = peak_to_peak / 2.0
 
         common = {"frequency": frequency, "amplitude": amplitude, "offset": offset, "phase": phase}
         if kind == "square":

--- a/scpi_control/connection/mock/loopback.py
+++ b/scpi_control/connection/mock/loopback.py
@@ -1,0 +1,100 @@
+"""A patch cable from a mock AWG channel to a mock scope channel.
+
+The AWG and the scope are separate MockConnection instances, so nothing in the
+scope's synthesis can see the AWG's state. This object closes that gap: it is a
+callable suitable for `MockConnection(signals={...})`, and it reads the AWG's
+live channel state every time it is called, so a `C1:BSWV` write between two
+captures changes the second one.
+"""
+
+import logging
+import math
+from typing import Any, Dict, Optional
+
+from scpi_control.signal_synth import SignalSpec
+
+logger = logging.getLogger(__name__)
+
+# Waveform names come from awg_output.py:65. RAMP is absent because it maps to
+# two kinds depending on symmetry, and ARB is absent because the mock stores no
+# arbitrary sample data; both are handled explicitly below.
+_FUNCTION_KINDS = {
+    "SINE": "sine",
+    "SQUARE": "square",
+    "NOISE": "noise",
+    "DC": "dc",
+    "PULSE": "pulse",
+}
+
+# Percent either side of 50 that still counts as a triangle rather than a sawtooth.
+_RAMP_SYMMETRY_TOLERANCE = 1.0
+
+# SignalSpec requires 0 < duty < 1; an AWG happily accepts 0 and 100.
+_MIN_DUTY = 0.01
+_MAX_DUTY = 0.99
+
+# An output that is off reads like a disconnected input: flat, not a zero-amplitude
+# waveform at some frequency.
+_OUTPUT_OFF = SignalSpec(kind="dc", offset=0.0)
+
+
+class AwgLoopback:
+    """Reads a mock AWG channel and yields the SignalSpec a scope would see.
+
+    Args:
+        awg_connection: A MockConnection built with ``awg_mode=True``.
+        awg_channel: Which of its channels to patch from.
+        dut: Optional device model (e.g. ``RCLowPass``) sitting between the two
+            instruments. Stored here rather than on the scope connection because
+            a DUT physically sits between them -- this object models the cable
+            run. It is APPLIED in connection/mock/synth.py's raw_volts, which is
+            the only layer that knows the sample rate and can render the filter's
+            lead-in.
+    """
+
+    def __init__(self, awg_connection: Any, awg_channel: int = 1, dut: Optional[Any] = None) -> None:
+        self.awg_connection = awg_connection
+        self.awg_channel = awg_channel
+        self.dut = dut
+        self._warned_about_arb = False
+
+    def __call__(self) -> SignalSpec:
+        state = getattr(self.awg_connection, "awg_channels", {}).get(self.awg_channel)
+        if not state or not state.get("enabled", False):
+            return _OUTPUT_OFF
+        return self._spec_from(state)
+
+    def _spec_from(self, state: Dict[str, Any]) -> SignalSpec:
+        function = str(state.get("function", "SINE")).upper()
+        frequency = float(state.get("frequency", 1000.0)) or 1000.0
+        # SDG `AMP` is peak-to-peak (PG02-E05B p.29); SignalSpec.amplitude is peak.
+        amplitude = float(state.get("amplitude", 1.0)) / 2.0
+        offset = float(state.get("offset", 0.0))
+        phase = math.radians(float(state.get("phase", 0.0)))
+        duty = min(_MAX_DUTY, max(_MIN_DUTY, float(state.get("pulse_duty", 50.0)) / 100.0))
+
+        if function == "RAMP":
+            symmetry = float(state.get("ramp_symmetry", 50.0))
+            kind = "triangle" if abs(symmetry - 50.0) <= _RAMP_SYMMETRY_TOLERANCE else "ramp"
+        elif function == "ARB":
+            if not self._warned_about_arb:
+                logger.warning("AwgLoopback: the mock stores no ARB sample data, so an ARB waveform is captured as a sine")
+                self._warned_about_arb = True
+            kind = "sine"
+        else:
+            kind = _FUNCTION_KINDS.get(function, "sine")
+
+        common = {"frequency": frequency, "amplitude": amplitude, "offset": offset, "phase": phase}
+        if kind == "square":
+            return SignalSpec(kind=kind, duty=duty, **common)
+        if kind == "pulse":
+            period = 1.0 / frequency
+            # edge_time shrinks with the period: SignalSpec's 10 us default is
+            # LONGER than the period above 100 kHz, and _validate then has no legal
+            # pulse_width at all.
+            edge_time = min(SignalSpec().edge_time, period / 10.0)
+            # _validate requires pulse_width > edge_time and
+            # pulse_width + edge_time <= period.
+            width = min(period - edge_time, max(edge_time * 1.01, duty * period))
+            return SignalSpec(kind=kind, pulse_width=width, edge_time=edge_time, **common)
+        return SignalSpec(kind=kind, **common)

--- a/scpi_control/connection/mock/synth.py
+++ b/scpi_control/connection/mock/synth.py
@@ -118,7 +118,24 @@ def raw_volts(conn: "MockConnection", channel: int, n_override: Optional[int] = 
     else:
         t0 = count * window * _DRIFT_FRACTION  # untriggerable: free-run drift
     per_acquisition = spec if spec.seed is None else replace(spec, seed=spec.seed + count)
-    return synthesize(per_acquisition, conn.sample_rate, n, t0=t0)
+    dut = getattr(conn._signals.get(channel), "dut", None)
+    if dut is None:
+        return synthesize(per_acquisition, conn.sample_rate, n, t0=t0)
+    # A DUT filter is STATEFUL, unlike every generator in signal_synth. Filtering
+    # the bare capture would start from y=0 and put a settling transient at the
+    # head of every acquisition, so render a lead-in BEFORE t0, filter across the
+    # whole extended window, then slice the lead-in off -- the same fix, for the
+    # same reason, as the ringing impairment's pre-t0 window (signal_synth.py:381).
+    #
+    # Note the extended t0 is computed as a subtraction rather than by shifting
+    # the index range the way the ringing path does, so the sample at index
+    # `warmup` can land a few ULP from `t0`. That is deliberate here: the output
+    # is low-pass filtered and then quantized to int8 at 25 codes/div, which is
+    # ~0.04 V -- a sub-femtosecond timebase difference is many orders of
+    # magnitude below the smallest representable change.
+    warmup = dut.warmup_samples(conn.sample_rate)
+    extended = synthesize(per_acquisition, conn.sample_rate, n + warmup, t0=t0 - warmup / conn.sample_rate)
+    return dut.apply(extended, conn.sample_rate)[warmup:]
 
 
 def payload_for(conn: "MockConnection", channel: int, *, include_offset: bool) -> bytes:

--- a/scpi_control/connection/mock/synth.py
+++ b/scpi_control/connection/mock/synth.py
@@ -130,9 +130,13 @@ def raw_volts(conn: "MockConnection", channel: int, n_override: Optional[int] = 
     # Note the extended t0 is computed as a subtraction rather than by shifting
     # the index range the way the ringing path does, so the sample at index
     # `warmup` can land a few ULP from `t0`. That is deliberate here: the output
-    # is low-pass filtered and then quantized to int8 at 25 codes/div, which is
-    # ~0.04 V -- a sub-femtosecond timebase difference is many orders of
-    # magnitude below the smallest representable change.
+    # is low-pass filtered and then quantized. The relevant grid is the FINER of
+    # the two this function feeds -- not the int8 path's 25 codes/div (~0.04 V at
+    # 1 V/div) but the modern dialect's WORD path at 6400 codes/div
+    # (siglent.py's _MODERN_CODE_PER_DIV_WORD), i.e. 0.15625 mV/LSB. A
+    # sub-femtosecond timebase difference is still many orders of magnitude below
+    # even that. The lead-in's DEPTH is sized against the same WORD grid rather
+    # than int8 -- see dut._WARMUP_TIME_CONSTANTS for the measured numbers.
     warmup = dut.warmup_samples(conn.sample_rate)
     extended = synthesize(per_acquisition, conn.sample_rate, n + warmup, t0=t0 - warmup / conn.sample_rate)
     return dut.apply(extended, conn.sample_rate)[warmup:]

--- a/scpi_control/connection/mock/synth.py
+++ b/scpi_control/connection/mock/synth.py
@@ -66,8 +66,19 @@ def _trigger_crossing(spec: SignalSpec, level: float, rising: bool) -> Optional[
 
 
 def spec_for(conn: "MockConnection", channel: int) -> SignalSpec:
-    """The signal a channel 'sees': user-specified, else the channel default."""
-    return conn._signals.get(channel) or _DEFAULT_SPECS.get(channel, _FALLBACK_SPEC)
+    """The signal a channel 'sees': user-specified, else the channel default.
+
+    A stored value is either a SignalSpec or a zero-argument callable returning
+    one. The callable is invoked at EVERY acquisition, which is what lets a live
+    source -- an AwgLoopback reading a mock AWG's state -- change what the scope
+    captures between captures. Everything downstream (point_count, raw_volts, the
+    trigger-crossing search, the three vendor personalities) keeps receiving a
+    plain SignalSpec and never learns the difference.
+    """
+    source = conn._signals.get(channel)
+    if source is None:
+        return _DEFAULT_SPECS.get(channel, _FALLBACK_SPEC)
+    return source() if callable(source) else source
 
 
 def point_count(conn: "MockConnection", channel: int) -> int:

--- a/scpi_control/dut.py
+++ b/scpi_control/dut.py
@@ -25,7 +25,18 @@ _MAX_WARMUP_SAMPLES = 200_000
 class RCLowPass:
     """A first-order RC low-pass standing in for a device under test.
 
-        y[n] = y[n-1] + alpha * (x[n] - y[n-1]),   alpha = dt / (tau + dt)
+        y[n] = y[n-1] + alpha * (x[n] - y[n-1]),   alpha = 1 - exp(-dt / tau)
+
+    `alpha` is the exact zero-order-hold (impulse-invariant) discretisation of a
+    continuous RC network sampled at `dt` -- not the backward-Euler approximation
+    `dt / (tau + dt)`, which agrees with `exp(-dt/tau)` only to second order in
+    `dt/tau`. That distinction matters here specifically because `signal_synth`'s
+    "exponential" kind is a closed-form solution built directly from
+    `exp(-t/tau)`: filtering a square wave through this class is mathematically
+    the same construction, so using the exact discretisation makes the two
+    agree to near machine precision instead of leaving a ~2% floor between two
+    different approximations of the same physics (see
+    `tests/test_loopback_capture.py`'s cross-validation test).
 
     **This filter is stateful**, unlike everything in `signal_synth`, which is
     closed-form precisely so that streamed chunks and consecutive mock
@@ -54,7 +65,7 @@ class RCLowPass:
         if not np.isfinite(sample_rate) or sample_rate <= 0:
             raise exceptions.InvalidParameterError(f"sample_rate must be a positive finite number: {sample_rate}")
         dt = 1.0 / sample_rate
-        alpha = dt / (self.tau + dt)
+        alpha = 1.0 - math.exp(-dt / self.tau)
         # scipy rather than a Python loop: a 14,000-point capture is the common
         # case and a deep-memory record is far larger.
         return scipy_signal.lfilter([alpha], [1.0, -(1.0 - alpha)], np.asarray(samples, dtype=float))

--- a/scpi_control/dut.py
+++ b/scpi_control/dut.py
@@ -12,10 +12,23 @@ from scipy import signal as scipy_signal
 
 from scpi_control import exceptions
 
-# After 5 time constants a first-order response has settled to within 0.7% of its
-# final value -- far below the int8 quantization the mock's scope path applies
-# afterwards, so a longer lead-in would cost samples and buy nothing.
-_WARMUP_TIME_CONSTANTS = 5
+# Lead-in depth in time constants. The un-settled residual left at the start of
+# the capture window is e^-N times the filter's initial deviation, so N is set by
+# the FINEST quantization the mock's scope path applies afterwards -- and that is
+# NOT the int8 path. connection/mock/synth.py's raw_volts also feeds the modern
+# dialect's WORD encoder (connection/mock/siglent.py's
+# _MODERN_CODE_PER_DIV_WORD = 25 * 256 = 6400 codes/div), which resolves
+# 0.15625 mV/LSB at 1 V/div -- 256x finer than int8's 0.04 V. Reachable with
+# `:WAVeform:WIDTh WORD` on a modern-dialect mock carrying a loopback DUT.
+#
+# Measured against a 40-time-constant lead-in reference (2 Vpp 1 kHz square,
+# cutoff 1 kHz, 1 MSa/s), worst case over lead-in start phase:
+#   N = 5   -> 6.153e-3 V = 0.15 int8 codes (invisible) but 39 WORD LSBs
+#   N = 12  -> 5.566e-6 V = 0.04 WORD LSB   (invisible on both paths)
+# e^-12 = 6.1e-6 is the reason: it puts the residual under 0.05 WORD LSB for a
+# unit initial deviation. The cost is 2.4x the lead-in samples, bounded by
+# _MAX_WARMUP_SAMPLES below and cheap.
+_WARMUP_TIME_CONSTANTS = 12
 
 # Backstop on the lead-in, mirroring signal_synth._MAX_RINGING_KERNEL_SAMPLES.
 # A near-zero cutoff makes tau -- and so the warmup -- unbounded otherwise.

--- a/scpi_control/dut.py
+++ b/scpi_control/dut.py
@@ -1,0 +1,60 @@
+"""Device-under-test models applied between a signal source and an instrument input.
+
+Written for the mock's AWG -> scope loopback, so a stimulus arrives at the scope
+shaped the way real hardware would shape it, but public and usable on its own:
+`apply` filters any float array.
+"""
+
+import math
+
+import numpy as np
+from scipy import signal as scipy_signal
+
+from scpi_control import exceptions
+
+# After 5 time constants a first-order response has settled to within 0.7% of its
+# final value -- far below the int8 quantization the mock's scope path applies
+# afterwards, so a longer lead-in would cost samples and buy nothing.
+_WARMUP_TIME_CONSTANTS = 5
+
+# Backstop on the lead-in, mirroring signal_synth._MAX_RINGING_KERNEL_SAMPLES.
+# A near-zero cutoff makes tau -- and so the warmup -- unbounded otherwise.
+_MAX_WARMUP_SAMPLES = 200_000
+
+
+class RCLowPass:
+    """A first-order RC low-pass standing in for a device under test.
+
+        y[n] = y[n-1] + alpha * (x[n] - y[n-1]),   alpha = dt / (tau + dt)
+
+    **This filter is stateful**, unlike everything in `signal_synth`, which is
+    closed-form precisely so that streamed chunks and consecutive mock
+    acquisitions join seamlessly. The recurrence carries `y` across samples, so a
+    caller must hand `apply` a buffer that already includes `warmup_samples()` of
+    lead-in and discard that lead-in afterwards (see `connection/mock/synth.py`'s
+    `raw_volts`). Filtering a bare capture would start from `y = 0` and put a
+    settling transient at the head of every acquisition -- the exact defect the
+    closed-form generators were written to avoid.
+    """
+
+    def __init__(self, cutoff_hz: float) -> None:
+        if not np.isfinite(cutoff_hz) or cutoff_hz <= 0:
+            raise exceptions.InvalidParameterError(f"cutoff_hz must be a positive finite number: {cutoff_hz}")
+        self.cutoff_hz = float(cutoff_hz)
+        self.tau = 1.0 / (2.0 * math.pi * self.cutoff_hz)
+
+    def warmup_samples(self, sample_rate: float) -> int:
+        """Lead-in length the caller must render before the window it wants."""
+        if not np.isfinite(sample_rate) or sample_rate <= 0:
+            raise exceptions.InvalidParameterError(f"sample_rate must be a positive finite number: {sample_rate}")
+        return int(min(_MAX_WARMUP_SAMPLES, max(1, round(_WARMUP_TIME_CONSTANTS * self.tau * sample_rate))))
+
+    def apply(self, samples: np.ndarray, sample_rate: float) -> np.ndarray:
+        """Filter `samples`, including whatever lead-in the caller prepended."""
+        if not np.isfinite(sample_rate) or sample_rate <= 0:
+            raise exceptions.InvalidParameterError(f"sample_rate must be a positive finite number: {sample_rate}")
+        dt = 1.0 / sample_rate
+        alpha = dt / (self.tau + dt)
+        # scipy rather than a Python loop: a 14,000-point capture is the common
+        # case and a deep-memory record is far larger.
+        return scipy_signal.lfilter([alpha], [1.0, -(1.0 - alpha)], np.asarray(samples, dtype=float))

--- a/scpi_control/dut.py
+++ b/scpi_control/dut.py
@@ -25,18 +25,22 @@ _MAX_WARMUP_SAMPLES = 200_000
 class RCLowPass:
     """A first-order RC low-pass standing in for a device under test.
 
-        y[n] = y[n-1] + alpha * (x[n] - y[n-1]),   alpha = 1 - exp(-dt / tau)
+        y[n] = y[n-1] + alpha * (x[n-1] - y[n-1]),   alpha = 1 - exp(-dt / tau)
 
-    `alpha` is the exact zero-order-hold (impulse-invariant) discretisation of a
-    continuous RC network sampled at `dt` -- not the backward-Euler approximation
+    `alpha` is the exact zero-order-hold discretisation of a continuous RC
+    network sampled at `dt` -- not the backward-Euler approximation
     `dt / (tau + dt)`, which agrees with `exp(-dt/tau)` only to second order in
-    `dt/tau`. That distinction matters here specifically because `signal_synth`'s
-    "exponential" kind is a closed-form solution built directly from
-    `exp(-t/tau)`: filtering a square wave through this class is mathematically
-    the same construction, so using the exact discretisation makes the two
-    agree to near machine precision instead of leaving a ~2% floor between two
-    different approximations of the same physics (see
-    `tests/test_loopback_capture.py`'s cross-validation test).
+    `dt/tau`. The recurrence is strictly proper: `y[n]` depends on `x[n-1]`, not
+    `x[n]`, because a real RC's output at a sampling instant reflects the input
+    held over the *previous* interval, not the current one (see `apply`'s
+    `[0.0, alpha]` numerator). That distinction matters here specifically
+    because `signal_synth`'s "exponential" kind is a closed-form solution built
+    directly from `exp(-t/tau)`: filtering a square wave through this class is
+    mathematically the same construction, so once the discretisation is exact
+    *and* strictly proper the two agree to near machine precision, with the
+    only remaining floor being the finite lead-in `apply`'s caller renders
+    before the window of interest (see `tests/test_loopback_capture.py`'s
+    cross-validation test).
 
     **This filter is stateful**, unlike everything in `signal_synth`, which is
     closed-form precisely so that streamed chunks and consecutive mock
@@ -68,4 +72,14 @@ class RCLowPass:
         alpha = 1.0 - math.exp(-dt / self.tau)
         # scipy rather than a Python loop: a 14,000-point capture is the common
         # case and a deep-memory record is far larger.
-        return scipy_signal.lfilter([alpha], [1.0, -(1.0 - alpha)], np.asarray(samples, dtype=float))
+        #
+        # The leading 0.0 in the numerator is not cosmetic: it is the z^-1 that
+        # the exact ZOH discretisation of 1/(1+s*tau) requires (H(z) =
+        # (1-a)*z^-1 / (1-a*z^-1), a = exp(-dt/tau)), making the filter strictly
+        # proper. Without it, lfilter([alpha], ...) gives the output a direct
+        # feedthrough of x[n] in the SAME sample -- a real RC cannot do that; its
+        # output at a sampling instant depends only on the input held over the
+        # previous interval. That missing z^-1 was the entire ~2% floor an
+        # earlier investigation attributed to a structural artifact of comparing
+        # a discrete filter to a continuous closed form.
+        return scipy_signal.lfilter([0.0, alpha], [1.0, -(1.0 - alpha)], np.asarray(samples, dtype=float))

--- a/tests/test_awg_loopback.py
+++ b/tests/test_awg_loopback.py
@@ -28,6 +28,20 @@ def test_amplitude_is_halved_because_the_awg_reports_peak_to_peak():
     assert spec.amplitude == pytest.approx(1.0)
 
 
+def test_noise_amplitude_becomes_a_standard_deviation_not_a_peak():
+    """`SignalSpec.amplitude` is the standard deviation for "noise" and a peak
+    for every other kind, so the Vpp->peak halving that is correct everywhere
+    else is a UNIT ERROR here: it feeds a peak value to sigma and captures about
+    3.8x the requested peak-to-peak (measured: 7.56 Vpp for a 2.0 Vpp request).
+    The convention taken is that a noise source's quoted peak-to-peak is its
+    +/-3 sigma span, so sigma = Vpp / 6."""
+    spec = AwgLoopback(_awg(function="NOISE", amplitude=2.0))()
+    assert spec.kind == "noise"
+    assert spec.amplitude == pytest.approx(2.0 / 6.0)
+    # Explicitly NOT the halved value every bounded kind gets.
+    assert spec.amplitude != pytest.approx(1.0)
+
+
 def test_phase_is_converted_from_degrees_to_radians():
     spec = AwgLoopback(_awg(phase=90.0))()
     assert spec.phase == pytest.approx(math.pi / 2)

--- a/tests/test_awg_loopback.py
+++ b/tests/test_awg_loopback.py
@@ -1,0 +1,128 @@
+"""Mapping a mock AWG's live channel state onto a SignalSpec.
+
+The AWG and the scope are separate MockConnection instances; this object is the
+patch cable between them. Everything here is a pure mapping -- the end-to-end
+behaviour through a scope session is covered in tests/test_loopback_capture.py.
+"""
+
+import math
+
+import pytest
+
+from scpi_control.connection import MockConnection
+from scpi_control.connection.mock.loopback import AwgLoopback
+
+
+def _awg(**overrides):
+    conn = MockConnection(awg_mode=True, awg_idn="Siglent Technologies,SDG1032X,SDG1XXXXX,2.01.01.37R1")
+    conn.awg_channels[1].update({"enabled": True})
+    conn.awg_channels[1].update(overrides)
+    return conn
+
+
+def test_amplitude_is_halved_because_the_awg_reports_peak_to_peak():
+    """The single most likely thing to get silently wrong: SDG `AMP` is Vpp
+    (PG02-E05B p.29) while SignalSpec.amplitude is peak, so a missed conversion
+    yields a perfectly plausible trace at exactly double amplitude."""
+    spec = AwgLoopback(_awg(amplitude=2.0))()
+    assert spec.amplitude == pytest.approx(1.0)
+
+
+def test_phase_is_converted_from_degrees_to_radians():
+    spec = AwgLoopback(_awg(phase=90.0))()
+    assert spec.phase == pytest.approx(math.pi / 2)
+
+
+@pytest.mark.parametrize(
+    "function,expected_kind",
+    [("SINE", "sine"), ("SQUARE", "square"), ("NOISE", "noise"), ("DC", "dc"), ("PULSE", "pulse")],
+)
+def test_the_function_maps_to_a_kind(function, expected_kind):
+    assert AwgLoopback(_awg(function=function))().kind == expected_kind
+
+
+def test_a_symmetric_ramp_is_a_triangle():
+    """A ramp at 50% symmetry IS a triangle; the synth engine models them as
+    separate kinds, so the mapping has to choose."""
+    assert AwgLoopback(_awg(function="RAMP", ramp_symmetry=50.0))().kind == "triangle"
+
+
+def test_an_asymmetric_ramp_is_a_sawtooth():
+    assert AwgLoopback(_awg(function="RAMP", ramp_symmetry=10.0))().kind == "ramp"
+
+
+def test_arb_falls_back_to_a_sine_and_says_so(caplog):
+    """The mock stores no arbitrary sample data, so ARB cannot be honoured. It
+    must degrade visibly rather than silently."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="scpi_control.connection.mock.loopback"):
+        spec = AwgLoopback(_awg(function="ARB"))()
+    assert spec.kind == "sine"
+    assert any("ARB" in record.message for record in caplog.records)
+
+
+def test_a_disabled_output_reads_flat():
+    """An output that is off is a disconnected input, not a signal of zero
+    amplitude at some frequency."""
+    conn = _awg()
+    conn.awg_channels[1]["enabled"] = False
+    spec = AwgLoopback(conn)()
+    assert spec.kind == "dc"
+    assert spec.offset == 0.0
+
+
+def test_frequency_and_offset_pass_through():
+    spec = AwgLoopback(_awg(frequency=2_500.0, offset=0.25))()
+    assert spec.frequency == pytest.approx(2_500.0)
+    assert spec.offset == pytest.approx(0.25)
+
+
+def test_the_state_is_read_live_not_captured_at_construction():
+    """The loopback must see writes that happen after it is wired up."""
+    conn = _awg(function="SINE")
+    loop = AwgLoopback(conn)
+    assert loop().kind == "sine"
+    conn.awg_channels[1]["function"] = "SQUARE"
+    assert loop().kind == "square"
+
+
+@pytest.mark.parametrize("duty", [0.0, 100.0])
+def test_an_extreme_duty_is_clamped_rather_than_raising(duty):
+    """An AWG accepts DUTY,0 and DUTY,100; SignalSpec requires 0 < duty < 1. A
+    mock instrument must not explode because a duty was set to an edge value --
+    a real one would output something."""
+    from scpi_control.signal_synth import synthesize
+
+    spec = AwgLoopback(_awg(function="SQUARE", pulse_duty=duty))()
+    synthesize(spec, 1_000_000.0, 1_000)  # must not raise
+
+
+@pytest.mark.parametrize("duty", [0.0, 100.0])
+def test_an_extreme_pulse_duty_is_clamped_rather_than_raising(duty):
+    from scpi_control.signal_synth import synthesize
+
+    spec = AwgLoopback(_awg(function="PULSE", pulse_duty=duty))()
+    synthesize(spec, 1_000_000.0, 1_000)  # must not raise
+
+
+def test_a_high_frequency_pulse_still_produces_a_legal_spec():
+    """At 1 MHz the period is 1 us, shorter than SignalSpec's default 10 us
+    edge_time, so the edge has to shrink with the period or no legal pulse
+    width exists."""
+    from scpi_control.signal_synth import synthesize
+
+    spec = AwgLoopback(_awg(function="PULSE", frequency=1_000_000.0))()
+    synthesize(spec, 100_000_000.0, 1_000)  # must not raise
+
+
+def test_the_dut_is_carried_but_not_applied_here():
+    """The loopback holds the DUT; raw_volts applies it, because only that layer
+    knows the sample rate and can render the filter's lead-in."""
+    sentinel = object()
+    loop = AwgLoopback(_awg(), dut=sentinel)
+    assert loop.dut is sentinel
+
+
+def test_an_unknown_awg_channel_reads_flat():
+    assert AwgLoopback(_awg(), awg_channel=99)().kind == "dc"

--- a/tests/test_dut.py
+++ b/tests/test_dut.py
@@ -1,0 +1,81 @@
+"""The RC low-pass standing in for a device under test.
+
+Its defining property is the one the tests lead with: at the cutoff frequency a
+first-order response is down 3 dB, i.e. 1/sqrt(2). Everything else follows from
+that. The filter is STATEFUL, which is why warmup_samples exists -- see the
+module docstring for why that matters to a mock that must produce seamless
+consecutive captures.
+"""
+
+import numpy as np
+import pytest
+
+from scpi_control import exceptions
+from scpi_control.dut import RCLowPass
+from scpi_control.signal_synth import SignalSpec, synthesize
+
+RATE = 1_000_000.0
+
+
+def _steady_amplitude(filtered, warmup):
+    """Peak amplitude after the filter has settled, measured past the lead-in."""
+    settled = filtered[warmup:]
+    return (settled.max() - settled.min()) / 2.0
+
+
+def _filtered_sine(cutoff_hz, signal_hz, amplitude=1.0):
+    dut = RCLowPass(cutoff_hz=cutoff_hz)
+    warmup = dut.warmup_samples(RATE)
+    n = warmup + int(RATE / signal_hz) * 20  # 20 whole periods past the lead-in
+    samples = synthesize(SignalSpec(kind="sine", frequency=signal_hz, amplitude=amplitude), RATE, n)
+    return _steady_amplitude(dut.apply(samples, RATE), warmup)
+
+
+def test_at_the_cutoff_the_response_is_down_three_db():
+    """The defining property of a first-order low-pass: 1/sqrt(2) at f_c."""
+    assert _filtered_sine(cutoff_hz=1_000.0, signal_hz=1_000.0) == pytest.approx(1.0 / np.sqrt(2.0), rel=0.02)
+
+
+def test_well_below_the_cutoff_the_signal_passes():
+    assert _filtered_sine(cutoff_hz=10_000.0, signal_hz=100.0) == pytest.approx(1.0, rel=0.01)
+
+
+def test_well_above_the_cutoff_the_signal_is_attenuated():
+    """First order rolls off 20 dB/decade, so a decade up is ~1/10."""
+    assert _filtered_sine(cutoff_hz=1_000.0, signal_hz=10_000.0) == pytest.approx(0.1, rel=0.1)
+
+
+def test_dc_passes_unchanged():
+    dut = RCLowPass(cutoff_hz=1_000.0)
+    warmup = dut.warmup_samples(RATE)
+    samples = synthesize(SignalSpec(kind="dc", offset=2.5), RATE, warmup + 1_000)
+    assert dut.apply(samples, RATE)[-1] == pytest.approx(2.5, rel=1e-3)
+
+
+def test_warmup_scales_with_the_time_constant_and_the_sample_rate():
+    slow = RCLowPass(cutoff_hz=100.0)
+    fast = RCLowPass(cutoff_hz=10_000.0)
+    assert slow.warmup_samples(RATE) > fast.warmup_samples(RATE)
+    assert slow.warmup_samples(2 * RATE) == pytest.approx(2 * slow.warmup_samples(RATE), rel=0.01)
+
+
+def test_the_warmup_window_is_capped():
+    """A near-zero cutoff would otherwise make tau -- and the lead-in -- unbounded,
+    the same backstop signal_synth applies to the ringing kernel."""
+    assert RCLowPass(cutoff_hz=1e-9).warmup_samples(RATE) == 200_000
+
+
+def test_the_time_constant_matches_the_cutoff():
+    assert RCLowPass(cutoff_hz=1_000.0).tau == pytest.approx(1.0 / (2 * np.pi * 1_000.0))
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0, float("nan"), float("inf")])
+def test_an_invalid_cutoff_is_rejected(bad):
+    with pytest.raises(exceptions.InvalidParameterError):
+        RCLowPass(cutoff_hz=bad)
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0, float("nan")])
+def test_an_invalid_sample_rate_is_rejected(bad):
+    with pytest.raises(exceptions.InvalidParameterError):
+        RCLowPass(cutoff_hz=1_000.0).warmup_samples(bad)

--- a/tests/test_dynamic_signals.py
+++ b/tests/test_dynamic_signals.py
@@ -1,0 +1,68 @@
+"""A channel's signal may be computed fresh at every acquisition.
+
+`signals={1: SignalSpec(...)}` pins a channel to one static signal. Allowing a
+callable is what lets a LIVE source -- an AwgLoopback reading a mock AWG's state
+-- change what the scope captures between captures. Everything downstream keeps
+receiving a plain SignalSpec and never learns the difference.
+"""
+
+import numpy as np
+import pytest
+
+from scpi_control.connection import MockConnection
+from scpi_control.oscilloscope import Oscilloscope
+from scpi_control.signal_synth import SignalSpec
+
+LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+
+
+def _scope(**kwargs):
+    # Channel 2 is ENABLED here, unlike the helper in test_mock_synthesis.py:
+    # one test below captures it to prove an unlisted channel still falls back
+    # to its built-in default signal.
+    conn = MockConnection(
+        "mock",
+        idn=LEGACY_IDN,
+        channel_states={1: True, 2: True, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=1_000_000.0,
+        timebase=1e-3,
+        **kwargs,
+    )
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    return scope, conn
+
+
+def test_a_callable_signal_is_re_read_on_every_acquisition():
+    """The whole point: the source is consulted per capture, not once."""
+    box = {"spec": SignalSpec(kind="dc", offset=1.0)}
+    scope, _ = _scope(signals={1: lambda: box["spec"]})
+    try:
+        first = scope.get_waveform(1, provenance=False)
+        box["spec"] = SignalSpec(kind="dc", offset=-1.0)
+        second = scope.get_waveform(1, provenance=False)
+    finally:
+        scope.disconnect()
+    assert np.mean(first.voltage) == pytest.approx(1.0, abs=0.1)
+    assert np.mean(second.voltage) == pytest.approx(-1.0, abs=0.1)
+
+
+def test_a_static_spec_still_works_unchanged():
+    """The non-breaking guarantee: a SignalSpec is not callable, so the new
+    branch never fires for an existing caller."""
+    scope, _ = _scope(signals={1: SignalSpec(kind="dc", offset=0.5)})
+    try:
+        data = scope.get_waveform(1, provenance=False)
+    finally:
+        scope.disconnect()
+    assert np.mean(data.voltage) == pytest.approx(0.5, abs=0.1)
+
+
+def test_a_channel_with_no_entry_still_gets_its_default():
+    scope, _ = _scope(signals={1: SignalSpec(kind="dc", offset=0.5)})
+    try:
+        data = scope.get_waveform(2, provenance=False)
+    finally:
+        scope.disconnect()
+    assert np.ptp(data.voltage) > 0.1, "channel 2 falls back to its built-in default signal"

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -63,6 +63,7 @@ EXECUTE = [
     ("report_ai_qa.py", "requests"),
     ("waveform_provenance_and_extract.py", None),
     ("synthetic_signals.py", None),
+    ("awg_scope_loopback.py", None),
     ("comparison_report.py", None),
     ("batch_report.py", None),
 ]

--- a/tests/test_loopback_capture.py
+++ b/tests/test_loopback_capture.py
@@ -47,8 +47,8 @@ def _scope(source):
 def test_the_capture_is_in_steady_state_from_its_very_first_period():
     """The lead-in is what makes this true. Filtering a bare capture starts from
     y=0, so the first period would carry a settling ramp the last period does not
-    -- and at 1 kHz the RC settles in ~159 samples, well inside one 1000-sample
-    period, so the two windows would visibly disagree."""
+    -- and at 1 kHz the RC settles in ~159 samples (5 tau), well inside one
+    1000-sample period, so the two windows would visibly disagree."""
     awg = _awg(function="SQUARE", frequency=1_000.0, amplitude=2.0)
     scope = _scope(AwgLoopback(awg, dut=RCLowPass(cutoff_hz=5_000.0)))
     try:
@@ -56,8 +56,23 @@ def test_the_capture_is_in_steady_state_from_its_very_first_period():
     finally:
         scope.disconnect()
     period = 1_000  # 1 kHz at 1 MSa/s
-    # atol covers one int8 code: 25 codes/div at the mock's 1 V/div default.
-    np.testing.assert_allclose(data.voltage[:period], data.voltage[-period:], atol=0.05)
+    # atol is two int8 codes (25 codes/div at the mock's 1 V/div default), not
+    # one, because the residual this comparison sees is NOT the settling
+    # transient it is guarding against. Measured on the pre-quantization volts
+    # for this exact capture:
+    #   no lead-in at all      1.0309 V   <- the regression this test exists for
+    #   with the lead-in       0.0619 V, of which the settling part is 5.8e-6 V
+    # The 0.0619 V is one sample, smeared forward by the RC. It is the square
+    # generator's razor's-edge boundary: trigger alignment puts t0 exactly on a
+    # cycle boundary (t0 = -6.000 ms for a 1 kHz square in a 14 ms window), and
+    # signal_synth._cycle_fraction's `(f*t) % 1.0` maps the mathematically
+    # identical instant 13 periods later to 0.99999999999 rather than 0.0, so
+    # one sample of one period takes the opposite rail. It is independent of the
+    # DUT -- the same flip is present in the un-filtered capture -- and which
+    # samples it hits is a float64 lottery decided by the lead-in length, so it
+    # moved when _WARMUP_TIME_CONSTANTS went 5 -> 12. Two codes keeps an 11x
+    # margin over the no-lead-in failure mode this test is actually for.
+    np.testing.assert_allclose(data.voltage[:period], data.voltage[-period:], atol=0.09)
 
 
 def test_consecutive_captures_of_a_triggered_signal_agree():
@@ -113,10 +128,12 @@ def test_a_filtered_square_matches_the_independently_derived_exponential_kind():
     Now that RCLowPass.apply is the exact, strictly-proper zero-order-hold
     discretisation (see dut.py), the two agree to near machine precision. The
     only remaining floor is how much lead-in THIS TEST renders before the
-    comparison window -- production's `warmup_samples()` alone leaves ~0.0067 V
-    of the initial y=0 transient un-settled (fine there: it's below the mock's
-    ~0.04 V int8 quantization step), so this test renders more (see `lead_in`
-    below) to push that floor far below the precision being asserted here."""
+    comparison window -- production's `warmup_samples()` alone leaves e^-12,
+    about 6.1e-6 of the step, of the initial y=0 transient un-settled (fine
+    there: it is under 0.05 LSB of the finest grid the mock quantizes to, the
+    modern WORD path's 6400 codes/div -- see dut._WARMUP_TIME_CONSTANTS), so
+    this test renders more (see `lead_in` below) to push that floor far below
+    the precision being asserted here."""
     tau = 1e-4
     cutoff = 1.0 / (2 * np.pi * tau)
     dut = RCLowPass(cutoff_hz=cutoff)
@@ -127,12 +144,34 @@ def test_a_filtered_square_matches_the_independently_derived_exponential_kind():
     # number of the signal's own periods and rendered from t0=0.0 rather than
     # t0=-lead_in/RATE. Both matter, and skipping either reintroduces a full
     # spurious error unrelated to the filter:
-    #   - A non-whole-period lead-in can leave the square wave in the WRONG
-    #     phase relative to `closed_form` (which always starts high at t=0),
-    #     producing a phase-inverted ~2x amplitude mismatch that looks like a
-    #     total failure of the filter when it is actually a bookkeeping error
-    #     (verified: 1x and 3x warmup here are 0.5 and 1.5 periods -- both
-    #     wrong; 2x and 4x are 1 and 2 whole periods -- both fine).
+    #   - The lead-in must satisfy TWO INDEPENDENT conditions, and no raw
+    #     multiple of warmup_samples() reliably satisfies both:
+    #       (a) WHOLE PERIODS. `closed_form` always starts high at t=0, so a
+    #           fractional-period lead-in hands the filter a square wave in the
+    #           wrong phase; the comparison then picks up a phase-inversion term
+    #           of order 2 * amplitude, which looks like a total failure of the
+    #           filter but is pure bookkeeping.
+    #       (b) ENOUGH TIME CONSTANTS. Whole-period alignment removes ONLY that
+    #           ~2.0 term. What is left is the SETTLING FLOOR -- the un-decayed
+    #           remainder of the initial y=0 transient, ~e^(-lead_in*dt/tau) --
+    #           which alignment does nothing about.
+    #     Measured as max|filtered - closed_form| across multiples of
+    #     warmup_samples(), against this test's 1e-6 bound. With the older
+    #     5-time-constant warmup (500 samples = 0.5 period each):
+    #         1x 1.98        2x 4.479e-05   3x 1.973
+    #         4x 2.034e-09   5x 1.973       6x 9.27e-14
+    #     -- only 2x and 4x are whole periods (1 and 2), and 2x STILL FAILS: one
+    #     period is just 10 tau, e^-10 = 4.5e-5, 45x over the bound. Condition
+    #     (a) alone was never sufficient. With today's 12-time-constant warmup
+    #     (1200 samples = 1.2 periods each) the multiples land differently again:
+    #         1x 1.718   2x 1.950   3x 1.950
+    #         4x 1.718   5x 7.94e-15   6x 1.718
+    #     -- now only 5x is whole-period (6 periods = 60 tau) at all.
+    #     Hence rounding up to whole periods below rather than trusting any fixed
+    #     multiple: that makes (a) true by construction, and >=3x warmup (>=36
+    #     tau) makes (b) true with enormous margin. As built it comes out at 4
+    #     periods = 4000 samples = 40 tau, measuring 7.9e-15 -- machine
+    #     precision, not a settling floor at all.
     #   - Passing t0 as a pre-computed `-lead_in / RATE` looks equivalent to
     #     starting the extended array at t0=0.0 and slicing off `lead_in`
     #     samples, but is NOT bit-for-bit equivalent: synthesize() computes
@@ -152,7 +191,7 @@ def test_a_filtered_square_matches_the_independently_derived_exponential_kind():
     filtered = dut.apply(square, RATE)[lead_in:]
     closed_form = synthesize(SignalSpec(kind="exponential", frequency=1_000.0, amplitude=1.0, tau=tau), RATE, n)
 
-    # Measured 2.0e-9 with the correct construction above. For comparison,
+    # Measured 7.9e-15 with the correct construction above. For comparison,
     # against this SAME construction: backward Euler (the pre-fix discretisation)
     # measures 3.5e-3, and a tau mistuned by 2% measures 1.4e-2 -- both several
     # orders of magnitude over this bound, so this test would catch either

--- a/tests/test_loopback_capture.py
+++ b/tests/test_loopback_capture.py
@@ -42,18 +42,20 @@ def _scope(source):
     return scope
 
 
-def test_the_capture_has_no_settling_transient_at_its_head():
-    """The load-bearing test. Without the lead-in the first samples ramp up from
-    zero, so the head of the capture would differ wildly from its body."""
+def test_the_capture_is_in_steady_state_from_its_very_first_period():
+    """The lead-in is what makes this true. Filtering a bare capture starts from
+    y=0, so the first period would carry a settling ramp the last period does not
+    -- and at 1 kHz the RC settles in ~159 samples, well inside one 1000-sample
+    period, so the two windows would visibly disagree."""
     awg = _awg(function="SQUARE", frequency=1_000.0, amplitude=2.0)
     scope = _scope(AwgLoopback(awg, dut=RCLowPass(cutoff_hz=5_000.0)))
     try:
         data = scope.get_waveform(1, provenance=False)
     finally:
         scope.disconnect()
-    head = data.voltage[:2_000]
-    body = data.voltage[6_000:8_000]
-    assert np.ptp(head) == pytest.approx(np.ptp(body), rel=0.15), "the head must already be settled"
+    period = 1_000  # 1 kHz at 1 MSa/s
+    # atol covers one int8 code: 25 codes/div at the mock's 1 V/div default.
+    np.testing.assert_allclose(data.voltage[:period], data.voltage[-period:], atol=0.05)
 
 
 def test_consecutive_captures_of_a_triggered_signal_agree():
@@ -115,7 +117,13 @@ def test_a_filtered_square_matches_the_independently_derived_exponential_kind():
     filtered = dut.apply(square, RATE)[warmup:]
     closed_form = synthesize(SignalSpec(kind="exponential", frequency=1_000.0, amplitude=1.0, tau=tau), RATE, n)
 
-    # Tolerance is the IIR's first-order discretisation error at tau/dt = 100.
-    # Report the measured maximum in the task report -- if it is far below this,
-    # tighten the bound rather than leaving slack.
-    assert np.max(np.abs(filtered - closed_form)) < 0.02
+    # RCLowPass.apply uses the exact zero-order-hold discretisation (alpha = 1 -
+    # exp(-dt/tau)), so this is NOT a per-step approximation gap between the IIR
+    # and the closed form -- measured max ~0.0198, concentrated at each square-
+    # wave transition and decaying with the filter's own tau over the following
+    # samples (an inherent one-sample edge-registration artifact where a
+    # discretely-sampled instantaneous edge meets a causal recurrence, present
+    # under any single-pole discretisation, not specific to this one). Bound
+    # carries a small margin above the measured value rather than the 0.02 a
+    # backward-Euler discretisation needed.
+    assert np.max(np.abs(filtered - closed_form)) < 0.021

--- a/tests/test_loopback_capture.py
+++ b/tests/test_loopback_capture.py
@@ -103,10 +103,33 @@ def test_no_dut_means_no_filtering():
 
 
 def test_a_filtered_square_matches_the_independently_derived_exponential_kind():
-    """The strongest evidence in this plan. An RC low-pass fed a square wave IS
-    the `exponential` kind, which was implemented separately in 5.5.0 as a
-    closed-form periodic steady state. Two independently derived implementations
-    of the same physics must agree; neither is checked against a golden array."""
+    """An RC low-pass fed a square wave IS the `exponential` kind, which was
+    implemented separately in 5.5.0 as a closed-form periodic steady state. Two
+    independently derived implementations of the same physics should agree on
+    the bulk of the waveform; neither is checked against a golden array.
+
+    This does NOT converge to machine precision, and that is expected rather
+    than a defect to chase. RCLowPass.apply uses the exact zero-order-hold
+    discretisation (alpha = 1 - exp(-dt/tau)), so the per-step approximation gap
+    between the IIR and the closed form is not the story here -- switching from
+    backward Euler to exact ZOH only moved the measured max from 0.020047 to
+    0.019811, not the order-of-magnitude drop a per-step fix would produce.
+    Per-sample inspection shows the ~2% error is concentrated at each square-
+    wave transition and decays with the filter's own tau over the following
+    samples (0.0198 at the edge, ~0.0072 by 100 samples later, ~0.0027 by 200 --
+    matching 0.0198*exp(-k/tau) closely). A one-sample registration offset (the
+    discrete square's transition landing between samples n and n+1 while the
+    closed form assumes an ideal step at an exact instant) was tested directly
+    and ruled out as the (sole) explanation: shifting the comparison by one
+    sample in either direction does not collapse the error by an order of
+    magnitude -- one shift roughly doubles it (0.0394) and the other roughly
+    thirds it (0.0066), neither of which is the clean collapse a pure one-sample
+    offset would produce. So the residual is treated here as a structural
+    artifact of comparing a discrete causal filter against a continuous,
+    idealised closed form at a signal discontinuity -- not a bug, and not
+    something to tighten away by changing the filter's own sample-timing
+    convention (that would be contorting production code to shrink a test
+    number)."""
     tau = 1e-4
     cutoff = 1.0 / (2 * np.pi * tau)
     dut = RCLowPass(cutoff_hz=cutoff)
@@ -117,13 +140,8 @@ def test_a_filtered_square_matches_the_independently_derived_exponential_kind():
     filtered = dut.apply(square, RATE)[warmup:]
     closed_form = synthesize(SignalSpec(kind="exponential", frequency=1_000.0, amplitude=1.0, tau=tau), RATE, n)
 
-    # RCLowPass.apply uses the exact zero-order-hold discretisation (alpha = 1 -
-    # exp(-dt/tau)), so this is NOT a per-step approximation gap between the IIR
-    # and the closed form -- measured max ~0.0198, concentrated at each square-
-    # wave transition and decaying with the filter's own tau over the following
-    # samples (an inherent one-sample edge-registration artifact where a
-    # discretely-sampled instantaneous edge meets a causal recurrence, present
-    # under any single-pole discretisation, not specific to this one). Bound
-    # carries a small margin above the measured value rather than the 0.02 a
-    # backward-Euler discretisation needed.
+    # Bound is ~2% of amplitude, with a small margin above the measured 0.019811
+    # -- not slack to be tightened. Do not shrink this without re-running the
+    # per-sample/shift investigation above; a tighter bound will make this test
+    # flake on transition-adjacent samples for no gain in real coverage.
     assert np.max(np.abs(filtered - closed_form)) < 0.021

--- a/tests/test_loopback_capture.py
+++ b/tests/test_loopback_capture.py
@@ -56,23 +56,28 @@ def test_the_capture_is_in_steady_state_from_its_very_first_period():
     finally:
         scope.disconnect()
     period = 1_000  # 1 kHz at 1 MSa/s
-    # atol is two int8 codes (25 codes/div at the mock's 1 V/div default), not
-    # one, because the residual this comparison sees is NOT the settling
-    # transient it is guarding against. Measured on the pre-quantization volts
-    # for this exact capture:
-    #   no lead-in at all      1.0309 V   <- the regression this test exists for
-    #   with the lead-in       0.0619 V, of which the settling part is 5.8e-6 V
-    # The 0.0619 V is one sample, smeared forward by the RC. It is the square
-    # generator's razor's-edge boundary: trigger alignment puts t0 exactly on a
-    # cycle boundary (t0 = -6.000 ms for a 1 kHz square in a 14 ms window), and
-    # signal_synth._cycle_fraction's `(f*t) % 1.0` maps the mathematically
-    # identical instant 13 periods later to 0.99999999999 rather than 0.0, so
-    # one sample of one period takes the opposite rail. It is independent of the
-    # DUT -- the same flip is present in the un-filtered capture -- and which
-    # samples it hits is a float64 lottery decided by the lead-in length, so it
-    # moved when _WARMUP_TIME_CONSTANTS went 5 -> 12. Two codes keeps an 11x
-    # margin over the no-lead-in failure mode this test is actually for.
-    np.testing.assert_allclose(data.voltage[:period], data.voltage[-period:], atol=0.09)
+    # This bound is set by a float64 ARTIFACT, not by anything this comparison
+    # is actually checking. It is signal_synth._cycle_fraction's razor's-edge
+    # boundary: trigger alignment puts t0 exactly on a cycle boundary (t0 =
+    # -6.000 ms for a 1 kHz square in a 14 ms window), and `(f*t) % 1.0` maps
+    # the mathematically identical instant 13 periods later to 0.99999999999
+    # rather than 0.0, so one sample takes the opposite rail. That artifact is
+    # PRE-EXISTING in signal_synth and unrelated to the DUT -- the same flip is
+    # present in the un-filtered capture. It is NOT confined to a single
+    # sample, either: the RC smears it forward, and measured on this capture's
+    # quantized volts (25 codes/div at the mock's 1 V/div default), 8 samples
+    # tie at the 2-code peak (0.0800 V) before decaying below 1 code by
+    # roughly the 90th sample. So excluding "the worst sample" buys nothing --
+    # the runner-up ties the leader -- and which samples it hits at all is a
+    # float64 lottery that shifts with numpy/scipy version (it already moved
+    # once, when _WARMUP_TIME_CONSTANTS went 5 -> 12), so no fixed exclusion
+    # count would be safe across CI. Hence a flat, wider bound rather than
+    # per-sample surgery. The regression this test actually exists for is a
+    # missing lead-in, measured on this capture (via a mutation that forces
+    # RCLowPass.warmup_samples() to 0) at 1.0309 V pre-quantization / 1.04 V
+    # quantized -- four orders of magnitude past the artifact, so 0.12 still
+    # keeps an 8.6x margin under it.
+    np.testing.assert_allclose(data.voltage[:period], data.voltage[-period:], atol=0.12)
 
 
 def test_consecutive_captures_of_a_triggered_signal_agree():

--- a/tests/test_loopback_capture.py
+++ b/tests/test_loopback_capture.py
@@ -10,6 +10,7 @@ window.
 import math
 
 import numpy as np
+import pytest
 
 from scpi_control.connection import MockConnection
 from scpi_control.connection.mock.loopback import AwgLoopback
@@ -157,3 +158,54 @@ def test_a_filtered_square_matches_the_independently_derived_exponential_kind():
     # orders of magnitude over this bound, so this test would catch either
     # regression.
     assert np.max(np.abs(filtered - closed_form)) < 1e-6
+
+
+def test_writing_to_the_awg_changes_the_next_scope_capture():
+    """The whole feature in one test: two instruments, one cable, a SCPI write on
+    one visibly changing what the other captures."""
+    from scpi_control.function_generator import FunctionGenerator
+
+    awg_conn = _awg(function="SINE", frequency=1_000.0, amplitude=2.0)
+    awg = FunctionGenerator("mock", connection=awg_conn)
+    awg.connect()
+    scope = _scope(AwgLoopback(awg_conn))
+    try:
+        as_sine = scope.get_waveform(1, provenance=False)
+        awg_conn.write("C1:BSWV WVTP,SQUARE")
+        as_square = scope.get_waveform(1, provenance=False)
+    finally:
+        scope.disconnect()
+        awg.disconnect()
+
+    # A square spends its time at the rails; a sine sweeps through the middle.
+    # The fraction of samples near an extreme separates them without relying on
+    # any particular amplitude.
+    def rail_fraction(v):
+        return float(np.mean(np.abs(v) > 0.8 * np.max(np.abs(v))))
+
+    assert rail_fraction(as_square.voltage) > 2 * rail_fraction(as_sine.voltage)
+
+
+def test_turning_the_output_off_flattens_the_capture():
+    awg_conn = _awg(function="SINE", frequency=1_000.0, amplitude=2.0)
+    scope = _scope(AwgLoopback(awg_conn))
+    try:
+        driven = scope.get_waveform(1, provenance=False)
+        awg_conn.awg_channels[1]["enabled"] = False
+        idle = scope.get_waveform(1, provenance=False)
+    finally:
+        scope.disconnect()
+    assert np.ptp(driven.voltage) > 1.5
+    assert np.ptp(idle.voltage) < 0.1
+
+
+def test_the_captured_amplitude_is_the_awg_setting_not_double_it():
+    """End-to-end guard on the Vpp conversion: an AMP of 2.0 Vpp must arrive as a
+    2.0 V peak-to-peak trace, not 4.0."""
+    awg_conn = _awg(function="SINE", frequency=1_000.0, amplitude=2.0)
+    scope = _scope(AwgLoopback(awg_conn))
+    try:
+        data = scope.get_waveform(1, provenance=False)
+    finally:
+        scope.disconnect()
+    assert np.ptp(data.voltage) == pytest.approx(2.0, abs=0.2)

--- a/tests/test_loopback_capture.py
+++ b/tests/test_loopback_capture.py
@@ -209,3 +209,25 @@ def test_the_captured_amplitude_is_the_awg_setting_not_double_it():
     finally:
         scope.disconnect()
     assert np.ptp(data.voltage) == pytest.approx(2.0, abs=0.2)
+
+
+def test_a_captured_noise_trace_has_roughly_the_requested_peak_to_peak():
+    """The one kind where `SignalSpec.amplitude` is a standard deviation rather
+    than a peak, so the Vpp->peak halving every other kind needs is a unit error
+    here -- it captured 7.560 Vpp at sigma = 1.006 V for a 2.0 Vpp request. The
+    mapping takes Vpp as the +/-3 sigma span, so sigma is asserted tightly (it is
+    exactly what the mapping sets, and 14,000 samples estimate it well), while
+    the trace's peak-to-peak is asserted loosely: the extreme of N Gaussian
+    samples is itself a random variable that grows with N, and this spec is
+    unseeded. Measured over 12 unseeded captures: sigma 0.329 to 0.336,
+    peak-to-peak 2.44 to 2.76."""
+    awg_conn = _awg(function="NOISE", amplitude=2.0)
+    scope = _scope(AwgLoopback(awg_conn))
+    try:
+        data = scope.get_waveform(1, provenance=False)
+    finally:
+        scope.disconnect()
+    assert np.std(data.voltage) == pytest.approx(2.0 / 6.0, abs=0.03)
+    # Wide enough to survive the randomness, narrow enough that the pre-fix
+    # 7.56 Vpp (and an unconverted 2.0-as-sigma, ~15 Vpp) both fail.
+    assert 1.5 < np.ptp(data.voltage) < 4.0

--- a/tests/test_loopback_capture.py
+++ b/tests/test_loopback_capture.py
@@ -1,0 +1,121 @@
+"""The DUT applied to a mock capture, and the lead-in that makes it seamless.
+
+RCLowPass is stateful while every generator in signal_synth is closed-form, so a
+naive application would put a settling transient at the head of every
+acquisition. raw_volts renders a lead-in before t0, filters across it and slices
+it off -- the same fix, for the same reason, as the ringing impairment's pre-t0
+window.
+"""
+
+import numpy as np
+import pytest
+
+from scpi_control.connection import MockConnection
+from scpi_control.connection.mock.loopback import AwgLoopback
+from scpi_control.dut import RCLowPass
+from scpi_control.oscilloscope import Oscilloscope
+from scpi_control.signal_synth import SignalSpec, synthesize
+
+LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+RATE = 1_000_000.0
+
+
+def _awg(**overrides):
+    conn = MockConnection(awg_mode=True, awg_idn="Siglent Technologies,SDG1032X,SDG1XXXXX,2.01.01.37R1")
+    conn.awg_channels[1].update({"enabled": True})
+    conn.awg_channels[1].update(overrides)
+    return conn
+
+
+def _scope(source):
+    conn = MockConnection(
+        "mock",
+        idn=LEGACY_IDN,
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=RATE,
+        timebase=1e-3,
+        signals={1: source},
+    )
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    return scope
+
+
+def test_the_capture_has_no_settling_transient_at_its_head():
+    """The load-bearing test. Without the lead-in the first samples ramp up from
+    zero, so the head of the capture would differ wildly from its body."""
+    awg = _awg(function="SQUARE", frequency=1_000.0, amplitude=2.0)
+    scope = _scope(AwgLoopback(awg, dut=RCLowPass(cutoff_hz=5_000.0)))
+    try:
+        data = scope.get_waveform(1, provenance=False)
+    finally:
+        scope.disconnect()
+    head = data.voltage[:2_000]
+    body = data.voltage[6_000:8_000]
+    assert np.ptp(head) == pytest.approx(np.ptp(body), rel=0.15), "the head must already be settled"
+
+
+def test_consecutive_captures_of_a_triggered_signal_agree():
+    """A transient that depended on filter state would make them differ."""
+    awg = _awg(function="SQUARE", frequency=1_000.0, amplitude=2.0)
+    scope = _scope(AwgLoopback(awg, dut=RCLowPass(cutoff_hz=5_000.0)))
+    try:
+        first = scope.get_waveform(1, provenance=False)
+        second = scope.get_waveform(1, provenance=False)
+    finally:
+        scope.disconnect()
+    np.testing.assert_array_equal(first.voltage, second.voltage)
+
+
+def test_the_dut_visibly_rounds_a_square_wave():
+    awg = _awg(function="SQUARE", frequency=1_000.0, amplitude=2.0)
+    sharp = _scope(AwgLoopback(awg))
+    try:
+        unfiltered = sharp.get_waveform(1, provenance=False)
+    finally:
+        sharp.disconnect()
+    soft = _scope(AwgLoopback(awg, dut=RCLowPass(cutoff_hz=2_000.0)))
+    try:
+        filtered = soft.get_waveform(1, provenance=False)
+    finally:
+        soft.disconnect()
+    # The steepest sample-to-sample step is the direct measure of edge rounding.
+    assert np.max(np.abs(np.diff(filtered.voltage))) < np.max(np.abs(np.diff(unfiltered.voltage)))
+
+
+def test_no_dut_means_no_filtering():
+    """A loopback without a DUT must produce exactly what the unfiltered path does."""
+    awg = _awg(function="SINE", frequency=1_000.0, amplitude=2.0)
+    scope = _scope(AwgLoopback(awg))
+    try:
+        via_loopback = scope.get_waveform(1, provenance=False)
+    finally:
+        scope.disconnect()
+    direct = _scope(SignalSpec(kind="sine", frequency=1_000.0, amplitude=1.0))
+    try:
+        via_spec = direct.get_waveform(1, provenance=False)
+    finally:
+        direct.disconnect()
+    np.testing.assert_array_equal(via_loopback.voltage, via_spec.voltage)
+
+
+def test_a_filtered_square_matches_the_independently_derived_exponential_kind():
+    """The strongest evidence in this plan. An RC low-pass fed a square wave IS
+    the `exponential` kind, which was implemented separately in 5.5.0 as a
+    closed-form periodic steady state. Two independently derived implementations
+    of the same physics must agree; neither is checked against a golden array."""
+    tau = 1e-4
+    cutoff = 1.0 / (2 * np.pi * tau)
+    dut = RCLowPass(cutoff_hz=cutoff)
+    warmup = dut.warmup_samples(RATE)
+    n = 4_000  # four whole 1 kHz periods at 1 MSa/s
+
+    square = synthesize(SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0), RATE, n + warmup, t0=-warmup / RATE)
+    filtered = dut.apply(square, RATE)[warmup:]
+    closed_form = synthesize(SignalSpec(kind="exponential", frequency=1_000.0, amplitude=1.0, tau=tau), RATE, n)
+
+    # Tolerance is the IIR's first-order discretisation error at tau/dt = 100.
+    # Report the measured maximum in the task report -- if it is far below this,
+    # tighten the bound rather than leaving slack.
+    assert np.max(np.abs(filtered - closed_form)) < 0.02

--- a/tests/test_loopback_capture.py
+++ b/tests/test_loopback_capture.py
@@ -7,8 +7,9 @@ it off -- the same fix, for the same reason, as the ringing impairment's pre-t0
 window.
 """
 
+import math
+
 import numpy as np
-import pytest
 
 from scpi_control.connection import MockConnection
 from scpi_control.connection.mock.loopback import AwgLoopback
@@ -105,43 +106,54 @@ def test_no_dut_means_no_filtering():
 def test_a_filtered_square_matches_the_independently_derived_exponential_kind():
     """An RC low-pass fed a square wave IS the `exponential` kind, which was
     implemented separately in 5.5.0 as a closed-form periodic steady state. Two
-    independently derived implementations of the same physics should agree on
-    the bulk of the waveform; neither is checked against a golden array.
+    independently derived implementations of the same physics must agree;
+    neither is checked against a golden array.
 
-    This does NOT converge to machine precision, and that is expected rather
-    than a defect to chase. RCLowPass.apply uses the exact zero-order-hold
-    discretisation (alpha = 1 - exp(-dt/tau)), so the per-step approximation gap
-    between the IIR and the closed form is not the story here -- switching from
-    backward Euler to exact ZOH only moved the measured max from 0.020047 to
-    0.019811, not the order-of-magnitude drop a per-step fix would produce.
-    Per-sample inspection shows the ~2% error is concentrated at each square-
-    wave transition and decays with the filter's own tau over the following
-    samples (0.0198 at the edge, ~0.0072 by 100 samples later, ~0.0027 by 200 --
-    matching 0.0198*exp(-k/tau) closely). A one-sample registration offset (the
-    discrete square's transition landing between samples n and n+1 while the
-    closed form assumes an ideal step at an exact instant) was tested directly
-    and ruled out as the (sole) explanation: shifting the comparison by one
-    sample in either direction does not collapse the error by an order of
-    magnitude -- one shift roughly doubles it (0.0394) and the other roughly
-    thirds it (0.0066), neither of which is the clean collapse a pure one-sample
-    offset would produce. So the residual is treated here as a structural
-    artifact of comparing a discrete causal filter against a continuous,
-    idealised closed form at a signal discontinuity -- not a bug, and not
-    something to tighten away by changing the filter's own sample-timing
-    convention (that would be contorting production code to shrink a test
-    number)."""
+    Now that RCLowPass.apply is the exact, strictly-proper zero-order-hold
+    discretisation (see dut.py), the two agree to near machine precision. The
+    only remaining floor is how much lead-in THIS TEST renders before the
+    comparison window -- production's `warmup_samples()` alone leaves ~0.0067 V
+    of the initial y=0 transient un-settled (fine there: it's below the mock's
+    ~0.04 V int8 quantization step), so this test renders more (see `lead_in`
+    below) to push that floor far below the precision being asserted here."""
     tau = 1e-4
     cutoff = 1.0 / (2 * np.pi * tau)
     dut = RCLowPass(cutoff_hz=cutoff)
     warmup = dut.warmup_samples(RATE)
     n = 4_000  # four whole 1 kHz periods at 1 MSa/s
 
-    square = synthesize(SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0), RATE, n + warmup, t0=-warmup / RATE)
-    filtered = dut.apply(square, RATE)[warmup:]
+    # At least 3x warmup_samples(), per the above, but ALSO rounded up to a whole
+    # number of the signal's own periods and rendered from t0=0.0 rather than
+    # t0=-lead_in/RATE. Both matter, and skipping either reintroduces a full
+    # spurious error unrelated to the filter:
+    #   - A non-whole-period lead-in can leave the square wave in the WRONG
+    #     phase relative to `closed_form` (which always starts high at t=0),
+    #     producing a phase-inverted ~2x amplitude mismatch that looks like a
+    #     total failure of the filter when it is actually a bookkeeping error
+    #     (verified: 1x and 3x warmup here are 0.5 and 1.5 periods -- both
+    #     wrong; 2x and 4x are 1 and 2 whole periods -- both fine).
+    #   - Passing t0 as a pre-computed `-lead_in / RATE` looks equivalent to
+    #     starting the extended array at t0=0.0 and slicing off `lead_in`
+    #     samples, but is NOT bit-for-bit equivalent: synthesize() computes
+    #     `t0 + arange(n)/sample_rate`, so a subtraction-based t0 accumulates a
+    #     DIFFERENT rounding error than `closed_form`'s own t=0-based times get,
+    #     in exactly the "razor's-edge boundary comparison" way signal_synth.py's
+    #     ringing path already documents and avoids (t0 + (index-decay_len)/sr,
+    #     NOT (t0-decay_len/sr)+index/sr). Verified: with t0=-lead_in/RATE, some
+    #     lead-in lengths misregister exactly one transition by a full sample,
+    #     producing a spurious ~0.02 error that looks like a filter defect but
+    #     disappears entirely once t0=0.0 is used instead.
+    period_samples = RATE / 1_000.0
+    periods_needed = math.ceil((3 * warmup) / period_samples)
+    lead_in = int(periods_needed * period_samples)
+
+    square = synthesize(SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0), RATE, n + lead_in, t0=0.0)
+    filtered = dut.apply(square, RATE)[lead_in:]
     closed_form = synthesize(SignalSpec(kind="exponential", frequency=1_000.0, amplitude=1.0, tau=tau), RATE, n)
 
-    # Bound is ~2% of amplitude, with a small margin above the measured 0.019811
-    # -- not slack to be tightened. Do not shrink this without re-running the
-    # per-sample/shift investigation above; a tighter bound will make this test
-    # flake on transition-adjacent samples for no gain in real coverage.
-    assert np.max(np.abs(filtered - closed_form)) < 0.021
+    # Measured 2.0e-9 with the correct construction above. For comparison,
+    # against this SAME construction: backward Euler (the pre-fix discretisation)
+    # measures 3.5e-3, and a tau mistuned by 2% measures 1.4e-2 -- both several
+    # orders of magnitude over this bound, so this test would catch either
+    # regression.
+    assert np.max(np.abs(filtered - closed_form)) < 1e-6


### PR DESCRIPTION
A mock AWG and a mock oscilloscope were separate `MockConnection` instances with nothing connecting them, so the AWG was a write-only surface: you could set a waveform and read it back, but nothing in the system responded to its output. With no hardware on this project, that made it untestable end to end. This branch wires them together.

```python
awg   = MockConnection("mock", awg_mode=True)
scope = MockConnection("mock", signals={1: AwgLoopback(awg, awg_channel=1, dut=RCLowPass(cutoff_hz=2_000))})
```

Write `C1:BSWV WVTP,SQUARE` to the AWG and the scope's next capture is a square.

## Three pieces

**`signals=` now accepts a callable** returning a `SignalSpec`, evaluated at every acquisition. That is the whole mechanism, and it is deliberately general — any dynamic signal source works, not just an AWG. Everything downstream (`point_count`, `raw_volts`, the trigger search, all three vendor personalities) still receives a plain `SignalSpec` and never learns the difference. A static `SignalSpec` is not callable, so existing callers are byte-identical.

**`AwgLoopback`** reads the AWG's live channel state and maps it. Two conversions are the ones that silently produce plausible-but-wrong output, and each has a dedicated test: AWG amplitude is **peak-to-peak** and becomes peak, phase is **degrees** and becomes radians. `RAMP` becomes a triangle within a percentage point of 50% symmetry; `ARB` becomes a sine with a logged warning, since the mock stores no arbitrary sample data; an output that is off reads flat. Derived duty and pulse width are **clamped** into the ranges `_validate` enforces — an AWG accepts `DUTY,0` where `SignalSpec` requires `0 < duty < 1`, and a mock should not explode where a real instrument would output something.

**`RCLowPass`** (`scpi_control/dut.py`) is an optional device model between the two. It lives on the loopback rather than the scope connection, because a DUT physically sits between the instruments — the loopback models the cable run.

## The part that took the work

`RCLowPass` is **stateful** while every generator in `signal_synth` is closed-form in absolute time, deliberately, so streamed chunks and consecutive acquisitions join seamlessly. Filtering a bare capture would start from `y = 0` and put a settling transient at the head of every acquisition. So `raw_volts` renders a lead-in before the window, filters across it, and slices it off — the same pattern the ringing impairment already uses.

Getting the filter itself right took three rounds, and the sequence is worth recording:

1. A cross-validation against the `exponential` signal kind — implemented separately in 5.5.0 as a closed-form periodic steady state — failed at 0.020 against a 0.02 bound. Investigation ruled out scipy and settling, and concluded the residual was structural.
2. That conclusion was wrong. Review found the actual cause: `lfilter([alpha], ...)` **omits the `z^-1` the ZOH numerator requires**, giving the filter a direct feedthrough a physical RC cannot have. `(1-a)*2A = 0.019900` against the measured 0.019811 — the feedthrough *was* the entire residual. The earlier investigation's own data had contained the answer; measuring a global maximum hid it behind a second, unrelated error term.
3. With `b = [0.0, alpha]`, cross-validation agreement went from 0.0198 to **7.9e-15**.

The bound is now 1e-6, and it **fails backward Euler at 0.0035** — the previous 0.021 bound would have passed it, meaning the test could not have detected the very defect it existed to catch.

Final review re-derived the filter independently: DC gain error exactly 0.0 across `dt/tau` from 1e-9 to 1e9, step response matching `1-e^(-n·dt/tau)` to **1.1e-15**.

## Two bugs review caught that testing did not

**`NOISE` mapped a peak-to-peak value into a standard deviation.** For `kind="noise"`, `SignalSpec.amplitude` is σ, not a peak — so halving it produced a **7.560 V** capture from a 2.0 Vpp request, reachable from plain SCPI. A 25-combination frequency × duty sweep had cleared the mapping, but the `NOISE` case asserted only `.kind` and the amplitude test used `SINE`. Now σ = Vpp/6 on the ±3σ convention, with the docs stating that a Gaussian capture's measured peak-to-peak grows with capture length rather than scattering around the requested figure.

**The lead-in was sized against the wrong quantization grid.** Three comments justified a 5-time-constant lead-in as "far below the int8 quantization" of 0.04 V — but `raw_volts` also feeds the modern WORD path at 6400 codes/div, i.e. 0.15625 mV/LSB, where the residual measured **84 LSBs**. Now 12 time constants, with all three comments naming the path that actually governs.

## Verification

- Full suite **2006 passed, 19 skipped, 0 failed**.
- `black --check --line-length 200 scpi_control/ examples/` clean; `flake8 --select=E9,F63,F7,F82` = 0; `--select=F401` clean on the new production files.
- CI-extras parity with PyQt6, reportlab and h5py blocked: **identical** 2004/19 at that point, no import errors.
- Final review verified the paths no per-task review exercised: the `n_override` deep-memory route (50,000-point record, identical across acquisitions), `waveform_payloads` correctly bypassing the DUT on both dialects, and `provenance=True` with a callable `signals` entry.

## Known follow-up, filed not hidden

While raising the lead-in, a **pre-existing** defect in `signal_synth._cycle_fraction` surfaced: at an exact cycle boundary `(f*t) % 1.0` can return `0.9999999999999991` instead of `0.0`, flipping one sample by the full amplitude. It reproduces with **no DUT at all**, and `git diff main..HEAD -- scpi_control/signal_synth.py` is empty — this branch does not touch that module. So the mock emits a spurious full-amplitude single-sample glitch on the plain square path, under trigger alignment, today on `main`. Out of scope here; worth its own change.

Also deliberately not in scope, per the spec's non-goals: no gateway/UI work (the AWG stays `connectable: false`), no sweep/burst/modulation, no ARB sample store, no load-impedance modelling, one AWG channel per scope channel, one first-order filter type.
