### PR TITLE
chore(release): 5.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.0] - 2026-07-26
+
 ### Added
 
 - `batch_capture` gained a circuit breaker: `max_consecutive_failures` (default 3) stops a run

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.0] - 2026-07-26
+
 ### Added
 
 - `batch_capture` gained a circuit breaker: `max_consecutive_failures` (default 3) stops a run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "5.6.0"
+version = "5.7.0"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "5.6.0"
+__version__ = "5.7.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
Cuts 5.7.0. MINOR — additive plus two documented behaviour changes; nothing broke, nothing was renamed or removed, and the only signature changes are new optional parameters with defaults.

## Contents

Six entries from three merged PRs.

**Added**

- **AWG-to-scope loopback** (#120). A mock function generator's output can now be captured by a mock oscilloscope: wire `AwgLoopback(awg_connection, awg_channel=1)` into the scope's `signals=`, and a SCPI write to the AWG changes the next capture. Previously the mock AWG was write-only — you could set a waveform and read it back, but nothing responded to it, which made it untestable end to end without hardware. `MockConnection`'s `signals=` also now accepts any callable returning a `SignalSpec`, evaluated per acquisition; that is a general extension point, not AWG-specific. Ships with `scpi_control.dut.RCLowPass`, a first-order RC device model usable between the two instruments or on any array on its own.
- **`batch_capture` circuit breaker** (#119). `max_consecutive_failures` (default 3) stops a run after that many back-to-back capture failures, counted across configurations and reset by any success. Guards the common unattended failure — a trigger level the signal never crosses — which otherwise times out on every capture: at a 70 s timeout and 100 triggers per configuration, hours of waiting to collect nothing.

**Changed**

- `start_continuous_capture` with `output_dir` set now returns per-capture metadata instead of an empty list (#118). It previously returned `[]` whether it had written ten thousand files or none.

**Fixed**

- `start_continuous_capture` no longer hides save failures (#118). Saving sat inside the capture loop's broad `except`, so a rejected `file_format` failed identically every iteration for a run's whole duration while returning an empty list. This is what kept the `npz` default invisible until 5.6.0.
- `batch_capture` no longer discards the whole run when interrupted or when the instrument stops answering (#119), and records any `SiglentError` as a failed entry rather than only `SiglentTimeoutError`.

## Release mechanics

- `pyproject.toml` and `scpi_control/__init__.py` bumped 5.6.0 → 5.7.0 (`tests/test_version_consistency.py` enforces they agree)
- `## [5.7.0] - 2026-07-26` inserted under `## [Unreleased]`
- `docs/about/changelog.md` re-synced — byte-identical hand-maintained mirrors that nothing in the suite enforces
- PyPI summary re-checked at **387 characters**, inside the hard 512 cap that failed the v3.2.0 publish

## Verification

- Full suite **2006 passed, 19 skipped, 0 failed**
- `tests/test_version_consistency.py` 2 passed
- `black --check --line-length 200 scpi_control/ examples/` clean (183 files); `flake8 --select=E9,F63,F7,F82` = 0

## Known issue carried into this release

A pre-existing defect in `scpi_control/signal_synth._cycle_fraction`, surfaced during #120 but **not introduced by it**: at an exact cycle boundary `(f*t) % 1.0` can return `0.9999999999999991` instead of `0.0`, flipping a single sample by the full amplitude. It reproduces with no DUT on the plain square path under trigger alignment, and is present on `main` before this release. Documented rather than hidden; worth its own change.

After merge: tag `v5.7.0` and publish the GitHub release, which triggers the build/PyPI/docs workflow.
