### PR TITLE
test(docs): enforce that the two changelogs stay identical

### DIFF
--- a/tests/test_changelog_mirror.py
+++ b/tests/test_changelog_mirror.py
@@ -1,0 +1,57 @@
+"""`docs/about/changelog.md` is a byte-for-byte copy of `CHANGELOG.md`.
+
+The repo keeps two changelogs: `CHANGELOG.md` at the root, and a copy under
+`docs/` that mkdocs publishes (`mkdocs.yml` maps it to `about/changelog.md`).
+Nothing generated the copy and nothing checked it, so keeping them identical was
+a step someone had to remember in every change that touched a changelog -- and
+in one release it was forgotten, shipping a docs site whose changelog was
+missing the entry the release existed to describe.
+
+This is the same class of defect as tests/test_version_consistency.py: two
+hand-maintained files that must agree, with no mechanism enforcing it.
+
+No `skip` and no tolerance for "close enough". A drift of one line is exactly
+the drift that happens, and it is invisible until someone reads the published
+site.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ROOT_CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+DOCS_CHANGELOG = REPO_ROOT / "docs" / "about" / "changelog.md"
+
+
+def test_both_changelogs_exist():
+    """Fail loudly rather than vacuously passing if either file is moved."""
+    assert ROOT_CHANGELOG.is_file(), f"missing {ROOT_CHANGELOG}"
+    assert DOCS_CHANGELOG.is_file(), f"missing {DOCS_CHANGELOG}"
+
+
+def test_the_docs_changelog_matches_the_root_changelog():
+    """Read as text so the comparison is about CONTENT, not line endings.
+
+    Git may check the two files out with different EOLs depending on
+    `core.autocrlf` and `.gitattributes`; that is not drift worth failing on.
+    A missing or reworded entry is.
+    """
+    root = ROOT_CHANGELOG.read_text(encoding="utf-8")
+    docs = DOCS_CHANGELOG.read_text(encoding="utf-8")
+    if root == docs:
+        return
+
+    root_lines = root.splitlines()
+    docs_lines = docs.splitlines()
+    first_difference = next(
+        (i for i, (a, b) in enumerate(zip(root_lines, docs_lines)) if a != b),
+        min(len(root_lines), len(docs_lines)),
+    )
+    raise AssertionError(
+        "docs/about/changelog.md has drifted from CHANGELOG.md.\n"
+        f"First difference at line {first_difference + 1} "
+        f"(root has {len(root_lines)} lines, docs has {len(docs_lines)}).\n"
+        f"  CHANGELOG.md:            {root_lines[first_difference:first_difference + 1] or ['<end of file>']}\n"
+        f"  docs/about/changelog.md: {docs_lines[first_difference:first_difference + 1] or ['<end of file>']}\n"
+        "Fix by copying the root file over the docs one:\n"
+        "  cp CHANGELOG.md docs/about/changelog.md"
+    )


### PR DESCRIPTION
`docs/about/changelog.md` is a byte-for-byte copy of `CHANGELOG.md` that mkdocs publishes. Nothing generated it and nothing checked it, so keeping the two identical was a step someone had to remember in every change that touched a changelog.

It needed manual re-syncing in **six** separate changes across recent work, and it has already drifted once for real — during the 5.5.0 release a changelog edit touched only the root file, so the published docs site was missing the entry that release existed to describe.

This is the same class of defect `tests/test_version_consistency.py` already guards: two hand-maintained files that must agree, with no mechanism enforcing it.

## The test

Two assertions — both files exist, and their content matches. Read as text rather than bytes, so the comparison is about content and not about whether git checked the files out with CRLF or LF; that is not drift worth failing a suite over, but a missing entry is.

On failure it reports the first differing line number, both files' line counts, the two lines themselves, and the one-line fix:

```
AssertionError: docs/about/changelog.md has drifted from CHANGELOG.md.
First difference at line 1789 (root has 1788 lines, docs has 1790).
  CHANGELOG.md:            ['<end of file>']
  docs/about/changelog.md: ['']
Fix by copying the root file over the docs one:
  cp CHANGELOG.md docs/about/changelog.md
```

That output is from a real mutation check: appending one line to the docs copy makes it fail as shown, and reverting makes it pass.

## Note

No changelog entry for this change. It adds no user-facing behaviour — it is internal tooling that guards the changelog itself, and Keep a Changelog is for what users of the package experience. Recording it would also be faintly absurd.
