### PR TITLE
fix(synth): snap a near-integer cycle count so a boundary sample reads correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A synthesized waveform no longer carries a spurious full-amplitude sample where a cycle begins.
+  `synthesize` builds its time array as `t0 + i / sample_rate`, and for an arbitrary `t0` — a trigger
+  crossing, a free-run drift offset, a device model's lead-in — that sum cannot land exactly on a
+  whole number of periods, so the cycle count came out an ULP below an integer and the modulo mapped
+  it to 0.9999999999999991 instead of 0. Continuous kinds never showed it, but `square` read its low
+  level at the instant it should switch high and `ramp` reset a sample early: one sample at full
+  amplitude, roughly 50 int8 codes of spike in a mock capture. The cycle count is now snapped to a
+  whole cycle when it sits within a few ULP of one, which moves the cycle position by less than any
+  consumer can resolve and leaves every other sample bit-identical. Note this covers the cycle wrap
+  only; a sample landing exactly on a *duty* or edge threshold is still subject to the same float
+  error, which shifts that edge by one sample rather than inverting a sample, and
+  `tests/test_cycle_boundary.py` pins that residual so it stays visible.
+
 ## [5.7.0] - 2026-07-26
 
 ### Added

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A synthesized waveform no longer carries a spurious full-amplitude sample where a cycle begins.
+  `synthesize` builds its time array as `t0 + i / sample_rate`, and for an arbitrary `t0` — a trigger
+  crossing, a free-run drift offset, a device model's lead-in — that sum cannot land exactly on a
+  whole number of periods, so the cycle count came out an ULP below an integer and the modulo mapped
+  it to 0.9999999999999991 instead of 0. Continuous kinds never showed it, but `square` read its low
+  level at the instant it should switch high and `ramp` reset a sample early: one sample at full
+  amplitude, roughly 50 int8 codes of spike in a mock capture. The cycle count is now snapped to a
+  whole cycle when it sits within a few ULP of one, which moves the cycle position by less than any
+  consumer can resolve and leaves every other sample bit-identical. Note this covers the cycle wrap
+  only; a sample landing exactly on a *duty* or edge threshold is still subject to the same float
+  error, which shifts that edge by one sample rather than inverting a sample, and
+  `tests/test_cycle_boundary.py` pins that residual so it stays visible.
+
 ## [5.7.0] - 2026-07-26
 
 ### Added

--- a/scpi_control/signal_synth.py
+++ b/scpi_control/signal_synth.py
@@ -101,8 +101,49 @@ class SignalSpec:
     )  # "multitone": relative amplitudes of the 2nd, 3rd, ... harmonic; non-empty by default so SignalSpec(kind="multitone") is not a bit-identical duplicate of "sine"
 
 
+# How close to a whole cycle a sample may sit and still count as landing exactly
+# on the boundary. In ULPs so it scales with the magnitude of the cycle count --
+# see _cycle_fraction for why this exists at all.
+_CYCLE_BOUNDARY_ULPS = 4
+
+
 def _cycle_fraction(spec: SignalSpec, t: np.ndarray) -> np.ndarray:
-    return (spec.frequency * t + spec.phase / (2.0 * np.pi)) % 1.0
+    """Position within the current cycle, in [0, 1).
+
+    The near-integer snap is load-bearing, not defensive. `synthesize` builds
+    `t = t0 + i / sample_rate`, and for an arbitrary t0 -- a trigger crossing, a
+    free-run drift offset, a DUT's lead-in -- that sum cannot land exactly on a
+    whole number of periods. The product then comes out an ULP *below* an
+    integer and `%` maps it to 0.9999999999999991 rather than 0.0.
+
+    On a continuous kind that is invisible. On one that is discontinuous at the
+    wrap it inverts a sample: "square" reads its low level at the instant it
+    should switch high, and "ramp" resets a sample early. In a mock capture that
+    is a full-amplitude artifact -- about 50 int8 codes -- on an otherwise
+    correct trace, which reads as a broken instrument model rather than as
+    arithmetic.
+
+    Snapping cannot do harm larger than it repairs: it moves the cycle position
+    by at most _CYCLE_BOUNDARY_ULPS ULPs, below the resolution of every consumer.
+    A legitimate sample would have to fall within a few ULP of a boundary to be
+    touched -- adjacent samples are frequency/sample_rate apart, many orders of
+    magnitude more -- and a sample that close to a boundary belongs on it. A
+    sweep of 3000 random specs (1 Hz to 10 MHz, 1 kSa/s to 1 GSa/s, arbitrary t0
+    and phase) snapped nothing at all.
+
+    KNOWN RESIDUAL: this fixes the wrap at fraction 0, not the other decision
+    points. `_square` compares against `duty`, `_pulse` against its edge and
+    width, `_exponential` against its high-phase length; a sample landing on one
+    of those thresholds is subject to the same float error, which moves that edge
+    by one sample. Strictly smaller than an inverted sample, and closing it means
+    making every threshold comparison in every generator boundary-aware. See
+    tests/test_cycle_boundary.py, which pins the current behaviour so the gap is
+    visible.
+    """
+    cycles = spec.frequency * t + spec.phase / (2.0 * np.pi)
+    nearest = np.round(cycles)
+    cycles = np.where(np.abs(cycles - nearest) <= _CYCLE_BOUNDARY_ULPS * np.spacing(np.abs(cycles)), nearest, cycles)
+    return cycles % 1.0
 
 
 def _sine(spec: SignalSpec, t: np.ndarray, rng: np.random.Generator) -> np.ndarray:

--- a/tests/test_cycle_boundary.py
+++ b/tests/test_cycle_boundary.py
@@ -1,0 +1,119 @@
+"""A sample landing on a cycle boundary must read as the start of a cycle.
+
+`_cycle_fraction` computes `(frequency * t + phase / 2pi) % 1.0`. The time array
+is built as `t0 + i / sample_rate`, and for an arbitrary `t0` -- a trigger
+crossing, a free-run drift offset, a filter's lead-in -- that sum cannot land
+exactly on a whole number of periods. So the product comes out an ULP *below* an
+integer and `%` maps it to 0.9999999999999991 instead of 0.0.
+
+For a continuous kind that is invisible. For a kind that is discontinuous at the
+wrap it inverts the sample: a square reads its low level at the instant it should
+switch high, a sawtooth resets one sample early. One sample, full amplitude, on
+an otherwise correct trace -- roughly 50 int8 codes of spike in a mock capture,
+which is exactly the sort of thing that makes someone distrust the instrument
+model rather than the arithmetic.
+
+Reproduced from the mock's own trigger-aligned path: a 1 kHz square at 1 MSa/s
+from `t0 = -0.006` puts boundaries at samples 9000, 11000 and 13000.
+"""
+
+import numpy as np
+import pytest
+
+from scpi_control.signal_synth import SignalSpec, synthesize
+
+RATE = 1_000_000.0
+
+
+def test_a_boundary_sample_of_a_square_reads_high_not_low():
+    """The defect, at the level a user sees it: one inverted sample."""
+    spec = SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0)
+    samples = synthesize(spec, RATE, 14_000, t0=-0.006)
+    # 0.006 is 6 whole periods, so index 9000 (3 ms later) starts a cycle and a
+    # 50%-duty square must be at its HIGH level there.
+    for boundary in (9000, 11000, 13000):
+        assert samples[boundary] == pytest.approx(1.0), f"sample {boundary} sits on a cycle boundary and must read high"
+
+
+def test_a_boundary_sample_of_a_sawtooth_resets_at_the_boundary():
+    """`ramp` is the other kind discontinuous at the wrap, and it fails the same
+    way -- it resets one sample early, reading +amplitude where the new cycle
+    should already have restarted at -amplitude."""
+    spec = SignalSpec(kind="ramp", frequency=1_000.0, amplitude=1.0)
+    samples = synthesize(spec, RATE, 14_000, t0=-0.006)
+    for boundary in (9000, 11000, 13000):
+        assert samples[boundary] == pytest.approx(-1.0), f"sample {boundary} starts a cycle and a sawtooth must have reset"
+
+
+def test_every_cycle_boundary_starts_a_high_run():
+    """The artifact does NOT show up as a lone spike -- it delays the RISING edge
+    (the one at the cycle wrap) by one sample. So the property to pin is that a
+    high run begins at every whole-cycle index, which is what fails before the
+    snap and holds after it."""
+    spec = SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, duty=0.5)
+    samples = synthesize(spec, RATE, 14_000, t0=-0.006)
+    # t0 = -0.006 is six whole periods, so cycles start every 1000 samples.
+    for boundary in range(0, 14_000, 1_000):
+        assert samples[boundary] > 0, f"sample {boundary} starts a cycle and must begin the high run"
+        if boundary:
+            assert samples[boundary - 1] < 0, f"sample {boundary - 1} is the last of the previous cycle and must still be low"
+
+
+def test_the_duty_threshold_is_a_separate_boundary_and_is_not_covered():
+    """Deliberately documents a KNOWN residual rather than hiding it.
+
+    The wrap at cycle fraction 0 is not the only decision point: `_square`
+    compares against `duty`, and a sample landing exactly on that threshold is
+    subject to the same float error from `t0 + i / sample_rate`. Snapping the
+    integer boundary does not touch it, so a 50% duty can still measure 500/501
+    samples per half cycle depending on t0.
+
+    That is a strictly smaller defect -- the falling edge moves by one sample,
+    rather than a full-amplitude sample inverting -- and fixing it means making
+    every threshold comparison in every generator boundary-aware, which is a
+    different piece of work. This test asserts the CURRENT behaviour so the gap
+    is visible and so that closing it later fails here loudly rather than
+    silently.
+    """
+    spec = SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, duty=0.5)
+    samples = synthesize(spec, RATE, 14_000, t0=-0.006)
+    high = int(np.count_nonzero(samples > 0))
+    assert high != 7_000, "duty-threshold snapping now works -- delete this test and tighten the one above"
+    assert abs(high - 7_000) <= 14, "the residual must stay at most one sample per cycle"
+
+
+def test_the_snap_leaves_every_other_sample_bit_identical():
+    """The fix must be inert away from boundaries. A trace whose samples avoid
+    the boundaries entirely must be unchanged to the last bit -- this is what
+    makes the correction safe to apply unconditionally."""
+    spec = SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0)
+    # t0 = 0 lands every sample cleanly, so nothing here needs correcting.
+    clean = synthesize(spec, RATE, 14_000, t0=0.0)
+    expected = np.where((np.arange(14_000) % 1000) < 500, 1.0, -1.0)
+    np.testing.assert_array_equal(clean, expected)
+
+
+@pytest.mark.parametrize("kind", ["sine", "triangle", "multitone", "exponential"])
+def test_continuous_kinds_are_unaffected(kind):
+    """These are continuous across the wrap, so the artifact never showed on them
+    and the correction must not perturb them either."""
+    spec = SignalSpec(kind=kind, frequency=1_000.0, amplitude=1.0)
+    samples = synthesize(spec, RATE, 4_000, t0=-0.006)
+    assert np.all(np.isfinite(samples))
+    assert np.max(np.abs(np.diff(samples))) < 0.05, "a continuous kind must have no full-amplitude jump"
+
+
+def test_the_snap_applies_to_the_phase_shifted_cycle_too():
+    """The correction is applied to `frequency * t + phase / 2pi`, so the shifted
+    boundary must be snapped as well. A half-cycle phase puts the wrap where the
+    falling edge used to be, so the boundary sample must read LOW."""
+    spec = SignalSpec(kind="square", frequency=1_000.0, amplitude=1.0, phase=np.pi)
+    samples = synthesize(spec, RATE, 14_000, t0=-0.006)
+    # A pi phase is half a cycle, so the wrap moves off the round indices: it now
+    # falls at 8500, 9500, 10500... Index 9000 lands on the DUTY threshold
+    # instead, which is the separate residual documented above.
+    # These also cover both directions of the snap -- index 8500 computes
+    # 3.0000000000000004 (just above the integer) and 9500 computes
+    # 3.9999999999999996 (just below), and both must resolve to 0.0.
+    for boundary in (8_500, 9_500, 10_500):
+        assert samples[boundary] > 0, f"with a pi phase, sample {boundary} starts a cycle and must begin the high run"


### PR DESCRIPTION
A synthesized waveform carries a spurious full-amplitude sample wherever a cycle begins. Surfaced during #120 but present long before it — `git log` shows `signal_synth.py` untouched by that branch.

## Root cause

`synthesize` builds `t = t0 + i / sample_rate`. For an arbitrary `t0` — a trigger crossing, a free-run drift offset, a device model's lead-in — that sum cannot land exactly on a whole number of periods:

| Step | Value at i = 13000, `t0 = -0.006`, 1 kHz, 1 MSa/s |
|---|---|
| `t0 + i / sample_rate` | `0.006999999999999999` (not `0.007`) |
| `frequency * t` | `6.999999999999999` — one ULP below 7 |
| `% 1.0` | `0.9999999999999991` instead of `0.0` |
| `square`: `cf < duty` | **low**, when the boundary sample should be high |

Measured blast radius across all ten kinds, comparing the boundary instant against one ULP below it:

- **`square` and `ramp` flip by the full 2 V.** `pulse` is conditionally vulnerable depending on duty and phase.
- `sine`, `triangle`, `multitone`, `chirp`, `exponential`, `noise`, `dc` are continuous across the wrap and unaffected.

In a mock capture that is about 50 int8 codes of spike on an otherwise correct trace — the kind of thing that makes someone distrust the instrument model rather than the arithmetic.

## The fix

Snap the cycle count to a whole cycle when it sits within 4 ULP of one, before the modulo.

It is safe by construction: the operation moves the cycle position by at most 4 ULP, which is below what any consumer can resolve, so it cannot do harm larger than it repairs. And it is empirically inert — across **3000 random specs** (1 Hz to 10 MHz, 1 kSa/s to 1 GSa/s, arbitrary `t0` and phase) it snapped **zero** samples. A legitimate sample would have to fall within a few ULP of a boundary to be touched at all, when adjacent samples are `frequency/sample_rate` apart — many orders of magnitude more.

Verified it fixes exactly the affected samples and leaves **every other sample bitwise identical**.

## A residual, pinned rather than hidden

Writing the tests turned up something I had not expected, and it is worth being explicit about: the wrap at fraction 0 is **not the only decision point**. `_square` compares against `duty`, `_pulse` against its edge and width, `_exponential` against its high-phase length. A sample landing on one of *those* thresholds hits the same float error.

That defect is strictly smaller — the edge moves by one sample, rather than a sample inverting — and closing it means making every threshold comparison in every generator boundary-aware, which is different work. So this PR fixes the wrap and `tests/test_cycle_boundary.py` contains a test asserting the *current* residual behaviour, written so that closing the gap later fails loudly rather than silently.

Two of my first-draft tests passed against the unfixed code and had to be rewritten: the artifact does not create an isolated spike, it makes the rising edge land one sample late. That is recorded in the test docstrings so the next person does not re-derive it.

## Verification

- Full suite **2016 passed, 19 skipped, 0 failed**; `black --check` and `flake8 --select=E9,F63,F7,F82` clean.
- Mutation-checked: removing the snap turns four of the ten new tests red.
- 181 passed across every file that exercises synthesis, the mock capture path, the loopback and the known-answer analysis tests.
