### PR TITLE
chore(release): 5.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.1] - 2026-07-26
+
 ### Fixed
 
 - A synthesized waveform no longer carries a spurious full-amplitude sample where a cycle begins.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.1] - 2026-07-26
+
 ### Fixed
 
 - A synthesized waveform no longer carries a spurious full-amplitude sample where a cycle begins.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "5.7.0"
+version = "5.7.1"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "5.7.0"
+__version__ = "5.7.1"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
Cuts 5.7.1. PATCH — one correctness fix to signal synthesis, no new features and no behaviour changes beyond removing the artifact.

## Contents

A synthesized waveform no longer carries a spurious full-amplitude sample where a cycle begins (#123).

`synthesize` builds its time array as `t0 + i / sample_rate`, and for an arbitrary `t0` — a trigger crossing, a free-run drift offset, a device model's lead-in — that sum cannot land exactly on a whole number of periods. The cycle count came out an ULP below an integer and the modulo mapped it to `0.9999999999999991` instead of `0`. Continuous kinds never showed it, but `square` read its low level at the instant it should switch high and `ramp` reset a sample early: one sample at full amplitude, roughly 50 int8 codes of spike in a mock capture.

The cycle count is now snapped to a whole cycle when it sits within a few ULP of one — a correction bounded by 4 ULP, below what any consumer can resolve, and empirically inert across 3000 random specs. Every non-boundary sample is bit-identical.

The fix covers the cycle wrap only. A sample landing exactly on a *duty* or edge threshold is still subject to the same float error, which shifts that edge by one sample rather than inverting a sample; `tests/test_cycle_boundary.py` pins that residual so it stays visible rather than becoming folklore.

Also landing in this release, though not user-facing enough for a changelog entry: `tests/test_changelog_mirror.py` (#122) now enforces that `docs/about/changelog.md` stays identical to `CHANGELOG.md`. That pair needed manual re-syncing in six separate changes recently and had already drifted once during the 5.5.0 release.

## Release mechanics

- `pyproject.toml` and `scpi_control/__init__.py` bumped 5.7.0 → 5.7.1 (`tests/test_version_consistency.py` enforces they agree)
- `## [5.7.1] - 2026-07-26` inserted under `## [Unreleased]`
- `docs/about/changelog.md` re-synced — and now checked by the new mirror test rather than by memory
- PyPI summary re-checked at **387 characters**, inside the hard 512 cap that failed the v3.2.0 publish

## Verification

- **2017 passed, 19 skipped, 0 failed**
- `tests/test_version_consistency.py` and `tests/test_changelog_mirror.py` — 4 passed
- `black --check --line-length 200 scpi_control/ examples/` clean (183 files); `flake8 --select=E9,F63,F7,F82` = 0

One transparency note on the suite run: `test_no_hardware_example_runs[report_ai_qa.py]` was deselected. It performs live local-LLM inference, taking 121s and holding 18 GB resident, and it was green in the pre-merge full run of #123 against identical library code. Every other example still executed.

After merge: tag `v5.7.1` and publish the release, which triggers the build/PyPI/docs workflow.
