### PR TITLE
feat(server,webapp): host any instrument kind in the gateway, and ship PSU support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,web]" httpx "ollama>=0.6.0"  # httpx: fastapi.testclient; ollama: LLM tool-calling schema tests
-          pip install pytest pytest-cov pytest-xdist
+          pip install pytest pytest-cov pytest-xdist pytest-timeout  # pytest-timeout: tests/test_server_stream_ws.py is marked, and --strict-markers errors without the plugin
 
       - name: Run tests with coverage
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The web gateway can now host a power supply (SPD3303X series) alongside oscilloscopes. Connect
-  a PSU from the home screen, control each output's voltage and current limit, switch it on or
-  off, and watch live measurements (voltage, current, power) stream in real time. The web UI shows
-  per-output setpoints, enable toggles, and live readings. Mock PSU sessions work with no
-  hardware, just like mock oscilloscopes do.
-- Session routes now accept an instrument `kind` (`POST /api/sessions` takes an optional `kind`
-  field, defaulting to `"scope"` for backward compatibility). For a real instrument, a session
-  created for a PSU validates the device identity against `*IDN?` rather than assuming a
-  particular type, and routes to the appropriate adapter. The 26 existing `/scope/` routes are
-  unchanged.
-- Internally, construction, connection, polling and kind-specific state moved from the session
-  layer to per-kind adapters. This architecture enables extending to AWG and DAQ sessions without
-  rebuilding the session core each time.
+- The web gateway can now host a power supply (SPD3303X series) alongside oscilloscopes. A power
+  supply found by the network scan shows up under "Power supplies" with its own Connect button,
+  and "Mock power supply" in the Connect-manually rail opens a PSU session with no hardware at
+  all. The panel gives every output a voltage setpoint, a current limit, an on/off switch, and
+  live voltage/current/power readings that update as the instrument does.
+- The output switch reflects what the instrument actually reports, never what was just asked for,
+  and a reading the supply will not answer shows as `--.--` or "state unknown" rather than as a
+  confident zero or a confident "off". An SPD3303X's CH3 has no output-state query at all, so
+  this is the normal case there, not an edge case.
+- `POST /api/sessions` accepts an optional `kind` field (`"scope"` by default, so an existing
+  caller that omits it is unaffected), and the new `/api/sessions/{id}/psu/...` routes read and
+  control PSU outputs. A session refuses to start if the connected instrument identifies as a
+  different kind than the one asked for. The 26 existing `/scope/` routes are unchanged, as is
+  every public name on `InstrumentSession`.
 
 ## [5.7.1] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The web gateway can now host a power supply (SPD3303X series) alongside oscilloscopes. Connect
+  a PSU from the home screen, control each output's voltage and current limit, switch it on or
+  off, and watch live measurements (voltage, current, power) stream in real time. The web UI shows
+  per-output setpoints, enable toggles, and live readings. Mock PSU sessions work with no
+  hardware, just like mock oscilloscopes do.
+- Session routes now accept an instrument `kind` (`POST /api/sessions` takes an optional `kind`
+  field, defaulting to `"scope"` for backward compatibility). For a real instrument, a session
+  created for a PSU validates the device identity against `*IDN?` rather than assuming a
+  particular type, and routes to the appropriate adapter. The 26 existing `/scope/` routes are
+  unchanged.
+- Internally, construction, connection, polling and kind-specific state moved from the session
+  layer to per-kind adapters. This architecture enables extending to AWG and DAQ sessions without
+  rebuilding the session core each time.
+
 ## [5.7.1] - 2026-07-26
 
 ### Fixed

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -9,19 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The web gateway can now host a power supply (SPD3303X series) alongside oscilloscopes. Connect
-  a PSU from the home screen, control each output's voltage and current limit, switch it on or
-  off, and watch live measurements (voltage, current, power) stream in real time. The web UI shows
-  per-output setpoints, enable toggles, and live readings. Mock PSU sessions work with no
-  hardware, just like mock oscilloscopes do.
-- Session routes now accept an instrument `kind` (`POST /api/sessions` takes an optional `kind`
-  field, defaulting to `"scope"` for backward compatibility). For a real instrument, a session
-  created for a PSU validates the device identity against `*IDN?` rather than assuming a
-  particular type, and routes to the appropriate adapter. The 26 existing `/scope/` routes are
-  unchanged.
-- Internally, construction, connection, polling and kind-specific state moved from the session
-  layer to per-kind adapters. This architecture enables extending to AWG and DAQ sessions without
-  rebuilding the session core each time.
+- The web gateway can now host a power supply (SPD3303X series) alongside oscilloscopes. A power
+  supply found by the network scan shows up under "Power supplies" with its own Connect button,
+  and "Mock power supply" in the Connect-manually rail opens a PSU session with no hardware at
+  all. The panel gives every output a voltage setpoint, a current limit, an on/off switch, and
+  live voltage/current/power readings that update as the instrument does.
+- The output switch reflects what the instrument actually reports, never what was just asked for,
+  and a reading the supply will not answer shows as `--.--` or "state unknown" rather than as a
+  confident zero or a confident "off". An SPD3303X's CH3 has no output-state query at all, so
+  this is the normal case there, not an edge case.
+- `POST /api/sessions` accepts an optional `kind` field (`"scope"` by default, so an existing
+  caller that omits it is unaffected), and the new `/api/sessions/{id}/psu/...` routes read and
+  control PSU outputs. A session refuses to start if the connected instrument identifies as a
+  different kind than the one asked for. The 26 existing `/scope/` routes are unchanged, as is
+  every public name on `InstrumentSession`.
 
 ## [5.7.1] - 2026-07-26
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The web gateway can now host a power supply (SPD3303X series) alongside oscilloscopes. Connect
+  a PSU from the home screen, control each output's voltage and current limit, switch it on or
+  off, and watch live measurements (voltage, current, power) stream in real time. The web UI shows
+  per-output setpoints, enable toggles, and live readings. Mock PSU sessions work with no
+  hardware, just like mock oscilloscopes do.
+- Session routes now accept an instrument `kind` (`POST /api/sessions` takes an optional `kind`
+  field, defaulting to `"scope"` for backward compatibility). For a real instrument, a session
+  created for a PSU validates the device identity against `*IDN?` rather than assuming a
+  particular type, and routes to the appropriate adapter. The 26 existing `/scope/` routes are
+  unchanged.
+- Internally, construction, connection, polling and kind-specific state moved from the session
+  layer to per-kind adapters. This architecture enables extending to AWG and DAQ sessions without
+  rebuilding the session core each time.
+
 ## [5.7.1] - 2026-07-26
 
 ### Fixed

--- a/docs/examples/intermediate.md
+++ b/docs/examples/intermediate.md
@@ -1622,15 +1622,15 @@ def main() -> None:
         # or here: a trivial subscriber).
         unsubscribe = session.subscribe(lambda message: None)
 
-        session.set_measurements([(1, "PKPK"), (1, "FREQ")])
-        session.start_recording()
+        session.adapter.set_measurements([(1, "PKPK"), (1, "FREQ")], session.publish)
+        session.adapter.start_recording(session.publish)
         print(f"Recording C1 PKPK + FREQ for {RECORD_SECONDS} s...")
         time.sleep(RECORD_SECONDS)
-        status = session.stop_recording()
+        status = session.adapter.stop_recording(session.publish)
         unsubscribe()
         print(f"Recorded {status['row_count']} rows")
 
-        rows = session.recorder.rows_since()
+        rows = session.adapter.recorder.rows_since()
         columns = [f"C{c['channel']} {c['mtype']}" for c in status["columns"]]
         with open("trend_log.csv", "w", newline="") as f:
             writer = csv.writer(f)

--- a/docs/examples/intermediate.md
+++ b/docs/examples/intermediate.md
@@ -1622,15 +1622,15 @@ def main() -> None:
         # or here: a trivial subscriber).
         unsubscribe = session.subscribe(lambda message: None)
 
-        session.adapter.set_measurements([(1, "PKPK"), (1, "FREQ")], session.publish)
-        session.adapter.start_recording(session.publish)
+        session.set_measurements([(1, "PKPK"), (1, "FREQ")])
+        session.start_recording()
         print(f"Recording C1 PKPK + FREQ for {RECORD_SECONDS} s...")
         time.sleep(RECORD_SECONDS)
-        status = session.adapter.stop_recording(session.publish)
+        status = session.stop_recording()
         unsubscribe()
         print(f"Recorded {status['row_count']} rows")
 
-        rows = session.adapter.recorder.rows_since()
+        rows = session.recorder.rows_since()
         columns = [f"C{c['channel']} {c['mtype']}" for c in status["columns"]]
         with open("trend_log.csv", "w", newline="") as f:
             writer = csv.writer(f)

--- a/examples/trend_logging_walkthrough.py
+++ b/examples/trend_logging_walkthrough.py
@@ -28,15 +28,15 @@ def main() -> None:
         # or here: a trivial subscriber).
         unsubscribe = session.subscribe(lambda message: None)
 
-        session.adapter.set_measurements([(1, "PKPK"), (1, "FREQ")], session.publish)
-        session.adapter.start_recording(session.publish)
+        session.set_measurements([(1, "PKPK"), (1, "FREQ")])
+        session.start_recording()
         print(f"Recording C1 PKPK + FREQ for {RECORD_SECONDS} s...")
         time.sleep(RECORD_SECONDS)
-        status = session.adapter.stop_recording(session.publish)
+        status = session.stop_recording()
         unsubscribe()
         print(f"Recorded {status['row_count']} rows")
 
-        rows = session.adapter.recorder.rows_since()
+        rows = session.recorder.rows_since()
         columns = [f"C{c['channel']} {c['mtype']}" for c in status["columns"]]
         with open("trend_log.csv", "w", newline="") as f:
             writer = csv.writer(f)

--- a/examples/trend_logging_walkthrough.py
+++ b/examples/trend_logging_walkthrough.py
@@ -28,15 +28,15 @@ def main() -> None:
         # or here: a trivial subscriber).
         unsubscribe = session.subscribe(lambda message: None)
 
-        session.set_measurements([(1, "PKPK"), (1, "FREQ")])
-        session.start_recording()
+        session.adapter.set_measurements([(1, "PKPK"), (1, "FREQ")], session.publish)
+        session.adapter.start_recording(session.publish)
         print(f"Recording C1 PKPK + FREQ for {RECORD_SECONDS} s...")
         time.sleep(RECORD_SECONDS)
-        status = session.stop_recording()
+        status = session.adapter.stop_recording(session.publish)
         unsubscribe()
         print(f"Recorded {status['row_count']} rows")
 
-        rows = session.recorder.rows_since()
+        rows = session.adapter.recorder.rows_since()
         columns = [f"C{c['channel']} {c['mtype']}" for c in status["columns"]]
         with open("trend_log.csv", "w", newline="") as f:
             writer = csv.writer(f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0.0",
     "pytest-testmon>=2.0",
+    "pytest-timeout>=2.1",
     "pytest-xdist>=3.5",
     "codecov>=2.1.0",
     "black>=26.5,<27; python_version >= '3.10'",

--- a/scpi_control/server/adapters.py
+++ b/scpi_control/server/adapters.py
@@ -10,13 +10,14 @@ much worse failure than a little indirection.
 """
 
 import time
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from scpi_control import Oscilloscope
 from scpi_control.connection.mock import MockConnection
-from scpi_control.exceptions import SiglentError
+from scpi_control.exceptions import InvalidParameterError, SiglentError
 from scpi_control.server import compute
 from scpi_control.server.netpolicy import validate_target
+from scpi_control.server.recorder import TrendRecorder
 
 MAX_FRAME_POINTS = 2000
 MEASUREMENT_EVERY_N_POLLS = 4
@@ -113,13 +114,14 @@ class ScopeAdapter(InstrumentAdapter):
     kind = "scope"
 
     def __init__(self) -> None:
-        # Transitional back-reference: filters/spectrum_config/measurements/
-        # recorder/active_reference are still owned by InstrumentSession (Task
-        # 3 moves the scope-specific ones onto this adapter). InstrumentSession
-        # sets this right after constructing the session so poll() below can
-        # read the current values -- never a snapshot, since request coroutines
-        # swap these dicts wholesale at any time.
-        self.session: Optional[Any] = None
+        self.measurements: List[Tuple[int, str]] = []
+        # Server-owned analysis config. Request coroutines swap these whole
+        # dicts atomically (never mutate in place); the worker thread only reads.
+        self.spectrum_config: Dict[str, Any] = {"enabled": False, "channel": 1, "window": "hanning", "db": True}
+        self.filters: Dict[int, Dict[str, Any]] = {n: {"source": 1, "kind": "lowpass", "cutoff_low": None, "cutoff_high": None, "order": 5, "enabled": False} for n in (1, 2)}
+        self.active_reference: Optional[Dict[str, Any]] = None  # {"name", "channel", "data": {"time","voltage",...}}
+        self._shown: set = set()  # trace keys (M1/M2/F1/F2/SPEC) live on subscribers' canvases; worker-thread-only
+        self.recorder = TrendRecorder()  # internally locked: worker appends, request threads control/read
 
     def build(self, address, port, mock, model, allowed_ports, connection):
         if mock:
@@ -142,8 +144,7 @@ class ScopeAdapter(InstrumentAdapter):
 
     def poll(self, instrument, publish, tick):
         scope = instrument
-        session = self.session
-        shown = session._shown if session is not None else set()
+        shown = self._shown
         acquired = {}
         for n in scope.supported_channels:
             ch = scope.get_channel(n)
@@ -161,7 +162,7 @@ class ScopeAdapter(InstrumentAdapter):
                 shown_now.add(label)
             elif label in shown:
                 publish(_decimate_frame(label, [], []))  # one-shot clear on transition
-        filters = session.filters if session is not None else {}
+        filters = self.filters
         for n in sorted(filters):
             config = filters[n]
             label = "F{0}".format(n)
@@ -171,30 +172,67 @@ class ScopeAdapter(InstrumentAdapter):
                 shown_now.add(label)
             elif label in shown:
                 publish(_decimate_frame(label, [], []))
-        spectrum_config = session.spectrum_config if session is not None else {"enabled": False}
+        spectrum_config = self.spectrum_config
         frame = _quiet(lambda: compute.spectrum_frame(spectrum_config, acquired)) if spectrum_config["enabled"] else None
         if frame is not None:
             publish(frame)
             shown_now.add("SPEC")
         elif "SPEC" in shown:
             publish(compute.empty_spectrum_frame(spectrum_config))
-        if session is not None:
-            session._shown = shown_now
-            if tick % MEASUREMENT_EVERY_N_POLLS == 0:
-                if session.measurements:
-                    now = time.time()
-                    values = []
-                    for channel, mtype in session.measurements:
-                        value = _safe(lambda: scope.measurement.measure(mtype, channel))
-                        values.append({"channel": channel, "mtype": mtype, "value": value})
-                    publish({"type": "measurements", "values": values, "timestamp": now})
-                    session.recorder.append(now, [entry["value"] for entry in values])
-                reference = session.active_reference  # snapshot for thread safety
-                if reference is not None:
-                    publish(compute.reference_stats(reference, acquired))
+        self._shown = shown_now
+        if tick % MEASUREMENT_EVERY_N_POLLS == 0:
+            if self.measurements:
+                now = time.time()
+                values = []
+                for channel, mtype in self.measurements:
+                    value = _safe(lambda: scope.measurement.measure(mtype, channel))
+                    values.append({"channel": channel, "mtype": mtype, "value": value})
+                publish({"type": "measurements", "values": values, "timestamp": now})
+                self.recorder.append(now, [entry["value"] for entry in values])
+            reference = self.active_reference  # snapshot for thread safety
+            if reference is not None:
+                publish(compute.reference_stats(reference, acquired))
 
     def close(self, instrument):
         instrument.disconnect()
+
+    def set_measurements(self, items: List[Tuple[int, str]], publish: Callable[[Dict[str, Any]], None]) -> None:
+        self.measurements = list(items)
+        publish({"type": "measurements_config", "items": [{"channel": c, "mtype": m} for c, m in self.measurements]})
+
+    def start_recording(self, publish: Callable[[Dict[str, Any]], None]) -> Dict[str, Any]:
+        # Local import: sessions.py imports this module at top level, so a
+        # module-level import of SessionError back from sessions.py here would
+        # be circular. By call time sessions.py is fully loaded.
+        from scpi_control.server.sessions import SessionError
+
+        if self.recorder.state == "recording":
+            raise SessionError("already recording")
+        if not self.measurements:
+            raise InvalidParameterError("no measurements selected")
+        self.recorder.start(list(self.measurements), time.time())
+        self._publish_log_status(publish)
+        return self.recorder.status()
+
+    def stop_recording(self, publish: Callable[[Dict[str, Any]], None]) -> Dict[str, Any]:
+        self.recorder.stop()
+        self._publish_log_status(publish)
+        return self.recorder.status()
+
+    def _publish_log_status(self, publish: Callable[[Dict[str, Any]], None]) -> None:
+        status = self.recorder.status()
+        publish({"type": "log_status", "state": status["state"], "started_at": status["started_at"], "row_count": status["row_count"], "columns": status["columns"]})
+
+    def reference_overlay(self) -> Dict[str, Any]:
+        active = self.active_reference
+        if active is None:
+            return {"name": None, "channel": None, "t0": 0.0, "dt": 1.0, "points": []}
+        frame = _decimate_frame(active["channel"], active["data"]["time"], active["data"]["voltage"])
+        return {"name": active["name"], "channel": active["channel"], "t0": frame["t0"], "dt": frame["dt"], "points": frame["points"]}
+
+    def set_active_reference(self, name: Optional[str], channel: Optional[int], data: Optional[Dict[str, Any]], publish: Callable[[Dict[str, Any]], None]) -> None:
+        self.active_reference = None if name is None else {"name": name, "channel": channel, "data": data}
+        publish({"type": "reference", **self.reference_overlay()})
 
 
 ADAPTERS: Dict[str, type] = {"scope": ScopeAdapter}

--- a/scpi_control/server/adapters.py
+++ b/scpi_control/server/adapters.py
@@ -112,6 +112,19 @@ class InstrumentAdapter:
         """Publish whatever this kind emits per tick. Called on the worker thread."""
         raise NotImplementedError
 
+    def initial_frame(self, instrument) -> Dict[str, Any]:
+        """The first frame a newly-opened live stream receives.
+
+        It must have the same shape this kind publishes on every subsequent
+        tick, otherwise a client that discriminates on the frame shape sees
+        one thing at connect and another a quarter-second later. Declared
+        here (rather than branched on ``session.kind`` in the stream handler)
+        so a new kind cannot be wired up while quietly inheriting some other
+        kind's frame -- NotImplementedError is loud, and the stream handler
+        turns it into an error frame plus a distinct close code.
+        """
+        raise NotImplementedError
+
     def close(self, instrument) -> None:
         raise NotImplementedError
 
@@ -199,6 +212,9 @@ class ScopeAdapter(InstrumentAdapter):
             if reference is not None:
                 publish(compute.reference_stats(reference, acquired))
 
+    def initial_frame(self, instrument):
+        return {"type": "state", "state": read_state(instrument)}
+
     def close(self, instrument):
         instrument.disconnect()
 
@@ -241,30 +257,54 @@ class ScopeAdapter(InstrumentAdapter):
         publish({"type": "reference", **self.reference_overlay()})
 
 
-def read_psu_outputs(psu: PowerSupply) -> List[Dict[str, Any]]:
+MEASURED_KEYS = ("measured_voltage", "measured_current", "measured_power")
+UNKNOWN_MEASURED: Dict[str, Any] = {key: None for key in MEASURED_KEYS}
+
+
+def read_psu_outputs(psu: PowerSupply, measure: bool = True) -> List[Dict[str, Any]]:
     """One dict per output. Shared by PsuAdapter.poll and GET /psu/state so the
-    streamed shape and the fetched shape cannot drift apart."""
+    streamed shape and the fetched shape cannot drift apart.
+
+    ``measure=False`` skips the three measured readings (leaving them None) so
+    a caller that only needs setpoints and enable state can do it in half the
+    queries; PsuAdapter.poll uses that to throttle the measured triplet.
+
+    Every field is read through _safe, so a query the model does not implement
+    or a timeout yields None rather than a fabricated value. ``enabled`` in
+    particular MUST NOT default to False: an SPD3303X's CH3 has no documented
+    status bit and falls through to an OUTP3? that the model does not answer,
+    so a False default would render an energised output as a confident "off".
+    None means "unknown", and the UI is required to show it as unknown.
+    """
     outputs = []
     for n in psu.supported_outputs:
         out = psu.get_output(n)
         if out is None:
             continue
-        outputs.append(
-            {
-                "output": n,
-                "voltage": _safe(lambda: out.voltage),
-                "current": _safe(lambda: out.current),
-                "enabled": _safe(lambda: out.enabled, default=False),
-                "measured_voltage": _safe(lambda: out.measure_voltage()),
-                "measured_current": _safe(lambda: out.measure_current()),
-                "measured_power": _safe(lambda: out.measure_power()),
-            }
-        )
+        row = {
+            "output": n,
+            "voltage": _safe(lambda: out.voltage),
+            "current": _safe(lambda: out.current),
+            "enabled": _safe(lambda: out.enabled),
+        }
+        if measure:
+            row["measured_voltage"] = _safe(lambda: out.measure_voltage())
+            row["measured_current"] = _safe(lambda: out.measure_current())
+            row["measured_power"] = _safe(lambda: out.measure_power())
+        else:
+            row.update(UNKNOWN_MEASURED)
+        outputs.append(row)
     return outputs
 
 
 class PsuAdapter(InstrumentAdapter):
     kind = "psu"
+
+    def __init__(self) -> None:
+        # Last known measured triplet per output, so the throttled ticks can
+        # still emit the full frame shape instead of blanking the readings
+        # three ticks out of four. Worker-thread-only, like ScopeAdapter._shown.
+        self._measured: Dict[int, Dict[str, Any]] = {}
 
     def build(self, address, port, mock, model, allowed_ports, connection):
         if mock:
@@ -286,7 +326,23 @@ class PsuAdapter(InstrumentAdapter):
         }
 
     def poll(self, instrument, publish, tick):
-        publish({"type": "state", "kind": "psu", "outputs": read_psu_outputs(instrument)})
+        # The measured triplet is 3 of the ~6 queries an output costs, and on a
+        # 3-output SPD3303X that is 18 queries every 250 ms. Setpoints and the
+        # enable state stay live on every tick (they are what a user is
+        # watching when they flip a switch); the measurements ride the same
+        # every-Nth-tick budget the scope's measurements do. The first tick
+        # always measures so a fresh stream is never briefly blank.
+        measure = tick % MEASUREMENT_EVERY_N_POLLS == 0 or not self._measured
+        outputs = read_psu_outputs(instrument, measure=measure)
+        for row in outputs:
+            if measure:
+                self._measured[row["output"]] = {key: row[key] for key in MEASURED_KEYS}
+            else:
+                row.update(self._measured.get(row["output"], UNKNOWN_MEASURED))
+        publish({"type": "state", "kind": "psu", "outputs": outputs})
+
+    def initial_frame(self, instrument):
+        return {"type": "state", "kind": "psu", "outputs": read_psu_outputs(instrument)}
 
     def close(self, instrument):
         instrument.disconnect()

--- a/scpi_control/server/adapters.py
+++ b/scpi_control/server/adapters.py
@@ -12,7 +12,7 @@ much worse failure than a little indirection.
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from scpi_control import Oscilloscope
+from scpi_control import Oscilloscope, PowerSupply
 from scpi_control.connection.mock import MockConnection
 from scpi_control.exceptions import InvalidParameterError, SiglentError
 from scpi_control.server import compute
@@ -23,6 +23,7 @@ MAX_FRAME_POINTS = 2000
 MEASUREMENT_EVERY_N_POLLS = 4
 
 DEFAULT_MOCK_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+DEFAULT_MOCK_PSU_IDN = "Siglent Technologies,SPD3303X,SPD123456,1.0"
 
 
 def _safe(fn, default=None):
@@ -88,6 +89,11 @@ def make_mock_scope_connection(model: Optional[str]) -> MockConnection:
     # No explicit waveform_payloads: channels serve state-coupled synthesized
     # signals (connection/mock/synth.py). 1 MSa/s x 14 div x 1 ms/div = 14k points.
     return MockConnection("mock", idn=idn, channel_states={1: True, 2: False, 3: False, 4: False}, trigger_status=["Stop"], sample_rate=1_000_000.0, timebase=1e-3)
+
+
+def make_mock_psu_connection(model: Optional[str]) -> MockConnection:
+    idn = DEFAULT_MOCK_PSU_IDN if model is None else "Siglent Technologies,{0},MOCK0001,1.0.0.0".format(model)
+    return MockConnection("mock", psu_mode=True, psu_idn=idn)
 
 
 class InstrumentAdapter:
@@ -235,4 +241,55 @@ class ScopeAdapter(InstrumentAdapter):
         publish({"type": "reference", **self.reference_overlay()})
 
 
-ADAPTERS: Dict[str, type] = {"scope": ScopeAdapter}
+def read_psu_outputs(psu: PowerSupply) -> List[Dict[str, Any]]:
+    """One dict per output. Shared by PsuAdapter.poll and GET /psu/state so the
+    streamed shape and the fetched shape cannot drift apart."""
+    outputs = []
+    for n in psu.supported_outputs:
+        out = psu.get_output(n)
+        if out is None:
+            continue
+        outputs.append(
+            {
+                "output": n,
+                "voltage": _safe(lambda: out.voltage),
+                "current": _safe(lambda: out.current),
+                "enabled": _safe(lambda: out.enabled, default=False),
+                "measured_voltage": _safe(lambda: out.measure_voltage()),
+                "measured_current": _safe(lambda: out.measure_current()),
+                "measured_power": _safe(lambda: out.measure_power()),
+            }
+        )
+    return outputs
+
+
+class PsuAdapter(InstrumentAdapter):
+    kind = "psu"
+
+    def build(self, address, port, mock, model, allowed_ports, connection):
+        if mock:
+            conn = connection if connection is not None else make_mock_psu_connection(model)
+            return PowerSupply("mock", connection=conn)
+        if not address:
+            raise ValueError("address is required for a non-mock session")
+        validate_target(address, port, allowed_ports=allowed_ports)
+        return PowerSupply(address, port=port)
+
+    def connect(self, instrument):
+        instrument.connect()
+        info = instrument.device_info or {}
+        return {
+            "idn": instrument.identify(),
+            "model": info.get("model", ""),
+            "dialect": "",  # a PSU has no scope-style dialect; the field stays for payload compatibility
+            "num_channels": len(instrument.supported_outputs),
+        }
+
+    def poll(self, instrument, publish, tick):
+        publish({"type": "state", "kind": "psu", "outputs": read_psu_outputs(instrument)})
+
+    def close(self, instrument):
+        instrument.disconnect()
+
+
+ADAPTERS: Dict[str, type] = {"scope": ScopeAdapter, "psu": PsuAdapter}

--- a/scpi_control/server/adapters.py
+++ b/scpi_control/server/adapters.py
@@ -1,0 +1,200 @@
+"""Per-kind adapters: what differs between instrument kinds in a session.
+
+InstrumentSession owns everything shared -- the worker thread, the job queue,
+pub/sub, viewers, ownership, the error state machine. An adapter owns the four
+things that actually vary by kind, plus any state only that kind needs.
+
+Keeping the lifecycle in ONE implementation is deliberate. It is threading code,
+and a subclass that overrides part of a thread or error path by accident is a
+much worse failure than a little indirection.
+"""
+
+import time
+from typing import Any, Callable, Dict, Optional
+
+from scpi_control import Oscilloscope
+from scpi_control.connection.mock import MockConnection
+from scpi_control.exceptions import SiglentError
+from scpi_control.server import compute
+from scpi_control.server.netpolicy import validate_target
+
+MAX_FRAME_POINTS = 2000
+MEASUREMENT_EVERY_N_POLLS = 4
+
+DEFAULT_MOCK_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+
+
+def _safe(fn, default=None):
+    try:
+        return fn()
+    except SiglentError:
+        return default
+
+
+def _quiet(fn, default=None):
+    """Like _safe, but for analysis compute: ANY exception degrades to default.
+
+    The poll tick is the session heartbeat; a numpy edge case in analysis
+    must never kill the worker thread.
+    """
+    try:
+        return fn()
+    except Exception:
+        return default
+
+
+def read_state(scope: Oscilloscope) -> Dict[str, Any]:
+    channels: Dict[int, Dict[str, Any]] = {}
+    for n in scope.supported_channels:
+        ch = scope.get_channel(n)
+        channels[n] = {
+            "enabled": ch.enabled,
+            "voltage_scale": ch.voltage_scale,
+            "voltage_offset": ch.voltage_offset,
+            "coupling": ch.coupling,
+            "probe_ratio": _safe(lambda: ch.probe_ratio),
+        }
+    trig = scope.trigger
+    return {
+        "run_state": scope.acquisition_status(),
+        "timebase": scope.timebase,
+        "channels": channels,
+        "trigger": {
+            "mode": trig.mode,
+            "source": _safe(lambda: trig.source),
+            "level": _safe(lambda: trig.level),
+            "slope": _safe(lambda: trig.slope),
+            "coupling": _safe(lambda: trig.coupling),
+        },
+    }
+
+
+def _decimate_frame(channel, time_axis, voltage) -> Dict[str, Any]:
+    step = max(1, -(-len(voltage) // MAX_FRAME_POINTS))  # ceiling division keeps len(points) <= cap
+    points = voltage[::step]
+    t0 = float(time_axis[0]) if len(time_axis) else 0.0
+    dt = float(time_axis[1] - time_axis[0]) * step if len(time_axis) > 1 else 1.0
+    return {"type": "waveform", "channel": channel, "t0": t0, "dt": dt, "points": [float(v) for v in points]}
+
+
+def _waveform_frame(scope: Oscilloscope, channel: int) -> Dict[str, Any]:
+    data = scope.get_waveform(channel, provenance=False)
+    return _decimate_frame(channel, data.time, data.voltage)
+
+
+def make_mock_scope_connection(model: Optional[str]) -> MockConnection:
+    idn = DEFAULT_MOCK_IDN if model is None else "Siglent Technologies,{0},MOCK0001,1.0.0.0".format(model)
+    # No explicit waveform_payloads: channels serve state-coupled synthesized
+    # signals (connection/mock/synth.py). 1 MSa/s x 14 div x 1 ms/div = 14k points.
+    return MockConnection("mock", idn=idn, channel_states={1: True, 2: False, 3: False, 4: False}, trigger_status=["Stop"], sample_rate=1_000_000.0, timebase=1e-3)
+
+
+class InstrumentAdapter:
+    """What a session needs to know about one kind of instrument."""
+
+    kind = ""
+
+    def build(self, address, port, mock, model, allowed_ports, connection) -> Any:
+        raise NotImplementedError
+
+    def connect(self, instrument) -> Dict[str, Any]:
+        """Connect, then return {"idn", "model", "dialect", "num_channels"}."""
+        raise NotImplementedError
+
+    def poll(self, instrument, publish: Callable[[Dict[str, Any]], None], tick: int) -> None:
+        """Publish whatever this kind emits per tick. Called on the worker thread."""
+        raise NotImplementedError
+
+    def close(self, instrument) -> None:
+        raise NotImplementedError
+
+
+class ScopeAdapter(InstrumentAdapter):
+    kind = "scope"
+
+    def __init__(self) -> None:
+        # Transitional back-reference: filters/spectrum_config/measurements/
+        # recorder/active_reference are still owned by InstrumentSession (Task
+        # 3 moves the scope-specific ones onto this adapter). InstrumentSession
+        # sets this right after constructing the session so poll() below can
+        # read the current values -- never a snapshot, since request coroutines
+        # swap these dicts wholesale at any time.
+        self.session: Optional[Any] = None
+
+    def build(self, address, port, mock, model, allowed_ports, connection):
+        if mock:
+            conn = connection if connection is not None else make_mock_scope_connection(model)
+            return Oscilloscope("mock", connection=conn)
+        if not address:
+            raise ValueError("address is required for a non-mock session")
+        validate_target(address, port, allowed_ports=allowed_ports)
+        return Oscilloscope(address, port=port)
+
+    def connect(self, instrument):
+        instrument.connect()
+        info = instrument.device_info or {}
+        return {
+            "idn": instrument.identify(),
+            "model": info.get("model", ""),
+            "dialect": instrument.dialect or "",
+            "num_channels": len(instrument.supported_channels),
+        }
+
+    def poll(self, instrument, publish, tick):
+        scope = instrument
+        session = self.session
+        shown = session._shown if session is not None else set()
+        acquired = {}
+        for n in scope.supported_channels:
+            ch = scope.get_channel(n)
+            if ch is not None and _safe(lambda: ch.enabled, default=False):
+                data = scope.get_waveform(n, provenance=False)
+                acquired["C{0}".format(n)] = data
+                publish(_decimate_frame(n, data.time, data.voltage))
+        shown_now = set()
+        for label, math in (("M1", scope.math1), ("M2", scope.math2)):
+            result = None
+            if math is not None and _safe(lambda: math.enabled, default=False):
+                result = _safe(lambda: math.compute(acquired))
+            if result is not None:
+                publish(_decimate_frame(label, result.time, result.voltage))
+                shown_now.add(label)
+            elif label in shown:
+                publish(_decimate_frame(label, [], []))  # one-shot clear on transition
+        filters = session.filters if session is not None else {}
+        for n in sorted(filters):
+            config = filters[n]
+            label = "F{0}".format(n)
+            result = _quiet(lambda: compute.filtered_waveform(config, acquired)) if config["enabled"] else None
+            if result is not None:
+                publish(_decimate_frame(label, result.time, result.voltage))
+                shown_now.add(label)
+            elif label in shown:
+                publish(_decimate_frame(label, [], []))
+        spectrum_config = session.spectrum_config if session is not None else {"enabled": False}
+        frame = _quiet(lambda: compute.spectrum_frame(spectrum_config, acquired)) if spectrum_config["enabled"] else None
+        if frame is not None:
+            publish(frame)
+            shown_now.add("SPEC")
+        elif "SPEC" in shown:
+            publish(compute.empty_spectrum_frame(spectrum_config))
+        if session is not None:
+            session._shown = shown_now
+            if tick % MEASUREMENT_EVERY_N_POLLS == 0:
+                if session.measurements:
+                    now = time.time()
+                    values = []
+                    for channel, mtype in session.measurements:
+                        value = _safe(lambda: scope.measurement.measure(mtype, channel))
+                        values.append({"channel": channel, "mtype": mtype, "value": value})
+                    publish({"type": "measurements", "values": values, "timestamp": now})
+                    session.recorder.append(now, [entry["value"] for entry in values])
+                reference = session.active_reference  # snapshot for thread safety
+                if reference is not None:
+                    publish(compute.reference_stats(reference, acquired))
+
+    def close(self, instrument):
+        instrument.disconnect()
+
+
+ADAPTERS: Dict[str, type] = {"scope": ScopeAdapter}

--- a/scpi_control/server/api/psu.py
+++ b/scpi_control/server/api/psu.py
@@ -1,0 +1,66 @@
+# scpi_control/server/api/psu.py
+import asyncio
+from typing import Any, Callable
+
+from fastapi import Request
+from fastapi import APIRouter
+
+from scpi_control.exceptions import InvalidParameterError
+from scpi_control.server.adapters import read_psu_outputs
+from scpi_control.server.api.sessions import require_kind, require_session
+from scpi_control.server.ownership import require_owner
+from scpi_control.server.schemas import PsuEnablePatch, PsuOutputPatch
+from scpi_control.server.sessions import InstrumentSession
+
+router = APIRouter(tags=["psu"])
+
+
+async def run_job(session: InstrumentSession, fn: Callable) -> Any:
+    return await asyncio.wrap_future(session.submit(fn))
+
+
+async def mutate(session: InstrumentSession, fn: Callable) -> dict:
+    """Run a mutation, then read + broadcast + return the fresh outputs."""
+    await run_job(session, fn)
+    outputs = await run_job(session, read_psu_outputs)
+    session.publish({"type": "state", "kind": "psu", "outputs": outputs})
+    return {"outputs": outputs}
+
+
+@router.get("/sessions/{session_id}/psu/state")
+async def get_state(session_id: str, request: Request):
+    session = require_session(request, session_id)
+    require_kind(session, "psu")
+    outputs = await run_job(session, read_psu_outputs)
+    return {"outputs": outputs}
+
+
+@router.patch("/sessions/{session_id}/psu/outputs/{n}")
+async def patch_output(session_id: str, n: int, body: PsuOutputPatch, request: Request):
+    session = require_owner(request, session_id)
+    require_kind(session, "psu")
+
+    def apply(psu):
+        output = psu.get_output(n)
+        if output is None:
+            raise InvalidParameterError("output {0} not available".format(n))
+        if body.voltage is not None:
+            output.voltage = body.voltage
+        if body.current is not None:
+            output.current = body.current
+
+    return await mutate(session, apply)
+
+
+@router.patch("/sessions/{session_id}/psu/outputs/{n}/enable")
+async def patch_enable(session_id: str, n: int, body: PsuEnablePatch, request: Request):
+    session = require_owner(request, session_id)
+    require_kind(session, "psu")
+
+    def apply(psu):
+        output = psu.get_output(n)
+        if output is None:
+            raise InvalidParameterError("output {0} not available".format(n))
+        output.enabled = body.enabled
+
+    return await mutate(session, apply)

--- a/scpi_control/server/api/psu.py
+++ b/scpi_control/server/api/psu.py
@@ -2,8 +2,7 @@
 import asyncio
 from typing import Any, Callable
 
-from fastapi import Request
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 from scpi_control.exceptions import InvalidParameterError
 from scpi_control.server.adapters import read_psu_outputs

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -124,21 +124,21 @@ async def send_command(session_id: str, body: CommandIn, request: Request):
 @router.put("/sessions/{session_id}/scope/measurements")
 async def put_measurements(session_id: str, body: List[MeasurementItem], request: Request):
     session = require_owner(request, session_id)
-    if session.recorder.state == "recording":
+    if session.adapter.recorder.state == "recording":
         raise SessionError("measurement selection is locked while recording")
     for item in body:
         if item.mtype.upper() not in ALLOWED_MEASUREMENTS:
             raise InvalidParameterError("unknown measurement type: {0}".format(item.mtype))
         if not 1 <= item.channel <= max(1, session.num_channels):
             raise InvalidParameterError("channel {0} out of range".format(item.channel))
-    session.set_measurements([(item.channel, item.mtype.upper()) for item in body])
-    return {"measurements": [{"channel": c, "mtype": m} for c, m in session.measurements]}
+    session.adapter.set_measurements([(item.channel, item.mtype.upper()) for item in body], session.publish)
+    return {"measurements": [{"channel": c, "mtype": m} for c, m in session.adapter.measurements]}
 
 
 @router.get("/sessions/{session_id}/scope/measurements")
 async def get_measurements(session_id: str, request: Request):
     session = require_session(request, session_id)
-    return {"measurements": [{"channel": c, "mtype": m} for c, m in session.measurements]}
+    return {"measurements": [{"channel": c, "mtype": m} for c, m in session.adapter.measurements]}
 
 
 def _build_csv(captures) -> str:
@@ -262,7 +262,7 @@ async def patch_math(session_id: str, n: int, body: MathPatch, request: Request)
 @router.get("/sessions/{session_id}/scope/spectrum")
 async def get_spectrum(session_id: str, request: Request):
     session = require_session(request, session_id)
-    return dict(session.spectrum_config)
+    return dict(session.adapter.spectrum_config)
 
 
 @router.patch("/sessions/{session_id}/scope/spectrum")
@@ -273,12 +273,12 @@ async def patch_spectrum(session_id: str, body: SpectrumPatch, request: Request)
         raise InvalidParameterError("unknown window: {0}".format(updates["window"]))
     if "channel" in updates and not 1 <= updates["channel"] <= max(1, session.num_channels):
         raise InvalidParameterError("channel {0} out of range".format(updates["channel"]))
-    session.spectrum_config = {**session.spectrum_config, **updates}
-    return dict(session.spectrum_config)
+    session.adapter.spectrum_config = {**session.adapter.spectrum_config, **updates}
+    return dict(session.adapter.spectrum_config)
 
 
 def _filter_state(session):
-    return [{"n": n, **session.filters[n]} for n in sorted(session.filters)]
+    return [{"n": n, **session.adapter.filters[n]} for n in sorted(session.adapter.filters)]
 
 
 @router.get("/sessions/{session_id}/scope/filters")
@@ -302,7 +302,7 @@ async def patch_filter(session_id: str, n: int, body: FilterPatch, request: Requ
     for key in ("cutoff_low", "cutoff_high"):
         if key in updates and updates[key] <= 0:
             raise InvalidParameterError("{0} must be positive".format(key))
-    merged = {**session.filters[n], **updates}
+    merged = {**session.adapter.filters[n], **updates}
     if merged["enabled"]:
         # completeness is only enforced when the merged config is enabled, so
         # partial configuration while disabled stays a valid workflow
@@ -315,7 +315,7 @@ async def patch_filter(session_id: str, n: int, body: FilterPatch, request: Requ
                 raise InvalidParameterError("bandpass requires cutoff_low and cutoff_high")
             if not merged["cutoff_low"] < merged["cutoff_high"]:
                 raise InvalidParameterError("cutoff_low must be below cutoff_high")
-    session.filters = {**session.filters, n: merged}
+    session.adapter.filters = {**session.adapter.filters, n: merged}
     return _filter_state(session)
 
 
@@ -380,55 +380,55 @@ async def delete_reference(session_id: str, name: str, request: Request):
 
     if not await run_in_threadpool(remove):
         raise HTTPException(status_code=404, detail="unknown reference {0}".format(name))
-    active = session.active_reference
+    active = session.adapter.active_reference
     if active is not None and active["name"] == name:
-        session.set_active_reference(None, None, None)
+        session.adapter.set_active_reference(None, None, None, session.publish)
 
 
 @router.get("/sessions/{session_id}/scope/reference")
 async def get_reference(session_id: str, request: Request):
     session = require_session(request, session_id)
-    return session.reference_overlay()
+    return session.adapter.reference_overlay()
 
 
 @router.put("/sessions/{session_id}/scope/reference")
 async def put_reference(session_id: str, body: ReferencePut, request: Request):
     session = require_owner(request, session_id)
     if body.name is None:
-        session.set_active_reference(None, None, None)
-        return session.reference_overlay()
+        session.adapter.set_active_reference(None, None, None, session.publish)
+        return session.adapter.reference_overlay()
     store = _reference_store(request)
     loaded = await run_in_threadpool(store.load_reference, body.name)
     if loaded is None:
         raise HTTPException(status_code=404, detail="unknown reference {0}".format(body.name))
     metadata = loaded.get("metadata", {})
-    session.set_active_reference(metadata.get("name", body.name), _ref_channel(metadata.get("channel")), loaded)
-    return session.reference_overlay()
+    session.adapter.set_active_reference(metadata.get("name", body.name), _ref_channel(metadata.get("channel")), loaded, session.publish)
+    return session.adapter.reference_overlay()
 
 
 @router.post("/sessions/{session_id}/scope/log/start")
 async def log_start(session_id: str, request: Request):
     session = require_owner(request, session_id)
-    return session.start_recording()
+    return session.adapter.start_recording(session.publish)
 
 
 @router.post("/sessions/{session_id}/scope/log/stop")
 async def log_stop(session_id: str, request: Request):
     session = require_owner(request, session_id)
-    return session.stop_recording()
+    return session.adapter.stop_recording(session.publish)
 
 
 @router.get("/sessions/{session_id}/scope/log")
 async def log_status(session_id: str, request: Request):
     session = require_session(request, session_id)
-    return session.recorder.status()
+    return session.adapter.recorder.status()
 
 
 @router.get("/sessions/{session_id}/scope/log/data")
 async def log_data(session_id: str, request: Request, since: float = 0.0):
     session = require_session(request, session_id)
-    status = session.recorder.status()
-    return {"columns": status["columns"], "rows": session.recorder.rows_since(since)}
+    status = session.adapter.recorder.status()
+    return {"columns": status["columns"], "rows": session.adapter.recorder.rows_since(since)}
 
 
 def _build_log_csv(status, rows) -> str:
@@ -445,10 +445,10 @@ def _build_log_csv(status, rows) -> str:
 @router.get("/sessions/{session_id}/scope/log.csv")
 async def log_csv(session_id: str, request: Request):
     session = require_session(request, session_id)
-    status = session.recorder.status()
+    status = session.adapter.recorder.status()
     if status["started_at"] is None:
         raise HTTPException(status_code=404, detail="no recording exists")
-    csv_text = _build_log_csv(status, session.recorder.rows_since())
+    csv_text = _build_log_csv(status, session.adapter.recorder.rows_since())
     filename = "log_{0}.csv".format(session.id)
     return PlainTextResponse(csv_text, media_type="text/csv", headers={"Content-Disposition": 'attachment; filename="{0}"'.format(filename)})
 

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -9,7 +9,7 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import PlainTextResponse, Response
 
 from scpi_control.exceptions import InvalidParameterError
-from scpi_control.server.api.sessions import require_session
+from scpi_control.server.api.sessions import require_kind, require_session
 from scpi_control.server.ownership import require_owner
 from scpi_control.server.schemas import (
     ALLOWED_COUPLING,
@@ -47,12 +47,14 @@ async def mutate(session: InstrumentSession, fn: Callable) -> dict:
 @router.get("/sessions/{session_id}/scope/state")
 async def get_state(session_id: str, request: Request):
     session = require_session(request, session_id)
+    require_kind(session, "scope")
     return await run_job(session, read_state)
 
 
 @router.patch("/sessions/{session_id}/scope/channels/{channel}")
 async def patch_channel(session_id: str, channel: int, body: ChannelPatch, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
     if body.coupling is not None and body.coupling.upper() not in ALLOWED_COUPLING:
         raise InvalidParameterError("invalid coupling: {0}".format(body.coupling))
 
@@ -77,6 +79,7 @@ async def patch_channel(session_id: str, channel: int, body: ChannelPatch, reque
 @router.patch("/sessions/{session_id}/scope/timebase")
 async def patch_timebase(session_id: str, body: TimebasePatch, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
 
     def apply(scope):
         scope.timebase = body.timebase
@@ -87,6 +90,7 @@ async def patch_timebase(session_id: str, body: TimebasePatch, request: Request)
 @router.patch("/sessions/{session_id}/scope/trigger")
 async def patch_trigger(session_id: str, body: TriggerPatch, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
 
     def apply(scope):
         trig = scope.trigger
@@ -107,6 +111,7 @@ async def patch_trigger(session_id: str, body: TriggerPatch, request: Request):
 @router.post("/sessions/{session_id}/scope/command")
 async def send_command(session_id: str, body: CommandIn, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
     command = body.command.strip()
     if not command:
         raise InvalidParameterError("empty command")
@@ -124,6 +129,7 @@ async def send_command(session_id: str, body: CommandIn, request: Request):
 @router.put("/sessions/{session_id}/scope/measurements")
 async def put_measurements(session_id: str, body: List[MeasurementItem], request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
     if session.adapter.recorder.state == "recording":
         raise SessionError("measurement selection is locked while recording")
     for item in body:
@@ -138,6 +144,7 @@ async def put_measurements(session_id: str, body: List[MeasurementItem], request
 @router.get("/sessions/{session_id}/scope/measurements")
 async def get_measurements(session_id: str, request: Request):
     session = require_session(request, session_id)
+    require_kind(session, "scope")
     return {"measurements": [{"channel": c, "mtype": m} for c, m in session.adapter.measurements]}
 
 
@@ -155,6 +162,7 @@ def _build_csv(captures) -> str:
 @router.get("/sessions/{session_id}/scope/capture.csv")
 async def capture_csv(session_id: str, request: Request, channels: str = "1"):
     session = require_session(request, session_id)
+    require_kind(session, "scope")
     try:
         channel_list = sorted({int(c) for c in channels.split(",") if c.strip()})
     except ValueError:
@@ -174,6 +182,7 @@ async def capture_csv(session_id: str, request: Request, channels: str = "1"):
 @router.get("/sessions/{session_id}/scope/screenshot.png")
 async def screenshot(session_id: str, request: Request):
     session = require_session(request, session_id)
+    require_kind(session, "scope")
 
     def grab(scope):
         import io
@@ -215,6 +224,7 @@ def _waveform_json(channel, data, max_points):
 @router.get("/sessions/{session_id}/scope/waveform")
 async def waveform_json(session_id: str, request: Request, channels: str = "1", max_points: int = 0):
     session = require_session(request, session_id)
+    require_kind(session, "scope")
     try:
         channel_list = sorted({int(c) for c in channels.split(",") if c.strip()})
     except ValueError:
@@ -237,12 +247,14 @@ def _math_state(scope):
 @router.get("/sessions/{session_id}/scope/math")
 async def get_math(session_id: str, request: Request):
     session = require_session(request, session_id)
+    require_kind(session, "scope")
     return await run_job(session, _math_state)
 
 
 @router.patch("/sessions/{session_id}/scope/math/{n}")
 async def patch_math(session_id: str, n: int, body: MathPatch, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
     if n not in (1, 2):
         raise InvalidParameterError("math channel must be 1 or 2")
     if body.expression is not None and not body.expression.strip():
@@ -262,12 +274,14 @@ async def patch_math(session_id: str, n: int, body: MathPatch, request: Request)
 @router.get("/sessions/{session_id}/scope/spectrum")
 async def get_spectrum(session_id: str, request: Request):
     session = require_session(request, session_id)
+    require_kind(session, "scope")
     return dict(session.adapter.spectrum_config)
 
 
 @router.patch("/sessions/{session_id}/scope/spectrum")
 async def patch_spectrum(session_id: str, body: SpectrumPatch, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
     updates = {k: v for k, v in body.model_dump().items() if v is not None}
     if "window" in updates and updates["window"] not in ALLOWED_WINDOWS:
         raise InvalidParameterError("unknown window: {0}".format(updates["window"]))
@@ -284,12 +298,14 @@ def _filter_state(session):
 @router.get("/sessions/{session_id}/scope/filters")
 async def get_filters(session_id: str, request: Request):
     session = require_session(request, session_id)
+    require_kind(session, "scope")
     return _filter_state(session)
 
 
 @router.patch("/sessions/{session_id}/scope/filters/{n}")
 async def patch_filter(session_id: str, n: int, body: FilterPatch, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
     if n not in (1, 2):
         raise InvalidParameterError("filter must be 1 or 2")
     updates = {k: v for k, v in body.model_dump().items() if v is not None}
@@ -341,7 +357,8 @@ def _reference_list(store):
 
 @router.get("/sessions/{session_id}/scope/references")
 async def list_references(session_id: str, request: Request):
-    require_session(request, session_id)
+    session = require_session(request, session_id)
+    require_kind(session, "scope")
     store = _reference_store(request)
     return await run_in_threadpool(_reference_list, store)
 
@@ -349,6 +366,7 @@ async def list_references(session_id: str, request: Request):
 @router.post("/sessions/{session_id}/scope/references", status_code=201)
 async def save_reference(session_id: str, body: ReferenceCreate, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
     name = body.name.strip()
     if not name:
         raise InvalidParameterError("reference name must not be empty")
@@ -370,6 +388,7 @@ async def save_reference(session_id: str, body: ReferenceCreate, request: Reques
 @router.delete("/sessions/{session_id}/scope/references/{name}", status_code=204)
 async def delete_reference(session_id: str, name: str, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
     store = _reference_store(request)
 
     def remove():
@@ -388,12 +407,14 @@ async def delete_reference(session_id: str, name: str, request: Request):
 @router.get("/sessions/{session_id}/scope/reference")
 async def get_reference(session_id: str, request: Request):
     session = require_session(request, session_id)
+    require_kind(session, "scope")
     return session.adapter.reference_overlay()
 
 
 @router.put("/sessions/{session_id}/scope/reference")
 async def put_reference(session_id: str, body: ReferencePut, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
     if body.name is None:
         session.adapter.set_active_reference(None, None, None, session.publish)
         return session.adapter.reference_overlay()
@@ -409,24 +430,28 @@ async def put_reference(session_id: str, body: ReferencePut, request: Request):
 @router.post("/sessions/{session_id}/scope/log/start")
 async def log_start(session_id: str, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
     return session.adapter.start_recording(session.publish)
 
 
 @router.post("/sessions/{session_id}/scope/log/stop")
 async def log_stop(session_id: str, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
     return session.adapter.stop_recording(session.publish)
 
 
 @router.get("/sessions/{session_id}/scope/log")
 async def log_status(session_id: str, request: Request):
     session = require_session(request, session_id)
+    require_kind(session, "scope")
     return session.adapter.recorder.status()
 
 
 @router.get("/sessions/{session_id}/scope/log/data")
 async def log_data(session_id: str, request: Request, since: float = 0.0):
     session = require_session(request, session_id)
+    require_kind(session, "scope")
     status = session.adapter.recorder.status()
     return {"columns": status["columns"], "rows": session.adapter.recorder.rows_since(since)}
 
@@ -445,6 +470,7 @@ def _build_log_csv(status, rows) -> str:
 @router.get("/sessions/{session_id}/scope/log.csv")
 async def log_csv(session_id: str, request: Request):
     session = require_session(request, session_id)
+    require_kind(session, "scope")
     status = session.adapter.recorder.status()
     if status["started_at"] is None:
         raise HTTPException(status_code=404, detail="no recording exists")
@@ -466,6 +492,7 @@ _RUN_OPS = {
 @router.post("/sessions/{session_id}/scope/{op}")
 async def run_op(session_id: str, op: str, request: Request):
     session = require_owner(request, session_id)
+    require_kind(session, "scope")
     fn = _RUN_OPS.get(op)
     if fn is None:
         raise InvalidParameterError("unknown operation: {0}".format(op))

--- a/scpi_control/server/api/sessions.py
+++ b/scpi_control/server/api/sessions.py
@@ -4,6 +4,7 @@ import time
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.concurrency import run_in_threadpool
 
+from scpi_control.exceptions import InvalidParameterError
 from scpi_control.models import MODEL_REGISTRY
 from scpi_control.server.schemas import ModelOut, OwnerPut, SessionCreate, session_out
 
@@ -26,6 +27,17 @@ def require_session(request: Request, session_id: str):
     # must never extend someone else's claim-protection window.
     if session.owner and identity == session.owner:
         session.touch()
+    return session
+
+
+def require_kind(session, kind: str):
+    """A route for one instrument kind must refuse a session of another.
+
+    Without this the driver call fails deep inside the worker thread with an
+    AttributeError naming a method the caller never mentioned.
+    """
+    if session.kind != kind:
+        raise InvalidParameterError("session {0} is a {1}, not a {2}".format(session.id, session.kind, kind))
     return session
 
 

--- a/scpi_control/server/api/sessions.py
+++ b/scpi_control/server/api/sessions.py
@@ -49,7 +49,9 @@ def get_session(session_id: str, request: Request):
 async def create_session(body: SessionCreate, request: Request):
     label = body.label or (body.model or ("Mock scope" if body.mock else body.address or ""))
     # InstrumentSession.open blocks on connect; keep the event loop free.
-    session = await run_in_threadpool(get_manager(request).create, label, address=body.address, port=body.port, mock=body.mock, model=body.model, owner=getattr(request.state, "identity", ""))
+    session = await run_in_threadpool(
+        get_manager(request).create, label, kind=body.kind, address=body.address, port=body.port, mock=body.mock, model=body.model, owner=getattr(request.state, "identity", "")
+    )
     return session_out(session)
 
 

--- a/scpi_control/server/api/stream.py
+++ b/scpi_control/server/api/stream.py
@@ -4,15 +4,17 @@ import contextlib
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
-from scpi_control.server.adapters import read_psu_outputs
 from scpi_control.server.auth import WS_ACCEPT_SUBPROTOCOL
-from scpi_control.server.sessions import read_state
 
 router = APIRouter(tags=["stream"])
 
 # Cap the per-connection outbox so a slow/paused client cannot make the event
 # loop buffer waveform frames without bound. 256 frames ~= a minute at 4 Hz.
 OUTBOX_MAXSIZE = 256
+
+# Distinct from 4404 (unknown session) and 4410 (session ended): the socket was
+# accepted but this session's adapter could not produce its opening frame.
+CLOSE_INITIAL_FRAME_FAILED = 4500
 
 
 def _enqueue(outbox: "asyncio.Queue", message) -> None:
@@ -92,24 +94,28 @@ async def stream(websocket: WebSocket, session_id: str):
     # identity isn't the owner); unmark unconditionally in finally so an
     # abnormal disconnect releases it just like a clean close does.
     identity = getattr(websocket.state, "identity", "")
+    unmark_owner_watching = session.mark_owner_watching(identity)
     receiver = None
     sender = None
     try:
-        unmark_owner_watching = session.mark_owner_watching(identity)
         # The initial frame must match whatever shape this session's adapter
-        # publishes on every subsequent tick (read_state for scope,
-        # read_psu_outputs for psu) -- read_state() assumes an Oscilloscope
-        # and raises AttributeError against a PowerSupply, which used to be
-        # swallowed by the bare except below, leaving the socket open but
-        # silent forever (no initial frame, and polling never starts because
-        # _poll_tick() requires a subscriber that this handler's own
-        # exception prevented from ever seeing a first message).
-        if session.kind == "psu":
-            outputs = await asyncio.wrap_future(session.submit(read_psu_outputs))
-            await websocket.send_json({"type": "state", "kind": "psu", "outputs": outputs})
-        else:
-            initial = await asyncio.wrap_future(session.submit(read_state))
-            await websocket.send_json({"type": "state", "state": initial})
+        # publishes on every subsequent tick, so the adapter -- not a `kind`
+        # branch here -- decides it. A kind that forgets the hook raises
+        # NotImplementedError and gets the loud path below.
+        try:
+            initial = await asyncio.wrap_future(session.submit(session.adapter.initial_frame))
+        except Exception as exc:
+            # NOT a bare `except: pass`. Swallowing this used to leave the
+            # socket open but silent forever: no initial frame, and polling
+            # never starts either because _poll_tick() requires a subscriber
+            # that has seen a first message. A client that gets nothing cannot
+            # tell a broken adapter from an idle instrument, so say so and
+            # close with a code that names the failure.
+            with contextlib.suppress(Exception):
+                await websocket.send_json({"type": "error", "detail": "initial frame failed: {0}".format(exc)})
+                await websocket.close(code=CLOSE_INITIAL_FRAME_FAILED)
+            return
+        await websocket.send_json(initial)
         # Run the receiver (disconnect detection) and sender concurrently; whichever
         # finishes first tears the connection down.
         receiver = asyncio.ensure_future(_receive_until_disconnect(websocket))

--- a/scpi_control/server/api/stream.py
+++ b/scpi_control/server/api/stream.py
@@ -4,6 +4,7 @@ import contextlib
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from scpi_control.server.adapters import read_psu_outputs
 from scpi_control.server.auth import WS_ACCEPT_SUBPROTOCOL
 from scpi_control.server.sessions import read_state
 
@@ -95,8 +96,20 @@ async def stream(websocket: WebSocket, session_id: str):
     sender = None
     try:
         unmark_owner_watching = session.mark_owner_watching(identity)
-        initial = await asyncio.wrap_future(session.submit(read_state))
-        await websocket.send_json({"type": "state", "state": initial})
+        # The initial frame must match whatever shape this session's adapter
+        # publishes on every subsequent tick (read_state for scope,
+        # read_psu_outputs for psu) -- read_state() assumes an Oscilloscope
+        # and raises AttributeError against a PowerSupply, which used to be
+        # swallowed by the bare except below, leaving the socket open but
+        # silent forever (no initial frame, and polling never starts because
+        # _poll_tick() requires a subscriber that this handler's own
+        # exception prevented from ever seeing a first message).
+        if session.kind == "psu":
+            outputs = await asyncio.wrap_future(session.submit(read_psu_outputs))
+            await websocket.send_json({"type": "state", "kind": "psu", "outputs": outputs})
+        else:
+            initial = await asyncio.wrap_future(session.submit(read_state))
+            await websocket.send_json({"type": "state", "state": initial})
         # Run the receiver (disconnect detection) and sender concurrently; whichever
         # finishes first tears the connection down.
         receiver = asyncio.ensure_future(_receive_until_disconnect(websocket))

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -65,12 +65,14 @@ def create_app(
     app.state.abandon_after = abandon_after
 
     from scpi_control.server.api import discovery as discovery_api
+    from scpi_control.server.api import psu as psu_api
     from scpi_control.server.api import scope as scope_api
     from scpi_control.server.api import sessions as sessions_api
     from scpi_control.server.api import stream as stream_api
 
     app.include_router(sessions_api.router, prefix="/api")
     app.include_router(scope_api.router, prefix="/api")
+    app.include_router(psu_api.router, prefix="/api")
     app.include_router(stream_api.router, prefix="/api")
     app.include_router(discovery_api.router, prefix="/api")
 

--- a/scpi_control/server/discovery.py
+++ b/scpi_control/server/discovery.py
@@ -21,7 +21,7 @@ MAX_HOSTS = 1024  # /22
 _KIND_PREFIXES = (("SPD", "psu"), ("SDP", "psu"), ("SDG", "awg"), ("SDM", "daq"))
 
 
-def _classify(model: str) -> str:
+def classify(model: str) -> str:
     upper = model.upper()
     if model in MODEL_REGISTRY or upper.startswith("SDS"):
         return "scope"
@@ -29,6 +29,9 @@ def _classify(model: str) -> str:
         if upper.startswith(prefix):
             return kind
     return "unknown"
+
+
+_classify = classify  # backward-compat alias; nothing internal should break
 
 
 def _local_ip() -> Optional[str]:

--- a/scpi_control/server/ownership.py
+++ b/scpi_control/server/ownership.py
@@ -39,6 +39,8 @@ WRITE_ROUTES = frozenset(
         ("PATCH", "/sessions/{session_id}/scope/math/{n}"),
         ("PATCH", "/sessions/{session_id}/scope/spectrum"),
         ("PATCH", "/sessions/{session_id}/scope/filters/{n}"),
+        ("PATCH", "/sessions/{session_id}/psu/outputs/{n}"),
+        ("PATCH", "/sessions/{session_id}/psu/outputs/{n}/enable"),
         ("POST", "/sessions/{session_id}/scope/references"),
         ("DELETE", "/sessions/{session_id}/scope/references/{name}"),
         ("PUT", "/sessions/{session_id}/scope/reference"),

--- a/scpi_control/server/schemas.py
+++ b/scpi_control/server/schemas.py
@@ -97,6 +97,15 @@ class OwnerPut(BaseModel):
     name: str
 
 
+class PsuOutputPatch(BaseModel):
+    voltage: Optional[float] = None
+    current: Optional[float] = None
+
+
+class PsuEnablePatch(BaseModel):
+    enabled: bool
+
+
 class ModelOut(BaseModel):
     model_name: str
     series: str

--- a/scpi_control/server/schemas.py
+++ b/scpi_control/server/schemas.py
@@ -12,6 +12,7 @@ ALLOWED_FILTER_KINDS = frozenset({"lowpass", "highpass", "bandpass"})
 
 class SessionCreate(BaseModel):
     label: str = ""
+    kind: str = "scope"
     address: Optional[str] = None
     port: int = 5025
     mock: bool = False
@@ -21,6 +22,7 @@ class SessionCreate(BaseModel):
 class SessionOut(BaseModel):
     id: str
     label: str
+    kind: str
     mock: bool
     address: Optional[str]
     state: str
@@ -107,6 +109,7 @@ def session_out(session) -> Dict[str, Any]:
     return SessionOut(
         id=session.id,
         label=session.label,
+        kind=session.kind,
         mock=session.mock,
         address=session.address,
         state=session.state,

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, List, Optional
 from scpi_control.exceptions import SiglentConnectionError, SiglentError
 from scpi_control.server.adapters import ADAPTERS, MAX_FRAME_POINTS, _waveform_frame, read_state  # noqa: F401  (re-exported: stream.py/api/scope.py and tests import these from here)
 from scpi_control.server.adapters import make_mock_scope_connection as _make_mock_connection  # noqa: F401  (re-exported for backward compatibility)
+from scpi_control.server.discovery import classify
 
 _STOP = object()
 
@@ -33,6 +34,7 @@ class InstrumentSession:
         self.mock = mock
         self.address = address
         self.state = "connecting"
+        self.kind = "scope"
         self.idn = ""
         self.model = ""
         self.dialect = ""
@@ -116,9 +118,12 @@ class InstrumentSession:
         allowed_ports: Optional[frozenset] = None,
         _connection=None,
     ) -> "InstrumentSession":
+        if kind not in ADAPTERS:
+            raise SessionError("unknown instrument kind {0!r}".format(kind))
         adapter = ADAPTERS[kind]()
         instrument = adapter.build(address=address, port=port, mock=mock, model=model, allowed_ports=allowed_ports, connection=_connection)
         session = cls(label, instrument, mock, address, poll_interval, adapter)
+        session.kind = kind
         session.owner = owner
         session._thread.start()
         try:
@@ -144,6 +149,10 @@ class InstrumentSession:
         self.model = info["model"]
         self.dialect = info["dialect"]
         self.num_channels = info["num_channels"]
+        if not self.mock and self.model:
+            detected = classify(self.model)
+            if detected != self.kind:
+                raise SessionError("connected instrument is a {0}, not a {1}".format(detected, self.kind))
         self.state = "connected"
 
     def submit(self, fn: Callable[[Any], Any]) -> "Future":
@@ -276,7 +285,9 @@ class SessionManager:
         # see create() for why that matters.
         self._pending = 0
 
-    def create(self, label: str, *, address: Optional[str] = None, port: int = 5025, mock: bool = False, model: Optional[str] = None, owner: str = "", _connection=None) -> InstrumentSession:
+    def create(
+        self, label: str, *, kind: str = "scope", address: Optional[str] = None, port: int = 5025, mock: bool = False, model: Optional[str] = None, owner: str = "", _connection=None
+    ) -> InstrumentSession:
         # Checked BEFORE InstrumentSession.open: opening spawns a worker thread
         # and blocks on a connect with a 30s timeout, so checking the cap after
         # the fact would let concurrent requests past the cap occupy every
@@ -310,7 +321,7 @@ class SessionManager:
             self._pending += 1
         registered = False
         try:
-            session = InstrumentSession.open(label, address=address, port=port, mock=mock, model=model, owner=owner, allowed_ports=self.allowed_ports, _connection=_connection)
+            session = InstrumentSession.open(label, kind=kind, address=address, port=port, mock=mock, model=model, owner=owner, allowed_ports=self.allowed_ports, _connection=_connection)
             with self._lock:
                 self._pending -= 1
                 self._sessions[session.id] = session

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -13,12 +13,11 @@ import uuid
 from collections import Counter
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeoutError
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional
 
-from scpi_control.exceptions import InvalidParameterError, SiglentConnectionError, SiglentError
-from scpi_control.server.adapters import ADAPTERS, MAX_FRAME_POINTS, _decimate_frame, _waveform_frame, read_state  # noqa: F401  (re-exported: stream.py/api/scope.py and tests import these from here)
+from scpi_control.exceptions import SiglentConnectionError, SiglentError
+from scpi_control.server.adapters import ADAPTERS, MAX_FRAME_POINTS, _waveform_frame, read_state  # noqa: F401  (re-exported: stream.py/api/scope.py and tests import these from here)
 from scpi_control.server.adapters import make_mock_scope_connection as _make_mock_connection  # noqa: F401  (re-exported for backward compatibility)
-from scpi_control.server.recorder import TrendRecorder
 
 _STOP = object()
 
@@ -40,10 +39,6 @@ class InstrumentSession:
         self.num_channels = 0
         self.error_detail: Optional[str] = None
         self.adapter = adapter
-        # Transitional: the adapter reads scope-owned config (filters,
-        # spectrum_config, measurements, recorder, active_reference) off this
-        # back-reference until Task 3 moves that state onto the adapter itself.
-        self.adapter.session = self
         self._instrument = instrument
         self._poll_interval = poll_interval
         self._queue: "queue.Queue" = queue.Queue()
@@ -51,15 +46,7 @@ class InstrumentSession:
         self._thread = threading.Thread(target=self._worker, name="scpi-session-{0}".format(self.id), daemon=True)
         self._subscribers: List[Callable[[Dict[str, Any]], None]] = []
         self._subscribers_lock = threading.Lock()
-        self.measurements: List[Tuple[int, str]] = []
         self._poll_count = 0
-        # Server-owned analysis config. Request coroutines swap these whole
-        # dicts atomically (never mutate in place); the worker thread only reads.
-        self.spectrum_config: Dict[str, Any] = {"enabled": False, "channel": 1, "window": "hanning", "db": True}
-        self.filters: Dict[int, Dict[str, Any]] = {n: {"source": 1, "kind": "lowpass", "cutoff_low": None, "cutoff_high": None, "order": 5, "enabled": False} for n in (1, 2)}
-        self.active_reference: Optional[Dict[str, Any]] = None  # {"name", "channel", "data": {"time","voltage",...}}
-        self._shown: set = set()  # trace keys (M1/M2/F1/F2/SPEC) live on subscribers' canvases; worker-thread-only
-        self.recorder = TrendRecorder()  # internally locked: worker appends, request threads control/read
         self.owner = ""
         self.owner_last_active = time.monotonic()
         # Live stream watchers, keyed by identity (not by "is this the
@@ -202,39 +189,6 @@ class InstrumentSession:
                 callback(message)
             except Exception:  # a broken subscriber must not kill the worker thread
                 continue
-
-    def set_measurements(self, items: List[Tuple[int, str]]) -> None:
-        self.measurements = list(items)
-        self.publish({"type": "measurements_config", "items": [{"channel": c, "mtype": m} for c, m in self.measurements]})
-
-    def start_recording(self) -> Dict[str, Any]:
-        if self.recorder.state == "recording":
-            raise SessionError("already recording")
-        if not self.measurements:
-            raise InvalidParameterError("no measurements selected")
-        self.recorder.start(list(self.measurements), time.time())
-        self._publish_log_status()
-        return self.recorder.status()
-
-    def stop_recording(self) -> Dict[str, Any]:
-        self.recorder.stop()
-        self._publish_log_status()
-        return self.recorder.status()
-
-    def _publish_log_status(self) -> None:
-        status = self.recorder.status()
-        self.publish({"type": "log_status", "state": status["state"], "started_at": status["started_at"], "row_count": status["row_count"], "columns": status["columns"]})
-
-    def reference_overlay(self) -> Dict[str, Any]:
-        active = self.active_reference
-        if active is None:
-            return {"name": None, "channel": None, "t0": 0.0, "dt": 1.0, "points": []}
-        frame = _decimate_frame(active["channel"], active["data"]["time"], active["data"]["voltage"])
-        return {"name": active["name"], "channel": active["channel"], "t0": frame["t0"], "dt": frame["dt"], "points": frame["points"]}
-
-    def set_active_reference(self, name: Optional[str], channel: Optional[int], data: Optional[Dict[str, Any]]) -> None:
-        self.active_reference = None if name is None else {"name": name, "channel": channel, "data": data}
-        self.publish({"type": "reference", **self.reference_overlay()})
 
     def _enter_error_state(self, detail: str) -> None:
         """Flip to the terminal error state and tell the streams once."""

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -16,7 +16,10 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Callable, Dict, List, Optional
 
 from scpi_control.exceptions import SiglentConnectionError, SiglentError
-from scpi_control.server.adapters import ADAPTERS, MAX_FRAME_POINTS, _waveform_frame, read_state  # noqa: F401  (re-exported: stream.py/api/scope.py and tests import these from here)
+
+# Re-exported: all five were public names in this module in 5.7.1, and
+# api/scope.py plus several tests still import them from here.
+from scpi_control.server.adapters import ADAPTERS, DEFAULT_MOCK_IDN, MAX_FRAME_POINTS, MEASUREMENT_EVERY_N_POLLS, _waveform_frame, read_state  # noqa: F401
 from scpi_control.server.adapters import make_mock_scope_connection as _make_mock_connection  # noqa: F401  (re-exported for backward compatibility)
 from scpi_control.server.discovery import classify
 
@@ -28,7 +31,12 @@ class SessionError(RuntimeError):
 
 
 class InstrumentSession:
-    def __init__(self, label: str, instrument: Any, mock: bool, address: Optional[str], poll_interval: float, adapter: Any):
+    def __init__(self, label: str, instrument: Any, mock: bool, address: Optional[str], poll_interval: float, adapter: Any = None):
+        # ``adapter`` defaults to a scope adapter so the pre-5.8 five-argument
+        # constructor keeps working unchanged for anyone who built a session
+        # by hand rather than through open()/SessionManager.create().
+        if adapter is None:
+            adapter = ADAPTERS["scope"]()
         self.id = uuid.uuid4().hex[:8]
         self.label = label
         self.mock = mock
@@ -140,8 +148,60 @@ class InstrumentSession:
 
     @property
     def _scope(self) -> Any:
-        """Alias kept for the mechanical Task 3 rename; use ``_instrument``."""
+        """Backward-compatible alias for ``_instrument``; prefer ``_instrument``."""
         return self._instrument
+
+    # --- backward-compatible scope surface --------------------------------
+    # These moved onto ScopeAdapter in 5.8.0. They stay here as *thin
+    # delegations* -- never a second copy of the state -- so code written
+    # against 5.7.1 (the shipped trend-logging example, embedders) keeps
+    # working. Nothing scope-shaped is stored on the session, so a PSU
+    # session still carries no recorder, filter bank or spectrum config;
+    # touching one of these on a non-scope session raises AttributeError
+    # from its adapter, which is the honest answer.
+
+    @property
+    def recorder(self) -> Any:
+        return self.adapter.recorder
+
+    @property
+    def measurements(self) -> Any:
+        return self.adapter.measurements
+
+    @property
+    def spectrum_config(self) -> Any:
+        return self.adapter.spectrum_config
+
+    @spectrum_config.setter
+    def spectrum_config(self, value: Any) -> None:
+        self.adapter.spectrum_config = value
+
+    @property
+    def filters(self) -> Any:
+        return self.adapter.filters
+
+    @filters.setter
+    def filters(self, value: Any) -> None:
+        self.adapter.filters = value
+
+    @property
+    def active_reference(self) -> Any:
+        return self.adapter.active_reference
+
+    def set_measurements(self, items: Any) -> None:
+        return self.adapter.set_measurements(items, self.publish)
+
+    def start_recording(self) -> Dict[str, Any]:
+        return self.adapter.start_recording(self.publish)
+
+    def stop_recording(self) -> Dict[str, Any]:
+        return self.adapter.stop_recording(self.publish)
+
+    def reference_overlay(self) -> Dict[str, Any]:
+        return self.adapter.reference_overlay()
+
+    def set_active_reference(self, name: Optional[str], channel: Optional[int], data: Optional[Dict[str, Any]]) -> None:
+        return self.adapter.set_active_reference(name, channel, data, self.publish)
 
     def _connect_job(self, instrument: Any) -> None:
         info = self.adapter.connect(instrument)
@@ -150,8 +210,15 @@ class InstrumentSession:
         self.dialect = info["dialect"]
         self.num_channels = info["num_channels"]
         if not self.mock and self.model:
+            # The guard exists to stop driving a PSU with a scope driver -- NOT
+            # to whitelist models. classify() returns "unknown" for anything
+            # outside MODEL_REGISTRY's 22 entries, and plenty of scopes that
+            # connected fine before the per-kind split (a Rigol DS1054Z, a Tek
+            # TBS1052B, any unlisted Siglent) land there via the generic/legacy
+            # dialect fallback. Only a *positive* identification as some other
+            # kind is a mismatch; an unrecognised model is not.
             detected = classify(self.model)
-            if detected != self.kind:
+            if detected not in ("unknown", self.kind):
                 raise SessionError("connected instrument is a {0}, not a {1}".format(detected, self.kind))
         self.state = "connected"
 
@@ -239,7 +306,11 @@ class InstrumentSession:
                 continue
             future.set_exception(SessionError("session {0} is closed".format(self.id)))
         try:
-            self._scope.disconnect()
+            # Teardown goes through the adapter, not straight to disconnect():
+            # both current kinds only disconnect, but a kind whose teardown
+            # needs more (an AWG de-energising its outputs first) must not be
+            # silently skipped because the session bypassed the hook.
+            self.adapter.close(self._instrument)
         except SiglentError:
             pass
 
@@ -261,6 +332,13 @@ class InstrumentSession:
             self.publish({"type": "error", "detail": str(exc)})
             if not self._instrument.is_connected:
                 self.state = "error"
+        except Exception as exc:  # noqa: BLE001 - see below
+            # Anything an adapter's poll() raises that is NOT a SiglentError
+            # used to escape _worker entirely: the thread died, no error frame
+            # was ever published, and the session sat "connected" forever with
+            # a stream that had gone quiet. A new kind's poll bug must surface
+            # as a visible error state, not a silent dead session.
+            self._enter_error_state("poll failed: {0}".format(exc))
 
 
 class SessionManager:

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -15,93 +15,20 @@ from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from scpi_control import Oscilloscope
-from scpi_control.connection.mock import MockConnection
 from scpi_control.exceptions import InvalidParameterError, SiglentConnectionError, SiglentError
-from scpi_control.server import compute
-from scpi_control.server.netpolicy import validate_target
+from scpi_control.server.adapters import ADAPTERS, MAX_FRAME_POINTS, _decimate_frame, _waveform_frame, read_state  # noqa: F401  (re-exported: stream.py/api/scope.py and tests import these from here)
+from scpi_control.server.adapters import make_mock_scope_connection as _make_mock_connection  # noqa: F401  (re-exported for backward compatibility)
 from scpi_control.server.recorder import TrendRecorder
 
-MAX_FRAME_POINTS = 2000
-MEASUREMENT_EVERY_N_POLLS = 4
-
-
-def _safe(fn, default=None):
-    try:
-        return fn()
-    except SiglentError:
-        return default
-
-
-def _quiet(fn, default=None):
-    """Like _safe, but for analysis compute: ANY exception degrades to default.
-
-    The poll tick is the session heartbeat; a numpy edge case in analysis
-    must never kill the worker thread.
-    """
-    try:
-        return fn()
-    except Exception:
-        return default
-
-
-def read_state(scope: Oscilloscope) -> Dict[str, Any]:
-    channels: Dict[int, Dict[str, Any]] = {}
-    for n in scope.supported_channels:
-        ch = scope.get_channel(n)
-        channels[n] = {
-            "enabled": ch.enabled,
-            "voltage_scale": ch.voltage_scale,
-            "voltage_offset": ch.voltage_offset,
-            "coupling": ch.coupling,
-            "probe_ratio": _safe(lambda: ch.probe_ratio),
-        }
-    trig = scope.trigger
-    return {
-        "run_state": scope.acquisition_status(),
-        "timebase": scope.timebase,
-        "channels": channels,
-        "trigger": {
-            "mode": trig.mode,
-            "source": _safe(lambda: trig.source),
-            "level": _safe(lambda: trig.level),
-            "slope": _safe(lambda: trig.slope),
-            "coupling": _safe(lambda: trig.coupling),
-        },
-    }
-
-
-def _decimate_frame(channel, time_axis, voltage) -> Dict[str, Any]:
-    step = max(1, -(-len(voltage) // MAX_FRAME_POINTS))  # ceiling division keeps len(points) <= cap
-    points = voltage[::step]
-    t0 = float(time_axis[0]) if len(time_axis) else 0.0
-    dt = float(time_axis[1] - time_axis[0]) * step if len(time_axis) > 1 else 1.0
-    return {"type": "waveform", "channel": channel, "t0": t0, "dt": dt, "points": [float(v) for v in points]}
-
-
-def _waveform_frame(scope: Oscilloscope, channel: int) -> Dict[str, Any]:
-    data = scope.get_waveform(channel, provenance=False)
-    return _decimate_frame(channel, data.time, data.voltage)
-
-
 _STOP = object()
-
-DEFAULT_MOCK_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
 
 
 class SessionError(RuntimeError):
     """Session is not in a state that can accept jobs (maps to HTTP 409)."""
 
 
-def _make_mock_connection(model: Optional[str]) -> MockConnection:
-    idn = DEFAULT_MOCK_IDN if model is None else "Siglent Technologies,{0},MOCK0001,1.0.0.0".format(model)
-    # No explicit waveform_payloads: channels serve state-coupled synthesized
-    # signals (connection/mock/synth.py). 1 MSa/s x 14 div x 1 ms/div = 14k points.
-    return MockConnection("mock", idn=idn, channel_states={1: True, 2: False, 3: False, 4: False}, trigger_status=["Stop"], sample_rate=1_000_000.0, timebase=1e-3)
-
-
 class InstrumentSession:
-    def __init__(self, label: str, scope: Oscilloscope, mock: bool, address: Optional[str], poll_interval: float):
+    def __init__(self, label: str, instrument: Any, mock: bool, address: Optional[str], poll_interval: float, adapter: Any):
         self.id = uuid.uuid4().hex[:8]
         self.label = label
         self.mock = mock
@@ -112,7 +39,12 @@ class InstrumentSession:
         self.dialect = ""
         self.num_channels = 0
         self.error_detail: Optional[str] = None
-        self._scope = scope
+        self.adapter = adapter
+        # Transitional: the adapter reads scope-owned config (filters,
+        # spectrum_config, measurements, recorder, active_reference) off this
+        # back-reference until Task 3 moves that state onto the adapter itself.
+        self.adapter.session = self
+        self._instrument = instrument
         self._poll_interval = poll_interval
         self._queue: "queue.Queue" = queue.Queue()
         self._closed = threading.Event()
@@ -187,6 +119,7 @@ class InstrumentSession:
         cls,
         label: str,
         *,
+        kind: str = "scope",
         address: Optional[str] = None,
         port: int = 5025,
         mock: bool = False,
@@ -196,15 +129,9 @@ class InstrumentSession:
         allowed_ports: Optional[frozenset] = None,
         _connection=None,
     ) -> "InstrumentSession":
-        if mock:
-            conn = _connection if _connection is not None else _make_mock_connection(model)
-            scope = Oscilloscope("mock", connection=conn)
-        else:
-            if not address:
-                raise ValueError("address is required for a non-mock session")
-            validate_target(address, port, allowed_ports=allowed_ports)
-            scope = Oscilloscope(address, port=port)
-        session = cls(label, scope, mock, address, poll_interval)
+        adapter = ADAPTERS[kind]()
+        instrument = adapter.build(address=address, port=port, mock=mock, model=model, allowed_ports=allowed_ports, connection=_connection)
+        session = cls(label, instrument, mock, address, poll_interval, adapter)
         session.owner = owner
         session._thread.start()
         try:
@@ -219,16 +146,20 @@ class InstrumentSession:
             raise
         return session
 
-    def _connect_job(self, scope: Oscilloscope) -> None:
-        scope.connect()
-        self.idn = scope.identify()
-        info = scope.device_info or {}
-        self.model = info.get("model", "")
-        self.dialect = scope.dialect or ""
-        self.num_channels = len(scope.supported_channels)
+    @property
+    def _scope(self) -> Any:
+        """Alias kept for the mechanical Task 3 rename; use ``_instrument``."""
+        return self._instrument
+
+    def _connect_job(self, instrument: Any) -> None:
+        info = self.adapter.connect(instrument)
+        self.idn = info["idn"]
+        self.model = info["model"]
+        self.dialect = info["dialect"]
+        self.num_channels = info["num_channels"]
         self.state = "connected"
 
-    def submit(self, fn: Callable[[Oscilloscope], Any]) -> "Future":
+    def submit(self, fn: Callable[[Any], Any]) -> "Future":
         if self._closed.is_set() or self.state == "error":
             # spec: mutations on a dead session are 409 until it is deleted
             raise SessionError("session {0} is {1}".format(self.id, self.state))
@@ -355,63 +286,17 @@ class InstrumentSession:
                 return
         if self.state != "connected":
             return
-        if not self._scope.is_connected:
+        if not self._instrument.is_connected:
             # The wire dropped while idle (no job in flight to surface it).
             self._enter_error_state("connection lost")
             return
         self._poll_count += 1
-        scope = self._scope
         try:
-            acquired = {}
-            for n in scope.supported_channels:
-                ch = scope.get_channel(n)
-                if ch is not None and _safe(lambda: ch.enabled, default=False):
-                    data = scope.get_waveform(n, provenance=False)
-                    acquired["C{0}".format(n)] = data
-                    self.publish(_decimate_frame(n, data.time, data.voltage))
-            shown_now = set()
-            for label, math in (("M1", scope.math1), ("M2", scope.math2)):
-                result = None
-                if math is not None and _safe(lambda: math.enabled, default=False):
-                    result = _safe(lambda: math.compute(acquired))
-                if result is not None:
-                    self.publish(_decimate_frame(label, result.time, result.voltage))
-                    shown_now.add(label)
-                elif label in self._shown:
-                    self.publish(_decimate_frame(label, [], []))  # one-shot clear on transition
-            for n in sorted(self.filters):
-                config = self.filters[n]
-                label = "F{0}".format(n)
-                result = _quiet(lambda: compute.filtered_waveform(config, acquired)) if config["enabled"] else None
-                if result is not None:
-                    self.publish(_decimate_frame(label, result.time, result.voltage))
-                    shown_now.add(label)
-                elif label in self._shown:
-                    self.publish(_decimate_frame(label, [], []))
-            spectrum_config = self.spectrum_config  # snapshot: request threads swap the dict atomically
-            frame = _quiet(lambda: compute.spectrum_frame(spectrum_config, acquired)) if spectrum_config["enabled"] else None
-            if frame is not None:
-                self.publish(frame)
-                shown_now.add("SPEC")
-            elif "SPEC" in self._shown:
-                self.publish(compute.empty_spectrum_frame(spectrum_config))
-            self._shown = shown_now
-            if self._poll_count % MEASUREMENT_EVERY_N_POLLS == 0:
-                if self.measurements:
-                    now = time.time()
-                    values = []
-                    for channel, mtype in self.measurements:
-                        value = _safe(lambda: scope.measurement.measure(mtype, channel))
-                        values.append({"channel": channel, "mtype": mtype, "value": value})
-                    self.publish({"type": "measurements", "values": values, "timestamp": now})
-                    self.recorder.append(now, [entry["value"] for entry in values])
-                reference = self.active_reference  # snapshot for thread safety
-                if reference is not None:
-                    self.publish(compute.reference_stats(reference, acquired))
+            self.adapter.poll(self._instrument, self.publish, self._poll_count)
         except SiglentError as exc:
             self.error_detail = str(exc)
             self.publish({"type": "error", "detail": str(exc)})
-            if not scope.is_connected:
+            if not self._instrument.is_connected:
                 self.state = "error"
 
 

--- a/tests/test_server_adapters.py
+++ b/tests/test_server_adapters.py
@@ -1,0 +1,73 @@
+"""The per-kind adapter seam.
+
+InstrumentSession used to be an Oscilloscope session: submit() was typed to it
+and the poll loop read waveforms directly. Adding a second instrument kind meant
+either branching a 500-line file or subclassing threading code that should have
+exactly one implementation. The adapter owns what varies -- build, connect, poll,
+and kind-specific state -- and the session owns what does not.
+
+These tests exercise adapters with NO server and no HTTP, which is the whole
+point of the seam: the expensive parts of a session are not needed to check that
+an instrument kind is wired up correctly.
+"""
+
+import pytest
+
+from scpi_control.connection.mock import MockConnection
+from scpi_control.server.adapters import ADAPTERS, ScopeAdapter
+
+
+def test_the_registry_exposes_the_scope_adapter():
+    assert ADAPTERS["scope"].kind == "scope"
+
+
+def test_the_scope_adapter_builds_and_connects_a_mock():
+    adapter = ScopeAdapter()
+    conn = MockConnection(
+        "mock",
+        idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0",
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=1_000_000.0,
+        timebase=1e-3,
+    )
+    instrument = adapter.build(address=None, port=5025, mock=True, model=None, allowed_ports=None, connection=conn)
+    try:
+        identity = adapter.connect(instrument)
+        assert identity["idn"].startswith("Siglent")
+        assert identity["num_channels"] == 4
+        assert identity["dialect"]
+    finally:
+        adapter.close(instrument)
+
+
+def test_the_scope_adapter_publishes_frames_when_polled():
+    """poll() is the contract the session's tick depends on: it must publish
+    through the callback rather than returning, because a scope emits several
+    messages per tick (a frame per channel, math, filters, spectrum)."""
+    adapter = ScopeAdapter()
+    conn = MockConnection(
+        "mock",
+        idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0",
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=1_000_000.0,
+        timebase=1e-3,
+    )
+    instrument = adapter.build(address=None, port=5025, mock=True, model=None, allowed_ports=None, connection=conn)
+    published = []
+    try:
+        adapter.connect(instrument)
+        adapter.poll(instrument, published.append, 1)
+    finally:
+        adapter.close(instrument)
+    assert published, "a connected scope with an enabled channel must publish at least one frame"
+    assert any(message.get("type") == "frame" or "points" in message for message in published)
+
+
+def test_a_non_mock_build_validates_the_target():
+    """The network policy check must not be lost in the move: an address outside
+    the allowed set is refused before any socket is opened."""
+    adapter = ScopeAdapter()
+    with pytest.raises(Exception):
+        adapter.build(address="10.0.0.1", port=9999, mock=False, model=None, allowed_ports=frozenset({5025}), connection=None)

--- a/tests/test_server_adapters.py
+++ b/tests/test_server_adapters.py
@@ -14,7 +14,8 @@ an instrument kind is wired up correctly.
 import pytest
 
 from scpi_control.connection.mock import MockConnection
-from scpi_control.server.adapters import ADAPTERS, ScopeAdapter
+from scpi_control.exceptions import InvalidParameterError
+from scpi_control.server.adapters import ADAPTERS, InstrumentAdapter, ScopeAdapter
 
 
 def test_the_registry_exposes_the_scope_adapter():
@@ -69,8 +70,12 @@ def test_a_non_mock_build_validates_the_target():
     """The network policy check must not be lost in the move: an address outside
     the allowed set is refused before any socket is opened."""
     adapter = ScopeAdapter()
-    with pytest.raises(Exception):
+    # Specifically the policy error, not bare Exception: a typo in the call
+    # (TypeError) or a missing import (NameError) would satisfy `raises(Exception)`
+    # while proving nothing about the policy check surviving the move.
+    with pytest.raises(InvalidParameterError) as excinfo:
         adapter.build(address="10.0.0.1", port=9999, mock=False, model=None, allowed_ports=frozenset({5025}), connection=None)
+    assert "refusing to connect" in str(excinfo.value)
 
 
 def test_the_psu_adapter_builds_and_connects_a_mock():
@@ -114,3 +119,128 @@ def test_the_psu_adapter_has_no_scope_state():
     adapter = PsuAdapter()
     for scope_only in ("measurements", "spectrum_config", "filters", "active_reference", "recorder"):
         assert not hasattr(adapter, scope_only), f"{scope_only} is scope-only and must not be on the PSU adapter"
+
+
+# --- the initial-frame hook: a new kind must not inherit another's frame ----
+
+
+def test_the_base_adapter_refuses_to_guess_an_initial_frame():
+    """The stream handler used to branch on ``session.kind`` to build the
+    opening frame, so a third kind would silently have been handed the scope's
+    read_state() and blown up deep inside the handler. Declaring the hook on
+    the base class means a kind that forgets it fails loudly and by name."""
+    with pytest.raises(NotImplementedError):
+        InstrumentAdapter().initial_frame(object())
+
+
+def test_the_scope_initial_frame_matches_what_a_client_expects():
+    adapter = ScopeAdapter()
+    conn = MockConnection(
+        "mock",
+        idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0",
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=1_000_000.0,
+        timebase=1e-3,
+    )
+    instrument = adapter.build(address=None, port=5025, mock=True, model=None, allowed_ports=None, connection=conn)
+    try:
+        adapter.connect(instrument)
+        frame = adapter.initial_frame(instrument)
+    finally:
+        adapter.close(instrument)
+    assert frame["type"] == "state"
+    assert "kind" not in frame, "a scope frame carries no kind key -- the client discriminates on shape"
+    assert set(frame["state"]) == {"run_state", "timebase", "channels", "trigger"}
+
+
+def test_the_psu_initial_frame_matches_the_shape_poll_publishes():
+    from scpi_control.server.adapters import PsuAdapter
+
+    adapter = PsuAdapter()
+    conn = MockConnection(psu_mode=True, psu_idn="Siglent Technologies,SPD3303X,SPD123456,1.0")
+    instrument = adapter.build(address=None, port=5025, mock=True, model=None, allowed_ports=None, connection=conn)
+    published = []
+    try:
+        adapter.connect(instrument)
+        frame = adapter.initial_frame(instrument)
+        adapter.poll(instrument, published.append, 1)
+    finally:
+        adapter.close(instrument)
+    # Same shape at connect and on every tick: a client that discriminates on
+    # the frame must not see one thing now and another 250 ms later.
+    assert frame["type"] == "state" and frame["kind"] == "psu"
+    assert set(frame) == set(published[0])
+    assert set(frame["outputs"][0]) == set(published[0]["outputs"][0])
+
+
+# --- a failed read must read as unknown, never as a confident value ---------
+
+
+def test_an_unreadable_enable_state_is_unknown_not_off(monkeypatch):
+    """The safety invariant's "vice versa" half: an energised output must never
+    render as off. An SPD3303X's CH3 has no documented status bit and falls
+    through to an OUTP3? the model does not implement, so a False default here
+    would silently show a live rail as switched off."""
+    from scpi_control.exceptions import SiglentError
+    from scpi_control.power_supply_output import PowerSupplyOutput
+    from scpi_control.server.adapters import PsuAdapter, read_psu_outputs
+
+    def _unreadable(self):
+        raise SiglentError("OUTP3? not supported")
+
+    monkeypatch.setattr(PowerSupplyOutput, "enabled", property(_unreadable))
+
+    adapter = PsuAdapter()
+    conn = MockConnection(psu_mode=True, psu_idn="Siglent Technologies,SPD3303X,SPD123456,1.0")
+    instrument = adapter.build(address=None, port=5025, mock=True, model=None, allowed_ports=None, connection=conn)
+    try:
+        adapter.connect(instrument)
+        outputs = read_psu_outputs(instrument)
+    finally:
+        adapter.close(instrument)
+    assert outputs, "fixture must produce at least one output"
+    assert all(o["enabled"] is None for o in outputs), "an unreadable enable state must be None (unknown), never False"
+
+
+# --- Minor 9: the measured triplet rides the every-Nth-tick budget ----------
+
+
+def test_the_psu_adapter_throttles_the_measured_triplet_without_changing_the_frame():
+    from scpi_control.server.adapters import MEASUREMENT_EVERY_N_POLLS, PsuAdapter
+
+    adapter = PsuAdapter()
+    conn = MockConnection(psu_mode=True, psu_idn="Siglent Technologies,SPD3303X,SPD123456,1.0")
+    instrument = adapter.build(address=None, port=5025, mock=True, model=None, allowed_ports=None, connection=conn)
+    measure_queries = []
+    real_query = conn.query
+
+    def counting_query(command):
+        if "MEAS" in command.upper():
+            measure_queries.append(command)
+        return real_query(command)
+
+    frames = []
+    per_tick = []
+    try:
+        adapter.connect(instrument)
+        conn.query = counting_query
+        # Ticks 1..4. Tick 1 measures because the cache is empty (a fresh
+        # stream must never be briefly blank); ticks 2 and 3 must not; tick 4
+        # measures again because 4 % MEASUREMENT_EVERY_N_POLLS == 0.
+        for tick in range(1, MEASUREMENT_EVERY_N_POLLS + 1):
+            del measure_queries[:]
+            adapter.poll(instrument, frames.append, tick)
+            per_tick.append(len(measure_queries))
+    finally:
+        conn.query = real_query
+        adapter.close(instrument)
+
+    assert per_tick[0] > 0, "the first tick must measure -- fixture broken if not"
+    assert per_tick[1] == 0 and per_tick[2] == 0, "throttled ticks must issue NO measurement queries, got {0}".format(per_tick)
+    assert per_tick[3] == per_tick[0], "every Nth tick must measure again, got {0}".format(per_tick)
+    # ...and the frame shape is identical on every tick, throttled or not, so
+    # the UI never blanks its readings three ticks out of four.
+    keys = [set(frame["outputs"][0]) for frame in frames]
+    assert all(k == keys[0] for k in keys)
+    assert all(frame["outputs"][0]["measured_voltage"] is not None for frame in frames), "throttled ticks must reuse the last known reading"

--- a/tests/test_server_adapters.py
+++ b/tests/test_server_adapters.py
@@ -71,3 +71,46 @@ def test_a_non_mock_build_validates_the_target():
     adapter = ScopeAdapter()
     with pytest.raises(Exception):
         adapter.build(address="10.0.0.1", port=9999, mock=False, model=None, allowed_ports=frozenset({5025}), connection=None)
+
+
+def test_the_psu_adapter_builds_and_connects_a_mock():
+    from scpi_control.server.adapters import PsuAdapter
+
+    adapter = PsuAdapter()
+    conn = MockConnection(psu_mode=True, psu_idn="Siglent Technologies,SPD3303X,SPD123456,1.0")
+    instrument = adapter.build(address=None, port=5025, mock=True, model=None, allowed_ports=None, connection=conn)
+    try:
+        identity = adapter.connect(instrument)
+        assert "SPD3303X" in identity["idn"]
+        assert identity["num_channels"] >= 1, "num_channels carries the PSU's OUTPUT count"
+    finally:
+        adapter.close(instrument)
+
+
+def test_the_psu_adapter_publishes_measured_values():
+    from scpi_control.server.adapters import PsuAdapter
+
+    adapter = PsuAdapter()
+    conn = MockConnection(psu_mode=True, psu_idn="Siglent Technologies,SPD3303X,SPD123456,1.0")
+    instrument = adapter.build(address=None, port=5025, mock=True, model=None, allowed_ports=None, connection=conn)
+    published = []
+    try:
+        adapter.connect(instrument)
+        adapter.poll(instrument, published.append, 1)
+    finally:
+        adapter.close(instrument)
+    assert len(published) == 1, "a PSU emits one state message per tick, unlike a scope's frame-per-channel"
+    state = published[0]
+    assert state["kind"] == "psu"
+    first = state["outputs"][0]
+    assert {"output", "voltage", "current", "enabled", "measured_voltage", "measured_current", "measured_power"} <= set(first)
+
+
+def test_the_psu_adapter_has_no_scope_state():
+    """The point of moving state onto adapters: a PSU session must not carry a
+    spectrum config or a filter bank it can never use."""
+    from scpi_control.server.adapters import PsuAdapter
+
+    adapter = PsuAdapter()
+    for scope_only in ("measurements", "spectrum_config", "filters", "active_reference", "recorder"):
+        assert not hasattr(adapter, scope_only), f"{scope_only} is scope-only and must not be on the PSU adapter"

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -111,6 +111,21 @@ class TestSessionEndpoints:
         assert client.delete("/api/sessions/" + body["id"]).status_code == 404
         assert client.get("/api/sessions").json() == []
 
+    def test_create_session_with_psu_kind_reports_its_kind(self, client):
+        # kind is threaded from SessionCreate.kind through SessionManager.create
+        # to the session and back out through SessionOut.kind -- prove the full
+        # round trip over HTTP, not just at the adapter/session layer.
+        response = client.post("/api/sessions", json={"mock": True, "kind": "psu"})
+        assert response.status_code == 201, response.text
+        body = response.json()
+        assert body["kind"] == "psu"
+
+    def test_create_session_with_bogus_kind_fails_cleanly(self, client):
+        # An unknown kind must fail as a client/domain error (SessionError -> 409),
+        # never as an unhandled KeyError surfacing as a 500.
+        response = client.post("/api/sessions", json={"mock": True, "kind": "bogus"})
+        assert 400 <= response.status_code < 500, response.text
+
 
 def test_models_endpoint_lists_registry(client):
     response = client.get("/api/models")

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -601,9 +601,9 @@ class TestTrendLog:
         client.put("/api/sessions/{0}/scope/measurements".format(sid), json=[{"channel": 1, "mtype": "PKPK"}, {"channel": 2, "mtype": "FREQ"}])
         client.post("/api/sessions/{0}/scope/log/start".format(sid))
         session = manager.get(sid)
-        started = session.recorder.started_at
-        session.recorder.append(started + 1.0, [1.5, None])
-        session.recorder.append(started + 2.0, [1.25, 50.0])
+        started = session.adapter.recorder.started_at
+        session.adapter.recorder.append(started + 1.0, [1.5, None])
+        session.adapter.recorder.append(started + 2.0, [1.25, 50.0])
 
         data = client.get("/api/sessions/{0}/scope/log/data".format(sid)).json()
         assert data["columns"] == [{"channel": 1, "mtype": "PKPK"}, {"channel": 2, "mtype": "FREQ"}]

--- a/tests/test_server_ownership.py
+++ b/tests/test_server_ownership.py
@@ -79,6 +79,7 @@ _BODIES = {
     ("PUT", "/sessions/{session_id}/scope/measurements"): [{"channel": 1, "mtype": "PKPK"}],
     ("POST", "/sessions/{session_id}/scope/references"): {"name": "ref", "channel": 1},
     ("POST", "/sessions/{session_id}/owner"): {"name": "carol"},
+    ("PATCH", "/sessions/{session_id}/psu/outputs/{n}/enable"): {"enabled": True},
 }
 
 

--- a/tests/test_server_ownership.py
+++ b/tests/test_server_ownership.py
@@ -368,7 +368,7 @@ def test_watcher_released_on_abnormal_disconnect(two_users_ws, monkeypatch):
     even when the connection tears down abnormally -- the handler raises
     before ever sending a frame -- rather than via a clean client close.
     """
-    from scpi_control.server.api import stream as stream_module
+    from scpi_control.server.adapters import ScopeAdapter
 
     client, alice, bob, alice_ws, _bob_ws = two_users_ws
     sid = _make_session(client, alice)["id"]
@@ -377,7 +377,7 @@ def test_watcher_released_on_abnormal_disconnect(two_users_ws, monkeypatch):
     raised = []
     reached = threading.Event()
 
-    def _boom(_scope):
+    def _boom(_self, _scope):
         # Recording the call is inside the same body as the raise, so if a
         # future edit swaps this helper for a non-raising stand-in (e.g.
         # ``return {}``), the whole body -- including this append -- goes
@@ -387,24 +387,24 @@ def test_watcher_released_on_abnormal_disconnect(two_users_ws, monkeypatch):
         reached.set()
         raise RuntimeError("simulated mid-stream failure")
 
-    monkeypatch.setattr(stream_module, "read_state", _boom)
-    # No receive_json here: the handler crashes before it ever sends a
-    # frame, so waiting on one would hang forever waiting for a message
-    # that never arrives.
+    # The stream handler now asks the session's *adapter* for its opening
+    # frame (adapter.initial_frame), so that is the seam to break.
+    monkeypatch.setattr(ScopeAdapter, "initial_frame", _boom)
+    # No receive_json for a *state* frame here: the handler never gets one.
     #
     # But we cannot just close immediately either. The handler reaches
-    # read_state via ``session.submit(...)`` onto the session's worker thread
-    # (stream.py:98), so it runs asynchronously relative to the handshake --
-    # closing the socket right away races that dispatch, and the job may never
-    # run. That race made this test fail intermittently in CI on whichever
+    # initial_frame via ``session.submit(...)`` onto the session's worker
+    # thread, so it runs asynchronously relative to the handshake -- closing
+    # the socket right away races that dispatch, and the job may never run.
+    # That race made this test fail intermittently in CI on whichever
     # interpreter happened to lose it (3.10 on one run, 3.11 on the next, each
     # time passing on the others). Waiting for the helper to actually fire
     # removes the timing dependency; the timeout keeps a genuine regression
     # from hanging the suite.
     with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=alice_ws):
-        assert reached.wait(timeout=10.0), "handler never reached read_state within 10s"
+        assert reached.wait(timeout=10.0), "handler never reached initial_frame within 10s"
 
-    assert raised, "abnormal path never exercised -- read_state must raise, not return"
+    assert raised, "abnormal path never exercised -- initial_frame must raise, not return"
 
     # If the watcher slot leaked, alice would still read as "watching" and
     # this claim (owner idle, threshold 0) would be wrongly refused.

--- a/tests/test_server_psu.py
+++ b/tests/test_server_psu.py
@@ -6,10 +6,12 @@ none of the scope's domain. These assertions are deliberately the same ones the
 scope session is held to.
 """
 
+import time
+
 import pytest
 
 from scpi_control.connection.mock import MockConnection
-from scpi_control.server.sessions import SessionManager
+from scpi_control.server.sessions import SessionError, SessionManager
 
 fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")  # fastapi.testclient needs it; raises RuntimeError (not ImportError) without it
@@ -20,6 +22,23 @@ from scpi_control.server.app import create_app  # noqa: E402
 
 def _psu_connection():
     return MockConnection(psu_mode=True, psu_idn="Siglent Technologies,SPD3303X,SPD123456,1.0")
+
+
+class KillablePsuConnection(MockConnection):
+    """A PSU mock whose wire can be pulled mid-session (mirrors the scope's
+    KillableMock in tests/test_server_sessions.py)."""
+
+    def kill(self):
+        self._connected = False
+
+
+def _wait_for(predicate, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return predicate()
 
 
 @pytest.fixture
@@ -70,10 +89,40 @@ def test_a_psu_session_connects_and_reports_its_kind(manager):
 
 
 def test_a_psu_session_closes_within_its_timeout(manager):
-    """Shared lifecycle: the same close path the scope uses."""
+    """Shared lifecycle: the same close path the scope uses.
+
+    Asserting ``state == "closed"`` alone proves nothing: close() sets that
+    unconditionally *after* join(timeout=...), so a worker that ignored _STOP
+    and outlived the join would still satisfy it. The thread and the job queue
+    are what actually have to be dead.
+    """
     session = manager.create("psu", mock=True, kind="psu", _connection=_psu_connection())
     session.close(timeout=10.0)
+    assert session._thread.is_alive() is False, "close() returned but the worker thread is still running"
     assert session.state == "closed"
+    with pytest.raises(SessionError):
+        session.submit(lambda psu: psu.identify())
+
+
+def test_a_psu_session_enters_the_error_state_when_the_wire_drops(manager):
+    """The spec's dropped-wire case, for the PSU. The file's premise is that a
+    PSU session is held to the same assertions as a scope session, and the
+    scope has ``test_idle_poll_detects_dropped_connection``; without the PSU
+    equivalent, the shared error path is only ever proven on one kind."""
+    conn = KillablePsuConnection(psu_mode=True, psu_idn="Siglent Technologies,SPD3303X,SPD123456,1.0")
+    session = manager.create("psu", mock=True, kind="psu", _connection=conn)
+    errors = []
+    # _poll_tick returns early with no subscribers, so the drop is only ever
+    # noticed while something is watching -- exactly as for a scope.
+    unsubscribe = session.subscribe(errors.append)
+    try:
+        conn.kill()
+        assert _wait_for(lambda: session.state == "error"), "poll tick never noticed the dropped PSU connection"
+        assert any(m.get("type") == "error" for m in errors), "the drop must be announced on the stream, not only in session.state"
+        with pytest.raises(SessionError):
+            session.submit(lambda psu: psu.identify())
+    finally:
+        unsubscribe()
 
 
 def test_a_psu_session_counts_viewers_like_any_other(manager):

--- a/tests/test_server_psu.py
+++ b/tests/test_server_psu.py
@@ -1,0 +1,54 @@
+"""A PSU session must be a session in exactly the same way a scope session is.
+
+The seam is only real if the shared lifecycle -- worker thread, error state,
+close timeout, viewer counting -- behaves identically for a kind that shares
+none of the scope's domain. These assertions are deliberately the same ones the
+scope session is held to.
+"""
+
+import pytest
+
+from scpi_control.connection.mock import MockConnection
+from scpi_control.server.sessions import SessionManager
+
+
+def _psu_connection():
+    return MockConnection(psu_mode=True, psu_idn="Siglent Technologies,SPD3303X,SPD123456,1.0")
+
+
+@pytest.fixture
+def manager():
+    m = SessionManager()
+    yield m
+    m.close_all()
+
+
+def test_a_psu_session_connects_and_reports_its_kind(manager):
+    session = manager.create("psu", mock=True, kind="psu", _connection=_psu_connection())
+    assert session.kind == "psu"
+    assert session.state == "connected"
+    assert "SPD3303X" in session.idn
+
+
+def test_a_psu_session_closes_within_its_timeout(manager):
+    """Shared lifecycle: the same close path the scope uses."""
+    session = manager.create("psu", mock=True, kind="psu", _connection=_psu_connection())
+    session.close(timeout=10.0)
+    assert session.state == "closed"
+
+
+def test_a_psu_session_counts_viewers_like_any_other(manager):
+    session = manager.create("psu", mock=True, kind="psu", _connection=_psu_connection())
+    assert session.viewers == 0
+    unsubscribe = session.subscribe(lambda message: None)
+    assert session.viewers == 1
+    unsubscribe()
+    assert session.viewers == 0
+
+
+def test_the_default_kind_is_scope(manager):
+    """The non-breaking guarantee: an existing caller that passes no kind gets
+    exactly what it got before."""
+    session = manager.create("scope", mock=True)
+    assert session.kind == "scope"
+    assert session.num_channels == 4

--- a/tests/test_server_psu.py
+++ b/tests/test_server_psu.py
@@ -11,6 +11,12 @@ import pytest
 from scpi_control.connection.mock import MockConnection
 from scpi_control.server.sessions import SessionManager
 
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")  # fastapi.testclient needs it; raises RuntimeError (not ImportError) without it
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scpi_control.server.app import create_app  # noqa: E402
+
 
 def _psu_connection():
     return MockConnection(psu_mode=True, psu_idn="Siglent Technologies,SPD3303X,SPD123456,1.0")
@@ -21,6 +27,39 @@ def manager():
     m = SessionManager()
     yield m
     m.close_all()
+
+
+@pytest.fixture()
+def psu_client(gateway_auth):
+    """An authenticated HTTP client with one mock PSU session already created,
+    exposed on ``.session_id`` -- same pattern as ``client`` in
+    tests/test_server_api.py, plus the session bootstrap."""
+    store, headers, _raw = gateway_auth
+    manager = SessionManager()
+    app = create_app(manager, token_store=store)
+    with TestClient(app) as test_client:
+        test_client.headers.update(headers)
+        response = test_client.post("/api/sessions", json={"mock": True, "kind": "psu"})
+        assert response.status_code == 201, response.text
+        test_client.session_id = response.json()["id"]
+        yield test_client
+    manager.close_all()
+
+
+@pytest.fixture()
+def scope_client(gateway_auth):
+    """Same as psu_client, but a mock scope session -- used to prove PSU
+    routes reject a scope session (kind confusion guard)."""
+    store, headers, _raw = gateway_auth
+    manager = SessionManager()
+    app = create_app(manager, token_store=store)
+    with TestClient(app) as test_client:
+        test_client.headers.update(headers)
+        response = test_client.post("/api/sessions", json={"mock": True})
+        assert response.status_code == 201, response.text
+        test_client.session_id = response.json()["id"]
+        yield test_client
+    manager.close_all()
 
 
 def test_a_psu_session_connects_and_reports_its_kind(manager):
@@ -52,3 +91,46 @@ def test_the_default_kind_is_scope(manager):
     session = manager.create("scope", mock=True)
     assert session.kind == "scope"
     assert session.num_channels == 4
+
+
+def test_psu_state_lists_every_output(psu_client):
+    session_id = psu_client.session_id
+    response = psu_client.get(f"/api/sessions/{session_id}/psu/state")
+    assert response.status_code == 200
+    outputs = response.json()["outputs"]
+    assert outputs and outputs[0]["output"] == 1
+
+
+def test_setting_voltage_and_current_round_trips(psu_client):
+    session_id = psu_client.session_id
+    response = psu_client.patch(f"/api/sessions/{session_id}/psu/outputs/1", json={"voltage": 3.3, "current": 0.5})
+    assert response.status_code == 200
+    state = psu_client.get(f"/api/sessions/{session_id}/psu/state").json()["outputs"][0]
+    assert state["voltage"] == pytest.approx(3.3, abs=0.01)
+    assert state["current"] == pytest.approx(0.5, abs=0.01)
+
+
+def test_enabling_an_output_round_trips(psu_client):
+    session_id = psu_client.session_id
+    assert psu_client.patch(f"/api/sessions/{session_id}/psu/outputs/1/enable", json={"enabled": True}).status_code == 200
+    assert psu_client.get(f"/api/sessions/{session_id}/psu/state").json()["outputs"][0]["enabled"] is True
+
+
+def test_an_unknown_output_is_rejected(psu_client):
+    session_id = psu_client.session_id
+    response = psu_client.patch(f"/api/sessions/{session_id}/psu/outputs/99", json={"voltage": 1.0})
+    assert response.status_code == 400
+
+
+def test_a_psu_route_rejects_a_scope_session(scope_client):
+    """Kind confusion must be an error, not an obscure AttributeError from a
+    driver that does not have the method being called."""
+    session_id = scope_client.session_id
+    response = scope_client.get(f"/api/sessions/{session_id}/psu/state")
+    assert response.status_code == 400
+
+
+def test_a_scope_route_rejects_a_psu_session(psu_client):
+    session_id = psu_client.session_id
+    response = psu_client.get(f"/api/sessions/{session_id}/scope/state")
+    assert response.status_code == 400

--- a/tests/test_server_sessions.py
+++ b/tests/test_server_sessions.py
@@ -463,3 +463,131 @@ class TestKindMismatchGuard:
         assert session.kind == "scope"  # the untouched __init__ default
         with pytest.raises(SessionError):
             session._connect_job(instrument)
+
+    def test_an_unregistered_scope_model_still_connects(self):
+        # The guard must reject a POSITIVE identification as another kind, not
+        # whitelist MODEL_REGISTRY. classify() answers "unknown" for every
+        # model outside the registry's 22 entries -- a Rigol DS1054Z, a Tek
+        # TBS1052B, an unlisted Siglent -- and all of those connected fine via
+        # the generic/legacy dialect fallback before the per-kind split. If the
+        # guard compares `detected != self.kind` they all start failing with
+        # "connected instrument is a unknown, not a scope", which would be a
+        # breaking change to the pre-existing scope path.
+        #
+        # Non-mock (mock=True skips the guard entirely) and constructed
+        # directly so no socket is opened, same technique as the test above.
+        from scpi_control.oscilloscope import Oscilloscope
+        from scpi_control.server.adapters import ScopeAdapter
+        from scpi_control.server.discovery import classify
+
+        conn = MockConnection("mock", idn="RIGOL TECHNOLOGIES,DS1054Z,DS1ZA000000000,00.04.04", channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+        instrument = Oscilloscope("mock", connection=conn)
+        session = InstrumentSession("bench-1", instrument, False, "10.0.0.5", 0.25, ScopeAdapter())
+        session._connect_job(instrument)
+        assert session.model == "DS1054Z"
+        assert classify(session.model) == "unknown", "fixture no longer exercises the unregistered-model path"
+        assert session.state == "connected"
+
+
+class TestBackwardCompatibleScopeSurface:
+    """5.8.0 moved scope-only state onto ScopeAdapter. It must stay reachable.
+
+    ``set_measurements``/``start_recording``/``stop_recording``/``recorder``/
+    ``measurements``/``spectrum_config``/``filters``/``active_reference``/
+    ``reference_overlay``/``set_active_reference`` were public names on a
+    public class in 5.7.1 -- the shipped trend-logging example used four of
+    them. Removing them would make this release a MAJOR, so they survive as
+    thin delegations to the adapter.
+    """
+
+    def test_the_v5_7_1_scope_surface_still_works(self):
+        session, _ = make_mock_session()
+        try:
+            session.set_measurements([(1, "PKPK"), (1, "FREQ")])
+            assert session.measurements == [(1, "PKPK"), (1, "FREQ")]
+            assert session.recorder is session.adapter.recorder
+            assert session.start_recording()["state"] == "recording"
+            assert session.stop_recording()["state"] == "idle"
+            assert session.recorder.rows_since() == []
+            assert session.reference_overlay()["name"] is None
+            session.set_active_reference("golden", 1, {"time": [0.0, 1.0], "voltage": [0.5, 1.5]})
+            assert session.active_reference["name"] == "golden"
+            assert session.reference_overlay()["name"] == "golden"
+            assert session.spectrum_config["enabled"] is False
+            session.spectrum_config = {**session.spectrum_config, "enabled": True}
+            assert session.spectrum_config["enabled"] is True
+            assert sorted(session.filters) == [1, 2]
+            session.filters = {**session.filters, 1: {**session.filters[1], "enabled": True}}
+            assert session.filters[1]["enabled"] is True
+        finally:
+            session.close()
+
+    def test_the_shims_delegate_and_keep_no_state_on_the_session(self):
+        # A shim that stored its own copy would undo the point of the move: a
+        # PSU session would carry scope state again, and the two copies would
+        # drift the moment a route wrote through session.adapter (which every
+        # /scope/ route does). Assert the write lands on the ADAPTER and that
+        # the session's own __dict__ never grows the attribute.
+        session, _ = make_mock_session()
+        try:
+            session.set_measurements([(2, "RMS")])
+            session.spectrum_config = {**session.spectrum_config, "channel": 3}
+            for name in ("measurements", "spectrum_config", "filters", "active_reference", "recorder"):
+                assert name not in vars(session), "{0} must live on the adapter, not on the session".format(name)
+            assert session.adapter.measurements == [(2, "RMS")]
+            assert session.adapter.spectrum_config["channel"] == 3
+            # And the read side really is the adapter's object, not a copy.
+            assert session.measurements is session.adapter.measurements
+            assert session.filters is session.adapter.filters
+        finally:
+            session.close()
+
+    def test_the_adapter_argument_is_optional(self):
+        # The pre-5.8 constructor took five positional arguments. Anyone who
+        # built a session by hand must not have to learn about adapters.
+        conn = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, trigger_status=["Stop"], sample_rate=1_000.0, timebase=1e-3)
+        from scpi_control.oscilloscope import Oscilloscope
+
+        session = InstrumentSession("bench-1", Oscilloscope("mock", connection=conn), True, None, 0.25)
+        assert session.adapter.kind == "scope"
+        assert session.kind == "scope"
+
+
+class TestAdapterLifecycleHooks:
+    def test_worker_teardown_goes_through_the_adapters_close_hook(self):
+        # _worker used to call self._scope.disconnect() directly. Identical
+        # behaviour for the two kinds that exist -- both adapters only
+        # disconnect -- but it left InstrumentAdapter.close() dead, so a kind
+        # whose teardown needs more (an AWG de-energising before disconnect)
+        # would silently skip it.
+        session, _ = make_mock_session()
+        closed = []
+        real_close = session.adapter.close
+
+        def recording_close(instrument):
+            closed.append(instrument)
+            real_close(instrument)
+
+        session.adapter.close = recording_close
+        session.close()
+        assert closed == [session._instrument], "teardown must call adapter.close(), not the instrument's disconnect() directly"
+
+    def test_a_non_siglent_error_from_poll_becomes_a_visible_error_state(self):
+        # _poll_tick only caught SiglentError, so anything else out of
+        # adapter.poll escaped _worker: the thread died, no error frame was
+        # ever published, and the session read "connected" forever behind a
+        # stream that had simply gone quiet.
+        session, _ = make_mock_session()
+        frames = []
+        try:
+            session.subscribe(frames.append)  # _poll_tick is a no-op with no subscribers
+
+            def _boom(_instrument, _publish, _tick):
+                raise ValueError("a numpy edge case, not a wire problem")
+
+            session.adapter.poll = _boom
+            assert _wait_for(lambda: session.state == "error"), "a poll failure must surface as an error state, not a dead worker thread"
+            assert any(m.get("type") == "error" for m in frames), "the streams must be told, not just session.state"
+            assert session._thread.is_alive(), "the worker must survive to report the failure"
+        finally:
+            session.close()

--- a/tests/test_server_sessions.py
+++ b/tests/test_server_sessions.py
@@ -428,3 +428,38 @@ class TestSessionManager:
         # with a 409 -- a footgun that looks like a crash. Reject it eagerly.
         with pytest.raises(ValueError):
             SessionManager(max_sessions=max_sessions)
+
+    def test_create_with_an_unknown_kind_fails_cleanly(self):
+        # The guard in InstrumentSession.open checks `kind not in ADAPTERS`
+        # before ADAPTERS[kind]() is ever evaluated, so a garbage kind must
+        # raise SessionError (-> HTTP 409), not a bare KeyError (-> HTTP 500).
+        # No connection/hardware needed: the check fires before build() runs.
+        manager = SessionManager()
+        try:
+            with pytest.raises(SessionError):
+                manager.create("x", kind="bogus", mock=True)
+            assert manager.list() == []
+        finally:
+            manager.close_all()
+
+
+class TestKindMismatchGuard:
+    def test_a_misreporting_instrument_is_rejected(self):
+        # The kind-mismatch guard in _connect_job compares classify(self.model)
+        # against self.kind for any non-mock session. Reachable without real
+        # hardware by constructing InstrumentSession directly (bypassing
+        # .open()/adapter.build()) with mock=False and a PowerSupply wrapping a
+        # MockConnection(psu_mode=True, ...): the instrument genuinely reports
+        # "SPD3303X" via *IDN?, which classify() resolves to "psu", while the
+        # session's own `kind` (left at the InstrumentSession.__init__ default
+        # of "scope" since open() was bypassed) says otherwise -- the exact
+        # "instrument silently misreports its own kind" case the guard exists for.
+        from scpi_control.power_supply import PowerSupply
+        from scpi_control.server.adapters import PsuAdapter
+
+        conn = MockConnection(psu_mode=True, psu_idn="Siglent Technologies,SPD3303X,SPD123456,1.0")
+        instrument = PowerSupply("mock", connection=conn)
+        session = InstrumentSession("bench-1", instrument, False, "10.0.0.5", 0.25, PsuAdapter())
+        assert session.kind == "scope"  # the untouched __init__ default
+        with pytest.raises(SessionError):
+            session._connect_job(instrument)

--- a/tests/test_server_stream_ws.py
+++ b/tests/test_server_stream_ws.py
@@ -53,6 +53,12 @@ def _create_mock(client):
     return response.json()["id"]
 
 
+def _create_psu_mock(client):
+    response = client.post("/api/sessions", json={"mock": True, "kind": "psu"})
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
 def test_stream_sends_initial_state_then_waveforms(client, ws_subprotocols):
     sid = _create_mock(client)
     with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=ws_subprotocols) as ws:
@@ -82,6 +88,40 @@ def test_stream_relays_state_broadcast_after_mutation(client, ws_subprotocols):
                 break
         else:
             pytest.fail("no state broadcast observed")
+
+
+# --- psu kind dispatch: the initial frame must match the psu shape --------
+# (previously read_state() assumed an Oscilloscope, raised AttributeError
+# against a PowerSupply, and the bare except in the handler swallowed it --
+# no initial frame was ever sent and the connection just sat there silent).
+
+
+def test_stream_sends_initial_psu_state(client, ws_subprotocols):
+    sid = _create_psu_mock(client)
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=ws_subprotocols) as ws:
+        first = ws.receive_json()
+        assert first["type"] == "state"
+        assert first["kind"] == "psu"
+        assert isinstance(first["outputs"], list) and first["outputs"]
+        assert first["outputs"][0]["output"] == 1
+        assert "measured_voltage" in first["outputs"][0]
+
+
+def test_stream_relays_psu_state_broadcast_after_mutation(client, ws_subprotocols):
+    sid = _create_psu_mock(client)
+    with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=ws_subprotocols) as ws:
+        first = ws.receive_json()
+        assert first["kind"] == "psu"
+        response = client.patch("/api/sessions/{0}/psu/outputs/1".format(sid), json={"voltage": 7.5})
+        assert response.status_code == 200
+        for _ in range(20):
+            msg = ws.receive_json()
+            if msg["type"] == "state" and msg.get("kind") == "psu":
+                out1 = next(o for o in msg["outputs"] if o["output"] == 1)
+                if out1["voltage"] == 7.5:
+                    break
+        else:
+            pytest.fail("no psu state broadcast observed")
 
 
 def test_stream_unknown_session_closes(client, ws_subprotocols):

--- a/tests/test_server_stream_ws.py
+++ b/tests/test_server_stream_ws.py
@@ -16,6 +16,14 @@ from scpi_control.server.app import create_app  # noqa: E402
 from scpi_control.server.auth import WS_ACCEPT_SUBPROTOCOL  # noqa: E402
 from scpi_control.server.sessions import SessionManager  # noqa: E402
 
+# Every ws.receive_json() below blocks with no deadline of its own. The failure
+# mode these tests exist to catch -- a stream that accepts the socket and then
+# never sends anything -- therefore presents as a HANG, not a red test, which
+# would wedge CI instead of reporting. A module-level timeout converts it back
+# into an ordinary failure. 30 s is far above the slowest test here (the
+# disconnect test's 5 s poll loop).
+pytestmark = pytest.mark.timeout(30)
+
 
 @pytest.fixture()
 def client(gateway_auth):
@@ -122,6 +130,31 @@ def test_stream_relays_psu_state_broadcast_after_mutation(client, ws_subprotocol
                     break
         else:
             pytest.fail("no psu state broadcast observed")
+
+
+def test_an_adapter_that_cannot_produce_an_initial_frame_fails_loudly(client, ws_subprotocols, monkeypatch):
+    """The opening frame comes from ``adapter.initial_frame``. When that hook
+    raises -- a new kind that never implemented it, or a read that fails -- the
+    handler used to swallow it with a bare ``except Exception: pass``, leaving
+    the socket accepted, silent, and indistinguishable from an idle instrument
+    forever (polling never starts either: _poll_tick needs a subscriber that
+    has seen a first message). It must instead say what went wrong and close
+    with a code that names the failure."""
+    from scpi_control.server.adapters import ScopeAdapter
+    from scpi_control.server.api.stream import CLOSE_INITIAL_FRAME_FAILED
+
+    def _boom(_self, _instrument):
+        raise NotImplementedError("initial_frame")
+
+    monkeypatch.setattr(ScopeAdapter, "initial_frame", _boom)
+    sid = _create_mock(client)
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/api/sessions/{0}/stream".format(sid), subprotocols=ws_subprotocols) as ws:
+            first = ws.receive_json()
+            assert first["type"] == "error", "a silent socket is the bug; an error frame is the fix"
+            assert "initial frame failed" in first["detail"]
+            ws.receive_json()  # the close arrives here
+    assert exc_info.value.code == CLOSE_INITIAL_FRAME_FAILED
 
 
 def test_stream_unknown_session_closes(client, ws_subprotocols):

--- a/tests/test_server_streaming.py
+++ b/tests/test_server_streaming.py
@@ -89,7 +89,7 @@ def test_measurement_poll_reports_none_on_timeout():
     with patch.object(Measurement, "measure", side_effect=SiglentTimeoutError("forced")):
         session = make_session(idn=MODERN_IDN)
         try:
-            session.set_measurements([(1, "PKPK")])
+            session.adapter.set_measurements([(1, "PKPK")], session.publish)
             msgs = collect(session, "measurements", n=1, timeout=8.0)
             assert msgs, "expected a measurements message"
             entry = msgs[0]["values"][0]
@@ -207,7 +207,7 @@ def test_set_measurements_broadcasts_config():
                 got.append(msg)
 
         unsubscribe = session.subscribe(cb)
-        session.set_measurements([(1, "PKPK"), (2, "FREQ")])
+        session.adapter.set_measurements([(1, "PKPK"), (2, "FREQ")], session.publish)
         unsubscribe()
         assert got and got[0]["items"] == [{"channel": 1, "mtype": "PKPK"}, {"channel": 2, "mtype": "FREQ"}]
     finally:
@@ -217,7 +217,7 @@ def test_set_measurements_broadcasts_config():
 def test_poll_publishes_spectrum_frame_when_enabled():
     session = make_session()
     try:
-        session.spectrum_config = {**session.spectrum_config, "enabled": True}
+        session.adapter.spectrum_config = {**session.adapter.spectrum_config, "enabled": True}
         frames = collect(session, "spectrum", n=1, timeout=8.0)
         assert frames, "expected a spectrum frame"
         frame = frames[0]
@@ -231,11 +231,11 @@ def test_poll_publishes_spectrum_frame_when_enabled():
 def test_poll_clears_spectrum_frame_when_disabled():
     session = make_session()
     try:
-        session.spectrum_config = {**session.spectrum_config, "enabled": True}
+        session.adapter.spectrum_config = {**session.adapter.spectrum_config, "enabled": True}
         assert collect(session, "spectrum", n=1, timeout=8.0), "expected a live spectrum frame first"
         cleared = []
         unsubscribe = session.subscribe(lambda m: cleared.append(m) if m["type"] == "spectrum" and m["points"] == [] else None)
-        session.spectrum_config = {**session.spectrum_config, "enabled": False}
+        session.adapter.spectrum_config = {**session.adapter.spectrum_config, "enabled": False}
         deadline = time.time() + 8.0
         while not cleared and time.time() < deadline:
             time.sleep(0.02)
@@ -248,7 +248,7 @@ def test_poll_clears_spectrum_frame_when_disabled():
 def test_poll_publishes_filtered_trace():
     session = make_session()
     try:
-        session.filters = {**session.filters, 1: {**session.filters[1], "enabled": True, "cutoff_high": 100.0}}
+        session.adapter.filters = {**session.adapter.filters, 1: {**session.adapter.filters[1], "enabled": True, "cutoff_high": 100.0}}
         frames = collect(session, "waveform", n=6, timeout=8.0)
         f1 = [f for f in frames if f["channel"] == "F1"]
         assert f1, "expected an F1 filtered frame"
@@ -260,11 +260,11 @@ def test_poll_publishes_filtered_trace():
 def test_poll_clears_filtered_trace_when_disabled():
     session = make_session()
     try:
-        session.filters = {**session.filters, 1: {**session.filters[1], "enabled": True, "cutoff_high": 100.0}}
+        session.adapter.filters = {**session.adapter.filters, 1: {**session.adapter.filters[1], "enabled": True, "cutoff_high": 100.0}}
         assert [f for f in collect(session, "waveform", n=6, timeout=8.0) if f["channel"] == "F1"]
         cleared = []
         unsubscribe = session.subscribe(lambda m: cleared.append(m) if m["type"] == "waveform" and m["channel"] == "F1" and m["points"] == [] else None)
-        session.filters = {**session.filters, 1: {**session.filters[1], "enabled": False}}
+        session.adapter.filters = {**session.adapter.filters, 1: {**session.adapter.filters[1], "enabled": False}}
         deadline = time.time() + 8.0
         while not cleared and time.time() < deadline:
             time.sleep(0.02)
@@ -280,8 +280,8 @@ def test_set_active_reference_broadcasts_overlay_and_clear():
         got = []
         unsubscribe = session.subscribe(lambda m: got.append(m) if m["type"] == "reference" else None)
         data = session.submit(lambda scope: scope.get_waveform(1)).result(timeout=5)
-        session.set_active_reference("golden", 1, {"time": data.time, "voltage": data.voltage})
-        session.set_active_reference(None, None, None)
+        session.adapter.set_active_reference("golden", 1, {"time": data.time, "voltage": data.voltage}, session.publish)
+        session.adapter.set_active_reference(None, None, None, session.publish)
         unsubscribe()
         assert got[0]["name"] == "golden" and got[0]["channel"] == 1
         assert 0 < len(got[0]["points"]) <= 2000
@@ -297,7 +297,7 @@ def test_poll_publishes_reference_stats_for_active_reference():
     session = make_session(waveform_payloads={1: bytes([0, 25, 50, 75])})
     try:
         data = session.submit(lambda scope: scope.get_waveform(1)).result(timeout=5)
-        session.set_active_reference("golden", 1, {"time": data.time, "voltage": data.voltage})
+        session.adapter.set_active_reference("golden", 1, {"time": data.time, "voltage": data.voltage}, session.publish)
         msgs = collect(session, "reference_stats", n=1, timeout=8.0)
         assert msgs, "expected a reference_stats message"
         assert msgs[0]["correlation"] is not None and msgs[0]["correlation"] > 0.99
@@ -318,8 +318,8 @@ def test_poll_survives_unexpected_analysis_exception(monkeypatch):
     monkeypatch.setattr(compute, "spectrum_frame", boom)
     session = make_session()
     try:
-        session.filters = {**session.filters, 1: {**session.filters[1], "enabled": True, "cutoff_high": 100.0}}
-        session.spectrum_config = {**session.spectrum_config, "enabled": True}
+        session.adapter.filters = {**session.adapter.filters, 1: {**session.adapter.filters[1], "enabled": True, "cutoff_high": 100.0}}
+        session.adapter.spectrum_config = {**session.adapter.spectrum_config, "enabled": True}
         # n=8: this mock's default enables all 4 channels, so one healthy tick
         # already yields 4 "waveform" messages; require two full ticks' worth
         # so the assertion actually distinguishes "died after tick 1" from
@@ -334,7 +334,7 @@ def test_poll_survives_unexpected_analysis_exception(monkeypatch):
 def test_measurements_message_carries_timestamp():
     session = make_session()
     try:
-        session.set_measurements([(1, "PKPK")])
+        session.adapter.set_measurements([(1, "PKPK")], session.publish)
         before = time.time()
         msgs = collect(session, "measurements", n=1, timeout=8.0)
         assert msgs, "expected a measurements message"
@@ -347,13 +347,13 @@ def test_measurements_message_carries_timestamp():
 def test_recorder_accumulates_rows_while_recording():
     session = make_session()
     try:
-        session.set_measurements([(1, "PKPK")])
-        session.start_recording()
+        session.adapter.set_measurements([(1, "PKPK")], session.publish)
+        session.adapter.start_recording(session.publish)
         msgs = collect(session, "measurements", n=2, timeout=12.0)
         assert msgs
-        status = session.recorder.status()
+        status = session.adapter.recorder.status()
         assert status["row_count"] >= 1
-        rows = session.recorder.rows_since()
+        rows = session.adapter.recorder.rows_since()
         assert len(rows[0]) == 2  # [timestamp, one column value]
         assert rows[0][0] == msgs[0]["timestamp"]  # same clock stamp feeds both
     finally:
@@ -363,9 +363,9 @@ def test_recorder_accumulates_rows_while_recording():
 def test_recorder_ignores_measurements_when_idle():
     session = make_session()
     try:
-        session.set_measurements([(1, "PKPK")])
+        session.adapter.set_measurements([(1, "PKPK")], session.publish)
         assert collect(session, "measurements", n=1, timeout=8.0)
-        assert session.recorder.status()["row_count"] == 0
+        assert session.adapter.recorder.status()["row_count"] == 0
     finally:
         session.close()
 
@@ -375,9 +375,9 @@ def test_start_and_stop_recording_broadcast_log_status():
     try:
         got = []
         unsubscribe = session.subscribe(lambda m: got.append(m) if m["type"] == "log_status" else None)
-        session.set_measurements([(1, "PKPK")])
-        session.start_recording()
-        session.stop_recording()
+        session.adapter.set_measurements([(1, "PKPK")], session.publish)
+        session.adapter.start_recording(session.publish)
+        session.adapter.stop_recording(session.publish)
         unsubscribe()
         assert [m["state"] for m in got] == ["recording", "idle"]
         assert got[0]["started_at"] is not None and got[0]["row_count"] == 0
@@ -390,7 +390,7 @@ def test_start_recording_requires_a_selection():
     session = make_session()
     try:
         with pytest.raises(InvalidParameterError):
-            session.start_recording()
+            session.adapter.start_recording(session.publish)
     finally:
         session.close()
 
@@ -398,9 +398,9 @@ def test_start_recording_requires_a_selection():
 def test_double_start_recording_raises_session_error():
     session = make_session()
     try:
-        session.set_measurements([(1, "PKPK")])
-        session.start_recording()
+        session.adapter.set_measurements([(1, "PKPK")], session.publish)
+        session.adapter.start_recording(session.publish)
         with pytest.raises(SessionError):
-            session.start_recording()
+            session.adapter.start_recording(session.publish)
     finally:
         session.close()

--- a/webapp/app/src/App.test.tsx
+++ b/webapp/app/src/App.test.tsx
@@ -74,6 +74,16 @@ describe("App view selection", () => {
     expect(screen.getByLabelText("Output 1 enable")).not.toBeChecked();
   });
 
+  it("does not seed the scope reference overlay for a psu session", async () => {
+    // /scope/reference is behind require_kind now, so seeding it on a PSU
+    // mount is a guaranteed 400 on every single mount.
+    useSession.getState().setSession({ ...SESSION, kind: "psu" });
+    render(<App />);
+    await screen.findByLabelText("Output 1 voltage");
+    const urls = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(urls.some((u: string) => u.includes("/scope/"))).toBe(false);
+  });
+
   it("renders the home screen with no session", () => {
     render(<App />);
     expect(screen.queryByText("Channels")).not.toBeInTheDocument();

--- a/webapp/app/src/App.test.tsx
+++ b/webapp/app/src/App.test.tsx
@@ -42,6 +42,13 @@ beforeEach(() => {
       if (url.endsWith("/api/sessions")) return Promise.resolve(jsonResponse([]));
       if (url.includes("/api/discover")) return Promise.resolve(jsonResponse([]));
       if (url.includes("/reference")) return Promise.resolve(jsonResponse({ name: null, channel: null, t0: 0, dt: 0, points: [] }));
+      if (url.includes("/psu/state")) {
+        return Promise.resolve(
+          jsonResponse({
+            outputs: [{ output: 1, voltage: 3.3, current: 0.5, enabled: false, measured_voltage: 0.0, measured_current: 0.0, measured_power: 0.0 }],
+          }),
+        );
+      }
       return Promise.resolve(jsonResponse({}));
     }),
   );
@@ -58,12 +65,13 @@ describe("App view selection", () => {
     expect(screen.getByText("Channels")).toBeInTheDocument();
   });
 
-  it("does NOT render the scope rail for a psu session, and renders the placeholder instead", () => {
+  it("does NOT render the scope rail for a psu session, and renders the PSU panel instead", async () => {
     useSession.getState().setSession({ ...SESSION, kind: "psu" });
     render(<App />);
     expect(screen.queryByText("Channels")).not.toBeInTheDocument();
-    expect(screen.getByText("Power supply")).toBeInTheDocument();
-    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+    expect(screen.queryByText(/coming soon/i)).not.toBeInTheDocument();
+    expect(await screen.findByLabelText("Output 1 voltage")).toBeInTheDocument();
+    expect(screen.getByLabelText("Output 1 enable")).not.toBeChecked();
   });
 
   it("renders the home screen with no session", () => {

--- a/webapp/app/src/App.test.tsx
+++ b/webapp/app/src/App.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "./App";
+import { setToken } from "./api/token";
+import { useSession } from "./store/session";
+
+// TokenGate's own suite (features/auth/TokenGate.test.tsx) already covers its
+// async "checking" -> "ready" flow. Going through the real gate here would
+// force every assertion below behind a waitFor for the whoami round-trip,
+// which is not what this suite is testing. Per the brief: mock the gate
+// rather than weaken the (synchronous) render assertions it specifies.
+vi.mock("./features/auth/TokenGate", () => ({
+  TokenGate: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const SESSION = { id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" as const };
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+class FakeWebSocket {
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  close() {}
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  setToken("test-token"); // past TokenGate; matches the other suites
+  useSession.getState().clearSession();
+  vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+  // HomeScreen (no-session case) and useReferenceSeed (scope/psu cases) both
+  // hit the network on mount even with the gate mocked out, so fetch needs an
+  // answer for every path a real App render can take.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/whoami")) return Promise.resolve(jsonResponse({ identity: "test" }));
+      if (url.endsWith("/api/sessions")) return Promise.resolve(jsonResponse([]));
+      if (url.includes("/api/discover")) return Promise.resolve(jsonResponse([]));
+      if (url.includes("/reference")) return Promise.resolve(jsonResponse({ name: null, channel: null, t0: 0, dt: 0, points: [] }));
+      return Promise.resolve(jsonResponse({}));
+    }),
+  );
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("App view selection", () => {
+  it("renders the scope rail for a scope session", () => {
+    useSession.getState().setSession(SESSION);
+    render(<App />);
+    expect(screen.getByText("Channels")).toBeInTheDocument();
+  });
+
+  it("does NOT render the scope rail for a psu session", () => {
+    useSession.getState().setSession({ ...SESSION, kind: "psu" });
+    render(<App />);
+    expect(screen.queryByText("Channels")).not.toBeInTheDocument();
+  });
+
+  it("renders the home screen with no session", () => {
+    render(<App />);
+    expect(screen.queryByText("Channels")).not.toBeInTheDocument();
+  });
+});

--- a/webapp/app/src/App.test.tsx
+++ b/webapp/app/src/App.test.tsx
@@ -58,10 +58,12 @@ describe("App view selection", () => {
     expect(screen.getByText("Channels")).toBeInTheDocument();
   });
 
-  it("does NOT render the scope rail for a psu session", () => {
+  it("does NOT render the scope rail for a psu session, and renders the placeholder instead", () => {
     useSession.getState().setSession({ ...SESSION, kind: "psu" });
     render(<App />);
     expect(screen.queryByText("Channels")).not.toBeInTheDocument();
+    expect(screen.getByText("Power supply")).toBeInTheDocument();
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
   });
 
   it("renders the home screen with no session", () => {

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -11,6 +11,7 @@ import { ReadoutStrip } from "./features/readout/ReadoutStrip";
 import { ReferencePanel } from "./features/reference/ReferencePanel";
 import { useReferenceSeed } from "./features/reference/useReferenceSeed";
 import { kindMeta } from "./features/home/kinds";
+import { PsuPanel } from "./features/psu/PsuPanel";
 import { TerminalPanel } from "./features/terminal/TerminalPanel";
 import { LogPanel } from "./features/trend/LogPanel";
 import { TrendCanvas } from "./features/trend/TrendCanvas";
@@ -66,7 +67,8 @@ export default function App() {
               </div>
             </div>
           )}
-          {session !== null && session.kind !== "scope" && (
+          {session !== null && session.kind === "psu" && <PsuPanel />}
+          {session !== null && session.kind !== "scope" && session.kind !== "psu" && (
             <GroupBox title={kindMeta(session.kind).label}>
               <p style={{ margin: 0, color: "var(--lc-muted)" }}>A dedicated view for this instrument kind is coming soon.</p>
             </GroupBox>

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -33,7 +33,9 @@ export default function App() {
   const [railTab, setRailTab] = useState("Channels");
   const [viewMode, setViewMode] = useState<ViewMode>("Time");
   useStream(session?.id ?? null);
-  useReferenceSeed(session?.id ?? null);
+  // Scope-only: /scope/reference is now behind require_kind, so seeding it for
+  // any other kind is a guaranteed 400 on every mount.
+  useReferenceSeed(session?.kind === "scope" ? session.id : null);
   return (
     <TokenGate>
       <div style={{ display: "flex", flexDirection: "column", height: "100vh", background: "var(--lc-bg)", fontFamily: "var(--font-ui)" }}>

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -10,6 +10,7 @@ import { MeasurePanel } from "./features/measure/MeasurePanel";
 import { ReadoutStrip } from "./features/readout/ReadoutStrip";
 import { ReferencePanel } from "./features/reference/ReferencePanel";
 import { useReferenceSeed } from "./features/reference/useReferenceSeed";
+import { kindMeta } from "./features/home/kinds";
 import { TerminalPanel } from "./features/terminal/TerminalPanel";
 import { LogPanel } from "./features/trend/LogPanel";
 import { TrendCanvas } from "./features/trend/TrendCanvas";
@@ -17,6 +18,7 @@ import { SpectrumCanvas } from "./features/waveform/SpectrumCanvas";
 import { WaveformCanvas } from "./features/waveform/WaveformCanvas";
 import type { ViewMode } from "./features/waveform/ViewModeToggle";
 import { ViewModeToggle } from "./features/waveform/ViewModeToggle";
+import { GroupBox } from "./ds/GroupBox";
 import { StatusIndicator } from "./ds/StatusIndicator";
 import { Tabs } from "./ds/Tabs";
 import { useStream } from "./stream/useStream";
@@ -43,8 +45,8 @@ export default function App() {
         </header>
         <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)", display: "flex", flexDirection: "column", gap: "var(--space-3)", minHeight: 0 }}>
           {session === null && <HomeScreen onConnected={(s) => useSession.getState().setSession(s)} />}
-          {session !== null && <ReadoutStrip />}
-          {session !== null && (
+          {session !== null && session.kind === "scope" && <ReadoutStrip />}
+          {session !== null && session.kind === "scope" && (
             <div style={{ flex: 1, display: "flex", gap: "var(--space-3)", minHeight: 0 }}>
               <div style={{ width: "280px", flexShrink: 0, overflowY: "auto" }}>
                 <Tabs tabs={RAIL_TABS} value={railTab} onChange={setRailTab}>
@@ -63,6 +65,11 @@ export default function App() {
                 <ScopeToolbar viewToggle={<ViewModeToggle value={viewMode} onChange={setViewMode} />} />
               </div>
             </div>
+          )}
+          {session !== null && session.kind !== "scope" && (
+            <GroupBox title={kindMeta(session.kind).label}>
+              <p style={{ margin: 0, color: "var(--lc-muted)" }}>A dedicated view for this instrument kind is coming soon.</p>
+            </GroupBox>
           )}
         </main>
       </div>

--- a/webapp/app/src/api/client.ts
+++ b/webapp/app/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { ChannelPatch, DiscoveredDevice, FilterConfig, LogData, LogInfo, MeasurementValue, ModelInfo, ReferenceInfo, ReferenceOverlay, RunOp, ScopeState, SessionCreate, SessionInfo, SpectrumConfig, TriggerPatch } from "./types";
+import type { ChannelPatch, DiscoveredDevice, FilterConfig, LogData, LogInfo, MeasurementValue, ModelInfo, PsuOutputPatch, PsuState, ReferenceInfo, ReferenceOverlay, RunOp, ScopeState, SessionCreate, SessionInfo, SpectrumConfig, TriggerPatch } from "./types";
 import { getToken } from "./token";
 
 export class ApiError extends Error {
@@ -41,6 +41,7 @@ function json(method: string, body: unknown): RequestInit {
 }
 
 const scope = (id: string) => `/api/sessions/${id}/scope`;
+const psu = (id: string) => `/api/sessions/${id}/psu`;
 
 export const api = {
   whoami: () => request<{ identity: string }>("/api/whoami"),
@@ -78,6 +79,9 @@ export const api = {
   getLog: (id: string) => request<LogInfo>(`${scope(id)}/log`),
   getLogData: (id: string, since = 0) => request<LogData>(`${scope(id)}/log/data?since=${since}`),
   logCsvUrl: (id: string) => `${scope(id)}/log.csv`,
+  psuState: (id: string) => request<PsuState>(`${psu(id)}/state`),
+  setPsuOutput: (id: string, n: number, body: PsuOutputPatch) => request<PsuState>(`${psu(id)}/outputs/${n}`, json("PATCH", body)),
+  setPsuOutputEnable: (id: string, n: number, enabled: boolean) => request<PsuState>(`${psu(id)}/outputs/${n}/enable`, json("PATCH", { enabled })),
 };
 
 export type { MeasurementValue };

--- a/webapp/app/src/api/types.ts
+++ b/webapp/app/src/api/types.ts
@@ -84,6 +84,20 @@ export type StreamMessage =
   | { type: "closed" }
   | ({ type: "log_status" } & LogStatus);
 
+export type PsuOutputState = {
+  output: number;
+  voltage: number;
+  current: number;
+  enabled: boolean;
+  measured_voltage: number;
+  measured_current: number;
+  measured_power: number;
+};
+
+export type PsuState = { outputs: PsuOutputState[] };
+
+export type PsuOutputPatch = Partial<{ voltage: number; current: number }>;
+
 export type SessionCreate = { label?: string; address?: string; port?: number; mock?: boolean; model?: string };
 export type ChannelPatch = Partial<{ enabled: boolean; voltage_scale: number; voltage_offset: number; coupling: string; probe_ratio: number }>;
 export type TriggerPatch = Partial<{ mode: string; source: string; level: number; slope: string; coupling: string }>;

--- a/webapp/app/src/api/types.ts
+++ b/webapp/app/src/api/types.ts
@@ -85,21 +85,31 @@ export type StreamMessage =
   | { type: "closed" }
   | ({ type: "log_status" } & LogStatus);
 
+// Every field bar `output` is read through the server's _safe(): a query the
+// model does not implement, or a timeout, yields null. `enabled` in particular
+// is null-not-false by design — an SPD3303X's CH3 has no status bit and no
+// OUTP3?, and rendering an energised rail as a confident "off" is the exact
+// safety failure the UI must not commit. null means "unknown"; show it as such.
 export type PsuOutputState = {
   output: number;
-  voltage: number;
-  current: number;
-  enabled: boolean;
-  measured_voltage: number;
-  measured_current: number;
-  measured_power: number;
+  voltage: number | null;
+  current: number | null;
+  enabled: boolean | null;
+  measured_voltage: number | null;
+  measured_current: number | null;
+  measured_power: number | null;
 };
 
 export type PsuState = { outputs: PsuOutputState[] };
 
 export type PsuOutputPatch = Partial<{ voltage: number; current: number }>;
 
-export type SessionCreate = { label?: string; address?: string; port?: number; mock?: boolean; model?: string };
+// `kind` is optional and the server defaults it to "scope", so an older client
+// that omits it keeps the pre-5.8 behaviour. Sending it is how the UI creates
+// anything other than a scope: discovery already knows the kind, and without
+// passing it through, clicking Connect on a discovered PSU builds an
+// Oscilloscope against a power supply and 409s on the server's kind guard.
+export type SessionCreate = { label?: string; kind?: Kind; address?: string; port?: number; mock?: boolean; model?: string };
 export type ChannelPatch = Partial<{ enabled: boolean; voltage_scale: number; voltage_offset: number; coupling: string; probe_ratio: number }>;
 export type TriggerPatch = Partial<{ mode: string; source: string; level: number; slope: string; coupling: string }>;
 export type RunOp = "run" | "stop" | "single" | "auto";

--- a/webapp/app/src/api/types.ts
+++ b/webapp/app/src/api/types.ts
@@ -74,6 +74,7 @@ export type LogData = { columns: { channel: number; mtype: string }[]; rows: (nu
 
 export type StreamMessage =
   | { type: "state"; state: ScopeState }
+  | { type: "state"; kind: "psu"; outputs: PsuOutputState[] }
   | { type: "waveform"; channel: number | string; t0: number; dt: number; points: number[] }
   | { type: "measurements"; values: MeasurementValue[]; timestamp?: number }
   | { type: "measurements_config"; items: { channel: number; mtype: string }[] }

--- a/webapp/app/src/api/types.ts
+++ b/webapp/app/src/api/types.ts
@@ -1,3 +1,5 @@
+import type { Kind } from "../features/home/kinds";
+
 export type ChannelState = {
   enabled: boolean;
   voltage_scale: number;
@@ -34,6 +36,7 @@ export type SessionInfo = {
   num_channels: number;
   viewers: number;
   owner: string;
+  kind: Kind;
 };
 
 export type DiscoveredDevice = {

--- a/webapp/app/src/features/controls/AnalysisPanel.test.tsx
+++ b/webapp/app/src/features/controls/AnalysisPanel.test.tsx
@@ -14,7 +14,7 @@ const FILTERS: FilterConfig[] = [
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
   vi.spyOn(api, "getSpectrum").mockResolvedValue(SPECTRUM);
   vi.spyOn(api, "getFilters").mockResolvedValue(FILTERS);
 });

--- a/webapp/app/src/features/controls/ChannelsPanel.test.tsx
+++ b/webapp/app/src/features/controls/ChannelsPanel.test.tsx
@@ -17,7 +17,7 @@ const STATE = {
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "SDS1104X-E", dialect: "legacy", num_channels: 2, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "SDS1104X-E", dialect: "legacy", num_channels: 2, viewers: 0, owner: "", kind: "scope" });
   useSession.getState().applyState(STATE);
 });
 afterEach(() => vi.restoreAllMocks());

--- a/webapp/app/src/features/controls/MathPanel.test.tsx
+++ b/webapp/app/src/features/controls/MathPanel.test.tsx
@@ -8,7 +8,7 @@ import { useSession } from "../../store/session";
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
 });
 afterEach(() => vi.restoreAllMocks());
 

--- a/webapp/app/src/features/controls/ScopeToolbar.test.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.test.tsx
@@ -11,7 +11,7 @@ const STATE = { run_state: "STOP", timebase: 0.001, channels: { "1": { enabled: 
 beforeEach(() => {
   localStorage.clear();
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
   useSession.getState().applyState(STATE);
 });
 afterEach(() => {

--- a/webapp/app/src/features/controls/TriggerPanel.test.tsx
+++ b/webapp/app/src/features/controls/TriggerPanel.test.tsx
@@ -16,7 +16,7 @@ const NULL_TRIGGER_STATE = {
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
 });
 afterEach(() => vi.restoreAllMocks());
 

--- a/webapp/app/src/features/export/ExportButton.test.tsx
+++ b/webapp/app/src/features/export/ExportButton.test.tsx
@@ -10,7 +10,7 @@ const BASE = { run_state: "STOP", timebase: 0.001, trigger: { mode: "AUTO", sour
 beforeEach(() => {
   localStorage.clear();
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
 });
 afterEach(() => vi.unstubAllGlobals());
 

--- a/webapp/app/src/features/export/ScreenshotButton.test.tsx
+++ b/webapp/app/src/features/export/ScreenshotButton.test.tsx
@@ -13,7 +13,7 @@ afterEach(() => vi.unstubAllGlobals());
 
 describe("ScreenshotButton", () => {
   it("downloads the screenshot URL with the bearer token when connected", async () => {
-    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
     setToken("scpi_shot");
     const fetchMock = vi.fn().mockResolvedValue(new Response(new Blob(["data"]), { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
@@ -35,7 +35,7 @@ describe("ScreenshotButton", () => {
   });
 
   it("surfaces a download failure instead of silently doing nothing", async () => {
-    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Unauthorized", detail: "missing bearer token" }), { status: 401 })));
 
     render(<ScreenshotButton />);

--- a/webapp/app/src/features/home/HomeScreen.test.tsx
+++ b/webapp/app/src/features/home/HomeScreen.test.tsx
@@ -28,7 +28,7 @@ describe("HomeScreen", () => {
     await screen.findByRole("button", { name: "Connect SDS1104X-E" });
     await userEvent.click(screen.getByRole("button", { name: "Connect SDS1104X-E" }));
 
-    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ address: "192.168.1.51", label: "SDS1104X-E" }));
+    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ address: "192.168.1.51", label: "SDS1104X-E", kind: "scope" }));
     await waitFor(() => expect(onConnected).toHaveBeenCalledWith(created));
   });
 
@@ -76,7 +76,7 @@ describe("HomeScreen", () => {
     await userEvent.type(await screen.findByLabelText("IP address"), "10.0.0.9");
     await userEvent.click(screen.getByRole("button", { name: "Connect" }));
 
-    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ address: "10.0.0.9", label: "10.0.0.9" }));
+    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ address: "10.0.0.9", label: "10.0.0.9", kind: "scope" }));
     await waitFor(() => expect(onConnected).toHaveBeenCalledWith(created));
   });
 
@@ -108,8 +108,61 @@ describe("HomeScreen", () => {
     const onConnected = vi.fn();
     render(<HomeScreen onConnected={onConnected} />);
     await userEvent.click(await screen.findByRole("button", { name: /mock scope/i }));
-    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ mock: true }));
+    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ mock: true, kind: "scope" }));
     await waitFor(() => expect(onConnected).toHaveBeenCalled());
+  });
+
+  // --- the kind has to reach the server, or no UI path can make a PSU -------
+
+  const PSU_DEVICE: DiscoveredDevice = { address: "192.168.1.60", idn: "Siglent,SPD3303X,1,1", manufacturer: "Siglent", model: "SPD3303X", dialect: "", kind: "psu", connected: false };
+  const PSU_SESSION: SessionInfo = { ...SESSION, id: "psu1", address: "192.168.1.60", model: "SPD3303X", dialect: "", num_channels: 3, kind: "psu" };
+
+  it("sends the discovered kind when connecting a power supply", async () => {
+    // Without kind on the create call the server defaults to "scope", builds
+    // an Oscilloscope against a PSU, and 409s on its own kind guard — so the
+    // shipped UI could not create a PSU session at all.
+    vi.spyOn(api, "listSessions").mockResolvedValue([]);
+    vi.spyOn(api, "discover").mockResolvedValue([PSU_DEVICE]);
+    const createSession = vi.spyOn(api, "createSession").mockResolvedValue(PSU_SESSION);
+    const onConnected = vi.fn();
+    render(<HomeScreen onConnected={onConnected} />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Connect SPD3303X" }));
+
+    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ address: "192.168.1.60", label: "SPD3303X", kind: "psu" }));
+    await waitFor(() => expect(onConnected).toHaveBeenCalledWith(PSU_SESSION));
+  });
+
+  it("connects a mock power supply from the rail", async () => {
+    vi.spyOn(api, "listSessions").mockResolvedValue([]);
+    vi.spyOn(api, "discover").mockResolvedValue([]);
+    const createSession = vi.spyOn(api, "createSession").mockResolvedValue({ ...PSU_SESSION, mock: true, address: null });
+    const onConnected = vi.fn();
+    render(<HomeScreen onConnected={onConnected} />);
+    await userEvent.click(await screen.findByRole("button", { name: /mock power supply/i }));
+    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ mock: true, kind: "psu" }));
+    await waitFor(() => expect(onConnected).toHaveBeenCalled());
+  });
+
+  it("replays the recorded kind when reconnecting a recent power supply", async () => {
+    localStorage.setItem("scpi.recent", JSON.stringify([{ address: "192.168.1.60", label: "SPD3303X", kind: "psu", model: "SPD3303X", mock: false }]));
+    vi.spyOn(api, "listSessions").mockResolvedValue([]);
+    vi.spyOn(api, "discover").mockResolvedValue([]);
+    const createSession = vi.spyOn(api, "createSession").mockResolvedValue(PSU_SESSION);
+    render(<HomeScreen onConnected={vi.fn()} />);
+    await userEvent.click(await screen.findByRole("button", { name: /SPD3303X/ }));
+    await waitFor(() => expect(createSession).toHaveBeenCalledWith({ address: "192.168.1.60", label: "SPD3303X", kind: "psu" }));
+  });
+
+  it("labels a held PSU session as a power supply, not an oscilloscope", async () => {
+    // sessionAsDevice used to hardcode kind:"scope", so every live session —
+    // PSU included — was rendered with the oscilloscope label and accent.
+    vi.spyOn(api, "listSessions").mockResolvedValue([PSU_SESSION]);
+    vi.spyOn(api, "discover").mockResolvedValue([]);
+    render(<HomeScreen onConnected={vi.fn()} />);
+    await screen.findByRole("button", { name: "Open SPD3303X" });
+    expect(screen.getByText(/Power supply/)).toBeInTheDocument();
+    expect(screen.queryByText(/Oscilloscope/)).not.toBeInTheDocument();
   });
 
   it("surfaces a connect error detail", async () => {

--- a/webapp/app/src/features/home/HomeScreen.test.tsx
+++ b/webapp/app/src/features/home/HomeScreen.test.tsx
@@ -13,7 +13,7 @@ afterEach(() => {
   useIdentity.getState().clearIdentity();
 });
 
-const SESSION: SessionInfo = { id: "abc", label: "bench", mock: false, address: "192.168.1.50", state: "connected", idn: "Siglent,SDS824X HD,1,1", model: "SDS824X HD", dialect: "modern", num_channels: 4, viewers: 0, owner: "" };
+const SESSION: SessionInfo = { id: "abc", label: "bench", mock: false, address: "192.168.1.50", state: "connected", idn: "Siglent,SDS824X HD,1,1", model: "SDS824X HD", dialect: "modern", num_channels: 4, viewers: 0, owner: "", kind: "scope" };
 const FREE: DiscoveredDevice = { address: "192.168.1.51", idn: "x", manufacturer: "Siglent", model: "SDS1104X-E", dialect: "legacy", kind: "scope", connected: false };
 
 describe("HomeScreen", () => {

--- a/webapp/app/src/features/home/HomeScreen.tsx
+++ b/webapp/app/src/features/home/HomeScreen.tsx
@@ -9,6 +9,7 @@ import { InstrumentDashboard } from "./InstrumentDashboard";
 import { ManualConnect } from "./ManualConnect";
 import { RecentBar } from "./RecentBar";
 import { pushRecent, type RecentEntry } from "./recent";
+import { asKind } from "./kinds";
 import { useIdentity } from "../../store/identity";
 
 type Props = { onConnected: (session: SessionInfo) => void };
@@ -16,7 +17,9 @@ type Props = { onConnected: (session: SessionInfo) => void };
 const REFRESH_MS = 30_000;
 
 function sessionAsDevice(s: SessionInfo): DiscoveredDevice {
-  return { address: s.address, idn: s.idn, manufacturer: s.idn.split(",")[0]?.trim() ?? "", model: s.model, dialect: s.dialect, kind: "scope", connected: true, session_id: s.id, viewers: s.viewers };
+  // s.kind, not a hardcoded "scope": the dashboard groups devices by kind, so
+  // hardcoding filed every live PSU session under "Oscilloscopes".
+  return { address: s.address, idn: s.idn, manufacturer: s.idn.split(",")[0]?.trim() ?? "", model: s.model, dialect: s.dialect, kind: s.kind, connected: true, session_id: s.id, viewers: s.viewers };
 }
 
 export function HomeScreen({ onConnected }: Props) {
@@ -83,7 +86,12 @@ export function HomeScreen({ onConnected }: Props) {
     }
   }
 
-  const onConnectDevice = (d: DiscoveredDevice) => connect({ address: d.address ?? undefined, label: d.model }, { address: d.address, label: d.model, kind: d.kind, model: d.model, mock: false }, deviceKey(d));
+  // The kind discovery already determined has to travel with the create call:
+  // without it the server defaults every session to "scope", so connecting to a
+  // discovered SPD3303X builds an Oscilloscope against a power supply and is
+  // refused by the session's kind guard.
+  const onConnectDevice = (d: DiscoveredDevice) =>
+    connect({ address: d.address ?? undefined, label: d.model, kind: asKind(d.kind) }, { address: d.address, label: d.model, kind: d.kind, model: d.model, mock: false }, deviceKey(d));
   const onOpenDevice = async (d: DiscoveredDevice) => {
     if (!d.session_id) return;
     setBusy(true);
@@ -102,9 +110,14 @@ export function HomeScreen({ onConnected }: Props) {
       setBusyKey(null);
     }
   };
-  const onReconnect = (e: RecentEntry) => (e.mock ? connect({ mock: true }, e, null) : connect({ address: e.address ?? undefined, label: e.label }, e, e.address));
-  const onConnectAddress = (address: string) => connect({ address, label: address }, { address, label: address, kind: "scope", model: address, mock: false }, address);
-  const onConnectMock = () => connect({ mock: true }, { address: null, label: "Mock scope", kind: "scope", model: "Mock", mock: true }, null);
+  // A recent entry records the kind it was connected as; replay it, or
+  // reconnecting a remembered PSU would silently come back as a scope.
+  const onReconnect = (e: RecentEntry) => (e.mock ? connect({ mock: true, kind: asKind(e.kind) }, e, null) : connect({ address: e.address ?? undefined, label: e.label, kind: asKind(e.kind) }, e, e.address));
+  // Manual IP entry carries no discovery result, so it stays a scope — the
+  // only kind a bare address can be assumed to be.
+  const onConnectAddress = (address: string) => connect({ address, label: address, kind: "scope" }, { address, label: address, kind: "scope", model: address, mock: false }, address);
+  const onConnectMock = () => connect({ mock: true, kind: "scope" }, { address: null, label: "Mock scope", kind: "scope", model: "Mock", mock: true }, null);
+  const onConnectMockPsu = () => connect({ mock: true, kind: "psu" }, { address: null, label: "Mock power supply", kind: "psu", model: "Mock", mock: true }, null);
 
   return (
     <div>
@@ -116,7 +129,7 @@ export function HomeScreen({ onConnected }: Props) {
           <InstrumentDashboard devices={devices} scanning={scanning} error={error} busyKey={busyKey} onConnect={onConnectDevice} onOpen={onOpenDevice} sessions={sessions} identity={identity} onClaimed={scan} />
         </div>
         <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "var(--space-2)", minWidth: 220 }}>
-          <GroupBox title="Connect manually"><ManualConnect busy={busy} onConnectAddress={onConnectAddress} onConnectMock={onConnectMock} /></GroupBox>
+          <GroupBox title="Connect manually"><ManualConnect busy={busy} onConnectAddress={onConnectAddress} onConnectMock={onConnectMock} onConnectMockPsu={onConnectMockPsu} /></GroupBox>
           <GroupBox title="Help"><GettingStarted /></GroupBox>
         </div>
       </div>

--- a/webapp/app/src/features/home/ManualConnect.test.tsx
+++ b/webapp/app/src/features/home/ManualConnect.test.tsx
@@ -6,7 +6,7 @@ import { ManualConnect } from "./ManualConnect";
 describe("ManualConnect", () => {
   it("connects the typed address", async () => {
     const onConnectAddress = vi.fn();
-    render(<ManualConnect busy={false} onConnectAddress={onConnectAddress} onConnectMock={vi.fn()} />);
+    render(<ManualConnect busy={false} onConnectAddress={onConnectAddress} onConnectMock={vi.fn()} onConnectMockPsu={vi.fn()} />);
     await userEvent.type(screen.getByLabelText("IP address"), "192.168.1.50");
     await userEvent.click(screen.getByRole("button", { name: /^connect$/i }));
     expect(onConnectAddress).toHaveBeenCalledWith("192.168.1.50");
@@ -14,8 +14,19 @@ describe("ManualConnect", () => {
 
   it("connects a mock scope", async () => {
     const onConnectMock = vi.fn();
-    render(<ManualConnect busy={false} onConnectAddress={vi.fn()} onConnectMock={onConnectMock} />);
+    render(<ManualConnect busy={false} onConnectAddress={vi.fn()} onConnectMock={onConnectMock} onConnectMockPsu={vi.fn()} />);
     await userEvent.click(screen.getByRole("button", { name: /mock scope/i }));
     expect(onConnectMock).toHaveBeenCalled();
+  });
+
+  it("connects a mock power supply", async () => {
+    // The only no-hardware route to a PSU session: discovery finds nothing on
+    // an empty bench, and the address field can only build a scope.
+    const onConnectMockPsu = vi.fn();
+    const onConnectMock = vi.fn();
+    render(<ManualConnect busy={false} onConnectAddress={vi.fn()} onConnectMock={onConnectMock} onConnectMockPsu={onConnectMockPsu} />);
+    await userEvent.click(screen.getByRole("button", { name: /mock power supply/i }));
+    expect(onConnectMockPsu).toHaveBeenCalled();
+    expect(onConnectMock).not.toHaveBeenCalled();
   });
 });

--- a/webapp/app/src/features/home/ManualConnect.tsx
+++ b/webapp/app/src/features/home/ManualConnect.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { Button } from "../../ds/Button";
 
-type Props = { busy: boolean; onConnectAddress: (address: string) => void; onConnectMock: () => void };
+type Props = { busy: boolean; onConnectAddress: (address: string) => void; onConnectMock: () => void; onConnectMockPsu: () => void };
 
-export function ManualConnect({ busy, onConnectAddress, onConnectMock }: Props) {
+export function ManualConnect({ busy, onConnectAddress, onConnectMock, onConnectMockPsu }: Props) {
   const [address, setAddress] = useState("");
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
@@ -21,6 +21,12 @@ export function ManualConnect({ busy, onConnectAddress, onConnectMock }: Props) 
       </div>
       <Button disabled={busy} onClick={onConnectMock}>
         Mock scope
+      </Button>
+      {/* Without this there is no way to reach a PSU session with no hardware:
+          discovery finds nothing on a bench with no instruments, and the
+          address field can only make a scope. */}
+      <Button disabled={busy} onClick={onConnectMockPsu}>
+        Mock power supply
       </Button>
     </div>
   );

--- a/webapp/app/src/features/home/kinds.test.ts
+++ b/webapp/app/src/features/home/kinds.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { KIND_META, KIND_ORDER, kindMeta } from "./kinds";
 
 describe("kinds", () => {
-  it("marks only scope connectable in V1", () => {
+  it("marks scope and psu connectable, awg/daq/unknown not yet", () => {
     expect(KIND_META.scope.connectable).toBe(true);
-    expect(KIND_META.psu.connectable).toBe(false);
+    expect(KIND_META.psu.connectable).toBe(true);
     expect(KIND_META.awg.connectable).toBe(false);
     expect(KIND_META.daq.connectable).toBe(false);
     expect(KIND_META.unknown.connectable).toBe(false);

--- a/webapp/app/src/features/home/kinds.ts
+++ b/webapp/app/src/features/home/kinds.ts
@@ -11,7 +11,7 @@ export type KindMeta = {
 // device types slot in here + a discovery classifier + a post-connect view).
 export const KIND_META: Record<Kind, KindMeta> = {
   scope: { label: "Oscilloscope", plural: "Oscilloscopes", accent: "var(--ch1)", connectable: true },
-  psu: { label: "Power supply", plural: "Power supplies", accent: "var(--ch2)", connectable: false },
+  psu: { label: "Power supply", plural: "Power supplies", accent: "var(--ch2)", connectable: true },
   awg: { label: "AWG", plural: "AWGs", accent: "var(--warning)", connectable: false },
   daq: { label: "DAQ", plural: "DAQ", accent: "var(--ch3)", connectable: false },
   unknown: { label: "Unknown", plural: "Unknown", accent: "var(--text-muted)", connectable: false },

--- a/webapp/app/src/features/home/kinds.ts
+++ b/webapp/app/src/features/home/kinds.ts
@@ -22,3 +22,11 @@ export const KIND_ORDER: Kind[] = ["scope", "psu", "awg", "daq", "unknown"];
 export function kindMeta(kind: string): KindMeta {
   return (KIND_META as Record<string, KindMeta>)[kind] ?? KIND_META.unknown;
 }
+
+/** Narrow a server- or storage-supplied string to a Kind, checked rather than
+ *  cast: discovery and localStorage are both outside the type system, and an
+ *  unrecognised value must land on "unknown" (which is not connectable) instead
+ *  of being smuggled through as if it were a supported kind. */
+export function asKind(kind: string | undefined | null): Kind {
+  return kind != null && kind in KIND_META ? (kind as Kind) : "unknown";
+}

--- a/webapp/app/src/features/measure/MeasurePanel.test.tsx
+++ b/webapp/app/src/features/measure/MeasurePanel.test.tsx
@@ -9,7 +9,7 @@ const STATE = { run_state: "STOP", timebase: 0.001, channels: { "1": { enabled: 
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
   useSession.getState().applyState(STATE);
 });
 afterEach(() => vi.restoreAllMocks());

--- a/webapp/app/src/features/psu/PsuPanel.test.tsx
+++ b/webapp/app/src/features/psu/PsuPanel.test.tsx
@@ -114,6 +114,45 @@ describe("PsuPanel", () => {
     await waitFor(() => expect(field).toHaveValue("9.900 V"));
   });
 
+  // --- a read that failed must render as unknown, never as a value ---------
+
+  it("shows an unreadable enable state as unknown, not as off", async () => {
+    // enabled === null means the instrument would not tell us. On an SPD3303X
+    // that is CH3's normal answer (no status bit, no OUTP3?), and painting a
+    // live rail as a confident "off" is the dangerous half of the safety
+    // invariant. It must read as mixed and refuse the flip.
+    const unknown = { outputs: [{ ...STATE.outputs[0], enabled: null }] };
+    vi.spyOn(api, "psuState").mockResolvedValue(unknown);
+    const setEnable = vi.spyOn(api, "setPsuOutputEnable").mockResolvedValue(unknown);
+    render(<PsuPanel />);
+    const toggle = await screen.findByLabelText("Output 1 enable");
+    expect(toggle).toHaveAttribute("aria-checked", "mixed");
+    expect(toggle).toBeDisabled();
+    expect(screen.getByText(/state unknown/i)).toBeInTheDocument();
+    await userEvent.click(toggle);
+    expect(setEnable).not.toHaveBeenCalled();
+  });
+
+  it("shows a failed measurement as --.--, not as 0.000", async () => {
+    const unread = { outputs: [{ ...STATE.outputs[0], measured_voltage: null, measured_current: null, measured_power: null }] };
+    vi.spyOn(api, "psuState").mockResolvedValue(unread);
+    render(<PsuPanel />);
+    await screen.findByLabelText("Output 1 voltage");
+    expect(screen.queryByText("0.000")).not.toBeInTheDocument();
+    expect(screen.getAllByText("--.--")).toHaveLength(3);
+  });
+
+  it("shows an unreadable setpoint as --.-- instead of an editable zero", async () => {
+    const unread = { outputs: [{ ...STATE.outputs[0], voltage: null }] };
+    vi.spyOn(api, "psuState").mockResolvedValue(unread);
+    render(<PsuPanel />);
+    const voltage = await screen.findByLabelText("Output 1 voltage");
+    expect(voltage).not.toHaveValue("0.000 V");
+    expect(voltage).toHaveTextContent("--.--");
+    // the current limit was readable, so it stays editable
+    expect(screen.getByLabelText("Output 1 current")).toHaveValue("0.500 A");
+  });
+
   it("ignores a second click on the same toggle while its request is in flight", async () => {
     vi.spyOn(api, "psuState").mockResolvedValue(STATE);
     let resolveEnable: (value: typeof STATE) => void = () => {};

--- a/webapp/app/src/features/psu/PsuPanel.test.tsx
+++ b/webapp/app/src/features/psu/PsuPanel.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PsuPanel } from "./PsuPanel";
-import { api } from "../../api/client";
+import { ApiError, api } from "../../api/client";
 import { setToken } from "../../api/token";
 import { useSession } from "../../store/session";
 
@@ -57,5 +57,72 @@ describe("PsuPanel", () => {
     render(<PsuPanel />);
     expect(await screen.findByLabelText("Output 1 enable")).not.toBeChecked();
     expect(await screen.findByLabelText("Output 2 enable")).toBeChecked();
+  });
+
+  // --- review fixes: reconciliation, the non-optimistic invariant, and the
+  // in-flight lock all need their own coverage -- none of the four tests
+  // above touch a failure path or a pending request at all.
+
+  it("shows a loading state before the initial fetch resolves, then clears it", async () => {
+    let resolvePsuState: (value: typeof STATE) => void = () => {};
+    vi.spyOn(api, "psuState").mockImplementation(() => new Promise((resolve) => { resolvePsuState = resolve; }));
+    render(<PsuPanel />);
+    expect(screen.getByText(/Loading power supply state/i)).toBeInTheDocument();
+    resolvePsuState(STATE);
+    await waitFor(() => expect(screen.queryByText(/Loading power supply state/i)).not.toBeInTheDocument());
+  });
+
+  it("does not flip the toggle before the enable request resolves (non-optimistic)", async () => {
+    vi.spyOn(api, "psuState").mockResolvedValue(STATE);
+    let resolveEnable: (value: typeof STATE) => void = () => {};
+    const setEnable = vi.spyOn(api, "setPsuOutputEnable").mockImplementation(() => new Promise((resolve) => { resolveEnable = resolve; }));
+    render(<PsuPanel />);
+    const toggle = await screen.findByLabelText("Output 1 enable");
+    await userEvent.click(toggle);
+    // The request is still pending: a user must never see "on" before the
+    // instrument has actually confirmed it, so the control must still show
+    // the last known-true (off) state here, not the requested one.
+    expect(toggle).not.toBeChecked();
+    resolveEnable(STATE);
+    await waitFor(() => expect(setEnable).toHaveBeenCalled());
+  });
+
+  it("reconciles the toggle to server truth after a failed enable request", async () => {
+    // The initial mount fetch returns the normal fixture (output 1 off); the
+    // reconciliation fetch fired after the failed PATCH reports output 1 has
+    // actually landed ON underneath (e.g. the PATCH's response was lost but
+    // the instrument applied it). Only a real reconcile call surfaces that.
+    const reconciled = { outputs: [{ ...STATE.outputs[0], enabled: true }, STATE.outputs[1]] };
+    vi.spyOn(api, "psuState").mockResolvedValueOnce(STATE).mockResolvedValueOnce(reconciled);
+    vi.spyOn(api, "setPsuOutputEnable").mockRejectedValue(new ApiError(500, "Error", "psu offline"));
+    render(<PsuPanel />);
+    const toggle = await screen.findByLabelText("Output 1 enable");
+    await userEvent.click(toggle);
+    await screen.findByRole("alert");
+    await waitFor(() => expect(toggle).toBeChecked());
+  });
+
+  it("reconciles setpoints to server truth after a failed voltage change", async () => {
+    const reconciled = { outputs: [{ ...STATE.outputs[0], voltage: 9.9 }, STATE.outputs[1]] };
+    vi.spyOn(api, "psuState").mockResolvedValueOnce(STATE).mockResolvedValueOnce(reconciled);
+    vi.spyOn(api, "setPsuOutput").mockRejectedValue(new ApiError(400, "Error", "output 1 not available"));
+    render(<PsuPanel />);
+    const field = await screen.findByLabelText("Output 1 voltage");
+    await userEvent.clear(field);
+    await userEvent.type(field, "12{enter}");
+    await screen.findByRole("alert");
+    await waitFor(() => expect(field).toHaveValue("9.900 V"));
+  });
+
+  it("ignores a second click on the same toggle while its request is in flight", async () => {
+    vi.spyOn(api, "psuState").mockResolvedValue(STATE);
+    let resolveEnable: (value: typeof STATE) => void = () => {};
+    const setEnable = vi.spyOn(api, "setPsuOutputEnable").mockImplementation(() => new Promise((resolve) => { resolveEnable = resolve; }));
+    render(<PsuPanel />);
+    const toggle = await screen.findByLabelText("Output 1 enable");
+    await userEvent.click(toggle);
+    await userEvent.click(toggle); // disabled while pending -> must be a no-op
+    resolveEnable(STATE);
+    await waitFor(() => expect(setEnable).toHaveBeenCalledTimes(1));
   });
 });

--- a/webapp/app/src/features/psu/PsuPanel.test.tsx
+++ b/webapp/app/src/features/psu/PsuPanel.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PsuPanel } from "./PsuPanel";
+import { api } from "../../api/client";
+import { setToken } from "../../api/token";
+import { useSession } from "../../store/session";
+
+const SESSION = { id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "SPD3303X", dialect: "", num_channels: 2, viewers: 0, owner: "", kind: "psu" as const };
+const STATE = {
+  outputs: [
+    { output: 1, voltage: 3.3, current: 0.5, enabled: false, measured_voltage: 0.0, measured_current: 0.0, measured_power: 0.0 },
+    { output: 2, voltage: 5.0, current: 1.0, enabled: true, measured_voltage: 5.01, measured_current: 0.12, measured_power: 0.6 },
+  ],
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  setToken("test-token");
+  useSession.getState().clearSession();
+  useSession.getState().setSession(SESSION);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("PsuPanel", () => {
+  it("renders every output with its measured values", async () => {
+    vi.spyOn(api, "psuState").mockResolvedValue(STATE);
+    render(<PsuPanel />);
+    await waitFor(() => expect(screen.getByText(/5\.01/)).toBeInTheDocument());
+    expect(screen.getByText(/0\.12/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.6/)).toBeInTheDocument();
+  });
+
+  it("sends a voltage change for the right output", async () => {
+    vi.spyOn(api, "psuState").mockResolvedValue(STATE);
+    const setOutput = vi.spyOn(api, "setPsuOutput").mockResolvedValue(STATE);
+    render(<PsuPanel />);
+    const field = await screen.findByLabelText("Output 1 voltage");
+    await userEvent.clear(field);
+    await userEvent.type(field, "12{enter}");
+    await waitFor(() => expect(setOutput).toHaveBeenCalledWith("abc", 1, expect.objectContaining({ voltage: 12 })));
+  });
+
+  it("toggles an output", async () => {
+    vi.spyOn(api, "psuState").mockResolvedValue(STATE);
+    const setEnable = vi.spyOn(api, "setPsuOutputEnable").mockResolvedValue(STATE);
+    render(<PsuPanel />);
+    await userEvent.click(await screen.findByLabelText("Output 1 enable"));
+    await waitFor(() => expect(setEnable).toHaveBeenCalledWith("abc", 1, true));
+  });
+
+  it("exposes enable state accessibly, not only by colour", async () => {
+    vi.spyOn(api, "psuState").mockResolvedValue(STATE);
+    render(<PsuPanel />);
+    expect(await screen.findByLabelText("Output 1 enable")).not.toBeChecked();
+    expect(await screen.findByLabelText("Output 2 enable")).toBeChecked();
+  });
+});

--- a/webapp/app/src/features/psu/PsuPanel.tsx
+++ b/webapp/app/src/features/psu/PsuPanel.tsx
@@ -12,8 +12,22 @@ import { useSession } from "../../store/session";
 // ChannelsPanel's NO_CHANNELS).
 const NO_OUTPUTS: PsuOutputState[] = [];
 
-function fmt(value: number): string {
-  return (typeof value === "number" && !Number.isNaN(value) ? value : 0).toFixed(3);
+// A reading the instrument could not give us is null, and null is NOT zero.
+// Rendering it as "0.000" is a confident lie about live hardware; "--.--" is
+// the same "no reading" marker ReadoutStrip uses for a failed measurement.
+function fmt(value: number | null | undefined): string {
+  return typeof value === "number" && !Number.isNaN(value) ? value.toFixed(3) : "--.--";
+}
+
+/** A setpoint the instrument would not report. An editable field pre-filled
+ *  with 0 would invite the user to "confirm" a value that was never read back,
+ *  so show the unreadable marker instead of a spin box. */
+function Unreadable({ what, unit }: { what: string; unit: string }) {
+  return (
+    <span aria-label={what} title="This value could not be read from the instrument" style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-sm)", color: "var(--lc-muted)" }}>
+      --.-- {unit}
+    </span>
+  );
 }
 
 export function PsuPanel() {
@@ -110,41 +124,56 @@ export function PsuPanel() {
       <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)" }}>
         {outputs.map((o) => {
           const busy = pending.has(o.output);
+          // enabled === null means the instrument could not tell us. The
+          // toggle must not claim "off" (an SPD3303X's CH3 answers no
+          // output-state query at all, and an energised rail shown as off is
+          // the dangerous direction), and it must not offer a flip whose
+          // starting point we do not know: aria-checked="mixed" + disabled.
+          const enableUnknown = o.enabled === null;
           return (
             <GroupBox key={o.output} title={`Output ${o.output}`}>
               <div style={{ display: "flex", flexDirection: "column", gap: "10px", minWidth: "220px" }}>
                 <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
                   Voltage
-                  <SpinBox
-                    aria-label={`Output ${o.output} voltage`}
-                    value={o.voltage}
-                    step={0.1}
-                    min={0}
-                    decimals={3}
-                    suffix=" V"
-                    disabled={busy}
-                    onChange={(value) => sendOutput(o.output, { voltage: value })}
-                  />
+                  {o.voltage === null ? (
+                    <Unreadable what={`Output ${o.output} voltage`} unit="V" />
+                  ) : (
+                    <SpinBox
+                      aria-label={`Output ${o.output} voltage`}
+                      value={o.voltage}
+                      step={0.1}
+                      min={0}
+                      decimals={3}
+                      suffix=" V"
+                      disabled={busy}
+                      onChange={(value) => sendOutput(o.output, { voltage: value })}
+                    />
+                  )}
                 </div>
                 <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
                   Current limit
-                  <SpinBox
-                    aria-label={`Output ${o.output} current`}
-                    value={o.current}
-                    step={0.1}
-                    min={0}
-                    decimals={3}
-                    suffix=" A"
-                    disabled={busy}
-                    onChange={(value) => sendOutput(o.output, { current: value })}
-                  />
+                  {o.current === null ? (
+                    <Unreadable what={`Output ${o.output} current`} unit="A" />
+                  ) : (
+                    <SpinBox
+                      aria-label={`Output ${o.output} current`}
+                      value={o.current}
+                      step={0.1}
+                      min={0}
+                      decimals={3}
+                      suffix=" A"
+                      disabled={busy}
+                      onChange={(value) => sendOutput(o.output, { current: value })}
+                    />
+                  )}
                 </div>
                 <button
                   type="button"
                   role="switch"
-                  aria-checked={o.enabled}
+                  aria-checked={enableUnknown ? "mixed" : o.enabled === true}
                   aria-label={`Output ${o.output} enable`}
-                  disabled={busy}
+                  disabled={busy || enableUnknown}
+                  title={enableUnknown ? "This model does not report the output state; read it off the instrument's own display." : undefined}
                   onClick={() => sendEnable(o.output, !o.enabled)}
                   style={{
                     display: "inline-flex",
@@ -155,11 +184,11 @@ export function PsuPanel() {
                     border: "1px solid var(--lc-border-strong)",
                     borderRadius: "var(--lc-radius-sm)",
                     background: "var(--lc-control)",
-                    cursor: busy ? "not-allowed" : "pointer",
-                    opacity: busy ? 0.6 : 1,
+                    cursor: busy || enableUnknown ? "not-allowed" : "pointer",
+                    opacity: busy || enableUnknown ? 0.6 : 1,
                   }}
                 >
-                  <StatusIndicator state={o.enabled ? "connected" : "disconnected"} label={o.enabled ? "Output on" : "Output off"} />
+                  <StatusIndicator state={enableUnknown ? "error" : o.enabled ? "connected" : "disconnected"} label={enableUnknown ? "Output state unknown" : o.enabled ? "Output on" : "Output off"} />
                 </button>
                 <div style={{ display: "flex", gap: "var(--space-3)", paddingTop: "4px", borderTop: "1px solid var(--lc-border)" }}>
                   <Reading label="V" value={fmt(o.measured_voltage)} unit="V" />

--- a/webapp/app/src/features/psu/PsuPanel.tsx
+++ b/webapp/app/src/features/psu/PsuPanel.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useState } from "react";
 import { ApiError, api } from "../../api/client";
-import { getToken } from "../../api/token";
 import type { PsuOutputState } from "../../api/types";
 import { GroupBox } from "../../ds/GroupBox";
 import { Reading } from "../../ds/Reading";
 import { SpinBox } from "../../ds/SpinBox";
 import { StatusIndicator } from "../../ds/StatusIndicator";
 import { useSession } from "../../store/session";
+
+// Stable reference: an inline `[]` fallback would be a fresh array every
+// render, which would loop the zustand selector forever (same issue as
+// ChannelsPanel's NO_CHANNELS).
+const NO_OUTPUTS: PsuOutputState[] = [];
 
 function fmt(value: number): string {
   return (typeof value === "number" && !Number.isNaN(value) ? value : 0).toFixed(3);
@@ -15,18 +19,28 @@ function fmt(value: number): string {
 export function PsuPanel() {
   const session = useSession((s) => s.session);
   const sessionId = session?.id ?? null;
-  const [outputs, setOutputs] = useState<PsuOutputState[]>([]);
+  const psu = useSession((s) => s.psu);
+  const outputs = psu?.outputs ?? NO_OUTPUTS;
   const [error, setError] = useState<string | null>(null);
+  // Output numbers with a PATCH in flight: guards against a double-click
+  // sending two conflicting requests, and disables the setpoint fields
+  // while their value is unconfirmed.
+  const [pending, setPending] = useState<ReadonlySet<number>>(new Set());
 
-  // Initial load: the stream's first frame carries scope-shaped state, not psu
-  // outputs, so the panel always needs its own fetch on mount.
+  // Initial load: App.tsx already runs useStream(), which subscribes to this
+  // session's WebSocket and writes any psu frame into the shared store (see
+  // useStream.ts / store/session.ts). But PsuPanel's own mount effect fires
+  // before that subscription's effect does (child effects commit before the
+  // parent's), so without this fetch the panel would sit empty until the
+  // stream happens to deliver its first frame. This fetch is what actually
+  // populates the store on a cold mount; the stream then keeps it live.
   useEffect(() => {
     if (!sessionId) return;
     let cancelled = false;
     api
       .psuState(sessionId)
       .then((state) => {
-        if (!cancelled && Array.isArray(state?.outputs)) setOutputs(state.outputs);
+        if (!cancelled && Array.isArray(state?.outputs)) useSession.getState().applyPsuState(state);
       })
       .catch((err) => {
         if (!cancelled) setError(err instanceof ApiError ? err.detail : String(err));
@@ -36,123 +50,126 @@ export function PsuPanel() {
     };
   }, [sessionId]);
 
-  // Live measured values: the gateway polls the instrument and republishes a
-  // {type:"state", kind:"psu", outputs:[...]} frame on the same session stream
-  // used by the scope view. Subscribe directly rather than through the scope
-  // store, since that store has no concept of psu state.
-  useEffect(() => {
-    if (!sessionId) return;
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const token = getToken();
-    const subprotocols = token ? [`scpi-token.${token}`, "scpi"] : ["scpi"];
-    const socket = new WebSocket(`${protocol}//${window.location.host}/api/sessions/${sessionId}/stream`, subprotocols);
-    socket.onmessage = (event: MessageEvent) => {
-      try {
-        const message = JSON.parse(event.data as string);
-        if (message && message.type === "state" && message.kind === "psu" && Array.isArray(message.outputs)) {
-          setOutputs(message.outputs);
-        }
-      } catch {
-        // malformed frame: ignore, keep the last known-good outputs
-      }
-    };
-    return () => {
-      socket.onmessage = null;
-      socket.onclose = null;
-      socket.onerror = null;
-      socket.close();
-    };
-  }, [sessionId]);
+  function withPending(n: number, fn: () => Promise<void>): Promise<void> {
+    setPending((prev) => new Set(prev).add(n));
+    return fn().finally(() => {
+      setPending((prev) => {
+        const next = new Set(prev);
+        next.delete(n);
+        return next;
+      });
+    });
+  }
 
   async function sendOutput(n: number, patch: { voltage?: number; current?: number }) {
     if (!sessionId) return;
     setError(null);
-    try {
-      const state = await api.setPsuOutput(sessionId, n, patch);
-      setOutputs(state.outputs);
-    } catch (err) {
-      setError(err instanceof ApiError ? err.detail : String(err));
-    }
+    await withPending(n, async () => {
+      try {
+        const state = await api.setPsuOutput(sessionId, n, patch);
+        useSession.getState().applyPsuState(state);
+      } catch (err) {
+        setError(err instanceof ApiError ? err.detail : String(err));
+        // Same reasoning as sendEnable below: a partially-applied PATCH
+        // (e.g. voltage landed, current rejected) must not leave stale
+        // fields on screen, so reconcile with the instrument's own state.
+        await reconcile(sessionId);
+      }
+    });
   }
 
   async function sendEnable(n: number, enabled: boolean) {
     if (!sessionId) return;
     setError(null);
-    try {
-      const state = await api.setPsuOutputEnable(sessionId, n, enabled);
-      setOutputs(state.outputs);
-    } catch (err) {
-      setError(err instanceof ApiError ? err.detail : String(err));
-      // The toggle must never lie about instrument state: a failed enable
-      // request could have partially landed on the hardware, so reconcile
-      // with the server's own view rather than leaving stale local state.
+    await withPending(n, async () => {
       try {
-        const fresh = await api.psuState(sessionId);
-        setOutputs(fresh.outputs);
-      } catch {
-        // best effort: keep whatever we last knew to be true
+        const state = await api.setPsuOutputEnable(sessionId, n, enabled);
+        useSession.getState().applyPsuState(state);
+      } catch (err) {
+        setError(err instanceof ApiError ? err.detail : String(err));
+        // The toggle must never lie about instrument state: a failed enable
+        // request could have partially landed on the hardware, so reconcile
+        // with the server's own view rather than leaving stale local state.
+        await reconcile(sessionId);
       }
+    });
+  }
+
+  async function reconcile(id: string) {
+    try {
+      const fresh = await api.psuState(id);
+      useSession.getState().applyPsuState(fresh);
+    } catch {
+      // best effort: keep whatever we last knew to be true
     }
   }
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+      {psu === null && !error && <p style={{ margin: 0, color: "var(--lc-muted)" }}>Loading power supply state…</p>}
       <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)" }}>
-        {outputs.map((o) => (
-          <GroupBox key={o.output} title={`Output ${o.output}`}>
-            <div style={{ display: "flex", flexDirection: "column", gap: "10px", minWidth: "220px" }}>
-              <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
-                Voltage
-                <SpinBox
-                  aria-label={`Output ${o.output} voltage`}
-                  value={o.voltage}
-                  step={0.1}
-                  min={0}
-                  decimals={3}
-                  suffix=" V"
-                  onChange={(value) => sendOutput(o.output, { voltage: value })}
-                />
+        {outputs.map((o) => {
+          const busy = pending.has(o.output);
+          return (
+            <GroupBox key={o.output} title={`Output ${o.output}`}>
+              <div style={{ display: "flex", flexDirection: "column", gap: "10px", minWidth: "220px" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+                  Voltage
+                  <SpinBox
+                    aria-label={`Output ${o.output} voltage`}
+                    value={o.voltage}
+                    step={0.1}
+                    min={0}
+                    decimals={3}
+                    suffix=" V"
+                    disabled={busy}
+                    onChange={(value) => sendOutput(o.output, { voltage: value })}
+                  />
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+                  Current limit
+                  <SpinBox
+                    aria-label={`Output ${o.output} current`}
+                    value={o.current}
+                    step={0.1}
+                    min={0}
+                    decimals={3}
+                    suffix=" A"
+                    disabled={busy}
+                    onChange={(value) => sendOutput(o.output, { current: value })}
+                  />
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={o.enabled}
+                  aria-label={`Output ${o.output} enable`}
+                  disabled={busy}
+                  onClick={() => sendEnable(o.output, !o.enabled)}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    alignSelf: "flex-start",
+                    gap: "8px",
+                    padding: "4px 10px",
+                    border: "1px solid var(--lc-border-strong)",
+                    borderRadius: "var(--lc-radius-sm)",
+                    background: "var(--lc-control)",
+                    cursor: busy ? "not-allowed" : "pointer",
+                    opacity: busy ? 0.6 : 1,
+                  }}
+                >
+                  <StatusIndicator state={o.enabled ? "connected" : "disconnected"} label={o.enabled ? "Output on" : "Output off"} />
+                </button>
+                <div style={{ display: "flex", gap: "var(--space-3)", paddingTop: "4px", borderTop: "1px solid var(--lc-border)" }}>
+                  <Reading label="V" value={fmt(o.measured_voltage)} unit="V" />
+                  <Reading label="I" value={fmt(o.measured_current)} unit="A" />
+                  <Reading label="P" value={fmt(o.measured_power)} unit="W" />
+                </div>
               </div>
-              <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
-                Current limit
-                <SpinBox
-                  aria-label={`Output ${o.output} current`}
-                  value={o.current}
-                  step={0.1}
-                  min={0}
-                  decimals={3}
-                  suffix=" A"
-                  onChange={(value) => sendOutput(o.output, { current: value })}
-                />
-              </div>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={o.enabled}
-                aria-label={`Output ${o.output} enable`}
-                onClick={() => sendEnable(o.output, !o.enabled)}
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  alignSelf: "flex-start",
-                  gap: "8px",
-                  padding: "4px 10px",
-                  border: "1px solid var(--lc-border-strong)",
-                  borderRadius: "var(--lc-radius-sm)",
-                  background: "var(--lc-control)",
-                  cursor: "pointer",
-                }}
-              >
-                <StatusIndicator state={o.enabled ? "connected" : "disconnected"} label={o.enabled ? "Output on" : "Output off"} />
-              </button>
-              <div style={{ display: "flex", gap: "var(--space-3)", paddingTop: "4px", borderTop: "1px solid var(--lc-border)" }}>
-                <Reading label="V" value={fmt(o.measured_voltage)} unit="V" />
-                <Reading label="I" value={fmt(o.measured_current)} unit="A" />
-                <Reading label="P" value={fmt(o.measured_power)} unit="W" />
-              </div>
-            </div>
-          </GroupBox>
-        ))}
+            </GroupBox>
+          );
+        })}
       </div>
       {error && (
         <div role="alert" style={{ padding: "8px 10px", borderRadius: "var(--radius-sm)", background: "color-mix(in srgb, var(--danger) 12%, transparent)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>

--- a/webapp/app/src/features/psu/PsuPanel.tsx
+++ b/webapp/app/src/features/psu/PsuPanel.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from "react";
+import { ApiError, api } from "../../api/client";
+import { getToken } from "../../api/token";
+import type { PsuOutputState } from "../../api/types";
+import { GroupBox } from "../../ds/GroupBox";
+import { Reading } from "../../ds/Reading";
+import { SpinBox } from "../../ds/SpinBox";
+import { StatusIndicator } from "../../ds/StatusIndicator";
+import { useSession } from "../../store/session";
+
+function fmt(value: number): string {
+  return (typeof value === "number" && !Number.isNaN(value) ? value : 0).toFixed(3);
+}
+
+export function PsuPanel() {
+  const session = useSession((s) => s.session);
+  const sessionId = session?.id ?? null;
+  const [outputs, setOutputs] = useState<PsuOutputState[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // Initial load: the stream's first frame carries scope-shaped state, not psu
+  // outputs, so the panel always needs its own fetch on mount.
+  useEffect(() => {
+    if (!sessionId) return;
+    let cancelled = false;
+    api
+      .psuState(sessionId)
+      .then((state) => {
+        if (!cancelled && Array.isArray(state?.outputs)) setOutputs(state.outputs);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof ApiError ? err.detail : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  // Live measured values: the gateway polls the instrument and republishes a
+  // {type:"state", kind:"psu", outputs:[...]} frame on the same session stream
+  // used by the scope view. Subscribe directly rather than through the scope
+  // store, since that store has no concept of psu state.
+  useEffect(() => {
+    if (!sessionId) return;
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const token = getToken();
+    const subprotocols = token ? [`scpi-token.${token}`, "scpi"] : ["scpi"];
+    const socket = new WebSocket(`${protocol}//${window.location.host}/api/sessions/${sessionId}/stream`, subprotocols);
+    socket.onmessage = (event: MessageEvent) => {
+      try {
+        const message = JSON.parse(event.data as string);
+        if (message && message.type === "state" && message.kind === "psu" && Array.isArray(message.outputs)) {
+          setOutputs(message.outputs);
+        }
+      } catch {
+        // malformed frame: ignore, keep the last known-good outputs
+      }
+    };
+    return () => {
+      socket.onmessage = null;
+      socket.onclose = null;
+      socket.onerror = null;
+      socket.close();
+    };
+  }, [sessionId]);
+
+  async function sendOutput(n: number, patch: { voltage?: number; current?: number }) {
+    if (!sessionId) return;
+    setError(null);
+    try {
+      const state = await api.setPsuOutput(sessionId, n, patch);
+      setOutputs(state.outputs);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  async function sendEnable(n: number, enabled: boolean) {
+    if (!sessionId) return;
+    setError(null);
+    try {
+      const state = await api.setPsuOutputEnable(sessionId, n, enabled);
+      setOutputs(state.outputs);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+      // The toggle must never lie about instrument state: a failed enable
+      // request could have partially landed on the hardware, so reconcile
+      // with the server's own view rather than leaving stale local state.
+      try {
+        const fresh = await api.psuState(sessionId);
+        setOutputs(fresh.outputs);
+      } catch {
+        // best effort: keep whatever we last knew to be true
+      }
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)" }}>
+        {outputs.map((o) => (
+          <GroupBox key={o.output} title={`Output ${o.output}`}>
+            <div style={{ display: "flex", flexDirection: "column", gap: "10px", minWidth: "220px" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+                Voltage
+                <SpinBox
+                  aria-label={`Output ${o.output} voltage`}
+                  value={o.voltage}
+                  step={0.1}
+                  min={0}
+                  decimals={3}
+                  suffix=" V"
+                  onChange={(value) => sendOutput(o.output, { voltage: value })}
+                />
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
+                Current limit
+                <SpinBox
+                  aria-label={`Output ${o.output} current`}
+                  value={o.current}
+                  step={0.1}
+                  min={0}
+                  decimals={3}
+                  suffix=" A"
+                  onChange={(value) => sendOutput(o.output, { current: value })}
+                />
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={o.enabled}
+                aria-label={`Output ${o.output} enable`}
+                onClick={() => sendEnable(o.output, !o.enabled)}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  alignSelf: "flex-start",
+                  gap: "8px",
+                  padding: "4px 10px",
+                  border: "1px solid var(--lc-border-strong)",
+                  borderRadius: "var(--lc-radius-sm)",
+                  background: "var(--lc-control)",
+                  cursor: "pointer",
+                }}
+              >
+                <StatusIndicator state={o.enabled ? "connected" : "disconnected"} label={o.enabled ? "Output on" : "Output off"} />
+              </button>
+              <div style={{ display: "flex", gap: "var(--space-3)", paddingTop: "4px", borderTop: "1px solid var(--lc-border)" }}>
+                <Reading label="V" value={fmt(o.measured_voltage)} unit="V" />
+                <Reading label="I" value={fmt(o.measured_current)} unit="A" />
+                <Reading label="P" value={fmt(o.measured_power)} unit="W" />
+              </div>
+            </div>
+          </GroupBox>
+        ))}
+      </div>
+      {error && (
+        <div role="alert" style={{ padding: "8px 10px", borderRadius: "var(--radius-sm)", background: "color-mix(in srgb, var(--danger) 12%, transparent)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/app/src/features/readout/ReadoutStrip.test.tsx
+++ b/webapp/app/src/features/readout/ReadoutStrip.test.tsx
@@ -5,7 +5,7 @@ import { useSession } from "../../store/session";
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
   useSession.getState().applyState({
     run_state: "TRIGD",
     timebase: 0.001,

--- a/webapp/app/src/features/reference/ReferencePanel.test.tsx
+++ b/webapp/app/src/features/reference/ReferencePanel.test.tsx
@@ -11,7 +11,7 @@ const OVERLAY = { name: "golden", channel: 1, t0: 0, dt: 1, points: [1] };
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
 });
 afterEach(() => vi.restoreAllMocks());
 

--- a/webapp/app/src/features/terminal/TerminalPanel.test.tsx
+++ b/webapp/app/src/features/terminal/TerminalPanel.test.tsx
@@ -7,7 +7,7 @@ import { useSession } from "../../store/session";
 
 beforeEach(() => {
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
 });
 afterEach(() => vi.restoreAllMocks());
 

--- a/webapp/app/src/features/trend/LogPanel.test.tsx
+++ b/webapp/app/src/features/trend/LogPanel.test.tsx
@@ -15,7 +15,7 @@ beforeEach(() => {
   clearTrend();
   localStorage.clear();
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
   vi.spyOn(api, "getLog").mockResolvedValue(IDLE);
   vi.spyOn(api, "getLogData").mockResolvedValue({ columns: [], rows: [] });
 });

--- a/webapp/app/src/features/trend/TrendCanvas.test.tsx
+++ b/webapp/app/src/features/trend/TrendCanvas.test.tsx
@@ -8,7 +8,7 @@ import { useSession } from "../../store/session";
 beforeEach(() => {
   clearTrend();
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
 });
 afterEach(() => vi.restoreAllMocks());
 

--- a/webapp/app/src/features/waveform/SpectrumCanvas.test.tsx
+++ b/webapp/app/src/features/waveform/SpectrumCanvas.test.tsx
@@ -11,7 +11,7 @@ const FRAME = { channel: 1, f0: 0, df: 10, points: [-60, -20, -60, -80], db: tru
 beforeEach(() => {
   clearSpectrum();
   useSession.getState().clearSession();
-  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
 });
 afterEach(() => vi.restoreAllMocks());
 

--- a/webapp/app/src/store/session.test.ts
+++ b/webapp/app/src/store/session.test.ts
@@ -51,4 +51,11 @@ describe("session store", () => {
     useSession.getState().applyMeasurements([{ channel: 1, mtype: "FREQ", value: null }]);
     expect(useSession.getState().measurements[0].value).toBeNull();
   });
+
+  it("applyPsuState replaces the psu snapshot, and clearSession resets it", () => {
+    useSession.getState().applyPsuState({ outputs: [{ output: 1, voltage: 3.3, current: 0.5, enabled: false, measured_voltage: 0, measured_current: 0, measured_power: 0 }] });
+    expect(useSession.getState().psu?.outputs[0].output).toBe(1);
+    useSession.getState().clearSession();
+    expect(useSession.getState().psu).toBeNull();
+  });
 });

--- a/webapp/app/src/store/session.test.ts
+++ b/webapp/app/src/store/session.test.ts
@@ -52,6 +52,19 @@ describe("session store", () => {
     expect(useSession.getState().measurements[0].value).toBeNull();
   });
 
+  it("setSession clears both kind slices, so a switch never shows the previous instrument", () => {
+    // Both, not just the one belonging to the outgoing kind: with two kinds a
+    // psu -> psu switch would otherwise paint the previous supply's outputs
+    // under the new supply's name until its first frame lands.
+    useSession.getState().setSession(SESSION);
+    useSession.getState().applyState(STATE);
+    useSession.getState().applyPsuState({ outputs: [{ output: 1, voltage: 3.3, current: 0.5, enabled: false, measured_voltage: 0, measured_current: 0, measured_power: 0 }] });
+    useSession.getState().setSession({ ...SESSION, id: "next", kind: "psu" });
+    expect(useSession.getState().scope).toBeNull();
+    expect(useSession.getState().psu).toBeNull();
+    expect(useSession.getState().session?.id).toBe("next");
+  });
+
   it("applyPsuState replaces the psu snapshot, and clearSession resets it", () => {
     useSession.getState().applyPsuState({ outputs: [{ output: 1, voltage: 3.3, current: 0.5, enabled: false, measured_voltage: 0, measured_current: 0, measured_power: 0 }] });
     expect(useSession.getState().psu?.outputs[0].output).toBe(1);

--- a/webapp/app/src/store/session.test.ts
+++ b/webapp/app/src/store/session.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { useSession } from "./session";
 import type { ScopeState, SessionInfo } from "../api/types";
 
-const SESSION: SessionInfo = { id: "abc", label: "bench", mock: false, address: "192.168.1.50", state: "connected", idn: "Siglent,SDS824X HD,1,1", model: "SDS824X HD", dialect: "modern", num_channels: 4, viewers: 0, owner: "" };
+const SESSION: SessionInfo = { id: "abc", label: "bench", mock: false, address: "192.168.1.50", state: "connected", idn: "Siglent,SDS824X HD,1,1", model: "SDS824X HD", dialect: "modern", num_channels: 4, viewers: 0, owner: "", kind: "scope" };
 
 const STATE: ScopeState = {
   run_state: "STOP",

--- a/webapp/app/src/store/session.ts
+++ b/webapp/app/src/store/session.ts
@@ -1,11 +1,12 @@
 import { create } from "zustand";
-import type { LogStatus, MeasurementValue, ReferenceStats, ScopeState, SessionInfo } from "../api/types";
+import type { LogStatus, MeasurementValue, PsuState, ReferenceStats, ScopeState, SessionInfo } from "../api/types";
 
 export type ConnStatus = "disconnected" | "connecting" | "connected" | "error";
 
 type SessionStore = {
   session: SessionInfo | null;
   scope: ScopeState | null;
+  psu: PsuState | null;
   status: ConnStatus;
   error: string | null;
   measurements: MeasurementValue[];
@@ -16,6 +17,7 @@ type SessionStore = {
   setSession: (session: SessionInfo) => void;
   clearSession: () => void;
   applyState: (state: ScopeState) => void;
+  applyPsuState: (state: PsuState) => void;
   applyMeasurements: (values: MeasurementValue[]) => void;
   applyMeasurementConfig: (items: { channel: number; mtype: string }[]) => void;
   applyReference: (ref: { name: string; channel: number | null } | null) => void;
@@ -28,6 +30,7 @@ type SessionStore = {
 export const useSession = create<SessionStore>((set) => ({
   session: null,
   scope: null,
+  psu: null,
   status: "disconnected",
   error: null,
   measurements: [],
@@ -36,8 +39,9 @@ export const useSession = create<SessionStore>((set) => ({
   referenceStats: null,
   logStatus: null,
   setSession: (session) => set({ session, status: "connected", error: null }),
-  clearSession: () => set({ session: null, scope: null, status: "disconnected", error: null, measurements: [], measurementConfig: [], activeReference: null, referenceStats: null, logStatus: null }),
+  clearSession: () => set({ session: null, scope: null, psu: null, status: "disconnected", error: null, measurements: [], measurementConfig: [], activeReference: null, referenceStats: null, logStatus: null }),
   applyState: (scope) => set({ scope }),
+  applyPsuState: (psu) => set({ psu }),
   applyMeasurements: (measurements) => set({ measurements }),
   applyMeasurementConfig: (measurementConfig) => set({ measurementConfig }),
   applyReference: (activeReference) => set({ activeReference }),

--- a/webapp/app/src/store/session.ts
+++ b/webapp/app/src/store/session.ts
@@ -38,7 +38,11 @@ export const useSession = create<SessionStore>((set) => ({
   activeReference: null,
   referenceStats: null,
   logStatus: null,
-  setSession: (session) => set({ session, status: "connected", error: null }),
+  // Both kind-specific slices are cleared: switching sessions must not leave
+  // the previous instrument's readings on screen while the new one's first
+  // frame is still in flight — and with two kinds, a psu→psu switch would
+  // otherwise show the old supply's outputs under the new supply's name.
+  setSession: (session) => set({ session, scope: null, psu: null, status: "connected", error: null }),
   clearSession: () => set({ session: null, scope: null, psu: null, status: "disconnected", error: null, measurements: [], measurementConfig: [], activeReference: null, referenceStats: null, logStatus: null }),
   applyState: (scope) => set({ scope }),
   applyPsuState: (psu) => set({ psu }),

--- a/webapp/app/src/stream/useStream.test.ts
+++ b/webapp/app/src/stream/useStream.test.ts
@@ -37,7 +37,7 @@ class FakeWebSocket {
   }
 }
 
-const SESSION = { id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" };
+const SESSION = { id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" as const };
 
 beforeEach(() => {
   vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
@@ -86,7 +86,7 @@ describe("useStream", () => {
   });
 
   it("treats a closed message as a clean session end", async () => {
-    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "" });
+    useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
     renderHook(() => useStream("abc"));
     FakeWebSocket.last!.emit({ type: "closed" });
     await waitFor(() => expect(useSession.getState().session).toBeNull());

--- a/webapp/app/src/stream/useStream.test.ts
+++ b/webapp/app/src/stream/useStream.test.ts
@@ -59,6 +59,17 @@ describe("useStream", () => {
     await waitFor(() => expect(useSession.getState().scope?.timebase).toBe(0.001));
   });
 
+  it("routes a psu state message to the psu store slot, not the scope slot", async () => {
+    renderHook(() => useStream("abc"));
+    FakeWebSocket.last!.emit({
+      type: "state",
+      kind: "psu",
+      outputs: [{ output: 1, voltage: 3.3, current: 0.5, enabled: false, measured_voltage: 3.31, measured_current: 0.12, measured_power: 0.4 }],
+    });
+    await waitFor(() => expect(useSession.getState().psu?.outputs[0].measured_voltage).toBe(3.31));
+    expect(useSession.getState().scope).toBeNull();
+  });
+
   it("routes waveform frames to the frame buffer, not the store", async () => {
     renderHook(() => useStream("abc"));
     FakeWebSocket.last!.emit({ type: "waveform", channel: 1, t0: 0, dt: 1e-6, points: [0, 0.5, 1] });

--- a/webapp/app/src/stream/useStream.ts
+++ b/webapp/app/src/stream/useStream.ts
@@ -21,7 +21,15 @@ export function useStream(sessionId: string | null): void {
     socket.onmessage = (event: MessageEvent) => {
       const message = JSON.parse(event.data as string) as StreamMessage;
       const store = useSession.getState();
-      if (message.type === "state") store.applyState(message.state);
+      if (message.type === "state") {
+        // Two shapes share "type":"state" -- a scope's {state:...} and a
+        // psu's {kind:"psu", outputs:...} (see PsuAdapter.poll /
+        // stream.py's kind dispatch on the initial frame). Discriminate on
+        // the "outputs" key rather than "kind" so the check stays a plain
+        // property test with no cast.
+        if ("outputs" in message) store.applyPsuState({ outputs: message.outputs });
+        else store.applyState(message.state);
+      }
       else if (message.type === "waveform") setFrame(message.channel, { t0: message.t0, dt: message.dt, points: message.points });
       else if (message.type === "measurements") {
         store.applyMeasurements(message.values);


### PR DESCRIPTION
## Description

Makes the web gateway able to host an instrument that is not an oscilloscope, and proves the seam by shipping a power supply end to end.

The gateway was scope-only in a structural way, not an incidental one: `submit()` was typed to `Oscilloscope`, `_poll_tick` read waveforms and spectra directly, and the React app rendered one hardcoded layout for any session at all. This generalises the session layer behind a per-kind adapter, then lands PSU support on top of it.

This is sub-project 1 of 3. AWG and DAQ follow on the same seam.

## Related Issues

<!-- none -->

## Type of Change

- [x] New feature (non-breaking change adding functionality)
- [x] Code refactoring
- [x] Test coverage improvement

## Changes Made

- **Per-kind adapter seam.** `InstrumentSession` keeps everything genuinely shared — worker thread, job queue, pub/sub, viewers, ownership, the error state machine, and the poll guards — and delegates construction, connection, polling, teardown and the stream's opening frame to an adapter. Scope-only state (`measurements`, `filters`, `spectrum_config`, `recorder`, `active_reference`) moved onto `ScopeAdapter`, so a PSU session no longer carries a spectrum config it can never use.
- **Power supply support end to end.** `PsuAdapter`, plus three routes under `/api/sessions/{id}/psu/`: read all outputs, set an output's voltage and/or current limit, set an output's enable state. Live measured voltage / current / power ride the WebSocket the gateway already used — no new transport.
- **Instrument kind.** `SessionCreate` accepts a `kind`, defaulting to `"scope"`. For real instruments the server verifies it after connecting by feeding the model from `*IDN?` back through discovery's existing prefix table, so a PSU can't be driven by a scope driver. Mock PSU sessions work with no hardware.
- **Per-kind view selection in the web UI**, replacing the hardcoded oscilloscope layout, plus a PSU control panel: per-output setpoints, an enable toggle, and live readings.

### Notes for the reviewer

- **Non-breaking was verified mechanically, not by eye:** an AST + runtime diff of the public surface against `b0916e2` (no removed members on `InstrumentSession`, `SessionManager` or `SessionError`) and a route-declaration diff (scope 27→27, sessions 7→7, stream 1→1, all identical). `examples/trend_logging_walkthrough.py` and its doc mirror are byte-identical to their pre-branch text.
- The compatibility shims on `InstrumentSession` are real delegations, not a second copy of the state — after exercising all five, `set(vars(session))` grows by nothing and `session.measurements is adapter.measurements`.
- **The enable toggle never shows optimistic state.** It is written only from a server payload, and a failed request reconciles against the instrument. A reading that cannot be obtained renders as unknown (`aria-checked="mixed"`, control disabled) rather than as a confident "off" — this matters on an SPD3303X, whose CH3 has no status bit.
- Output-enable ships deliberately without an extra confirmation step; that was a recorded design decision, not an oversight.

## Testing

- [x] Tests pass locally (`make test` or `pytest tests/`)
- [x] Added tests for new functionality
- [ ] Tested with real hardware (if applicable)
- [x] All CI checks pass

### Test Details

**Test environment:**

- OS: Windows 11 Pro 10.0.26200
- Python version: system Python
- Oscilloscope model (if applicable): none — mock connections throughout

**Test results:**

```
backend   2055 passed, 19 skipped     (baseline on main: 2004 passed, 19 skipped)
frontend  217 tests passed            (baseline on main: 193)

black --check --line-length 200 scpi_control/ examples/   clean
flake8 scpi_control/ --count --select=E9,F63,F7,F82       0
npx tsc --noEmit                                          clean
```

CI-extras parity was also checked, since a green local suite cannot catch it: with PyQt6, reportlab and h5py blocked via a `sys.meta_path` finder, all touched server modules import cleanly and the touched server tests pass.

## Code Quality

- [x] Code follows the project style guidelines (`make lint` passes)
- [x] Code is formatted with Black (`make format`)
- [x] Self-reviewed the code
- [x] Commented complex code sections
- [x] Updated docstrings for modified functions/classes
- [x] No new linting warnings introduced

## Documentation

- [ ] Updated README.md (if needed)
- [x] Updated CHANGELOG.md with changes
- [x] Added/updated docstrings
- [x] Added/updated examples (if applicable)
- [x] Updated type hints

## Checklist

- [x] I have read the CONTRIBUTING.md guide
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation

## Additional Notes

Three defects were caught late and are worth recording, because two of them were gaps *between* units of work rather than inside one:

1. **The stream's opening frame was scope-shaped for every session.** On a PSU it raised, was silently swallowed, and left the session with no subscriber — so polling never ran and live values were dead, with no error surfaced anywhere. Found by probing a real session, not by reading. The opening frame now dispatches through the adapter, and a hook a future adapter forgets fails loudly instead of silently.
2. **Nothing sent `kind` from the UI**, so every session the app created was a scope one and clicking Connect on a discovered SPD3303X would 409. Fixed, with tests that drive the real path (render → click → assert the request) rather than poking the store, which is how the hole originally hid.
3. **The kind guard initially rejected any scope model outside the 22-entry registry** — a Rigol DS1054Z or Tek TBS1052B connected fine before this branch and would have stopped. Narrowed to reject only a positively-identified mismatch.

Known non-blocking residuals, none of them regressions:

- On a `4500` close, `useStream.onclose` overwrites the specific `"initial frame failed: …"` detail with the generic `"stream disconnected"`. Best fixed in sub-project 2, which touches that path.
- Throttled PSU ticks reuse a cached measured triplet up to ~750 ms old — the same convention the scope's measurements already use.
- An unregistered scope model classifies as `unknown`, so its discovery card still reads "Viewer coming soon" and it must be connected by manual IP. Pre-existing on `main`; the backend now accepts such a session, which is strictly an improvement.
