### PR TITLE
chore(release): 5.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.8.0] - 2026-07-27
+
 ### Added
 
 - The web gateway can now host a power supply (SPD3303X series) alongside oscilloscopes. A power

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.8.0] - 2026-07-27
+
 ### Added
 
 - The web gateway can now host a power supply (SPD3303X series) alongside oscilloscopes. A power

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "5.7.1"
+version = "5.8.0"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "5.7.1"
+__version__ = "5.8.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
Cuts v5.8.0. No code changes — changelog section header, the mirror, and the two version strings.

The release covers the gateway instrument-kinds work merged in #125: the web gateway can host a power supply alongside oscilloscopes, `POST /api/sessions` gained an optional `kind` field defaulting to `"scope"`, and the session layer's construction/connection/polling moved behind a per-kind adapter. Non-breaking throughout — the 26 existing `/scope/` routes and every public name on `InstrumentSession` are untouched — so this is a MINOR bump.

Verification on this branch:

- `pytest tests/ -q -n 8` (deselecting the local-LLM example): **2055 passed, 19 skipped**
- `npm test -- --run` in `webapp/app`: **217 passed** across 42 files
- `black --check --line-length 200 scpi_control/ examples/`: clean, 185 files
- `flake8 scpi_control/ --select=E9,F63,F7,F82`: 0
- PyPI summary length: 387 of the 512-char limit
