### PR TITLE
feat(webapp): make the session chrome tell the truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   report shows as unknown rather than off.
 - `POST /api/sessions` accepts `kind: "awg"`, and the new `/api/sessions/{id}/awg/...` routes read
   and control the channels.
+- A session that fails now says why. A dropped stream or an error from the instrument shows as a
+  banner under the header carrying the detail, instead of only turning the status dot red.
+  Dismissing the banner clears the message but does not change what the status dot reports — the
+  connection state is the instrument's to report, not a side effect of closing a notification.
+- Any session can be disconnected from the header. Disconnect moved out of the oscilloscope
+  toolbar, so a power supply or function generator session no longer has to be left by reloading
+  the page.
+- A non-owner is now told, in session, that it's read-only and who owns it, with the same Claim
+  action the home screen offers. Previously they found out by having a write rejected.
+
+### Fixed
+
+- An AWG channel whose waveform the instrument will not report now shows the same `--.--` marker
+  every other unreadable field uses, instead of a blank dropdown.
+- The home screen's no-instruments-found message no longer singles out "start a Mock scope" — it
+  points at the mock button for whichever instrument kind, since a mock power supply and mock
+  function generator are just as available.
 
 ## [5.8.0] - 2026-07-27
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -38,6 +38,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   report shows as unknown rather than off.
 - `POST /api/sessions` accepts `kind: "awg"`, and the new `/api/sessions/{id}/awg/...` routes read
   and control the channels.
+- A session that fails now says why. A dropped stream or an error from the instrument shows as a
+  banner under the header carrying the detail, instead of only turning the status dot red.
+  Dismissing the banner clears the message but does not change what the status dot reports — the
+  connection state is the instrument's to report, not a side effect of closing a notification.
+- Any session can be disconnected from the header. Disconnect moved out of the oscilloscope
+  toolbar, so a power supply or function generator session no longer has to be left by reloading
+  the page.
+- A non-owner is now told, in session, that it's read-only and who owns it, with the same Claim
+  action the home screen offers. Previously they found out by having a write rejected.
+
+### Fixed
+
+- An AWG channel whose waveform the instrument will not report now shows the same `--.--` marker
+  every other unreadable field uses, instead of a blank dropdown.
+- The home screen's no-instruments-found message no longer singles out "start a Mock scope" — it
+  points at the mock button for whichever instrument kind, since a mock power supply and mock
+  function generator are just as available.
 
 ## [5.8.0] - 2026-07-27
 

--- a/docs/gateway/browser-ui.md
+++ b/docs/gateway/browser-ui.md
@@ -21,6 +21,26 @@ oscilloscope session. A power supply or function generator session replaces
 all of it with its own panel; see [Power supply session](#power-supply-session)
 and [Function generator session](#function-generator-session) below.
 
+## Header
+
+The header spans the top of the window and looks the same no matter which
+instrument kind is connected: the connection status indicator, a
+**read-only** badge with a **Claim** button when the session belongs to
+someone else (the same control the home screen offers — see
+[Home screen](#home-screen) above), the **Terminal** button (see
+[SCPI terminal](#scpi-terminal) below), and **Disconnect**, which ends the
+session and returns to the home screen. Because it's in the header rather
+than an instrument-specific toolbar, Disconnect is available for every
+session kind — a power supply or function generator session no longer has
+to be abandoned by reloading the page.
+
+Directly under the header, an error banner appears when the session itself
+fails — a dropped stream, or an error frame from the instrument — carrying
+the detail that a red status dot alone can't show. Dismissing the banner
+clears the message but does **not** change what the status indicator
+reports: the connection state is the instrument's to report, not a side
+effect of closing a notification.
+
 ## Canvas modes
 
 Once connected, the main canvas toggles between three modes:
@@ -63,7 +83,9 @@ The side rail holds one tab per feature area:
 ## Toolbar
 
 Across the top: Run / Stop / Single / Auto acquisition controls, the canvas
-view-mode toggle, CSV / JSON / Screenshot export buttons, and Disconnect.
+view-mode toggle, and CSV / JSON / Screenshot export buttons. Disconnect
+lives in the header, not here — see [Header](#header) below, since it applies
+to every session kind, not just an oscilloscope's.
 
 ## Power supply session
 

--- a/docs/gateway/browser-ui.md
+++ b/docs/gateway/browser-ui.md
@@ -16,10 +16,12 @@ it. A mock oscilloscope, mock power supply and mock function generator are
 all available here too — one button per connectable instrument kind — so
 there's never a hardware requirement to get started with any of them.
 
-The next three sections — Canvas modes, Rail tabs, and Toolbar — describe an
-oscilloscope session. A power supply or function generator session replaces
-all of it with its own panel; see [Power supply session](#power-supply-session)
-and [Function generator session](#function-generator-session) below.
+The next section, Header, describes chrome that looks the same no matter
+which instrument kind is connected. The three sections after it — Canvas
+modes, Rail tabs, and Toolbar — describe an oscilloscope session
+specifically. A power supply or function generator session replaces all of
+it with its own panel; see [Power supply session](#power-supply-session) and
+[Function generator session](#function-generator-session) below.
 
 ## Header
 
@@ -84,7 +86,7 @@ The side rail holds one tab per feature area:
 
 Across the top: Run / Stop / Single / Auto acquisition controls, the canvas
 view-mode toggle, and CSV / JSON / Screenshot export buttons. Disconnect
-lives in the header, not here — see [Header](#header) below, since it applies
+lives in the header, not here — see [Header](#header) above, since it applies
 to every session kind, not just an oscilloscope's.
 
 ## Power supply session

--- a/webapp/app/src/App.test.tsx
+++ b/webapp/app/src/App.test.tsx
@@ -192,6 +192,15 @@ describe("App view selection", () => {
     expect(screen.queryByRole("button", { name: /terminal/i })).not.toBeInTheDocument();
   });
 
+  it("surfaces a session error in the app, not just in the store", () => {
+    // Guards the wiring: the banner exists but is useless if the shell never
+    // renders it.
+    useSession.getState().setSession(SESSION);
+    useSession.getState().setError("connection lost");
+    render(<App />);
+    expect(screen.getByRole("alert")).toHaveTextContent("connection lost");
+  });
+
   it("reports its expanded state and target on the terminal toggle button", async () => {
     useSession.getState().setSession(SESSION);
     render(<App />);

--- a/webapp/app/src/App.test.tsx
+++ b/webapp/app/src/App.test.tsx
@@ -75,6 +75,16 @@ describe("App view selection", () => {
     expect(screen.getByText("Channels")).toBeInTheDocument();
   });
 
+  // Disconnect moved from ScopeToolbar to AppHeader so every session kind
+  // gets it, not just a scope's. Nothing else pins it out of ScopeToolbar --
+  // a future edit could re-add a Disconnect button there and give a scope
+  // session two, with the rest of the suite still green.
+  it("renders exactly one Disconnect control for a scope session", () => {
+    useSession.getState().setSession(SESSION);
+    render(<App />);
+    expect(screen.getAllByRole("button", { name: /disconnect/i })).toHaveLength(1);
+  });
+
   // Closes the registry hole from the branch review: kindViews.test.tsx only
   // ever asserted `typeof view.body === "function"`, so `readout` could be
   // deleted from a KIND_VIEWS entry -- silently dropping the scope's PKPK/FREQ

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -1,40 +1,17 @@
 import { TokenGate } from "./features/auth/TokenGate";
 import { HomeScreen } from "./features/home/HomeScreen";
+import { AppHeader } from "./features/shell/AppHeader";
 import { InstrumentShell } from "./features/shell/InstrumentShell";
-import { TERMINAL_DRAWER_ID } from "./features/shell/TerminalDrawer";
-import { useTerminalDrawer } from "./features/shell/useTerminalDrawer";
-import { StatusIndicator } from "./ds/StatusIndicator";
 import { useStream } from "./stream/useStream";
 import { useSession } from "./store/session";
 
 export default function App() {
-  const status = useSession((s) => s.status);
   const session = useSession((s) => s.session);
-  const terminalOpen = useTerminalDrawer((s) => s.open);
-  const toggleTerminal = useTerminalDrawer((s) => s.toggle);
   useStream(session?.id ?? null);
   return (
     <TokenGate>
       <div style={{ display: "flex", flexDirection: "column", height: "100vh", background: "var(--lc-bg)", fontFamily: "var(--font-ui)" }}>
-        <header style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", padding: "10px 14px", background: "var(--lc-panel)", borderBottom: "1px solid var(--lc-border)" }}>
-          <strong style={{ color: "var(--lc-text)" }}>SCPI Instrument Control</strong>
-          <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-xs)", color: "var(--lc-muted)" }}>{session ? `${session.model} · ${session.address ?? "mock"}` : "no instrument"}</span>
-          {session !== null && (
-            <button
-              type="button"
-              id="terminal-toggle"
-              onClick={toggleTerminal}
-              aria-expanded={terminalOpen}
-              aria-controls={TERMINAL_DRAWER_ID}
-              style={{ marginLeft: "auto", fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "4px 10px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", background: terminalOpen ? "var(--lc-accent-soft)" : "transparent", cursor: "pointer" }}
-            >
-              Terminal
-            </button>
-          )}
-          <span style={{ marginLeft: session === null ? "auto" : undefined }}>
-            <StatusIndicator state={status} />
-          </span>
-        </header>
+        <AppHeader />
         <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)", display: "flex", flexDirection: "column", gap: "var(--space-3)", minHeight: 0 }}>
           {session === null ? <HomeScreen onConnected={(s) => useSession.getState().setSession(s)} /> : <InstrumentShell />}
         </main>

--- a/webapp/app/src/App.tsx
+++ b/webapp/app/src/App.tsx
@@ -1,6 +1,7 @@
 import { TokenGate } from "./features/auth/TokenGate";
 import { HomeScreen } from "./features/home/HomeScreen";
 import { AppHeader } from "./features/shell/AppHeader";
+import { ErrorBanner } from "./features/shell/ErrorBanner";
 import { InstrumentShell } from "./features/shell/InstrumentShell";
 import { useStream } from "./stream/useStream";
 import { useSession } from "./store/session";
@@ -12,6 +13,7 @@ export default function App() {
     <TokenGate>
       <div style={{ display: "flex", flexDirection: "column", height: "100vh", background: "var(--lc-bg)", fontFamily: "var(--font-ui)" }}>
         <AppHeader />
+        <ErrorBanner />
         <main style={{ flex: 1, padding: "var(--space-3)", color: "var(--lc-text)", display: "flex", flexDirection: "column", gap: "var(--space-3)", minHeight: 0 }}>
           {session === null ? <HomeScreen onConnected={(s) => useSession.getState().setSession(s)} /> : <InstrumentShell />}
         </main>

--- a/webapp/app/src/features/awg/AwgPanel.test.tsx
+++ b/webapp/app/src/features/awg/AwgPanel.test.tsx
@@ -134,4 +134,16 @@ describe("AwgPanel", () => {
     expect(frequency).not.toHaveValue("0.000 Hz");
     expect(frequency).toHaveTextContent("--.--");
   });
+
+  it("shows an unreadable function as unknown, not as a blank dropdown", async () => {
+    // Every other field says WHY it is empty. A blank <select> is the one
+    // control that leaves the user guessing whether the instrument reported
+    // nothing or the app simply failed to render.
+    const unread = { channels: [{ ...STATE.channels[0], function: null }] };
+    vi.spyOn(api, "awgState").mockResolvedValue(unread);
+    render(<AwgPanel />);
+    const field = await screen.findByLabelText("Channel 1 function");
+    expect(field).toHaveTextContent("--.--");
+    expect(field.tagName).not.toBe("SELECT");
+  });
 });

--- a/webapp/app/src/features/awg/AwgPanel.tsx
+++ b/webapp/app/src/features/awg/AwgPanel.tsx
@@ -126,13 +126,17 @@ export function AwgPanel() {
               <div style={{ display: "flex", flexDirection: "column", gap: "10px", minWidth: "240px" }}>
                 <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
                   Function
-                  <ComboBox
-                    aria-label={`Channel ${c.channel} function`}
-                    options={FUNCTIONS}
-                    value={c.function ?? ""}
-                    disabled={busy}
-                    onChange={(value) => sendChannel(c.channel, { function: value })}
-                  />
+                  {c.function === null ? (
+                    <Unreadable what={`Channel ${c.channel} function`} unit="" />
+                  ) : (
+                    <ComboBox
+                      aria-label={`Channel ${c.channel} function`}
+                      options={FUNCTIONS}
+                      value={c.function}
+                      disabled={busy}
+                      onChange={(value) => sendChannel(c.channel, { function: value })}
+                    />
+                  )}
                 </div>
                 <Field label="Frequency" what={`Channel ${c.channel} frequency`} value={c.frequency} unit=" Hz" step={100} min={0} busy={busy} onChange={(v) => sendChannel(c.channel, { frequency: v })} />
                 <Field label="Amplitude" what={`Channel ${c.channel} amplitude`} value={c.amplitude} unit=" Vpp" step={0.1} min={0} busy={busy} onChange={(v) => sendChannel(c.channel, { amplitude: v })} />

--- a/webapp/app/src/features/controls/ScopeToolbar.test.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.test.tsx
@@ -65,13 +65,4 @@ describe("ScopeToolbar", () => {
     await userEvent.click(screen.getByRole("button", { name: "JSON" }));
     expect(await screen.findByRole("alert")).toHaveTextContent("missing bearer token");
   });
-
-  it("returns to disconnected even if the session is already gone (DELETE 404)", async () => {
-    const { ApiError } = await import("../../api/client");
-    vi.spyOn(api, "deleteSession").mockRejectedValue(new ApiError(404, "HTTPException", "unknown session abc"));
-    render(<ScopeToolbar />);
-    await userEvent.click(screen.getByRole("button", { name: /disconnect/i }));
-    await waitFor(() => expect(useSession.getState().session).toBeNull());
-    expect(useSession.getState().status).toBe("disconnected");
-  });
 });

--- a/webapp/app/src/features/controls/ScopeToolbar.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.tsx
@@ -46,18 +46,6 @@ export function ScopeToolbar({ viewToggle }: { viewToggle?: ReactNode }) {
     }
   }
 
-  async function disconnect() {
-    if (!session) return;
-    setError(null);
-    try {
-      await api.deleteSession(session.id);
-    } catch {
-      // already gone server-side (404) or unreachable — we're disconnecting locally regardless
-    } finally {
-      useSession.getState().clearSession();
-    }
-  }
-
   return (
     <div style={{ display: "flex", flexDirection: "column" }}>
       <Toolbar
@@ -72,7 +60,6 @@ export function ScopeToolbar({ viewToggle }: { viewToggle?: ReactNode }) {
               </button>
             )}
             <ScreenshotButton />
-            <Button variant="danger" onClick={disconnect}>Disconnect</Button>
           </>
         }
       >

--- a/webapp/app/src/features/home/InstrumentDashboard.tsx
+++ b/webapp/app/src/features/home/InstrumentDashboard.tsx
@@ -68,7 +68,7 @@ export function InstrumentDashboard({ devices, scanning, error, busyKey, onConne
         {scanning && devices.length === 0 && <p style={{ color: "var(--lc-muted)" }}>Scanning your network…</p>}
         {error && <p role="alert" style={{ color: "var(--danger)" }}>{error}</p>}
         {!scanning && !error && devices.length === 0 && (
-          <p style={{ color: "var(--lc-muted)" }}>No instruments found on your network. Check the instrument's LAN settings, enter an IP manually, or start a Mock scope.</p>
+          <p style={{ color: "var(--lc-muted)" }}>No instruments found on your network. Check the instrument's LAN settings, enter an IP manually, or start one of the mock instruments.</p>
         )}
         {q && filtered.length === 0 && available.length > 0 && <p style={{ color: "var(--lc-muted)" }}>No instruments match &ldquo;{query.trim()}&rdquo;.</p>}
 

--- a/webapp/app/src/features/shell/AppHeader.test.tsx
+++ b/webapp/app/src/features/shell/AppHeader.test.tsx
@@ -1,9 +1,11 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppHeader } from "./AppHeader";
 import { useTerminalDrawer } from "./useTerminalDrawer";
+import { ApiError, api } from "../../api/client";
 import { setToken } from "../../api/token";
+import { useIdentity } from "../../store/identity";
 import { useSession } from "../../store/session";
 
 const SESSION = { id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "SDG1032X", dialect: "", num_channels: 2, viewers: 0, owner: "", kind: "awg" as const };
@@ -12,6 +14,7 @@ beforeEach(() => {
   localStorage.clear();
   setToken("test-token");
   useSession.getState().clearSession();
+  useIdentity.getState().clearIdentity();
   useTerminalDrawer.getState().close();
 });
 afterEach(() => {
@@ -51,5 +54,72 @@ describe("AppHeader", () => {
     useSession.getState().setSession(SESSION);
     render(<AppHeader />);
     expect(screen.getByRole("button", { name: /terminal/i })).toHaveAttribute("aria-controls");
+  });
+});
+
+describe("AppHeader disconnect", () => {
+  it("offers Disconnect in a session of any kind", () => {
+    useSession.getState().setSession({ ...SESSION, kind: "psu" });
+    render(<AppHeader />);
+    expect(screen.getByRole("button", { name: /disconnect/i })).toBeInTheDocument();
+  });
+
+  it("does not offer Disconnect with no session", () => {
+    render(<AppHeader />);
+    expect(screen.queryByRole("button", { name: /disconnect/i })).not.toBeInTheDocument();
+  });
+
+  it("returns to disconnected even if the session is already gone (DELETE 404)", async () => {
+    // Moved from ScopeToolbar.test.tsx: the behaviour is unchanged, only its
+    // home is. A session may already be gone server-side, and the user must
+    // still end up disconnected locally.
+    vi.spyOn(api, "deleteSession").mockRejectedValue(new ApiError(404, "HTTPException", "unknown session abc"));
+    useSession.getState().setSession(SESSION);
+    render(<AppHeader />);
+    await userEvent.click(screen.getByRole("button", { name: /disconnect/i }));
+    await waitFor(() => expect(useSession.getState().session).toBeNull());
+    expect(useSession.getState().status).toBe("disconnected");
+  });
+});
+
+describe("AppHeader ownership", () => {
+  it("tells a non-owner their session is read-only", () => {
+    useIdentity.getState().setIdentity("bob");
+    useSession.getState().setSession({ ...SESSION, owner: "alice" });
+    render(<AppHeader />);
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+    expect(screen.getByText(/alice/)).toBeInTheDocument();
+  });
+
+  it("shows the owner no ownership chrome at all", () => {
+    useIdentity.getState().setIdentity("alice");
+    useSession.getState().setSession({ ...SESSION, owner: "alice" });
+    render(<AppHeader />);
+    expect(screen.queryByText(/read-only/i)).not.toBeInTheDocument();
+  });
+
+  it("drops the read-only badge once the claim succeeds", async () => {
+    useIdentity.getState().setIdentity("bob");
+    useSession.getState().setSession({ ...SESSION, owner: "alice" });
+    vi.spyOn(api, "claimSession").mockResolvedValue({ ...SESSION, owner: "bob" });
+    vi.spyOn(api, "getSession").mockResolvedValue({ ...SESSION, owner: "bob" });
+    render(<AppHeader />);
+    await userEvent.click(screen.getByRole("button", { name: /claim/i }));
+    await waitFor(() => expect(screen.queryByText(/read-only/i)).not.toBeInTheDocument());
+  });
+
+  it("keeps live instrument readings through a claim", async () => {
+    // Claiming changes who owns the session, not what the instrument reads.
+    // Blanking the readings would make the panel flash empty for a poll
+    // interval over a change that has nothing to do with them.
+    useIdentity.getState().setIdentity("bob");
+    useSession.getState().setSession({ ...SESSION, owner: "alice" });
+    useSession.getState().applyAwgState({ channels: [{ channel: 1, function: "SINE", frequency: 1000, amplitude: 2, offset: 0, phase: 0, enabled: true, duty_cycle: null, symmetry: null }] });
+    vi.spyOn(api, "claimSession").mockResolvedValue({ ...SESSION, owner: "bob" });
+    vi.spyOn(api, "getSession").mockResolvedValue({ ...SESSION, owner: "bob" });
+    render(<AppHeader />);
+    await userEvent.click(screen.getByRole("button", { name: /claim/i }));
+    await waitFor(() => expect(useSession.getState().session?.owner).toBe("bob"));
+    expect(useSession.getState().awg?.channels).toHaveLength(1);
   });
 });

--- a/webapp/app/src/features/shell/AppHeader.test.tsx
+++ b/webapp/app/src/features/shell/AppHeader.test.tsx
@@ -108,6 +108,26 @@ describe("AppHeader ownership", () => {
     await waitFor(() => expect(screen.queryByText(/read-only/i)).not.toBeInTheDocument());
   });
 
+  it("does not leak an unhandled rejection when the post-claim refresh fails, and keeps the badge up with the failure reported", async () => {
+    // The claim itself succeeds (claimSession resolves); the refresh that
+    // would let the header stop claiming read-only fails. Two things must be
+    // true: nothing escapes as an unhandled rejection (if it did, Vitest
+    // itself attaches an "Unhandled Errors" failure to this test -- see the
+    // finding's revert-verification for what that looks like), and the badge
+    // staying up is the honest outcome here -- ownership could not be
+    // re-confirmed locally, and the server enforces it regardless of what
+    // this tab shows.
+    useIdentity.getState().setIdentity("bob");
+    useSession.getState().setSession({ ...SESSION, owner: "alice" });
+    vi.spyOn(api, "claimSession").mockResolvedValue({ ...SESSION, owner: "bob" });
+    vi.spyOn(api, "getSession").mockRejectedValue(new ApiError(500, "Error", "could not refresh session"));
+    render(<AppHeader />);
+    await userEvent.click(screen.getByRole("button", { name: /claim/i }));
+    await waitFor(() => expect(useSession.getState().error).toBe("could not refresh session"));
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+    expect(screen.getByText(/alice/)).toBeInTheDocument();
+  });
+
   it("keeps live instrument readings through a claim", async () => {
     // Claiming changes who owns the session, not what the instrument reads.
     // Blanking the readings would make the panel flash empty for a poll

--- a/webapp/app/src/features/shell/AppHeader.test.tsx
+++ b/webapp/app/src/features/shell/AppHeader.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppHeader } from "./AppHeader";
+import { useTerminalDrawer } from "./useTerminalDrawer";
+import { setToken } from "../../api/token";
+import { useSession } from "../../store/session";
+
+const SESSION = { id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "SDG1032X", dialect: "", num_channels: 2, viewers: 0, owner: "", kind: "awg" as const };
+
+beforeEach(() => {
+  localStorage.clear();
+  setToken("test-token");
+  useSession.getState().clearSession();
+  useTerminalDrawer.getState().close();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("AppHeader", () => {
+  it("names the instrument when there is a session", () => {
+    useSession.getState().setSession(SESSION);
+    render(<AppHeader />);
+    expect(screen.getByText(/SDG1032X/)).toBeInTheDocument();
+  });
+
+  it("says there is no instrument when there is no session", () => {
+    render(<AppHeader />);
+    expect(screen.getByText("no instrument")).toBeInTheDocument();
+  });
+
+  it("offers no terminal toggle without a session", () => {
+    render(<AppHeader />);
+    expect(screen.queryByRole("button", { name: /terminal/i })).not.toBeInTheDocument();
+  });
+
+  it("offers the terminal toggle in a session and reports its state", async () => {
+    // Note: one render() per test. Rendering AppHeader twice in a single test
+    // would put two headers in the DOM and make every getByRole ambiguous.
+    useSession.getState().setSession(SESSION);
+    render(<AppHeader />);
+    const toggle = screen.getByRole("button", { name: /terminal/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("points the toggle at the drawer it controls", () => {
+    useSession.getState().setSession(SESSION);
+    render(<AppHeader />);
+    expect(screen.getByRole("button", { name: /terminal/i })).toHaveAttribute("aria-controls");
+  });
+});

--- a/webapp/app/src/features/shell/AppHeader.tsx
+++ b/webapp/app/src/features/shell/AppHeader.tsx
@@ -1,5 +1,9 @@
+import { api } from "../../api/client";
+import { Button } from "../../ds/Button";
 import { StatusIndicator } from "../../ds/StatusIndicator";
+import { useIdentity } from "../../store/identity";
 import { useSession } from "../../store/session";
+import { OwnerBadge } from "../sessions/OwnerBadge";
 import { TERMINAL_DRAWER_ID } from "./TerminalDrawer";
 import { useTerminalDrawer } from "./useTerminalDrawer";
 
@@ -10,8 +14,27 @@ import { useTerminalDrawer } from "./useTerminalDrawer";
 export function AppHeader() {
   const status = useSession((s) => s.status);
   const session = useSession((s) => s.session);
+  const identity = useIdentity((s) => s.identity);
   const terminalOpen = useTerminalDrawer((s) => s.open);
   const toggleTerminal = useTerminalDrawer((s) => s.toggle);
+
+  async function disconnect() {
+    if (!session) return;
+    try {
+      await api.deleteSession(session.id);
+    } catch {
+      // already gone server-side (404) or unreachable — we disconnect locally regardless
+    } finally {
+      useSession.getState().clearSession();
+    }
+  }
+
+  async function refreshSession() {
+    if (!session) return;
+    // Ownership changed; the readings did not. applySessionInfo replaces the
+    // session record without clearing the instrument slices.
+    useSession.getState().applySessionInfo(await api.getSession(session.id));
+  }
 
   return (
     <header style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", padding: "10px 14px", background: "var(--lc-panel)", borderBottom: "1px solid var(--lc-border)" }}>
@@ -20,6 +43,7 @@ export function AppHeader() {
       {/* One right-hand group claims the auto margin, rather than passing it
           between whichever control happens to be rendered. */}
       <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: "var(--space-3)" }}>
+        {session !== null && identity != null && <OwnerBadge session={session} identity={identity} onClaimed={() => void refreshSession()} />}
         {session !== null && (
           <button
             type="button"
@@ -33,6 +57,11 @@ export function AppHeader() {
           </button>
         )}
         <StatusIndicator state={status} />
+        {session !== null && (
+          <Button variant="danger" onClick={() => void disconnect()}>
+            Disconnect
+          </Button>
+        )}
       </div>
     </header>
   );

--- a/webapp/app/src/features/shell/AppHeader.tsx
+++ b/webapp/app/src/features/shell/AppHeader.tsx
@@ -1,0 +1,39 @@
+import { StatusIndicator } from "../../ds/StatusIndicator";
+import { useSession } from "../../store/session";
+import { TERMINAL_DRAWER_ID } from "./TerminalDrawer";
+import { useTerminalDrawer } from "./useTerminalDrawer";
+
+/** The shell's chrome: what instrument this is, and the controls that belong to
+ *  the session rather than to any one instrument kind. Everything here works
+ *  the same for a scope, a power supply or a generator, which is why it lives
+ *  in the shell and not in a kind's view. */
+export function AppHeader() {
+  const status = useSession((s) => s.status);
+  const session = useSession((s) => s.session);
+  const terminalOpen = useTerminalDrawer((s) => s.open);
+  const toggleTerminal = useTerminalDrawer((s) => s.toggle);
+
+  return (
+    <header style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", padding: "10px 14px", background: "var(--lc-panel)", borderBottom: "1px solid var(--lc-border)" }}>
+      <strong style={{ color: "var(--lc-text)" }}>SCPI Instrument Control</strong>
+      <span style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-xs)", color: "var(--lc-muted)" }}>{session ? `${session.model} · ${session.address ?? "mock"}` : "no instrument"}</span>
+      {/* One right-hand group claims the auto margin, rather than passing it
+          between whichever control happens to be rendered. */}
+      <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: "var(--space-3)" }}>
+        {session !== null && (
+          <button
+            type="button"
+            id="terminal-toggle"
+            onClick={toggleTerminal}
+            aria-expanded={terminalOpen}
+            aria-controls={TERMINAL_DRAWER_ID}
+            style={{ fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "4px 10px", borderRadius: "var(--lc-radius-sm)", border: "1px solid var(--lc-border-strong)", color: "var(--lc-text)", background: terminalOpen ? "var(--lc-accent-soft)" : "transparent", cursor: "pointer" }}
+          >
+            Terminal
+          </button>
+        )}
+        <StatusIndicator state={status} />
+      </div>
+    </header>
+  );
+}

--- a/webapp/app/src/features/shell/AppHeader.tsx
+++ b/webapp/app/src/features/shell/AppHeader.tsx
@@ -1,4 +1,4 @@
-import { api } from "../../api/client";
+import { ApiError, api } from "../../api/client";
 import { Button } from "../../ds/Button";
 import { StatusIndicator } from "../../ds/StatusIndicator";
 import { useIdentity } from "../../store/identity";
@@ -31,9 +31,20 @@ export function AppHeader() {
 
   async function refreshSession() {
     if (!session) return;
-    // Ownership changed; the readings did not. applySessionInfo replaces the
-    // session record without clearing the instrument slices.
-    useSession.getState().applySessionInfo(await api.getSession(session.id));
+    try {
+      // Ownership changed; the readings did not. applySessionInfo replaces the
+      // session record without clearing the instrument slices.
+      useSession.getState().applySessionInfo(await api.getSession(session.id));
+    } catch (caught) {
+      // The claim itself already succeeded server-side -- OwnerBadge only
+      // calls onClaimed after api.claimSession resolves. This refresh is only
+      // what lets *this tab* stop showing read-only; if it fails, leaving the
+      // badge up is the honest state, not a bug: ownership could not be
+      // re-confirmed here, and the server enforces it regardless of what this
+      // tab displays. The failure must still reach the user, through the same
+      // banner every other session-level failure uses.
+      useSession.getState().setError(caught instanceof ApiError ? caught.detail || caught.message : caught instanceof Error ? caught.message : "Could not refresh session after claim.");
+    }
   }
 
   return (

--- a/webapp/app/src/features/shell/ErrorBanner.test.tsx
+++ b/webapp/app/src/features/shell/ErrorBanner.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorBanner } from "./ErrorBanner";
+import { useSession } from "../../store/session";
+
+const SESSION = { id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "SDS1104X-E", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" as const };
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("ErrorBanner", () => {
+  it("renders nothing when there is no error", () => {
+    useSession.getState().setSession(SESSION);
+    const { container } = render(<ErrorBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the detail of a session error", () => {
+    // useStream writes this field on an error frame and on an unclean close.
+    // Before this component existed, nothing read it: the user got a red dot
+    // and no explanation.
+    useSession.getState().setSession(SESSION);
+    useSession.getState().setError("connection lost");
+    render(<ErrorBanner />);
+    expect(screen.getByRole("alert")).toHaveTextContent("connection lost");
+  });
+
+  it("shows a dropped stream", () => {
+    useSession.getState().setSession(SESSION);
+    useSession.getState().setError("stream disconnected");
+    render(<ErrorBanner />);
+    expect(screen.getByRole("alert")).toHaveTextContent("stream disconnected");
+  });
+
+  it("dismisses the message without claiming the session recovered", async () => {
+    // THE point of dismissError. setError(null) would flip status back to
+    // "connected", so closing a message would make the UI claim the
+    // connection came back. The message is the user's to dismiss; the
+    // connection state is the instrument's to report.
+    useSession.getState().setSession(SESSION);
+    useSession.getState().setError("connection lost");
+    render(<ErrorBanner />);
+    await userEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(useSession.getState().status).toBe("error");
+    expect(useSession.getState().error).toBeNull();
+  });
+
+  it("clears itself when a new session starts", () => {
+    useSession.getState().setSession(SESSION);
+    useSession.getState().setError("connection lost");
+    useSession.getState().setSession({ ...SESSION, id: "def" });
+    render(<ErrorBanner />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/webapp/app/src/features/shell/ErrorBanner.tsx
+++ b/webapp/app/src/features/shell/ErrorBanner.tsx
@@ -1,0 +1,38 @@
+import { useSession } from "../../store/session";
+
+/** Session-level failures, which arrive unprompted: an error frame from the
+ *  server, or a stream that dropped. Panels keep their own alert regions for
+ *  failures of a write the user just made -- different things, both needed.
+ *
+ *  role="alert" so a screen reader announces it on arrival, which is the case
+ *  this exists for: a connection lost part-way through a capture. */
+export function ErrorBanner() {
+  const error = useSession((s) => s.error);
+  const dismiss = useSession((s) => s.dismissError);
+  if (error === null) return null;
+  return (
+    <div
+      role="alert"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "var(--space-3)",
+        padding: "8px 14px",
+        background: "color-mix(in srgb, var(--danger) 12%, transparent)",
+        color: "var(--danger)",
+        borderBottom: "1px solid var(--lc-border)",
+        fontSize: "var(--text-sm)",
+      }}
+    >
+      <span aria-hidden>⚠</span>
+      <span style={{ flex: 1 }}>{error}</span>
+      <button
+        type="button"
+        onClick={dismiss}
+        style={{ fontSize: "var(--text-sm)", fontFamily: "var(--font-ui)", padding: "2px 10px", borderRadius: "var(--lc-radius-sm)", border: "1px solid currentColor", color: "inherit", background: "transparent", cursor: "pointer" }}
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}

--- a/webapp/app/src/store/session.ts
+++ b/webapp/app/src/store/session.ts
@@ -16,6 +16,7 @@ type SessionStore = {
   referenceStats: ReferenceStats | null;
   logStatus: LogStatus | null;
   setSession: (session: SessionInfo) => void;
+  applySessionInfo: (session: SessionInfo) => void;
   clearSession: () => void;
   applyState: (state: ScopeState) => void;
   applyPsuState: (state: PsuState) => void;
@@ -47,6 +48,13 @@ export const useSession = create<SessionStore>((set) => ({
   // awg→awg) switch would otherwise show the old instrument's state under the
   // new one's name.
   setSession: (session) => set({ session, scope: null, psu: null, awg: null, status: "connected", error: null }),
+  // Replaces the session record ONLY. setSession additionally clears every
+  // instrument slice, which is right when you connect to a different
+  // instrument and wrong when the same instrument merely changed hands: a
+  // claim changes who may write, not what the instrument is reading, and
+  // blanking the readings would flash the panel empty for a poll interval
+  // over a change that has nothing to do with them.
+  applySessionInfo: (session) => set({ session }),
   clearSession: () => set({ session: null, scope: null, psu: null, awg: null, status: "disconnected", error: null, measurements: [], measurementConfig: [], activeReference: null, referenceStats: null, logStatus: null }),
   applyState: (scope) => set({ scope }),
   applyPsuState: (psu) => set({ psu }),

--- a/webapp/app/src/store/session.ts
+++ b/webapp/app/src/store/session.ts
@@ -28,6 +28,7 @@ type SessionStore = {
   applyLogStatus: (status: LogStatus | null) => void;
   setStatus: (status: ConnStatus) => void;
   setError: (error: string | null) => void;
+  dismissError: () => void;
 };
 
 export const useSession = create<SessionStore>((set) => ({
@@ -66,4 +67,9 @@ export const useSession = create<SessionStore>((set) => ({
   applyLogStatus: (logStatus) => set({ logStatus }),
   setStatus: (status) => set({ status }),
   setError: (error) => set({ error, status: error ? "error" : "connected" }),
+  // Clears the message WITHOUT touching status. setError(null) sets status to
+  // "connected", which would make dismissing a message claim the connection
+  // recovered. What the UI says about the connection is the instrument's to
+  // report, not a side effect of closing a notification.
+  dismissError: () => set({ error: null }),
 }));


### PR DESCRIPTION
Makes the gateway's shell chrome tell the truth about the session it is showing: what went wrong, who owns it, and how to leave it.

Sub-project 3 of 4 in the GUI work (kind-aware shell → AWG → **this** → multi-instrument workspace). Frontend and docs only — `git diff main...HEAD -- '*.py'` is empty.

## The one that matters

`useStream` has always written session error detail into the store: a server error frame, and `"stream disconnected"` on an unclean socket close. **Nothing read it.** A session that failed part-way through a capture showed a red status dot and no explanation of what happened. There is now a banner under the header carrying the detail, `role="alert"` so a screen reader announces it on arrival.

Dismissing it needed care. The existing setter is `setError: (error) => set({ error, status: error ? "error" : "connected" })`, so clearing the message through it would flip the status indicator back to *connected* — the UI claiming the session recovered because you closed a notification. Hence a separate `dismissError()` that clears the message and leaves the status alone, pinned by a test. Same principle the instrument readings already follow: report what's true, not what's convenient.

## Also

**Any session can be left.** Disconnect moved from the oscilloscope toolbar into the header. A power supply or generator session previously had no exit but a page reload. It lives in one place, not two.

**A non-owner is told, in session, that they're read-only** and who owns it, with the same Claim action the home screen offers. `OwnerBadge` needed no changes — it already renders nothing for the owner and for an unowned session, so this adds chrome only for the person who needs it. Previously they found out by having a write rejected.

**Two consistency fixes.** An AWG channel whose waveform the instrument won't report now shows the `--.--` marker every other unreadable field uses, rather than a blank dropdown that leaves you guessing whether the instrument said nothing or the app failed to render. And the home screen no longer says "start a Mock scope" when there's a mock button per instrument kind.

The header was extracted into `features/shell/AppHeader.tsx` first, as a pure refactor, so `App.tsx` stays composition.

## Verification

- Frontend `276 passed` across 50 files (+20 on main); `tsc --noEmit` clean
- `tests/test_changelog_mirror.py` passing; no server code touched

Every task passed a scoped review, then the branch passed a whole-branch review. Its one Important finding is fixed here, and it's worth recording why: `refreshSession()` awaited `api.getSession` with no error handling, invoked as `void refreshSession()`, so a rejection escaped `OwnerBadge`'s own try/catch entirely. The reviewer rendered the real app as a non-owner with the refetch failing and observed an unhandled rejection **and** the header still reading "Read-only — owned by alice" after a *successful* claim — this branch's own principle inverted. A failed refresh now surfaces through the very banner this branch added, and the badge honestly stays up, because ownership could not be re-confirmed and the server enforces it regardless.

I had deferred that finding at task-review time as "outside the brief's scope, not exercised by any test". Both were true and neither made it not a defect.

Also added: a length assertion pinning that a scope session renders exactly one Disconnect. Re-adding one to the toolbar would previously have given two buttons with the whole suite green.

## Known follow-ups, not addressed here

- The header now carries four controls with no shrink or overflow handling; a long owner name on a narrow viewport will squeeze. Responsive and density work is the next sub-project.
- An unreadable AWG function removes the dropdown entirely, so that channel's waveform can't be set for the life of the session. Consistent with how every unreadable numeric setpoint already behaves — the panel has no recovery path when an instrument stops reporting, which is a class worth addressing rather than a one-off.
- Two `role="alert"` regions can co-exist in the header (banner plus a failed claim). Not a defect today, but a trap for the next App-level test that reaches for `getByRole("alert")`.
- The stale-copy fix has no test; reverting the sentence leaves the suite green.
