### PR TITLE
Hand out gateway access with an invitation, not a permanent secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- A token name is now an identity rather than a unique credential. `scpi-web token add <name>`
+  no longer fails when that name already exists — it mints an additional token, so one person can
+  hold several devices, and `scpi-web token revoke <name>` cuts off every one of them at once.
+  Anything that relied on the duplicate-name error to detect an existing name should call
+  `TokenStore.names()` instead.
+- `DuplicateTokenName` has been removed from `scpi_control.server.auth`. It can no longer be
+  raised, so any `except DuplicateTokenName` clause is now an `ImportError` waiting to happen.
+- `TokenStore.names()` now returns distinct names, sorted. It previously returned one entry per
+  token, which is one entry per device under the new model.
+
 ### Added
 
+- Handing out gateway access no longer means sending someone a permanent secret. `scpi-web invite
+  <name>` prints a link and a six-digit code for the same ten-minute invitation: send the link, or
+  read the code down the phone. Either one is exchanged in the browser for a real token, so a
+  scientist never sees an `scpi_…` string and a leaked chat message stops working in minutes. The
+  same command is how you get someone back in after they clear their browser or switch laptops.
+  The sign-in screen now asks for a join code first, with the raw-token field kept for scripts and
+  CI.
+- `scpi-web token list` now shows how many devices each identity holds and when it was last used.
 - The SCPI terminal now works for any connected instrument, not just oscilloscopes. It moved out
   of the oscilloscope's control rail (eight tabs down to seven) into a drawer across the bottom of
   the window, opened from a Terminal button in the header and closed with Escape, so a power
@@ -50,6 +70,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Revoking a token now takes effect immediately. The gateway reloads its token store when the file
+  changes, so `scpi-web token revoke` no longer requires restarting the server to lock someone out
+  — which meant the documented remedy for a leaked credential silently did nothing until someone
+  remembered to restart.
+- The token store is now written atomically, so a crash or a concurrent read during a write can no
+  longer leave a `tokens.json` that the gateway refuses to start from.
 - An AWG channel whose waveform the instrument will not report now shows the same `--.--` marker
   every other unreadable field uses, instead of a blank dropdown.
 - The home screen's no-instruments-found message no longer singles out "start a Mock scope" — it

--- a/README.md
+++ b/README.md
@@ -628,23 +628,31 @@ Control instruments from any browser on your LAN:
 
 ```bash
 pip install scpi-instrument-control[web]   # includes the browser gateway
-scpi-web                                   # first run prints a URL with a token
+scpi-web                                   # prints its URL on every start
+scpi-web invite bob                        # a 10-minute link + code for someone else
 ```
 
-On first run the gateway mints an access token and prints a ready-to-open URL
-(`http://127.0.0.1:8765/?token=…`). **Every request needs a token** — mint more
-with `scpi-web token add <name>`. Sessions can target real scopes by IP or a
-built-in mock (`mock: true`) for hardware-free use. The OpenAPI schema is served
-at `/api/openapi.json` (token required); the interactive `/docs`/`/redoc` UIs are
-disabled. Bind to `127.0.0.1` (the default) unless your LAN is trusted, and use
-`--host 0.0.0.0` to expose it.
+The gateway prints its URL every time it starts; the very first run also mints
+a token and prints it in the URL (`http://127.0.0.1:8765/?token=…`). **Every
+request needs a token**, but nobody except the admin has to handle one:
+`scpi-web invite <name>` prints a link and a six-digit code, either of which
+signs a colleague in, both expiring in ten minutes. For scripts and CI, mint a
+long-lived token with `scpi-web token add <name>`. A name is an identity that
+can hold several devices' tokens, and `scpi-web token revoke <name>` cuts off
+all of them, immediately.
+
+Sessions can target real scopes by IP or a built-in mock (`mock: true`) for
+hardware-free use. The OpenAPI schema is served at `/api/openapi.json` (token
+required); the interactive `/docs`/`/redoc` UIs are disabled. Bind to
+`127.0.0.1` (the default) unless your LAN is trusted, and use `--host 0.0.0.0`
+to expose it.
 
 **Security model:** the gateway authenticates every request, gives each
 instrument session an owner (owner writes, everyone else watches), validates
 outbound connection targets, and caps concurrent sessions. It does **not**
 terminate TLS — put it behind a reverse proxy or keep it on a trusted network.
-See the **[Gateway security guide](docs/gateway/security.md)** for tokens,
-ownership, claiming, the SSRF gate, and deployment.
+See the **[Gateway security guide](docs/gateway/security.md)** for invitations,
+tokens, ownership, claiming, the SSRF gate, and deployment.
 
 > **Upgrading from 4.x:** the gateway now requires a token, and reference files
 > saved by 4.x must be converted once with `scpi-web references migrate`. Both
@@ -673,10 +681,12 @@ make webapp-build         # build the UI into the server
 scpi-web --host 0.0.0.0   # serve API + UI on one port
 ```
 
-Open the tokened URL the gateway prints on startup. For UI development, run
-`scpi-web` in one terminal and `cd webapp/app && npm run dev` in another — Vite
-proxies `/api` (HTTP and WebSocket) to the gateway with hot reload; open the dev
-server with the `?token=…` from the gateway's startup URL so the UI picks it up.
+Open the URL the gateway prints on startup — tokened on the first run, or use
+a code from `scpi-web invite`. For UI development, run `scpi-web` in one
+terminal and `cd webapp/app && npm run dev` in another — Vite proxies `/api`
+(HTTP and WebSocket) to the gateway with hot reload; open the dev server with
+an `?invite=…` from `scpi-web invite dev` (or a `?token=…`) so the UI picks up
+a credential.
 
 The home screen scans your LAN and lists instruments to connect to, resume, or
 open a shared session on — plus manual IP and a hardware-free mock.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,8 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- A token name is now an identity rather than a unique credential. `scpi-web token add <name>`
+  no longer fails when that name already exists — it mints an additional token, so one person can
+  hold several devices, and `scpi-web token revoke <name>` cuts off every one of them at once.
+  Anything that relied on the duplicate-name error to detect an existing name should call
+  `TokenStore.names()` instead.
+- `DuplicateTokenName` has been removed from `scpi_control.server.auth`. It can no longer be
+  raised, so any `except DuplicateTokenName` clause is now an `ImportError` waiting to happen.
+- `TokenStore.names()` now returns distinct names, sorted. It previously returned one entry per
+  token, which is one entry per device under the new model.
+
 ### Added
 
+- Handing out gateway access no longer means sending someone a permanent secret. `scpi-web invite
+  <name>` prints a link and a six-digit code for the same ten-minute invitation: send the link, or
+  read the code down the phone. Either one is exchanged in the browser for a real token, so a
+  scientist never sees an `scpi_…` string and a leaked chat message stops working in minutes. The
+  same command is how you get someone back in after they clear their browser or switch laptops.
+  The sign-in screen now asks for a join code first, with the raw-token field kept for scripts and
+  CI.
+- `scpi-web token list` now shows how many devices each identity holds and when it was last used.
 - The SCPI terminal now works for any connected instrument, not just oscilloscopes. It moved out
   of the oscilloscope's control rail (eight tabs down to seven) into a drawer across the bottom of
   the window, opened from a Terminal button in the header and closed with Escape, so a power
@@ -50,6 +70,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Revoking a token now takes effect immediately. The gateway reloads its token store when the file
+  changes, so `scpi-web token revoke` no longer requires restarting the server to lock someone out
+  — which meant the documented remedy for a leaked credential silently did nothing until someone
+  remembered to restart.
+- The token store is now written atomically, so a crash or a concurrent read during a write can no
+  longer leave a `tokens.json` that the gateway refuses to start from.
 - An AWG channel whose waveform the instrument will not report now shows the same `--.--` marker
   every other unreadable field uses, instead of a blank dropdown.
 - The home screen's no-instruments-found message no longer singles out "start a Mock scope" — it

--- a/docs/about/security.md
+++ b/docs/about/security.md
@@ -138,8 +138,9 @@ def safe_connect(ip_str):
   `POST /api/join`, which exchanges a short-lived invitation for a token
 - Invitations (`scpi-web invite <name>`) expire after ten minutes and are
   consumed on first use; failed join attempts are rate limited globally, and
-  every failure returns an identical 401 so the route cannot be used as an
-  oracle
+  every rejected invitation — wrong code, expired, already redeemed — returns
+  the same 401 with byte-identical wording, so the route cannot be used to
+  probe for which invitations exist
 - Revoking a name (`scpi-web token revoke <name>`) removes every token it
   holds and takes effect immediately — the gateway reloads its token store
   when the file changes

--- a/docs/about/security.md
+++ b/docs/about/security.md
@@ -134,7 +134,15 @@ def safe_connect(ip_str):
 ### Web gateway
 
 - The optional web gateway (`scpi-web`) authenticates every `/api/*` request
-  with a bearer token, except the unauthenticated `GET /api/health` probe
+  with a bearer token, except the unauthenticated `GET /api/health` probe and
+  `POST /api/join`, which exchanges a short-lived invitation for a token
+- Invitations (`scpi-web invite <name>`) expire after ten minutes and are
+  consumed on first use; failed join attempts are rate limited globally, and
+  every failure returns an identical 401 so the route cannot be used as an
+  oracle
+- Revoking a name (`scpi-web token revoke <name>`) removes every token it
+  holds and takes effect immediately — the gateway reloads its token store
+  when the file changes
 - Instrument sessions are owned by the token that created them — only the
   owner may issue writes; other tokens may read and watch
 - Outbound connection targets are validated (an SSRF gate) before the gateway

--- a/docs/examples/intermediate.md
+++ b/docs/examples/intermediate.md
@@ -515,10 +515,11 @@ python examples/gateway_rest_client.py
 Start the gateway first (in another terminal):
 
     pip install "SCPI-Instrument-Control[web]"
-    scpi-web            # prints a URL with a token on first run
+    scpi-web            # prints the gateway's URL on every start
 
-Every gateway request needs a bearer token. Mint one and export it before
-running this script:
+Every gateway request needs a bearer token. People sign in with an invitation
+(`scpi-web invite <name>`), but a script wants a credential it can keep, so
+mint one by hand and export it before running this:
 
     scpi-web token add rest-demo     # prints the token once
     export SCPI_WEB_TOKEN=scpi_...   # the token it printed

--- a/docs/gateway/api.md
+++ b/docs/gateway/api.md
@@ -12,8 +12,13 @@ Every route below requires `Authorization: Bearer <token>` **except**
 `GET /api/health` and `POST /api/join`. The latter exchanges an invitation for
 a token — `{"code": "417902"}` or `{"invite": "<nonce from an invite link>"}`
 in, `{"token", "identity"}` back — so it cannot require the credential it
-issues; every failure returns an identical **401**, and too many failures
-return **429**. See the [Gateway security guide](security.md) for how to
+issues. Every rejected invitation — wrong code, expired, already redeemed —
+returns the same **401** with byte-identical wording, so the route cannot be
+used to probe for which invitations exist; too many failures return **429**,
+and a body that is not valid JSON of the shape above is rejected **422** by
+request validation before the handler runs (which reveals nothing: the answer
+is the same whether or not an invitation is live). See the
+[Gateway security guide](security.md) for how to
 invite someone or mint a token, how ownership gates writes, and the WebSocket
 authentication handshake.
 

--- a/docs/gateway/api.md
+++ b/docs/gateway/api.md
@@ -9,9 +9,13 @@ works, but the shipping frontend calls the kind-agnostic
 [command console](#command-console) route instead.
 
 Every route below requires `Authorization: Bearer <token>` **except**
-`GET /api/health`. See the [Gateway security guide](security.md) for how to
-mint a token, how ownership gates writes, and the WebSocket authentication
-handshake.
+`GET /api/health` and `POST /api/join`. The latter exchanges an invitation for
+a token — `{"code": "417902"}` or `{"invite": "<nonce from an invite link>"}`
+in, `{"token", "identity"}` back — so it cannot require the credential it
+issues; every failure returns an identical **401**, and too many failures
+return **429**. See the [Gateway security guide](security.md) for how to
+invite someone or mint a token, how ownership gates writes, and the WebSocket
+authentication handshake.
 
 ## Sessions & discovery
 
@@ -183,10 +187,10 @@ Every error response is JSON: `{"error": "<ExceptionClassName>", "detail": "<mes
 
 ## Curl quickstart
 
-Create a mock session, configure a channel, and fetch its waveform as JSON — no hardware required. Start the gateway first (`scpi-web` prints a token on first run; mint another with `scpi-web token add <name>`) and export it:
+Create a mock session, configure a channel, and fetch its waveform as JSON — no hardware required. Start the gateway first, then mint a token for this script with `scpi-web token add curl-demo` (that is what `token add` is for: scripts and CI, where a long-lived secret is the right answer) and export it:
 
 ```bash
-export TOKEN=scpi_...   # from the gateway's startup output
+export TOKEN=scpi_...   # printed once by `scpi-web token add curl-demo`
 
 # 1. Create a mock scope session
 curl -s -X POST http://127.0.0.1:8765/api/sessions \

--- a/docs/gateway/browser-ui.md
+++ b/docs/gateway/browser-ui.md
@@ -4,6 +4,15 @@ This page walks through the gateway's browser interface tab by tab. There
 are no screenshots yet — read this alongside a running gateway
 (`scpi-web`) and follow along.
 
+## Signing in
+
+Before the home screen there is a **Sign in** panel with a single **Join code**
+field: type the six digits your lab admin read out and press **Connect**. An
+invitation link (`…/?invite=…`) skips this screen entirely — it redeems itself
+as the page loads. Automation authors, who hold an `scpi_…` token rather than a
+code, will find an **I have an access token** disclosure below the field. See
+[Gateway security](security.md#inviting-someone) for where codes come from.
+
 ## Home screen
 
 The home screen is split into two zones: sessions already held by the server

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -9,9 +9,9 @@ multi-sessions, so several instruments (or several views of the same
 instrument) can be open at once.
 
 > **Security first:** every request needs a bearer token. Read the
-> **[Gateway security guide](security.md)** for tokens, session ownership, the
-> SSRF gate, and deployment guidance before exposing the gateway beyond
-> `127.0.0.1`.
+> **[Gateway security guide](security.md)** for invitations, tokens, session
+> ownership, the SSRF gate, and deployment guidance before exposing the
+> gateway beyond `127.0.0.1`.
 
 ## Install and run
 
@@ -27,14 +27,20 @@ scpi-web
 python -m scpi_control.server
 ```
 
-By default the gateway listens on `http://127.0.0.1:8765`. On first run it
-mints an access token and prints a ready-to-open URL
-(`http://127.0.0.1:8765/?token=…`) — open that to reach the browser UI.
+By default the gateway listens on `http://127.0.0.1:8765`, and prints that URL
+every time it starts. On the very first run — when no tokens exist yet — it
+also mints one and prints it in the URL (`http://127.0.0.1:8765/?token=…`);
+open that to reach the browser UI.
+
+To give someone else access, run `scpi-web invite <name>` on the gateway host.
+It prints a link and a six-digit code, both good for ten minutes and for one
+sign-in; send either. Nobody but you needs to handle a raw token.
 
 ## Security posture
 
-Every `/api/*` route (other than `GET /api/health`) requires a valid bearer
-token — there is no unauthenticated path. The server also binds to
+Every `/api/*` route requires a valid bearer token, except `GET /api/health`
+and `POST /api/join` (which redeems an invitation, and so cannot require the
+credential it hands out). The server also binds to
 `127.0.0.1` by default, so it is not reachable from the network until you opt
 in. Exposing it to the LAN is an explicit choice:
 
@@ -77,8 +83,8 @@ ever plugging in an instrument.
 
 ## Where to next
 
-- [Gateway security](security.md) — tokens, session ownership, the SSRF gate,
-  and deployment guidance
+- [Gateway security](security.md) — invitations, tokens, session ownership,
+  the SSRF gate, and deployment guidance
 - [Browser UI Tour](browser-ui.md) — a walkthrough of the home screen, canvas
   modes, and rail tabs
 - [REST & WebSocket API](api.md) — the complete wire reference, with a curl

--- a/docs/gateway/security.md
+++ b/docs/gateway/security.md
@@ -18,16 +18,37 @@ gateway**. It is *not* hardened for the public internet, and it does not
 terminate TLS. The boundary stops an authenticated peer from doing things they
 should not — driving someone else's scope, scanning the internal network, or
 running code on the gateway host — and stops an unauthenticated peer from doing
-anything at all. It does **not** encrypt traffic; for that, put the gateway
+anything at all beyond an uptime probe and redeeming an invitation they were
+given (see [Inviting someone](#inviting-someone)). It does **not** encrypt
+traffic; for that, put the gateway
 behind a reverse proxy or keep it on a network you trust. See
 [Deployment](#deployment) for the specifics.
 
-## First run
+## Starting the gateway
 
-Start the gateway and it mints a token for you and prints a ready-to-open URL:
+Every start prints where the gateway can be reached:
 
 ```console
 $ scpi-web
+
+Gateway ready at http://127.0.0.1:8765/
+Hand out access with: scpi-web invite <name>
+```
+
+The URL is the address you bound to, with one adjustment: a wildcard bind
+(`--host 0.0.0.0`) prints this machine's LAN address, because `0.0.0.0` is not
+something a colleague can open. A concrete `--host` is used verbatim, and
+loopback stays loopback. The gateway also records this URL in `gateway.json`
+under its config directory, which is how `invite` (below) knows what link to
+print.
+
+The **very first** start is different: with no tokens on disk there is nobody
+to invite you, so the gateway mints a token named `default` and prints a URL
+carrying it:
+
+```console
+$ scpi-web
+
 Gateway ready. Open:
 
     http://127.0.0.1:8765/?token=scpi_Qy8…f3A
@@ -38,54 +59,105 @@ the browser, and immediately strips it from the URL — so it does not linger in
 your history or leak through the `Referer` header of any link you click. From
 then on the UI sends the token automatically.
 
-The token named `default` is created only when no tokens exist yet. Restarting
-the gateway does **not** mint a new one or reprint the URL — your existing token
-keeps working. To get the URL again, mint another token (below) or read the
-token file.
+That `?token=` bootstrap happens only while the token store is empty. Once it
+holds anything, every start prints the plain banner above instead.
+
+## Inviting someone
+
+Nobody in the lab should ever have to handle a `scpi_…` string. To give a
+colleague access, run one command on the gateway host:
+
+```console
+$ scpi-web invite bob
+
+Invitation for 'bob' — expires in 10 minutes.
+
+  Send this link:          http://127.0.0.1:8765/?invite=Vb2…9tQ
+  Or read out this code:   417 902
+```
+
+Send the link, or read the six digits down the phone — the two are **one**
+invitation with two ways in, and whichever is used first consumes it. Opening
+the link signs that browser in with no typing at all; the code goes in the
+**Join code** box on the gateway's sign-in screen. Either way the gateway
+mints a token named `bob`, and that name is the identity that owns Bob's
+sessions from then on.
+
+- The invitation lives **ten minutes**. That is deliberate: a link pasted into
+  a chat channel is worthless long before anyone scrolls back to it.
+- It is good for **one** person. Two colleagues, two `invite` commands.
+- Someone locked out — new laptop, cleared browser, no idea where the token
+  went — is the same command again: `scpi-web invite bob`. Their existing
+  tokens keep working alongside the new one. If they should not, run
+  `scpi-web token revoke bob` **first**, then invite: revoking a name cuts off
+  every token it holds, including one you just issued.
+
+The link's host and port come from the URL the gateway recorded when it last
+started, so what `invite` prints is openable as-is. If no gateway has ever
+started from this config directory, `invite` prints a note saying so, falls
+back to the default `http://127.0.0.1:8765/`, and points you at `--url` — pass
+`--url http://host:port/` to set the base yourself.
 
 ## Tokens
 
-Tokens are the gateway's credentials. They are long random strings prefixed
-`scpi_`, stored **hashed** (SHA-256) in `~/.siglent/tokens.json` — the raw token
-is shown once, at creation, and never written to disk or logged. Manage them
-with the `token` subcommands:
+A token is the gateway's actual credential: a long random string prefixed
+`scpi_`, stored **hashed** (SHA-256) in `~/.siglent/tokens.json` — the raw
+token is shown once, at creation, and never written to disk or logged. An
+invitation redeems into one of these.
+
+You mint one by hand for **scripts, notebooks, and CI** — the case where a
+long-lived secret that can be copied into a config or a secret store is
+exactly the right answer, and where nobody is sitting at a browser to type a
+join code.
 
 ```console
-$ scpi-web token add alice
-token 'alice' created. Copy it now, it is not stored:
+$ scpi-web token add ci-nightly
+token 'ci-nightly' created. Copy it now, it is not stored:
 
     scpi_7dK…2mР
 
 $ scpi-web token list
-alice
-default
+alice                2 devices   last used 2026-07-28T09:14:02+00:00
+ci-nightly           1 device    last used never
 
-$ scpi-web token revoke default
-revoked 'default'
+$ scpi-web token revoke alice
+revoked 'alice'
 ```
 
 - **`token add <name>`** mints a token and prints it **once**. Copy it then; it
-  cannot be recovered. The *name* is the identity — it is what appears as a
-  session's owner and in any attribution.
-- **`token list`** shows names only, never secrets.
-- **`token revoke <name>`** removes a token from `tokens.json`. Use it when a
-  token is shared too widely or a laptop walks off.
+  cannot be recovered. Hand it to automation through an environment variable or
+  a secret store rather than pasting it into a script — see
+  [Sending the token](#sending-the-token) for a worked example.
+- A **name is an identity, not a credential.** One name can hold several
+  tokens — a laptop, a bench tablet, a reinstalled browser — and every one of
+  them reports the same owner. Running `token add bob` twice succeeds and
+  leaves you with two working tokens for Bob; so does inviting him twice.
+- **`token list`** shows names, how many device tokens each holds, and when one
+  of them was last seen — never secrets. `last used` is best-effort bookkeeping
+  kept in memory by the running gateway; it resets when the store reloads and
+  is not an audit record.
+- **`token revoke <name>`** removes **every** token under that name, so "Bob
+  has left" is a single command whatever he signed in from.
 
-  > **A running gateway loads its tokens once, at startup.** `token revoke` (and
-  > `token add`) edit the file from a separate process, so **restart `scpi-web`
-  > for a revocation to take effect.** Until it restarts, a revoked token keeps
-  > working. If you have revoked a token because it leaked, restart the gateway.
+**Revocation takes effect immediately.** The gateway watches `tokens.json` and
+reloads it when it changes on disk, so a token revoked from another terminal
+stops working on the very next request — no restart, no window in which a
+leaked token still opens the door.
 
 Every token is equal: there are no roles or scopes. Anyone with a valid token can
 create sessions and read any session; ownership (below) governs who may *write*.
 
 The token store lives under `~/.siglent` by default; relocate it with
-`--config-dir <path>` (which applies to `token add|list|revoke` and to serving).
+`--config-dir <path>` (which applies to `token add|list|revoke`, to `invite`,
+and to serving).
 
 > **A malformed `tokens.json` is a hard error, by design.** If the file is
 > corrupt, the gateway refuses to start rather than falling back to "no tokens" —
 > because "no tokens" would be indistinguishable from a fresh install and could
-> silently open the gateway. Fix or remove the file.
+> silently open the gateway. Fix or remove the file. Pending invitations live
+> beside it in `invitations.json` and follow the same rule; that file holds no
+> tokens, so deleting it costs you nothing but the invitations you have not yet
+> handed out.
 
 ## Sending the token
 
@@ -104,11 +176,14 @@ credential in an API URL would leak it into logs and history, so there is exactl
 one way in for the API: the header.
 
 ```python
+import os
+
 import requests
 
-TOKEN = "scpi_7dK…2mР"
+# Mint it once with `scpi-web token add my-script`, then export it:
+#     export SCPI_WEB_TOKEN=scpi_...
 s = requests.Session()
-s.headers["Authorization"] = f"Bearer {TOKEN}"
+s.headers["Authorization"] = f"Bearer {os.environ['SCPI_WEB_TOKEN']}"
 
 s.post("http://127.0.0.1:8765/api/sessions", json={"label": "bench", "mock": True})
 ```
@@ -128,11 +203,48 @@ token back in a response header. An unauthenticated handshake is closed with cod
 **1008** (policy violation). If you only ever offer `scpi-token.<token>` with no
 `scpi` fallback, a real browser will fail the handshake, so always send both.
 
-### Health check
+### The two routes that need no token
 
-`GET /api/health` is the one route that needs no token — it exists so a load
-balancer or a "is it up?" probe does not require a credential. It returns only
-`{"status": "ok"}` and touches no instrument.
+Everything under `/api/` is authenticated except these:
+
+- **`GET /api/health`** exists so a load balancer or an "is it up?" probe does
+  not need a credential. It returns only `{"status": "ok"}` and touches no
+  instrument.
+- **`POST /api/join`** redeems an invitation — it cannot require a token,
+  because it is how you get one. Unlike the health probe it is a **write**: a
+  successful call mints a token and consumes the invitation. It takes
+  `{"code": "417902"}` or `{"invite": "<the link's nonce>"}` and returns
+  `{"token": …, "identity": …}`.
+
+`/api/join` is the most exposed surface the gateway has, so it is built to give
+nothing away. **Every** failure — wrong code, expired, already redeemed —
+returns the same **401** with byte-identical wording, so it cannot be used to
+probe for which invitations exist. Only a rate limit answers differently, with
+**429**.
+
+### Guessing a join code
+
+A six-digit code is 1,000,000 possibilities, which is only enough because of
+what surrounds it:
+
+- An invitation **expires in ten minutes**, so a guesser gets ten minutes, not
+  forever.
+- **Failed** `/api/join` attempts are limited to **ten per minute across all
+  clients** — not per IP. A per-IP budget means very little against someone on
+  the same lab network who can pick their own source addresses. Successes are
+  not counted, because a success consumes its invitation and so cannot be
+  repeated, and counting them would let a lab arriving together at 9am lock
+  each other out.
+
+That caps a determined guesser at roughly 100 attempts over an invitation's
+life: about a 1-in-10,000 chance per invitation.
+
+There is deliberately **no per-invitation attempt cap.** A wrong code cannot be
+attributed to any particular invitation, so the only way to charge one would be
+to charge all of them — which would hand any passer-by a way to invalidate
+everyone's pending access by typing garbage. The global failure limit is the
+trade: a burst of wrong guesses delays honest joiners by a minute rather than
+cancelling them.
 
 ### API schema
 
@@ -266,7 +378,8 @@ directory, when you run the command explicitly.
 - **TLS.** See the table above.
 - **Per-user reference storage.** References are a shared store; ownership
   applies to live instrument sessions only.
-- **Rate limiting** beyond the session cap.
+- **General rate limiting.** The only limiter is on failed `/api/join`
+  attempts (above); authenticated routes are bounded by the session cap alone.
 
 ## Quick reference
 
@@ -281,14 +394,16 @@ directory, when you run the command explicitly.
 
 | Command | Purpose |
 |---|---|
-| `scpi-web token add <name>` | Mint a token (printed once) |
-| `scpi-web token list` | List token names |
-| `scpi-web token revoke <name>` | Revoke a token (restart the gateway to apply) |
+| `scpi-web invite <name>` | Give a person access: a 10-minute link and code (`--url` overrides the base URL) |
+| `scpi-web token add <name>` | Mint a long-lived token for a script or CI job (printed once) |
+| `scpi-web token list` | List identities with device counts and last use |
+| `scpi-web token revoke <name>` | Revoke every token under a name (effective immediately) |
 | `scpi-web references migrate` | Convert pre-5.0 reference files |
 
 | Status | Meaning |
 |---|---|
-| **401** | Missing or invalid token |
+| **401** | Missing or invalid token — or, on `join`, an invitation that is wrong, expired, or already used (one message for all three) |
+| **429** on `join` | Too many failed join attempts across all clients; wait a minute |
 | **409** on a write | You are not the session owner (message names who is) |
 | **409** on `claim` | Owner still active/watching (message names them and their idle seconds) |
 | **409** on create | Session cap reached |

--- a/docs/gateway/security.md
+++ b/docs/gateway/security.md
@@ -141,8 +141,16 @@ revoked 'alice'
 
 **Revocation takes effect immediately.** The gateway watches `tokens.json` and
 reloads it when it changes on disk, so a token revoked from another terminal
-stops working on the very next request — no restart, no window in which a
-leaked token still opens the door.
+stops working on the very next request — no restart needed.
+
+> **One exception: a live-stream WebSocket already open.** A stream
+> authenticates once, at the handshake, and nothing re-checks it afterwards, so
+> revoking the token does not tear the connection down — it keeps receiving
+> waveform data until it closes. Worse, a watching stream marks its session as
+> owner-watching, and that *refuses* a claim outright however long the owner has
+> been idle, so the revoked tab also keeps you from taking over the session it
+> is holding. If you need a leaked credential cut off mid-capture, close that
+> stream (or restart the gateway); revoking the token alone is not enough.
 
 Every token is equal: there are no roles or scopes. Anyone with a valid token can
 create sessions and read any session; ownership (below) governs who may *write*.
@@ -387,7 +395,7 @@ directory, when you run the command explicitly.
 |---|---|---|
 | `--host` | `127.0.0.1` | Bind address; `0.0.0.0` exposes on the LAN |
 | `--port` | `8765` | Listen port |
-| `--config-dir` | `~/.siglent` | Where `tokens.json` lives |
+| `--config-dir` | `~/.siglent` | Where `tokens.json`, `gateway.json` and `invitations.json` live |
 | `--allow-port <n>` | `{5025}` | Extra instrument port(s) the gateway may connect to (repeatable) |
 | `--max-sessions` | `8` | Concurrent instrument-session cap |
 | `--abandon-after` | `300` | Seconds of owner inactivity before a session can be claimed |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -22,10 +22,12 @@ First, install the library:
     scpi-web
     `
 
-    On first run this prints a ready-to-open URL with an access token
-    (`http://127.0.0.1:8765/?token=…`) — open that in your browser. Every
-    request needs a token; see the
-    [Gateway security guide](../gateway/security.md) for details.
+    The gateway prints its URL every time it starts; on the very first run
+    that URL carries an access token
+    (`http://127.0.0.1:8765/?token=…`) — open it in your browser. To let a
+    colleague in, run `scpi-web invite <their name>`: it prints a link and a
+    six-digit code, either of which signs them in, both good for ten minutes.
+    See the [Gateway security guide](../gateway/security.md) for details.
 
 === "Everything"
 `bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -109,4 +109,12 @@ pip install "SCPI-Instrument-Control[web]"
 scpi-web
 ```
 
-Then run the client script.
+Then, back in your first terminal, mint a token for the script (`token add` is
+the credential for scripts and CI; people sign in with `scpi-web invite <name>`
+instead) and export it before running the client:
+
+```bash
+scpi-web token add rest-demo     # prints the token once
+export SCPI_WEB_TOKEN=scpi_...   # the token it printed
+python examples/gateway_rest_client.py
+```

--- a/examples/gateway_rest_client.py
+++ b/examples/gateway_rest_client.py
@@ -3,10 +3,11 @@
 Start the gateway first (in another terminal):
 
     pip install "SCPI-Instrument-Control[web]"
-    scpi-web            # prints a URL with a token on first run
+    scpi-web            # prints the gateway's URL on every start
 
-Every gateway request needs a bearer token. Mint one and export it before
-running this script:
+Every gateway request needs a bearer token. People sign in with an invitation
+(`scpi-web invite <name>`), but a script wants a credential it can keep, so
+mint one by hand and export it before running this:
 
     scpi-web token add rest-demo     # prints the token once
     export SCPI_WEB_TOKEN=scpi_...   # the token it printed

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -80,14 +80,17 @@ def main(argv=None) -> None:
             try:
                 print("token {0!r} created. Copy it now, it is not stored:\n\n    {1}\n".format(args.name, store.mint(args.name)))
             except ValueError as exc:
-                # Covers DuplicateTokenName (a ValueError subclass) as well as
-                # the bare ValueError mint() raises for an empty or
-                # whitespace-only name -- both must exit cleanly with a
-                # message, not surface as an uncaught traceback.
+                # mint() rejects an empty or whitespace-only name; exit cleanly
+                # with the message rather than surfacing a traceback.
                 sys.exit(str(exc))
         elif args.token_command == "list":
-            names = store.names()
-            print("\n".join(names) if names else "no tokens")
+            rows = store.summary()
+            if not rows:
+                print("no tokens")
+            else:
+                for row in rows:
+                    devices = "{0} device{1}".format(row["devices"], "" if row["devices"] == 1 else "s")
+                    print("{0:<20} {1:<11} last used {2}".format(row["name"], devices, row["last_used"] or "never"))
         elif args.token_command == "revoke":
             if not store.revoke(args.name):
                 sys.exit("no token named {0!r}".format(args.name))

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -8,12 +8,21 @@ import uvicorn
 
 from scpi_control.server.app import create_app
 from scpi_control.server.auth import DEFAULT_CONFIG_DIR, TokenStore
+from scpi_control.server.gateway_url import read_base_url, write_base_url
+from scpi_control.server.invitations import InvitationStore, format_code
 from scpi_control.server.netpolicy import DEFAULT_ALLOWED_PORTS
 
 
+def _config_dir(args) -> Path:
+    return Path(args.config_dir) if args.config_dir else DEFAULT_CONFIG_DIR
+
+
+def _invitations(args) -> InvitationStore:
+    return InvitationStore(str(_config_dir(args) / "invitations.json"))
+
+
 def _store(args) -> TokenStore:
-    config_dir = Path(args.config_dir) if args.config_dir else DEFAULT_CONFIG_DIR
-    return TokenStore(str(config_dir / "tokens.json"))
+    return TokenStore(str(_config_dir(args) / "tokens.json"))
 
 
 def _add_config_dir(parser, default=None) -> None:
@@ -60,6 +69,11 @@ def main(argv=None) -> None:
     revoke.add_argument("name")
     _add_config_dir(revoke, default=argparse.SUPPRESS)
 
+    invite = sub.add_parser("invite", help="create a join link and code for someone")
+    invite.add_argument("name")
+    invite.add_argument("--url", default=None, help="base URL to print (default: the URL the gateway last recorded)")
+    _add_config_dir(invite, default=argparse.SUPPRESS)
+
     references = sub.add_parser("references", help="reference file maintenance").add_subparsers(dest="references_command", required=True)
     migrate = references.add_parser("migrate", help="convert pre-5.0 pickled reference files")
     migrate.add_argument("--dir", default=None, help="reference storage directory (default: ~/.siglent/references)")
@@ -72,6 +86,23 @@ def main(argv=None) -> None:
         target = args.dir if args.dir else str(DEFAULT_CONFIG_DIR / "references")
         result = migrate_references(target)
         print("converted {converted}, skipped {skipped}, failed {failed} in {0}".format(target, **result))
+        return
+
+    if args.command == "invite":
+        base = args.url or read_base_url(_config_dir(args))
+        fallback = base is None
+        if fallback:
+            base = "http://{0}:{1}/".format(args.host, args.port)
+        try:
+            link, code = _invitations(args).create(args.name)
+        except ValueError as exc:
+            sys.exit(str(exc))
+        print("\nInvitation for {0!r} — expires in 10 minutes.\n".format(args.name))
+        print("  Send this link:          {0}?invite={1}".format(base, link))
+        print("  Or read out this code:   {0}\n".format(format_code(code)))
+        if fallback:
+            print("(No gateway has started from this config directory yet, so that link assumes")
+            print(" {0}. If the gateway runs elsewhere, pass --url.)\n".format(base))
         return
 
     if args.command == "token":
@@ -107,11 +138,18 @@ def main(argv=None) -> None:
         parser.error("--max-sessions must be at least 1 (got {0})".format(args.max_sessions))
 
     store = _store(args)
+    url = write_base_url(_config_dir(args), args.host, args.port)
     if store.is_empty():
         raw = store.mint("default")
-        print("\nGateway ready. Open:\n\n    http://{0}:{1}/?token={2}\n".format(args.host, args.port, raw))
+        print("\nGateway ready. Open:\n\n    {0}?token={1}\n".format(url, raw))
+    else:
+        print("\nGateway ready at {0}\nHand out access with: scpi-web invite <name>\n".format(url))
     allowed_ports = frozenset(args.allow_port) | DEFAULT_ALLOWED_PORTS if args.allow_port else None
-    uvicorn.run(create_app(token_store=store, abandon_after=args.abandon_after, allowed_ports=allowed_ports, max_sessions=args.max_sessions), host=args.host, port=args.port)
+    uvicorn.run(
+        create_app(token_store=store, invitation_store=_invitations(args), abandon_after=args.abandon_after, allowed_ports=allowed_ports, max_sessions=args.max_sessions),
+        host=args.host,
+        port=args.port,
+    )
 
 
 if __name__ == "__main__":

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -138,6 +138,16 @@ def main(argv=None) -> None:
         parser.error("--max-sessions must be at least 1 (got {0})".format(args.max_sessions))
 
     store = _store(args)
+    # Built here, not inline in the create_app(...) call below, for the same
+    # reason --max-sessions is checked above: InvitationStore.__init__ raises
+    # ValueError on a corrupt invitations.json, and constructing it after the
+    # mint meant the admin saw "Gateway ready. Open: ...?token=..." for a
+    # server that then died -- leaving a live token in tokens.json that, since
+    # the store is no longer empty, no later start would ever print again.
+    try:
+        invitations = _invitations(args)
+    except ValueError as exc:
+        sys.exit(str(exc))
     url = write_base_url(_config_dir(args), args.host, args.port)
     if store.is_empty():
         raw = store.mint("default")
@@ -146,7 +156,7 @@ def main(argv=None) -> None:
         print("\nGateway ready at {0}\nHand out access with: scpi-web invite <name>\n".format(url))
     allowed_ports = frozenset(args.allow_port) | DEFAULT_ALLOWED_PORTS if args.allow_port else None
     uvicorn.run(
-        create_app(token_store=store, invitation_store=_invitations(args), abandon_after=args.abandon_after, allowed_ports=allowed_ports, max_sessions=args.max_sessions),
+        create_app(token_store=store, invitation_store=invitations, abandon_after=args.abandon_after, allowed_ports=allowed_ports, max_sessions=args.max_sessions),
         host=args.host,
         port=args.port,
     )

--- a/scpi_control/server/api/join.py
+++ b/scpi_control/server/api/join.py
@@ -18,6 +18,7 @@ for it would hand an attacker the power to invalidate everyone's access at
 once.
 """
 
+import logging
 import time
 from collections import deque
 from typing import Optional
@@ -25,12 +26,21 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 
 # Ten failures a minute against a six-digit code, over an invitation's
 # ten-minute life, is about 100 guesses into a space of 1,000,000 -- roughly a
 # 1-in-10,000 chance per invitation. Raising either number weakens that
 # directly; do the arithmetic before you touch them.
+#
+# The limiter itself lives in app.state (see create_app), so the budget is
+# per-process, not per-deployment. Rule 2 above -- "across all clients" --
+# therefore holds only for the single-uvicorn-process server __main__.py
+# starts. Adding a --workers N would silently hand an attacker N times this
+# budget without changing either number here, so size the limit against the
+# worker count if you ever add one.
 FAILURE_LIMIT = 10
 FAILURE_WINDOW_SECONDS = 60.0
 
@@ -78,7 +88,19 @@ async def join(body: JoinRequest, request: Request):
     limiter = request.app.state.join_limiter
     if limiter.blocked():
         raise HTTPException(status_code=429, detail=THROTTLED)
-    name = request.app.state.invitations.redeem(code=body.code, link=body.invite)
+    try:
+        name = request.app.state.invitations.redeem(code=body.code, link=body.invite)
+    except ValueError as exc:
+        # A corrupt invitations.json makes redeem() raise, and the app-wide
+        # ValueError handler would render it as a 400 carrying the store's
+        # absolute path -- leaking the admin's username and directory layout
+        # to an anonymous caller, and giving this route a third distinguishable
+        # status. Rule 1 does not get an exception for our own bugs: answer
+        # with the shared rejection and tell the operator server-side.
+        # __main__.py refuses to start on a corrupt store, but the file can
+        # still be damaged while the gateway runs, so this stays needed.
+        logger.error("join rejected: invitation store unusable: %s", exc)
+        name = None
     if name is None:
         limiter.record_failure()
         raise HTTPException(status_code=401, detail=REJECTED)

--- a/scpi_control/server/api/join.py
+++ b/scpi_control/server/api/join.py
@@ -1,0 +1,85 @@
+"""Redeem an invitation into a token. The one unauthenticated write route.
+
+Everything else under /api is fail-closed (see AuthMiddleware). This route
+exists so someone holding no credential can obtain one, which makes it the
+most security-sensitive surface in the gateway. Two rules follow from that and
+must not be relaxed:
+
+1. Every failure returns one identical response. Distinguishing "wrong" from
+   "expired" from "already used" would let an attacker probe for the existence
+   and timing of invitations without ever guessing one.
+2. Failed attempts are rate limited across all clients, not per IP. A per-IP
+   budget is close to meaningless against someone on the same lab network who
+   can pick source addresses.
+
+There is deliberately no per-invitation attempt cap: a wrong code cannot be
+attributed to any particular invitation, and charging every live invitation
+for it would hand an attacker the power to invalidate everyone's access at
+once.
+"""
+
+import time
+from collections import deque
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+router = APIRouter()
+
+# Ten failures a minute against a six-digit code, over an invitation's
+# ten-minute life, is about 100 guesses into a space of 1,000,000 -- roughly a
+# 1-in-10,000 chance per invitation. Raising either number weakens that
+# directly; do the arithmetic before you touch them.
+FAILURE_LIMIT = 10
+FAILURE_WINDOW_SECONDS = 60.0
+
+# One message for every non-rate-limited failure. Keep it literal and shared:
+# two call sites with "the same" wording that drift apart reintroduce the
+# oracle this constant exists to prevent.
+REJECTED = "That code or link is not valid, or it has expired. Ask for a new one."
+THROTTLED = "Too many attempts. Wait a minute and try again."
+
+
+class JoinRequest(BaseModel):
+    code: Optional[str] = None
+    invite: Optional[str] = None
+
+
+class FailureLimiter:
+    """Sliding window over recent *failures*, shared by all clients.
+
+    Successes are not recorded: a successful join consumes its invitation, so
+    it cannot be repeated, and counting successes would let a lab full of
+    people arriving at 9am lock each other out.
+    """
+
+    def __init__(self, limit: int = FAILURE_LIMIT, window: float = FAILURE_WINDOW_SECONDS) -> None:
+        self.limit = limit
+        self.window = window
+        self._failures: deque = deque()
+
+    def _expire(self, now: float) -> None:
+        while self._failures and now - self._failures[0] > self.window:
+            self._failures.popleft()
+
+    def blocked(self) -> bool:
+        now = time.monotonic()
+        self._expire(now)
+        return len(self._failures) >= self.limit
+
+    def record_failure(self) -> None:
+        self._failures.append(time.monotonic())
+
+
+@router.post("/join")
+async def join(body: JoinRequest, request: Request):
+    """Exchange an invitation for a token. Requires no credential by design."""
+    limiter = request.app.state.join_limiter
+    if limiter.blocked():
+        raise HTTPException(status_code=429, detail=THROTTLED)
+    name = request.app.state.invitations.redeem(code=body.code, link=body.invite)
+    if name is None:
+        limiter.record_failure()
+        raise HTTPException(status_code=401, detail=REJECTED)
+    return {"token": request.app.state.tokens.mint(name), "identity": name}

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -10,7 +10,9 @@ from fastapi.responses import FileResponse, JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from scpi_control.exceptions import InvalidParameterError, SiglentError, SiglentTimeoutError
+from scpi_control.server.api.join import FailureLimiter
 from scpi_control.server.auth import AuthMiddleware, TokenStore
+from scpi_control.server.invitations import InvitationStore
 from scpi_control.server.sessions import SessionError, SessionManager
 
 STATIC_DIR = Path(__file__).parent / "static"
@@ -24,6 +26,7 @@ def create_app(
     manager: Optional[SessionManager] = None,
     references_dir: Optional[str] = None,
     token_store: Optional[TokenStore] = None,
+    invitation_store: Optional[InvitationStore] = None,
     abandon_after: float = 300.0,
     allowed_ports: Optional[frozenset] = None,
     max_sessions: Optional[int] = None,
@@ -55,6 +58,12 @@ def create_app(
     # ValueError) rather than be caught here and silently degrade to an empty
     # store, which would open the gateway to anonymous access.
     app.state.tokens = token_store if token_store is not None else TokenStore()
+    # Like the token store, a malformed invitation file must fail loudly
+    # rather than degrade to "no invitations" and leave the admin wondering
+    # why a link they just sent does nothing.
+    app.state.invitations = invitation_store if invitation_store is not None else InvitationStore()
+    # One limiter per app, so the window is shared across all clients.
+    app.state.join_limiter = FailureLimiter()
     # Reference store is created lazily on first use: ReferenceWaveform.__init__
     # mkdirs its storage directory, and most requests never need it.
     app.state.references_dir = references_dir
@@ -67,6 +76,7 @@ def create_app(
     from scpi_control.server.api import awg as awg_api
     from scpi_control.server.api import commands as commands_api
     from scpi_control.server.api import discovery as discovery_api
+    from scpi_control.server.api import join as join_api
     from scpi_control.server.api import psu as psu_api
     from scpi_control.server.api import scope as scope_api
     from scpi_control.server.api import sessions as sessions_api
@@ -79,6 +89,7 @@ def create_app(
     app.include_router(commands_api.router, prefix="/api")
     app.include_router(stream_api.router, prefix="/api")
     app.include_router(discovery_api.router, prefix="/api")
+    app.include_router(join_api.router, prefix="/api")
 
     @app.get("/api/health")
     async def health():

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -213,7 +213,10 @@ class TokenStore:
         return not self._tokens
 
 
-EXEMPT_PATHS = frozenset({"/api/health"})
+# /api/join is exempt because it is how a client with no credential gets one;
+# it defends itself (see api/join.py). /api/health is exempt so an uptime
+# probe does not need a token.
+EXEMPT_PATHS = frozenset({"/api/health", "/api/join"})
 WS_SUBPROTOCOL_PREFIX = "scpi-token."
 WS_ACCEPT_SUBPROTOCOL = "scpi"
 

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -64,19 +64,58 @@ def _atomic_write_json(path: Path, payload: Any) -> None:
         raise
 
 
+def _stat_key(path: Path):
+    """Cheap identity of a file's current contents, or None if absent.
+
+    st_ino is the load-bearing term. Timestamp granularity is coarse on some
+    platforms (a Windows filesystem timestamp can be shared by writes ~15ms
+    apart), so two edits inside one tick that happen to produce the same byte
+    count would be indistinguishable by (mtime, size) alone. Every save
+    publishes a fresh temp file via os.replace, so the file identity always
+    changes -- see _atomic_write_json. mtime and size are kept as belt and
+    braces for any platform that does not populate st_ino.
+    """
+    try:
+        info = path.stat()
+    except OSError:
+        return None
+    return (info.st_ino, info.st_mtime_ns, info.st_size)
+
+
 class TokenStore:
     """Named bearer tokens persisted as {name, hash, created, last_used}."""
 
     def __init__(self, path: Optional[str] = None) -> None:
         self.path = Path(path) if path is not None else DEFAULT_CONFIG_DIR / "tokens.json"
         self._tokens: List[Dict[str, Any]] = []
-        if self.path.exists():
-            try:
-                raw = json.loads(self.path.read_text(encoding="utf-8"))
-                self._tokens = self._validate_tokens(raw)
-            except (ValueError, OSError) as exc:
-                # Never fall back to "no tokens" — that would silently open the gateway.
-                raise ValueError("token store {0} is unreadable: {1}".format(self.path, exc))
+        self._stat = None
+        self._load()
+
+    def _load(self) -> None:
+        self._stat = _stat_key(self.path)
+        if self._stat is None:
+            self._tokens = []
+            return
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+            self._tokens = self._validate_tokens(raw)
+        except (ValueError, OSError) as exc:
+            # Never fall back to "no tokens" — that would silently open the gateway.
+            raise ValueError("token store {0} is unreadable: {1}".format(self.path, exc))
+
+    def _reload_if_changed(self) -> None:
+        """Pick up writes made by another process (the CLI mints and revokes).
+
+        Called on the verify path, so this runs once per authenticated
+        request: a stat is microseconds, and it is what makes `token revoke`
+        take effect immediately instead of at the next gateway restart.
+
+        Reloading discards the in-memory last_used updates. That is already
+        the documented contract -- see verify() -- because last_used is
+        ephemeral metadata, not an audit record.
+        """
+        if _stat_key(self.path) != self._stat:
+            self._load()
 
     @staticmethod
     def _validate_tokens(raw: Any) -> List[Dict[str, Any]]:
@@ -99,6 +138,7 @@ class TokenStore:
 
     def _save(self) -> None:
         _atomic_write_json(self.path, {"tokens": self._tokens})
+        self._stat = _stat_key(self.path)
 
     def mint(self, name: str) -> str:
         if not name or not name.strip():
@@ -119,6 +159,7 @@ class TokenStore:
     def verify(self, raw: str) -> Optional[str]:
         if not raw:
             return None
+        self._reload_if_changed()
         candidate = _hash(raw)
         for entry in self._tokens:
             if hmac.compare_digest(entry["hash"], candidate):

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -19,10 +19,6 @@ DEFAULT_CONFIG_DIR = Path.home() / ".siglent"
 TOKEN_PREFIX = "scpi_"
 
 
-class DuplicateTokenName(ValueError):
-    """Raised when minting a token with a name that already exists."""
-
-
 def _hash(raw: str) -> str:
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
@@ -144,6 +140,13 @@ class TokenStore:
         self._stat = _stat_key(self.path)
 
     def mint(self, name: str) -> str:
+        """Mint one more token for ``name``.
+
+        A name is an identity, not a credential: one person can hold several
+        tokens (laptop, bench tablet, a reinstalled browser) and every one of
+        them reports the same owner. revoke(name) removes all of them, which
+        is what makes "someone left" a single command.
+        """
         if not name or not name.strip():
             # An empty (or whitespace-only) name mints a token whose identity
             # is "" -- and require_owner() in ownership.py treats owner == ""
@@ -152,8 +155,6 @@ class TokenStore:
             # boundary, so reject it outright rather than normalize it (e.g.
             # by stripping): the operator needs to know and pick a real name.
             raise ValueError("token name must not be empty or whitespace-only")
-        if any(entry["name"] == name for entry in self._tokens):
-            raise DuplicateTokenName("a token named {0!r} already exists".format(name))
         raw = TOKEN_PREFIX + secrets.token_urlsafe(32)
         self._tokens.append({"name": name, "hash": _hash(raw), "created": _now(), "last_used": None})
         self._save()
@@ -189,7 +190,24 @@ class TokenStore:
         return True
 
     def names(self) -> List[str]:
-        return [str(entry["name"]) for entry in self._tokens]
+        """Distinct identities, sorted. One entry per person, not per device."""
+        return sorted({str(entry["name"]) for entry in self._tokens})
+
+    def summary(self) -> List[Dict[str, Any]]:
+        """Per-identity device count and most recent use. Never includes hashes.
+
+        last_used is best-effort: verify() updates it in memory only, so it
+        reflects this process's view and resets when the store reloads.
+        """
+        rows: Dict[str, Dict[str, Any]] = {}
+        for entry in self._tokens:
+            name = str(entry["name"])
+            row = rows.setdefault(name, {"name": name, "devices": 0, "last_used": None})
+            row["devices"] += 1
+            used = entry.get("last_used")
+            if used is not None and (row["last_used"] is None or used > row["last_used"]):
+                row["last_used"] = used
+        return [rows[name] for name in sorted(rows)]
 
     def is_empty(self) -> bool:
         return not self._tokens

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -63,13 +63,28 @@ def _atomic_write_json(path: Path, payload: Any) -> None:
 def _stat_key(path: Path):
     """Cheap identity of a file's current contents, or None if absent.
 
-    st_ino is the load-bearing term. Timestamp granularity is coarse on some
-    platforms (a Windows filesystem timestamp can be shared by writes ~15ms
-    apart), so two edits inside one tick that happen to produce the same byte
-    count would be indistinguishable by (mtime, size) alone. Every save
-    publishes a fresh temp file via os.replace, so the file identity always
-    changes -- see _atomic_write_json. mtime and size are kept as belt and
-    braces for any platform that does not populate st_ino.
+    No single term here is reliable on its own, and which one carries the
+    detection differs by platform:
+
+    * On Windows, filesystem timestamps are coarse -- two writes ~15ms apart
+      can share an mtime -- but os.replace publishes a file with a different
+      file index, so st_ino changes.
+    * On Linux the opposite holds. mtime is nanosecond-resolution, but
+      os.replace unlinks the old file and the next mkstemp in the same
+      directory can immediately reuse the freed inode number, so st_ino
+      repeats. CI caught exactly this: a revoke followed by a same-length mint
+      produced an identical st_ino AND an identical st_size.
+
+    So the tuple is the guarantee, not any one field, and an earlier version of
+    this docstring claiming "the file identity always changes" was wrong.
+
+    Residual, accepted rather than engineered around: on a platform with coarse
+    timestamp granularity that also reuses inodes, two writes inside one tick
+    producing byte-identical file sizes would be indistinguishable. That needs
+    two separate processes writing same-sized content within a few
+    milliseconds; the writers here are human-driven CLI commands, and a writer
+    in *this* process updates self._stat directly rather than going through a
+    stat comparison.
     """
     try:
         info = path.stat()

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -92,16 +92,19 @@ class TokenStore:
         self._load()
 
     def _load(self) -> None:
-        self._stat = _stat_key(self.path)
-        if self._stat is None:
+        stat = _stat_key(self.path)
+        if stat is None:
+            self._stat = stat
             self._tokens = []
             return
         try:
             raw = json.loads(self.path.read_text(encoding="utf-8"))
-            self._tokens = self._validate_tokens(raw)
+            tokens = self._validate_tokens(raw)
         except (ValueError, OSError) as exc:
             # Never fall back to "no tokens" — that would silently open the gateway.
             raise ValueError("token store {0} is unreadable: {1}".format(self.path, exc))
+        self._tokens = tokens
+        self._stat = stat
 
     def _reload_if_changed(self) -> None:
         """Pick up writes made by another process (the CLI mints and revokes).

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -10,6 +10,7 @@ import hmac
 import json
 import os
 import secrets
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -28,6 +29,39 @@ def _hash(raw: str) -> str:
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _atomic_write_json(path: Path, payload: Any) -> None:
+    """Publish ``payload`` to ``path`` so no reader ever sees a partial file.
+
+    The file is read live by a second process (the serving gateway reloads it
+    when it changes), while it is written by the CLI. A plain write truncates
+    first, and a truncated read is a hard startup failure by design -- see
+    TokenStore.__init__. Writing a sibling temp file and renaming it over the
+    target makes publication atomic, so a reader sees either the whole old
+    file or the whole new one. It also means a crash mid-write can no longer
+    leave a store that refuses to load.
+
+    The temp file is a sibling, not a file in the system temp directory,
+    because os.replace is only atomic within a single filesystem.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        try:
+            os.chmod(temp_name, 0o600)
+        except OSError:
+            pass  # best effort; Windows ACLs do not map onto POSIX modes
+        os.replace(temp_name, str(path))
+    except BaseException:
+        # Leave the existing file untouched and take the temp file with us.
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+        raise
 
 
 class TokenStore:
@@ -64,12 +98,7 @@ class TokenStore:
         return tokens
 
     def _save(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps({"tokens": self._tokens}, indent=2), encoding="utf-8")
-        try:
-            os.chmod(self.path, 0o600)
-        except OSError:
-            pass  # best effort; Windows ACLs do not map onto POSIX modes
+        _atomic_write_json(self.path, {"tokens": self._tokens})
 
     def mint(self, name: str) -> str:
         if not name or not name.strip():

--- a/scpi_control/server/gateway_url.py
+++ b/scpi_control/server/gateway_url.py
@@ -1,0 +1,59 @@
+"""Record where the gateway can be reached, so `invite` can print a real link.
+
+`scpi-web invite` runs in its own process and has no way to know the gateway
+was started with --host 0.0.0.0 --port 9000. Without this the printed link
+would say 127.0.0.1 -- unopenable by the person it was sent to -- or the admin
+would have to repeat the flags on every invitation, which is the friction this
+feature exists to remove.
+
+This file carries no secrets and no security decisions. A damaged one degrades
+to "unknown", never to an error.
+"""
+
+import json
+import socket
+from pathlib import Path
+from typing import Any, Optional
+
+FILENAME = "gateway.json"
+WILDCARD_HOSTS = frozenset({"0.0.0.0", "::", "[::]", ""})
+
+
+def local_address() -> str:
+    """This machine's address on the network it would use to reach the world.
+
+    Connecting a UDP socket sends no packets; it only makes the OS choose a
+    source address, which is the one a colleague on the same LAN can reach.
+    Falls back to loopback when there is no route at all -- an honest answer
+    for a machine that is not on a network.
+    """
+    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        probe.connect(("8.8.8.8", 80))
+        return str(probe.getsockname()[0])
+    except OSError:
+        return "127.0.0.1"
+    finally:
+        probe.close()
+
+
+def write_base_url(config_dir: Path, host: str, port: int) -> str:
+    """Record and return the externally-reachable base URL."""
+    advertised = local_address() if host in WILDCARD_HOSTS else host
+    url = "http://{0}:{1}/".format(advertised, port)
+    try:
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / FILENAME).write_text(json.dumps({"url": url}, indent=2), encoding="utf-8")
+    except OSError:
+        pass  # a link we cannot cache is not worth failing a server start over
+    return url
+
+
+def read_base_url(config_dir: Path) -> Optional[str]:
+    """The last recorded base URL, or None if unknown or unreadable."""
+    try:
+        payload: Any = json.loads((config_dir / FILENAME).read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return None
+    url = payload.get("url") if isinstance(payload, dict) else None
+    return url if isinstance(url, str) else None

--- a/scpi_control/server/invitations.py
+++ b/scpi_control/server/invitations.py
@@ -1,0 +1,148 @@
+"""Short-lived invitations that redeem into a real token.
+
+An invitation is the only credential that ever leaves the gateway host. It
+carries two redeemers for one grant: a long random nonce for a clickable link,
+and a six-digit code that can be read down a phone. Both expire in ten minutes
+and both are consumed on first use, so a leaked chat message is worthless
+almost immediately.
+
+Storage is a file, not process memory, because `scpi-web invite` runs in a
+different process from the serving gateway.
+
+The two redeemers are stored differently, deliberately. The link nonce is 32
+random bytes and is hashed for the same reason tokens are (see auth.py). The
+code is stored in the clear: hashing a secret drawn from a space of 10**6
+would be theater, since anyone who can read this file can enumerate every
+possible hash in well under a second. The code's real defenses are its
+lifetime, the failure limiter on /api/join, and the 0600 file mode. Hashing it
+would only make the code look safer than it is.
+"""
+
+import hmac
+import json
+import secrets
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from scpi_control.server.auth import DEFAULT_CONFIG_DIR, _atomic_write_json, _hash, _stat_key
+
+INVITATION_TTL_SECONDS = 600.0
+CODE_DIGITS = 6
+
+
+def format_code(code: str) -> str:
+    """Group a code for reading aloud: "417902" -> "417 902"."""
+    half = len(code) // 2
+    return code[:half] + " " + code[half:]
+
+
+def _normalize_code(value: str) -> str:
+    """Accept the code however it comes back: spaces, hyphens, stray padding."""
+    return "".join(char for char in value if char.isdigit())
+
+
+class InvitationStore:
+    """Pending invitations persisted as {name, link_hash, code, expires}."""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self.path = Path(path) if path is not None else DEFAULT_CONFIG_DIR / "invitations.json"
+        self._invitations: List[Dict[str, Any]] = []
+        self._stat = None
+        self._load()
+
+    def _load(self) -> None:
+        # Same ordering rule as TokenStore._load: commit the stat key only
+        # after a successful read, or a corrupt file matches its own recorded
+        # key forever and the store silently serves stale state.
+        stat = _stat_key(self.path)
+        if stat is None:
+            self._stat = stat
+            self._invitations = []
+            return
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+            invitations = self._validate(raw)
+        except (ValueError, OSError) as exc:
+            # Same rule as the token store: a file we cannot parse is an
+            # error, never an empty set. Silently discarding invitations
+            # would be less dangerous than silently discarding tokens, but
+            # the surprise -- "I sent Bob a link and it just did not work" --
+            # is exactly the failure this whole feature exists to remove.
+            raise ValueError("invitation store {0} is unreadable: {1}".format(self.path, exc))
+        self._invitations = invitations
+        self._stat = stat
+
+    @staticmethod
+    def _validate(raw: Any) -> List[Dict[str, Any]]:
+        if not isinstance(raw, dict):
+            raise ValueError("expected a JSON object at the top level, got {0}".format(type(raw).__name__))
+        entries = raw.get("invitations", [])
+        if not isinstance(entries, list):
+            raise ValueError('expected "invitations" to be a list, got {0}'.format(type(entries).__name__))
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise ValueError("expected each invitation to be an object, got {0}".format(type(entry).__name__))
+            if not isinstance(entry.get("name"), str) or not isinstance(entry.get("link_hash"), str) or not isinstance(entry.get("code"), str):
+                raise ValueError('each invitation must have string "name", "link_hash" and "code" keys')
+            if not isinstance(entry.get("expires"), (int, float)):
+                raise ValueError('each invitation must have a numeric "expires" key')
+        return entries
+
+    def _reload_if_changed(self) -> None:
+        if _stat_key(self.path) != self._stat:
+            self._load()
+
+    def _save(self) -> None:
+        _atomic_write_json(self.path, {"invitations": self._invitations})
+        self._stat = _stat_key(self.path)
+
+    def _prune(self) -> None:
+        now = time.time()
+        self._invitations = [entry for entry in self._invitations if entry["expires"] > now]
+
+    def create(self, name: str, ttl: float = INVITATION_TTL_SECONDS) -> Tuple[str, str]:
+        """Create an invitation for ``name``; returns (link_nonce, code).
+
+        Both are returned in the clear exactly once, to be printed and then
+        forgotten by this process.
+        """
+        if not name or not name.strip():
+            # Mirrors TokenStore.mint: an empty identity owns nothing, which
+            # makes every session it creates writable by anyone.
+            raise ValueError("invitation name must not be empty or whitespace-only")
+        self._reload_if_changed()
+        link = secrets.token_urlsafe(32)
+        code = "{0:0{1}d}".format(secrets.randbelow(10**CODE_DIGITS), CODE_DIGITS)
+        self._prune()
+        self._invitations.append({"name": name, "link_hash": _hash(link), "code": code, "expires": time.time() + ttl})
+        self._save()
+        return link, code
+
+    def redeem(self, code: Optional[str] = None, link: Optional[str] = None) -> Optional[str]:
+        """Consume the invitation matching ``code`` or ``link``; return its name.
+
+        Returns None for anything that does not match a live invitation --
+        wrong, expired, or already used. The caller must not distinguish those
+        cases to its client: doing so turns this into an oracle.
+        """
+        self._reload_if_changed()
+        self._prune()
+        match = None
+        if link:
+            candidate = _hash(link)
+            match = next((entry for entry in self._invitations if hmac.compare_digest(entry["link_hash"], candidate)), None)
+        elif code:
+            wanted = _normalize_code(code)
+            if wanted:
+                match = next((entry for entry in self._invitations if hmac.compare_digest(entry["code"], wanted)), None)
+        if match is None:
+            return None
+        self._invitations.remove(match)
+        self._save()
+        return str(match["name"])
+
+    def pending(self) -> int:
+        self._reload_if_changed()
+        self._prune()
+        return len(self._invitations)

--- a/scpi_control/server/invitations.py
+++ b/scpi_control/server/invitations.py
@@ -38,8 +38,18 @@ def format_code(code: str) -> str:
 
 
 def _normalize_code(value: str) -> str:
-    """Accept the code however it comes back: spaces, hyphens, stray padding."""
-    return "".join(char for char in value if char.isdigit())
+    """Accept the code however it comes back: spaces, hyphens, stray padding.
+
+    The ASCII set is written out rather than using ``str.isdigit()`` on
+    purpose, and must stay that way. ``"²".isdigit()`` and ``"٣".isdigit()``
+    are both True, but ``hmac.compare_digest`` raises TypeError on a str with
+    any non-ASCII character -- and that comparison only runs when at least one
+    invitation is live. Letting a non-ASCII digit through therefore turned an
+    anonymous request into a free oracle for gateway state: 401 with nothing
+    pending, 500 with an invitation waiting. Keep the comparison fed with
+    ASCII only.
+    """
+    return "".join(char for char in value if char in "0123456789")
 
 
 class InvitationStore:

--- a/tests/test_server_auth_store.py
+++ b/tests/test_server_auth_store.py
@@ -218,3 +218,66 @@ def test_each_save_publishes_a_new_file_identity(tmp_path):
     store.revoke("aaaa")
     store.mint("bbbb")  # same length name -> same file size
     assert path.stat().st_ino != first
+
+
+def test_revocation_by_another_process_takes_effect_without_restart(tmp_path):
+    # Two TokenStore instances on one path stand in for the serving gateway
+    # and the CLI, which really are separate processes. Before hot reload, the
+    # gateway kept honouring a revoked token until someone restarted it --
+    # which made the documented remedy for a leaked credential a no-op.
+    path = str(tmp_path / "tokens.json")
+    gateway = TokenStore(path)
+    raw = gateway.mint("robin")
+    assert gateway.verify(raw) == "robin"
+
+    cli = TokenStore(path)
+    assert cli.revoke("robin") is True
+
+    assert gateway.verify(raw) is None
+
+
+def test_a_token_minted_by_another_process_verifies_without_restart(tmp_path):
+    path = str(tmp_path / "tokens.json")
+    gateway = TokenStore(path)
+    gateway.mint("robin")
+
+    raw = TokenStore(path).mint("bob")
+
+    assert gateway.verify(raw) == "bob"
+
+
+def test_reload_still_does_not_write_on_the_verify_path(tmp_path):
+    path = tmp_path / "tokens.json"
+    store = TokenStore(str(path))
+    raw = store.mint("robin")
+    TokenStore(str(path)).mint("bob")  # force a reload on the next verify
+    before = path.read_bytes()
+    assert store.verify(raw) == "robin"
+    assert path.read_bytes() == before
+
+
+def test_a_store_whose_file_vanishes_verifies_nothing(tmp_path):
+    # Deleting tokens.json must fail closed, not freeze the last known good
+    # set in memory.
+    path = tmp_path / "tokens.json"
+    store = TokenStore(str(path))
+    raw = store.mint("robin")
+    path.unlink()
+    assert store.verify(raw) is None
+
+
+def test_a_store_corrupted_while_running_fails_closed_and_loudly(tmp_path):
+    # verify() could not raise before hot reload; now it can, because the
+    # file it re-reads may have been damaged since startup. That is the
+    # correct behaviour and must stay: __init__ already treats a corrupt
+    # store as a hard error precisely because "no tokens" is
+    # indistinguishable from a fresh install and would open the gateway.
+    # Catching this inside verify() and returning None would look like
+    # failing closed while actually turning a loud, fixable problem into
+    # every request mysteriously returning 401.
+    path = tmp_path / "tokens.json"
+    store = TokenStore(str(path))
+    raw = store.mint("robin")
+    path.write_text("{ truncated")
+    with pytest.raises(ValueError):
+        store.verify(raw)

--- a/tests/test_server_auth_store.py
+++ b/tests/test_server_auth_store.py
@@ -199,18 +199,21 @@ def test_save_leaves_no_temp_file_behind(tmp_path):
     assert [p.name for p in tmp_path.iterdir() if p.name != "fake-home"] == ["tokens.json"]
 
 
-def test_each_save_publishes_a_new_file_identity(tmp_path):
-    # Task 2's reload check keys on (st_ino, st_mtime_ns, st_size). st_ino is
-    # the reliable term: an atomic replace always publishes a different file,
-    # even when two writes land inside one filesystem timestamp tick and
-    # happen to produce the same size.
-    path = tmp_path / "tokens.json"
-    store = TokenStore(str(path))
-    store.mint("aaaa")
-    first = path.stat().st_ino
-    store.revoke("aaaa")
-    store.mint("bbbb")  # same length name -> same file size
-    assert path.stat().st_ino != first
+# A test asserting that every save changes st_ino used to live here. It was
+# wrong, and CI on Linux proved it: os.replace frees the old inode and the next
+# mkstemp in the same directory reuses the number, so a revoke followed by a
+# same-length mint produced an identical st_ino and an identical st_size. It
+# passed only on Windows, where the file index does change.
+#
+# It was not rewritten to assert the whole _stat_key tuple instead, because that
+# would be flaky by construction: with the inode reused and the size equal,
+# detection rests on st_mtime_ns alone, and Linux's coarse clock granularity
+# (~1-4ms) lets two rapid saves share a timestamp legitimately.
+#
+# What the reload mechanism actually has to do is covered behaviourally by the
+# four cross-process tests below, which is the right altitude for it. See
+# _stat_key's docstring for which term carries detection on which platform, and
+# for the residual this leaves.
 
 
 def test_revocation_by_another_process_takes_effect_without_restart(tmp_path):

--- a/tests/test_server_auth_store.py
+++ b/tests/test_server_auth_store.py
@@ -281,3 +281,9 @@ def test_a_store_corrupted_while_running_fails_closed_and_loudly(tmp_path):
     path.write_text("{ truncated")
     with pytest.raises(ValueError):
         store.verify(raw)
+    # And again: a corrupt store must keep failing loudly, not fail once and
+    # then silently resume serving the stale pre-corruption token list. The
+    # first version of this test called verify() only once, which is exactly
+    # how that bug survived the suite.
+    with pytest.raises(ValueError):
+        store.verify(raw)

--- a/tests/test_server_auth_store.py
+++ b/tests/test_server_auth_store.py
@@ -173,3 +173,48 @@ def test_no_argument_defaults_never_touch_the_real_home(tmp_path):
     reference = ReferenceWaveform()
     assert tmp_path in reference.storage_dir.parents
     assert reference.storage_dir != real_default_reference_dir
+
+
+def test_save_never_leaves_a_truncated_store(tmp_path, monkeypatch):
+    # The failure this guards: _save() used to truncate tokens.json before
+    # writing it. Once a second process reads the file live (hot reload), a
+    # read landing in that window sees invalid JSON -- and __init__ treats
+    # that as a hard refusal to start. Simulate a crash at the moment of
+    # publication and assert the previous store survived intact.
+    path = tmp_path / "tokens.json"
+    store = TokenStore(str(path))
+    raw = store.mint("robin")
+    good = path.read_bytes()
+
+    def boom(src, dst):
+        raise OSError("simulated crash during publish")
+
+    monkeypatch.setattr("os.replace", boom)
+    with pytest.raises(OSError):
+        store.mint("bench-laptop")
+    assert path.read_bytes() == good
+    assert TokenStore(str(path)).verify(raw) == "robin"
+
+
+def test_save_leaves_no_temp_file_behind(tmp_path):
+    path = tmp_path / "tokens.json"
+    TokenStore(str(path)).mint("robin")
+    # tmp_path also holds the autouse `_no_real_home` fixture's "fake-home"
+    # directory (see conftest.py) -- unrelated to this store. Filter it out;
+    # the point of this test is that _save() leaves no leftover temp file
+    # alongside tokens.json.
+    assert [p.name for p in tmp_path.iterdir() if p.name != "fake-home"] == ["tokens.json"]
+
+
+def test_each_save_publishes_a_new_file_identity(tmp_path):
+    # Task 2's reload check keys on (st_ino, st_mtime_ns, st_size). st_ino is
+    # the reliable term: an atomic replace always publishes a different file,
+    # even when two writes land inside one filesystem timestamp tick and
+    # happen to produce the same size.
+    path = tmp_path / "tokens.json"
+    store = TokenStore(str(path))
+    store.mint("aaaa")
+    first = path.stat().st_ino
+    store.revoke("aaaa")
+    store.mint("bbbb")  # same length name -> same file size
+    assert path.stat().st_ino != first

--- a/tests/test_server_auth_store.py
+++ b/tests/test_server_auth_store.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from scpi_control.server.__main__ import main
-from scpi_control.server.auth import DuplicateTokenName, TokenStore
+from scpi_control.server.auth import TokenStore
 
 
 def test_minted_token_verifies_to_its_name(tmp_path):
@@ -36,13 +36,6 @@ def test_revoked_token_stops_verifying(tmp_path):
     assert store.revoke("robin") is True
     assert store.verify(raw) is None
     assert store.revoke("robin") is False
-
-
-def test_duplicate_name_rejected(tmp_path):
-    store = TokenStore(str(tmp_path / "tokens.json"))
-    store.mint("robin")
-    with pytest.raises(DuplicateTokenName):
-        store.mint("robin")
 
 
 def test_mint_rejects_empty_name(tmp_path):
@@ -287,3 +280,45 @@ def test_a_store_corrupted_while_running_fails_closed_and_loudly(tmp_path):
     # how that bug survived the suite.
     with pytest.raises(ValueError):
         store.verify(raw)
+
+
+def test_a_name_can_hold_several_device_tokens(tmp_path):
+    # Bob has a laptop and a bench tablet. Both are Bob.
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    laptop = store.mint("bob")
+    tablet = store.mint("bob")
+    assert laptop != tablet
+    assert store.verify(laptop) == "bob"
+    assert store.verify(tablet) == "bob"
+
+
+def test_revoking_a_name_cuts_off_every_device(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    laptop = store.mint("bob")
+    tablet = store.mint("bob")
+    assert store.revoke("bob") is True
+    assert store.verify(laptop) is None
+    assert store.verify(tablet) is None
+
+
+def test_names_are_unique_and_sorted(tmp_path):
+    # api/sessions.py's ownership handoff tests membership in names(); a name
+    # repeated once per device would also make `token list` misleading.
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    store.mint("robin")
+    store.mint("bob")
+    store.mint("bob")
+    assert store.names() == ["bob", "robin"]
+
+
+def test_summary_counts_devices_without_revealing_secrets(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    raw = store.mint("bob")
+    store.mint("bob")
+    store.mint("robin")
+    store.verify(raw)
+    rows = {row["name"]: row for row in store.summary()}
+    assert rows["bob"]["devices"] == 2
+    assert rows["robin"]["devices"] == 1
+    assert rows["bob"]["last_used"] is not None
+    assert "hash" not in rows["bob"]

--- a/tests/test_server_cli_invite.py
+++ b/tests/test_server_cli_invite.py
@@ -1,0 +1,75 @@
+"""scpi-web invite: one command that prints a link and a code."""
+
+import pytest
+
+from scpi_control.server.__main__ import main
+from scpi_control.server.auth import TokenStore
+from scpi_control.server.invitations import InvitationStore
+
+
+def test_invite_prints_a_link_and_a_code(tmp_path, capsys):
+    main(["invite", "bob", "--config-dir", str(tmp_path)])
+    printed = capsys.readouterr().out
+    assert "?invite=" in printed
+    assert InvitationStore(str(tmp_path / "invitations.json")).pending() == 1
+
+
+def test_invite_prints_no_raw_token(tmp_path, capsys):
+    # A token is minted at redemption, not at invitation. If one ever appears
+    # here, the long-lived secret is back in the chat message.
+    main(["invite", "bob", "--config-dir", str(tmp_path)])
+    printed = capsys.readouterr().out
+    assert "scpi_" not in printed
+    assert TokenStore(str(tmp_path / "tokens.json")).names() == []
+
+
+def test_the_printed_code_actually_redeems(tmp_path, capsys):
+    main(["invite", "bob", "--config-dir", str(tmp_path)])
+    printed = capsys.readouterr().out
+    digits = "".join(char for char in printed.split("code:")[1] if char.isdigit() or char == "\n").split("\n")[0]
+    assert InvitationStore(str(tmp_path / "invitations.json")).redeem(code=digits) == "bob"
+
+
+def test_invite_uses_the_url_the_gateway_recorded(tmp_path, capsys, monkeypatch):
+    monkeypatch.setattr("uvicorn.run", lambda app, host, port: None)
+    main(["--config-dir", str(tmp_path), "--host", "192.168.1.50", "--port", "9000"])
+    capsys.readouterr()
+    main(["invite", "bob", "--config-dir", str(tmp_path)])
+    assert "http://192.168.1.50:9000/?invite=" in capsys.readouterr().out
+
+
+def test_invite_falls_back_with_a_note_when_no_gateway_has_run(tmp_path, capsys):
+    main(["invite", "bob", "--config-dir", str(tmp_path)])
+    printed = capsys.readouterr().out
+    assert "127.0.0.1:8765" in printed
+    assert "--url" in printed
+
+
+def test_url_override_wins(tmp_path, capsys):
+    main(["invite", "bob", "--url", "http://lab-pc:1234/", "--config-dir", str(tmp_path)])
+    assert "http://lab-pc:1234/?invite=" in capsys.readouterr().out
+
+
+def test_invite_with_an_empty_name_exits_nonzero(tmp_path):
+    with pytest.raises(SystemExit) as excinfo:
+        main(["invite", "", "--config-dir", str(tmp_path)])
+    assert excinfo.value.code != 0
+
+
+def test_config_dir_before_subcommand_is_used_for_invite(tmp_path, capsys):
+    # The argparse SUPPRESS trap documented in __main__._add_config_dir bit
+    # every token subcommand once already; a new subparser is a new chance to
+    # send an invitation into the developer's real ~/.siglent.
+    main(["--config-dir", str(tmp_path), "invite", "bob"])
+    capsys.readouterr()
+    assert (tmp_path / "invitations.json").exists()
+
+
+def test_serve_prints_the_url_every_time_not_just_the_first(tmp_path, capsys, monkeypatch):
+    monkeypatch.setattr("uvicorn.run", lambda app, host, port: None)
+    main(["--config-dir", str(tmp_path), "--port", "9999"])
+    capsys.readouterr()
+    main(["--config-dir", str(tmp_path), "--port", "9999"])
+    printed = capsys.readouterr().out
+    assert "9999" in printed
+    assert "invite" in printed

--- a/tests/test_server_cli_invite.py
+++ b/tests/test_server_cli_invite.py
@@ -65,6 +65,22 @@ def test_config_dir_before_subcommand_is_used_for_invite(tmp_path, capsys):
     assert (tmp_path / "invitations.json").exists()
 
 
+def test_a_corrupt_invitation_file_stops_serve_before_a_token_is_minted(tmp_path, capsys, monkeypatch):
+    # The invitation store used to be built inside the create_app(...) call,
+    # after the bootstrap mint and after "Gateway ready. Open: ...?token=...".
+    # So a corrupt invitations.json printed a URL for a server that never
+    # started AND left a live token behind -- and because the token store was
+    # no longer empty, no later start would ever print that URL again. Exiting
+    # is not enough to assert: the token is the damage.
+    monkeypatch.setattr("uvicorn.run", lambda app, host, port: pytest.fail("uvicorn should not have started"))
+    (tmp_path / "invitations.json").write_text("{ not json")
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--config-dir", str(tmp_path)])
+    assert excinfo.value.code != 0
+    assert TokenStore(str(tmp_path / "tokens.json")).names() == []
+    assert "?token=" not in capsys.readouterr().out
+
+
 def test_serve_prints_the_url_every_time_not_just_the_first(tmp_path, capsys, monkeypatch):
     monkeypatch.setattr("uvicorn.run", lambda app, host, port: None)
     main(["--config-dir", str(tmp_path), "--port", "9999"])

--- a/tests/test_server_cli_tokens.py
+++ b/tests/test_server_cli_tokens.py
@@ -35,13 +35,6 @@ def test_revoking_unknown_name_exits_nonzero(tmp_path):
     assert excinfo.value.code != 0
 
 
-def test_duplicate_name_exits_nonzero(tmp_path):
-    main(["token", "add", "robin", "--config-dir", str(tmp_path)])
-    with pytest.raises(SystemExit) as excinfo:
-        main(["token", "add", "robin", "--config-dir", str(tmp_path)])
-    assert excinfo.value.code != 0
-
-
 def test_serve_bootstraps_a_token_and_prints_url(tmp_path, capsys, monkeypatch):
     started = {}
     monkeypatch.setattr("uvicorn.run", lambda app, host, port: started.update(host=host, port=port))
@@ -135,3 +128,26 @@ def test_config_dir_before_bare_serve_bootstraps_into_given_directory(tmp_path, 
     main(["--config-dir", str(tmp_path), "--port", "9999"])
     assert (tmp_path / "tokens.json").exists()
     assert TokenStore(str(tmp_path / "tokens.json")).names() == ["default"]
+
+
+def test_token_add_twice_adds_a_device_instead_of_failing(tmp_path, capsys):
+    main(["token", "add", "bob", "--config-dir", str(tmp_path)])
+    main(["token", "add", "bob", "--config-dir", str(tmp_path)])
+    printed = capsys.readouterr().out
+    raws = [word for word in printed.split() if word.startswith("scpi_")]
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    assert len(raws) == 2
+    assert store.verify(raws[0]) == "bob"
+    assert store.verify(raws[1]) == "bob"
+    assert store.names() == ["bob"]
+
+
+def test_token_list_shows_device_counts(tmp_path, capsys):
+    main(["token", "add", "bob", "--config-dir", str(tmp_path)])
+    main(["token", "add", "bob", "--config-dir", str(tmp_path)])
+    capsys.readouterr()
+    main(["token", "list", "--config-dir", str(tmp_path)])
+    printed = capsys.readouterr().out
+    assert "bob" in printed
+    assert "2" in printed
+    assert "scpi_" not in printed

--- a/tests/test_server_gateway_url.py
+++ b/tests/test_server_gateway_url.py
@@ -1,0 +1,37 @@
+"""The base URL the gateway records so `invite` can print a clickable link."""
+
+from pathlib import Path
+
+from scpi_control.server.gateway_url import read_base_url, write_base_url
+
+
+def test_a_concrete_host_is_used_verbatim(tmp_path):
+    url = write_base_url(Path(tmp_path), "192.168.1.50", 8765)
+    assert url == "http://192.168.1.50:8765/"
+    assert read_base_url(Path(tmp_path)) == url
+
+
+def test_a_wildcard_host_resolves_to_a_reachable_address(tmp_path):
+    # Printing http://0.0.0.0:8765/ would hand the recipient a link that
+    # cannot be opened, which is the exact failure this feature removes.
+    url = write_base_url(Path(tmp_path), "0.0.0.0", 8765)
+    assert "0.0.0.0" not in url
+    assert url.startswith("http://") and url.endswith(":8765/")
+
+
+def test_loopback_is_kept_as_loopback(tmp_path):
+    # The default bind really is local-only; rewriting it to a LAN address
+    # would advertise access that does not exist.
+    assert write_base_url(Path(tmp_path), "127.0.0.1", 8765) == "http://127.0.0.1:8765/"
+
+
+def test_reading_before_any_gateway_started_returns_none(tmp_path):
+    assert read_base_url(Path(tmp_path)) is None
+
+
+def test_a_corrupt_url_record_reads_as_none(tmp_path):
+    # Unlike the token and invitation stores, this file holds no security
+    # state -- it is a convenience. A damaged one must degrade to "I don't
+    # know the URL", not stop the admin from issuing an invitation.
+    (tmp_path / "gateway.json").write_text("{ not json")
+    assert read_base_url(Path(tmp_path)) is None

--- a/tests/test_server_invitations.py
+++ b/tests/test_server_invitations.py
@@ -50,7 +50,11 @@ def test_a_wrong_code_redeems_nothing_and_consumes_nothing(tmp_path):
 def test_codes_are_six_digits_and_links_are_long(tmp_path):
     store = InvitationStore(str(tmp_path / "invitations.json"))
     link, code = store.create("bob")
-    assert len(code) == 6 and code.isdigit()
+    # Explicit ASCII rather than code.isdigit(): "²".isdigit() is True, and
+    # that idiom in _normalize_code was a live oracle (see the join API tests).
+    # Harmless here -- generated codes are ASCII -- but the idiom should not
+    # survive anywhere near this file.
+    assert len(code) == 6 and all(char in "0123456789" for char in code)
     assert len(link) >= 32
 
 

--- a/tests/test_server_invitations.py
+++ b/tests/test_server_invitations.py
@@ -1,0 +1,146 @@
+"""Short-lived invitations: creation, redemption, expiry, single use."""
+
+import json
+
+import pytest
+
+from scpi_control.server.invitations import InvitationStore, format_code
+
+
+def test_a_code_redeems_to_its_name(tmp_path):
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    _link, code = store.create("bob")
+    assert store.redeem(code=code) == "bob"
+
+
+def test_a_link_nonce_redeems_to_its_name(tmp_path):
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    link, _code = store.create("bob")
+    assert store.redeem(link=link) == "bob"
+
+
+def test_an_invitation_is_single_use(tmp_path):
+    # The whole point of a short-lived credential is that a leaked chat
+    # message is worthless. If redemption did not consume the invitation,
+    # anyone who saw the link could keep minting tokens until it expired.
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    link, code = store.create("bob")
+    assert store.redeem(code=code) == "bob"
+    assert store.redeem(code=code) is None
+    assert store.redeem(link=link) is None
+
+
+def test_an_expired_invitation_does_not_redeem(tmp_path):
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    _link, code = store.create("bob", ttl=-1.0)
+    assert store.redeem(code=code) is None
+
+
+def test_a_wrong_code_redeems_nothing_and_consumes_nothing(tmp_path):
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    _link, code = store.create("bob")
+    # Derived from the real code rather than hardcoded: a literal "000000"
+    # collides with a randomly generated code once in a million runs, and a
+    # guard test that flakes that rarely is worse than one that never does.
+    wrong = "{0:06d}".format((int(code) + 1) % 1000000)
+    assert store.redeem(code=wrong) is None
+    assert store.redeem(code=code) == "bob"
+
+
+def test_codes_are_six_digits_and_links_are_long(tmp_path):
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    link, code = store.create("bob")
+    assert len(code) == 6 and code.isdigit()
+    assert len(link) >= 32
+
+
+def test_a_code_redeems_however_the_user_spaces_it(tmp_path):
+    # It is printed as "417 902" and read out loud, so it comes back typed
+    # every which way. Rejecting the format we ourselves display would be a
+    # self-inflicted support call.
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    _link, code = store.create("bob")
+    spaced = format_code(code)
+    assert " " in spaced
+    assert store.redeem(code=spaced) == "bob"
+
+
+def test_the_link_nonce_is_not_stored_in_the_clear(tmp_path):
+    path = tmp_path / "invitations.json"
+    store = InvitationStore(str(path))
+    link, _code = store.create("bob")
+    assert link not in path.read_text()
+
+
+def test_the_code_is_stored_in_the_clear_by_design(tmp_path):
+    # Documented, not accidental: hashing a secret drawn from 10**6
+    # possibilities is theater -- anyone who can read this file can
+    # enumerate every hash in under a second. The code's defenses are its
+    # ten-minute life, the join limiter, and the file mode. This test exists
+    # so nobody "fixes" it into a hash and believes they gained something.
+    path = tmp_path / "invitations.json"
+    store = InvitationStore(str(path))
+    _link, code = store.create("bob")
+    assert code in path.read_text()
+
+
+def test_an_invitation_created_by_another_process_is_seen_without_restart(tmp_path):
+    # `scpi-web invite` really does run in a different process from the
+    # serving gateway. This is the whole reason invitations live in a file.
+    path = str(tmp_path / "invitations.json")
+    gateway = InvitationStore(path)
+    _link, code = InvitationStore(path).create("bob")
+    assert gateway.redeem(code=code) == "bob"
+
+
+def test_redemption_is_visible_to_another_process(tmp_path):
+    path = str(tmp_path / "invitations.json")
+    gateway = InvitationStore(path)
+    _link, code = gateway.create("bob")
+    assert gateway.redeem(code=code) == "bob"
+    assert InvitationStore(path).redeem(code=code) is None
+
+
+def test_expired_invitations_are_pruned_on_write(tmp_path):
+    path = tmp_path / "invitations.json"
+    store = InvitationStore(str(path))
+    store.create("stale", ttl=-1.0)
+    store.create("bob")
+    assert store.pending() == 1
+    assert [entry["name"] for entry in json.loads(path.read_text())["invitations"]] == ["bob"]
+
+
+def test_create_rejects_an_empty_name(tmp_path):
+    # Mirrors TokenStore.mint: an empty identity makes every session it
+    # creates unowned, and therefore writable by anyone.
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    with pytest.raises(ValueError):
+        store.create("  ")
+
+
+def test_a_corrupt_invitation_file_is_not_silently_empty(tmp_path):
+    path = tmp_path / "invitations.json"
+    path.write_text("{ not json")
+    with pytest.raises(ValueError):
+        InvitationStore(str(path))
+
+
+def test_a_store_corrupted_while_running_keeps_failing(tmp_path):
+    # The same ordering guard TokenStore needed: if _load() commits the stat
+    # key before the read succeeds, a corrupt file raises loudly exactly once
+    # and then matches its own recorded key forever, silently serving stale
+    # state. One redeem() call would not catch that -- two do.
+    path = tmp_path / "invitations.json"
+    store = InvitationStore(str(path))
+    _link, code = store.create("bob")
+    path.write_text("{ truncated")
+    with pytest.raises(ValueError):
+        store.redeem(code=code)
+    with pytest.raises(ValueError):
+        store.redeem(code=code)
+
+
+def test_redeem_without_a_credential_returns_none(tmp_path):
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    store.create("bob")
+    assert store.redeem() is None

--- a/tests/test_server_join_api.py
+++ b/tests/test_server_join_api.py
@@ -1,0 +1,115 @@
+"""POST /api/join -- the gateway's only unauthenticated write route."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scpi_control.server.app import create_app
+from scpi_control.server.auth import TokenStore
+from scpi_control.server.invitations import InvitationStore, format_code
+
+
+@pytest.fixture
+def gateway(tmp_path):
+    tokens = TokenStore(str(tmp_path / "tokens.json"))
+    invitations = InvitationStore(str(tmp_path / "invitations.json"))
+    app = create_app(token_store=tokens, invitation_store=invitations)
+    with TestClient(app) as client:
+        yield client, tokens, invitations
+
+
+def test_a_code_joins_and_returns_a_working_token(gateway):
+    client, tokens, invitations = gateway
+    _link, code = invitations.create("bob")
+    response = client.post("/api/join", json={"code": code})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["identity"] == "bob"
+    assert tokens.verify(body["token"]) == "bob"
+
+
+def test_a_spaced_code_joins(gateway):
+    client, _tokens, invitations = gateway
+    _link, code = invitations.create("bob")
+    assert client.post("/api/join", json={"code": format_code(code)}).status_code == 200
+
+
+def test_a_link_nonce_joins(gateway):
+    client, tokens, invitations = gateway
+    link, _code = invitations.create("bob")
+    response = client.post("/api/join", json={"invite": link})
+    assert response.status_code == 200
+    assert tokens.verify(response.json()["token"]) == "bob"
+
+
+def test_join_needs_no_bearer_token(gateway):
+    # The route is exempt on purpose: it is how someone with no credential
+    # obtains one. Everything else under /api stays fail-closed.
+    client, _tokens, invitations = gateway
+    _link, code = invitations.create("bob")
+    assert client.post("/api/join", json={"code": code}).status_code == 200
+    assert client.get("/api/sessions").status_code == 401
+
+
+def test_joining_twice_with_one_code_fails_the_second_time(gateway):
+    client, _tokens, invitations = gateway
+    _link, code = invitations.create("bob")
+    assert client.post("/api/join", json={"code": code}).status_code == 200
+    assert client.post("/api/join", json={"code": code}).status_code == 401
+
+
+def test_every_failure_looks_identical(gateway):
+    # Distinguishing "wrong" from "expired" from "already used" turns this
+    # endpoint into an oracle: an attacker could confirm a code's existence
+    # without knowing it, or map out when invitations were issued.
+    client, _tokens, invitations = gateway
+    _link, used = invitations.create("used")
+    client.post("/api/join", json={"code": used})
+    _link2, expired = invitations.create("stale", ttl=-1.0)
+
+    wrong = client.post("/api/join", json={"code": "000000"})
+    already = client.post("/api/join", json={"code": used})
+    gone = client.post("/api/join", json={"code": expired})
+    missing = client.post("/api/join", json={})
+
+    assert wrong.status_code == already.status_code == gone.status_code == missing.status_code == 401
+    assert wrong.content == already.content == gone.content == missing.content
+
+
+def test_a_failed_join_mints_no_token(gateway):
+    client, tokens, _invitations = gateway
+    client.post("/api/join", json={"code": "000000"})
+    assert tokens.names() == []
+
+
+def test_the_limiter_stops_a_burst_of_wrong_codes(gateway):
+    client, _tokens, _invitations = gateway
+    statuses = [client.post("/api/join", json={"code": "000000"}).status_code for _ in range(12)]
+    assert statuses[0] == 401
+    assert statuses[-1] == 429
+
+
+def test_successful_joins_are_not_counted_by_the_limiter(gateway):
+    # A success consumes its invitation, so it is self-limiting. Counting
+    # successes would let a busy lab lock itself out on a Monday morning.
+    client, _tokens, invitations = gateway
+    codes = [invitations.create("bob")[1] for _ in range(12)]
+    statuses = [client.post("/api/join", json={"code": code}).status_code for code in codes]
+    assert statuses == [200] * 12
+
+
+def test_the_limiter_does_not_block_a_correct_code_after_a_typo(gateway):
+    client, _tokens, invitations = gateway
+    _link, code = invitations.create("bob")
+    client.post("/api/join", json={"code": "000000"})
+    client.post("/api/join", json={"code": "000001"})
+    assert client.post("/api/join", json={"code": code}).status_code == 200
+
+
+def test_a_second_join_for_the_same_name_adds_a_device(gateway):
+    client, tokens, invitations = gateway
+    first = client.post("/api/join", json={"code": invitations.create("bob")[1]}).json()["token"]
+    second = client.post("/api/join", json={"code": invitations.create("bob")[1]}).json()["token"]
+    assert first != second
+    assert tokens.verify(first) == "bob"
+    assert tokens.verify(second) == "bob"
+    assert tokens.names() == ["bob"]

--- a/tests/test_server_join_api.py
+++ b/tests/test_server_join_api.py
@@ -75,6 +75,38 @@ def test_every_failure_looks_identical(gateway):
     assert wrong.content == already.content == gone.content == missing.content
 
 
+def test_a_unicode_digit_code_is_rejected_like_any_other(gateway):
+    # str.isdigit() is True for "²" and "٣"; hmac.compare_digest raises
+    # TypeError on a non-ASCII str. Because the comparison only runs when an
+    # invitation is live, an unhandled error here reported gateway state to an
+    # anonymous caller: 401 with nothing pending, 500 with something pending.
+    # The live invitation is the whole point of this test -- without it, it
+    # passes even with the bug present.
+    client, _tokens, invitations = gateway
+    invitations.create("bob")
+    plain = client.post("/api/join", json={"code": "000000"})
+    unicode_digits = client.post("/api/join", json={"code": "²²²²²²"})
+    arabic = client.post("/api/join", json={"code": "٤٥٦٧٨٩"})
+    assert plain.status_code == unicode_digits.status_code == arabic.status_code == 401
+    assert plain.content == unicode_digits.content == arabic.content
+
+
+def test_a_corrupt_invitation_store_is_indistinguishable_from_a_wrong_code(gateway, tmp_path):
+    # A ValueError out of redeem() used to reach the app-wide handler and come
+    # back as 400 {"detail": "invitation store C:\\Users\\...\\invitations.json
+    # is unreadable: ..."} -- an absolute path handed to an anonymous caller,
+    # and a third distinguishable status on a route whose whole contract is one
+    # response. The serve path now refuses to start on a corrupt store, but the
+    # file can still be damaged while the gateway is running.
+    client, _tokens, _invitations = gateway
+    wrong = client.post("/api/join", json={"code": "000000"})
+    (tmp_path / "invitations.json").write_text("{ truncated")
+    broken = client.post("/api/join", json={"code": "000000"})
+    assert broken.status_code == wrong.status_code == 401
+    assert broken.content == wrong.content
+    assert "invitations.json" not in broken.text
+
+
 def test_a_failed_join_mints_no_token(gateway):
     client, tokens, _invitations = gateway
     client.post("/api/join", json={"code": "000000"})
@@ -83,9 +115,12 @@ def test_a_failed_join_mints_no_token(gateway):
 
 def test_the_limiter_stops_a_burst_of_wrong_codes(gateway):
     client, _tokens, _invitations = gateway
+    # Pinned exactly, not just "starts 401, ends 429": join.py's comment does
+    # the brute-force arithmetic against FAILURE_LIMIT = 10, and a loose
+    # assertion passes for any limit from 1 to 11 -- so nothing would have
+    # caught someone quietly widening the budget.
     statuses = [client.post("/api/join", json={"code": "000000"}).status_code for _ in range(12)]
-    assert statuses[0] == 401
-    assert statuses[-1] == 429
+    assert statuses == [401] * 10 + [429] * 2
 
 
 def test_successful_joins_are_not_counted_by_the_limiter(gateway):

--- a/webapp/app/src/api/client.ts
+++ b/webapp/app/src/api/client.ts
@@ -46,6 +46,7 @@ const awg = (id: string) => `/api/sessions/${id}/awg`;
 
 export const api = {
   whoami: () => request<{ identity: string }>("/api/whoami"),
+  join: (body: { code?: string; invite?: string }) => request<{ token: string; identity: string }>("/api/join", json("POST", body)),
   models: () => request<ModelInfo[]>("/api/models"),
   discover: (cidr?: string) => request<DiscoveredDevice[]>(cidr ? `/api/discover?cidr=${encodeURIComponent(cidr)}` : "/api/discover"),
   createSession: (body: SessionCreate) => request<SessionInfo>("/api/sessions", json("POST", body)),

--- a/webapp/app/src/api/token.test.ts
+++ b/webapp/app/src/api/token.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { captureTokenFromUrl, clearToken, getToken, setToken } from "./token";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureTokenFromUrl, clearToken, getToken, redeemInviteFromUrl, setToken } from "./token";
 
 describe("token storage", () => {
   beforeEach(() => {
@@ -32,6 +32,75 @@ describe("token storage", () => {
   it("leaves an existing token alone when the URL has none", () => {
     setToken("scpi_existing");
     captureTokenFromUrl();
+    expect(getToken()).toBe("scpi_existing");
+  });
+});
+
+describe("invitation redemption", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.history.replaceState({}, "", "/");
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("redeems an invite from the URL and stores the token", async () => {
+    window.history.replaceState({}, "", "/?invite=abc123");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ token: "scpi_new", identity: "bob" }), { status: 200 })));
+    await redeemInviteFromUrl();
+    expect(getToken()).toBe("scpi_new");
+  });
+
+  it("strips the invite from the URL", async () => {
+    window.history.replaceState({}, "", "/?invite=abc123");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ token: "scpi_new", identity: "bob" }), { status: 200 })));
+    await redeemInviteFromUrl();
+    expect(window.location.search).not.toContain("invite");
+  });
+
+  it("strips the invite before the request resolves", async () => {
+    // The credential must leave the address bar immediately, not once the
+    // gateway answers. If the request hangs, a stripped-on-success
+    // implementation leaves the invite sitting in history and in the
+    // Referer of the next link the user clicks.
+    window.history.replaceState({}, "", "/?invite=abc123");
+    let release: (value: Response) => void = () => {};
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise<Response>((resolve) => { release = resolve; })));
+    const pending = redeemInviteFromUrl();
+    expect(window.location.search).not.toContain("invite");
+    release(new Response(JSON.stringify({ token: "scpi_new", identity: "bob" }), { status: 200 }));
+    await pending;
+  });
+
+  it("strips the invite even when the gateway rejects it", async () => {
+    window.history.replaceState({}, "", "/?invite=expired");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "HTTPException", detail: "no" }), { status: 401 })));
+    await redeemInviteFromUrl();
+    expect(window.location.search).not.toContain("invite");
+    expect(getToken()).toBeNull();
+  });
+
+  it("survives an unreachable gateway", async () => {
+    window.history.replaceState({}, "", "/?invite=abc123");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("network down")));
+    await expect(redeemInviteFromUrl()).resolves.toBeUndefined();
+    expect(getToken()).toBeNull();
+  });
+
+  it("preserves other query parameters", async () => {
+    window.history.replaceState({}, "", "/?invite=abc123&debug=1");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ token: "scpi_new", identity: "bob" }), { status: 200 })));
+    await redeemInviteFromUrl();
+    expect(window.location.search).toContain("debug=1");
+  });
+
+  it("does nothing when the URL carries no invite", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    setToken("scpi_existing");
+    await redeemInviteFromUrl();
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(getToken()).toBe("scpi_existing");
   });
 });

--- a/webapp/app/src/api/token.ts
+++ b/webapp/app/src/api/token.ts
@@ -22,3 +22,39 @@ export function captureTokenFromUrl(): void {
   const query = params.toString();
   window.history.replaceState({}, "", window.location.pathname + (query ? `?${query}` : ""));
 }
+
+/**
+ * Exchange an `?invite=` from the initial SPA load for a real token.
+ *
+ * The parameter is stripped BEFORE the request goes out, not after it
+ * succeeds: if the gateway is slow or unreachable, a credential left sitting
+ * in the address bar goes into history and leaks through the `Referer` of the
+ * next link the user clicks. Stripping first costs nothing — the value is
+ * already in hand.
+ *
+ * Every failure is silent by design. A bad or expired invite should land the
+ * user on the ordinary sign-in screen, which already knows how to ask for a
+ * code; a second error message here would just be noise about a link they
+ * were probably sent by someone else.
+ */
+export async function redeemInviteFromUrl(): Promise<void> {
+  const params = new URLSearchParams(window.location.search);
+  const invite = params.get("invite");
+  if (!invite) return;
+  params.delete("invite");
+  const query = params.toString();
+  window.history.replaceState({}, "", window.location.pathname + (query ? `?${query}` : ""));
+  try {
+    const response = await fetch("/api/join", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ invite }),
+    });
+    if (!response.ok) return;
+    const body = (await response.json()) as { token?: string };
+    if (body.token) setToken(body.token);
+  } catch {
+    // Unreachable gateway: leave the user unauthenticated and let the
+    // sign-in screen report the connection problem in its own words.
+  }
+}

--- a/webapp/app/src/features/auth/TokenGate.test.tsx
+++ b/webapp/app/src/features/auth/TokenGate.test.tsx
@@ -63,14 +63,8 @@ describe("TokenGate", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ identity: "robin" }), { status: 200 })));
     render(<TokenGate><div>inside</div></TokenGate>);
     await userEvent.type(screen.getByLabelText(/access token/i), "scpi_pasted");
-    await userEvent.click(screen.getByRole("button", { name: /connect/i }));
+    await userEvent.click(screen.getByRole("button", { name: /use token/i }));
     await waitFor(() => expect(screen.getByText("inside")).toBeInTheDocument());
-  });
-
-  it("explains how to obtain a token", () => {
-    clearToken();
-    render(<TokenGate><div>inside</div></TokenGate>);
-    expect(screen.getByText(/scpi-web token add/i)).toBeInTheDocument();
   });
 
   it("does not discard a stored token on a network error, and lets the user retry without retyping it", async () => {
@@ -93,5 +87,69 @@ describe("TokenGate", () => {
     render(<TokenGate><div>inside</div></TokenGate>);
     await screen.findByRole("alert");
     expect(getToken()).toBe("scpi_good");
+  });
+
+  it("asks for a join code, not a token, by default", () => {
+    clearToken();
+    render(<TokenGate><div>inside</div></TokenGate>);
+    expect(screen.getByLabelText(/join code/i)).toBeInTheDocument();
+  });
+
+  it("joins with a code and shows the app", async () => {
+    clearToken();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ token: "scpi_new", identity: "bob" }), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ identity: "bob" }), { status: 200 })),
+    );
+    render(<TokenGate><div>inside</div></TokenGate>);
+    await userEvent.type(screen.getByLabelText(/join code/i), "417902");
+    await userEvent.click(screen.getByRole("button", { name: /connect/i }));
+    await waitFor(() => expect(screen.getByText("inside")).toBeInTheDocument());
+    expect(getToken()).toBe("scpi_new");
+  });
+
+  it("accepts a code typed with a space, the way it is printed", async () => {
+    clearToken();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ token: "scpi_new", identity: "bob" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ identity: "bob" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<TokenGate><div>inside</div></TokenGate>);
+    await userEvent.type(screen.getByLabelText(/join code/i), "417 902");
+    await userEvent.click(screen.getByRole("button", { name: /connect/i }));
+    await waitFor(() => expect(screen.getByText("inside")).toBeInTheDocument());
+  });
+
+  it("reports a rejected code without blaming the user's token", async () => {
+    clearToken();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "HTTPException", detail: "That code or link is not valid, or it has expired. Ask for a new one." }), { status: 401 })));
+    render(<TokenGate><div>inside</div></TokenGate>);
+    await userEvent.type(screen.getByLabelText(/join code/i), "000000");
+    await userEvent.click(screen.getByRole("button", { name: /connect/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/not valid, or it has expired/i);
+  });
+
+  it("passes the rate-limit message through rather than inventing one", async () => {
+    clearToken();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "HTTPException", detail: "Too many attempts. Wait a minute and try again." }), { status: 429 })));
+    render(<TokenGate><div>inside</div></TokenGate>);
+    await userEvent.type(screen.getByLabelText(/join code/i), "000000");
+    await userEvent.click(screen.getByRole("button", { name: /connect/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/too many attempts/i);
+  });
+
+  it("still offers the raw token field for scripts and CI", () => {
+    clearToken();
+    render(<TokenGate><div>inside</div></TokenGate>);
+    expect(screen.getByLabelText(/access token/i)).toBeInTheDocument();
+  });
+
+  it("tells a locked-out scientist who to ask, not what to type in a shell", () => {
+    clearToken();
+    render(<TokenGate><div>inside</div></TokenGate>);
+    expect(screen.queryByText(/scpi-web token add/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/ask your lab admin/i)).toBeInTheDocument();
   });
 });

--- a/webapp/app/src/features/auth/TokenGate.tsx
+++ b/webapp/app/src/features/auth/TokenGate.tsx
@@ -9,6 +9,7 @@ type Status = "checking" | "needs-token" | "ready";
 
 const UNAUTHORIZED = "That token was not accepted.";
 const UNREACHABLE = "Could not reach the server. Check your connection and try again.";
+const CODE_REJECTED = "That code is not valid or has expired. Ask for a new one.";
 
 /**
  * Gates the app behind a verified bearer token. Every request already
@@ -24,6 +25,7 @@ const UNREACHABLE = "Could not reach the server. Check your connection and try a
 export function TokenGate({ children }: { children: React.ReactNode }) {
   const [status, setStatus] = useState<Status>("checking");
   const [value, setValue] = useState("");
+  const [code, setCode] = useState("");
   const [error, setError] = useState("");
   const [hasStoredToken, setHasStoredToken] = useState(false);
 
@@ -62,6 +64,26 @@ export function TokenGate({ children }: { children: React.ReactNode }) {
     void check();
   }, [check]);
 
+  /**
+   * Exchange a join code for a token. The gateway's own wording is preferred
+   * over ours for anything it chose to say (a wrong code, a rate limit): it
+   * knows which of those happened and we do not.
+   */
+  const join = useCallback(async () => {
+    const digits = code.replace(/\D/g, "");
+    if (!digits) return;
+    setStatus("checking");
+    try {
+      const { token } = await api.join({ code: digits });
+      setToken(token);
+      setCode("");
+      await check();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail || CODE_REJECTED : UNREACHABLE);
+      setStatus("needs-token");
+    }
+  }, [code, check]);
+
   if (status === "ready") return <>{children}</>;
   // aria-live so a screen-reader user hears the wait; without it the first
   // screen of the app is silent until it resolves.
@@ -80,27 +102,22 @@ export function TokenGate({ children }: { children: React.ReactNode }) {
             style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}
             onSubmit={(event) => {
               event.preventDefault();
-              const trimmed = value.trim();
-              if (!trimmed) return;
-              setToken(trimmed);
-              setValue("");
-              setStatus("checking");
-              void check();
+              void join();
             }}
           >
-            <label htmlFor="token" style={{ fontSize: "var(--text-sm)", color: "var(--lc-text)" }}>
-              Access token
+            <label htmlFor="join-code" style={{ fontSize: "var(--text-sm)", color: "var(--lc-text)" }}>
+              Join code
             </label>
             <input
-              id="token"
-              type="password"
-              value={value}
-              onChange={(event) => setValue(event.target.value)}
-              autoComplete="off"
-              style={{ padding: "6px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--text-sm)", border: "1px solid var(--lc-border-strong)", borderRadius: "var(--lc-radius-sm)", background: "var(--lc-control)", color: "var(--lc-text)" }}
+              id="join-code"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              value={code}
+              onChange={(event) => setCode(event.target.value)}
+              style={{ padding: "6px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--text-sm)", letterSpacing: "0.15em", border: "1px solid var(--lc-border-strong)", borderRadius: "var(--lc-radius-sm)", background: "var(--lc-control)", color: "var(--lc-text)" }}
             />
             <div style={{ display: "flex", gap: "var(--space-1)" }}>
-              <Button type="submit" variant="primary" disabled={!value.trim()} fullWidth>
+              <Button type="submit" variant="primary" disabled={!code.replace(/\D/g, "")} fullWidth>
                 Connect
               </Button>
               {hasStoredToken && (
@@ -121,9 +138,42 @@ export function TokenGate({ children }: { children: React.ReactNode }) {
               </p>
             ) : null}
             <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--lc-muted)" }}>
-              No token? Run <code>scpi-web token add &lt;name&gt;</code> on the gateway host to mint one.
+              No code? Ask your lab admin to send you a join link or read you a code.
             </p>
           </form>
+          {/* A scientist should never see an scpi_ string. An automation
+              author still needs one, so the field stays — just not in the
+              way of the ninety-nine percent case. */}
+          <details>
+            <summary style={{ fontSize: "var(--text-xs)", color: "var(--lc-muted)", cursor: "pointer" }}>I have an access token</summary>
+            <form
+              style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", marginTop: "var(--space-2)" }}
+              onSubmit={(event) => {
+                event.preventDefault();
+                const trimmed = value.trim();
+                if (!trimmed) return;
+                setToken(trimmed);
+                setValue("");
+                setStatus("checking");
+                void check();
+              }}
+            >
+              <label htmlFor="token" style={{ fontSize: "var(--text-sm)", color: "var(--lc-text)" }}>
+                Access token
+              </label>
+              <input
+                id="token"
+                type="password"
+                value={value}
+                onChange={(event) => setValue(event.target.value)}
+                autoComplete="off"
+                style={{ padding: "6px 8px", fontFamily: "var(--font-mono)", fontSize: "var(--text-sm)", border: "1px solid var(--lc-border-strong)", borderRadius: "var(--lc-radius-sm)", background: "var(--lc-control)", color: "var(--lc-text)" }}
+              />
+              <Button type="submit" disabled={!value.trim()} fullWidth>
+                Use token
+              </Button>
+            </form>
+          </details>
         </GroupBox>
       </div>
     </div>

--- a/webapp/app/src/main.tsx
+++ b/webapp/app/src/main.tsx
@@ -3,12 +3,16 @@ import ReactDOM from "react-dom/client";
 import "@design/styles.css";
 import "./ds/ds.css";
 import App from "./App";
-import { captureTokenFromUrl } from "./api/token";
+import { captureTokenFromUrl, redeemInviteFromUrl } from "./api/token";
 
 captureTokenFromUrl();
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+// Render only once any invitation in the URL has been exchanged, so the gate
+// sees the token this load just obtained rather than briefly demanding one.
+void redeemInviteFromUrl().finally(() => {
+  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+});


### PR DESCRIPTION
Handing out gateway access meant copying a permanent `scpi_…` secret out of a terminal and sending it through chat, where it stayed valid forever. Locked-out users had to find the admin. Revoking a leaked token required restarting the gateway — a caveat the docs described as permanent.

This replaces that with **invitations**.

```console
$ scpi-web invite bob
Invitation for 'bob' — expires in 10 minutes.

  Send this link:          http://192.168.1.50:8765/?invite=Kf3xQ7…
  Or read out this code:   417 902
```

One invitation, two ways to redeem it, ten-minute life. Send the link or read the six digits down the phone; either is exchanged in the browser for a real token. A scientist never sees an `scpi_` string, and a leaked chat message stops working in minutes. The same command is how someone gets back in after clearing their browser — there is no second command to learn.

## What changed

- **`scpi-web invite <name>`** prints a clickable link and a six-digit code for a single, ten-minute, single-use invitation. The link is built from the URL the gateway records at startup, so it points at the machine's real LAN address rather than `127.0.0.1`.
- **A token name is now an identity**, not a credential. One person can hold several device tokens — laptop, bench tablet, a reinstalled browser — and `scpi-web token revoke <name>` cuts off every one at once.
- **Revocation takes effect immediately.** The gateway reloads its token store when the file changes, so the documented remedy for a leaked credential no longer silently does nothing until someone remembers to restart.
- **The sign-in screen asks for a join code first**, with the raw-token field moved behind a disclosure for scripts and CI.
- `scpi-web token list` shows device counts and last-seen.

## Security notes for review

`POST /api/join` is the gateway's only unauthenticated write route, so it carries the most caution here:

- Every non-rate-limited failure returns a **byte-identical 401** — wrong, expired, and already-used are indistinguishable, so the route cannot be used as an oracle.
- Failed attempts are limited to **ten per minute across all clients**, not per IP; a per-IP budget means little against someone on the same LAN who can choose source addresses. Successes are not counted, because a success consumes its invitation.
- There is deliberately **no per-invitation attempt cap**. A wrong code cannot be attributed to any particular invitation, and charging every live one would let a single guesser invalidate everyone's access.
- The link nonce is hashed; the six-digit code is stored in clear **by design**. Hashing a secret drawn from a space of 10⁶ is theater — anyone who can read the file can enumerate every hash in under a second. Its real defenses are the ten-minute TTL, the limiter, and the 0600 file mode. There is a test whose only job is to stop someone "fixing" this.

## Known gap, documented rather than fixed

Revocation does not tear down an **already-open WebSocket**: the stream authenticates once at handshake and is never re-checked. Worse, the open socket keeps `owner_watching()` true, which makes the claim rule refuse outright — so a revoked colleague's forgotten browser tab blocks the admin from claiming that session. `docs/gateway/security.md` now says this plainly instead of claiming there is "no window in which a leaked token still opens the door". Fixing the behaviour is follow-up work.

## Breaking changes

Marked ⚠️ in the changelog, so the next release is **6.0.0**:

- `token add <name>` no longer fails when the name exists — it adds a device.
- `DuplicateTokenName` is removed from `scpi_control.server.auth`.
- `TokenStore.names()` returns distinct names, sorted.

## Testing

2042 passed, 19 skipped (Python); 289/289 (frontend). Four load-bearing guards were mutation-tested — proven to fail when their target bug is reintroduced: single-use redemption, strip-the-invite-before-awaiting, the limiter counting failures only, and the store reload itself.

Three defects were caught during development and are worth knowing about, since two came from the implementation plan's own code rather than from writing it wrong:

1. **`_load()` committed its stat key before the read succeeded**, so a corrupt store failed loudly exactly once and then silently served stale authorization decisions forever. Found by execution. The identical bug was swept out of `InvitationStore` before it shipped.
2. **`str.isdigit()` is true for non-ASCII digits** (`²`, `٣`), and `hmac.compare_digest` raises `TypeError` on a non-ASCII `str`. Because the comparison only ran when an invitation was live, `{"code":"²²²²²²"}` returned 401 with nothing pending and **500 with something pending** — a free oracle revealing exactly when an invitation was issued, which defeats the TTL arithmetic. Now an explicit ASCII filter, with a guard test that creates a live invitation first (without that precondition it passes for the wrong reason).
3. **A corrupt `invitations.json` minted an orphaned live token before crashing** — the admin saw an openable URL for a server that never started, and because the store was no longer empty, that token's URL was never shown again.
