### PR TITLE
Administer the gateway from a panel on the machine it runs on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,43 @@ jobs:
         run: npm run build
         working-directory: webapp/app
 
+      - name: Build the admin bundle
+        run: npm run build:admin
+        working-directory: webapp/app
+
+      - name: The LAN bundle must not contain admin code
+        # The admin panel is served only on a loopback-bound listener and has no
+        # authentication. If admin code reaches the LAN bundle, every browser in
+        # the lab is served the UI for administering access.
+        #
+        # Vite's default single entry means admin.html cannot be swept in by
+        # accident, so this guards the deliberate case: an import from
+        # src/admin/* into the main app's module graph. That leaves the
+        # filenames untouched and only shows up inside the emitted chunks, which
+        # is why this greps content rather than listing files.
+        #
+        # "/api/identities" is an admin-only route string; it is a plain string
+        # literal in src/admin/api.ts and esbuild's minifier leaves it intact
+        # (verified against both built bundles).
+        run: |
+          # Assert the haystacks exist first. A missing dist/ would make grep
+          # exit 2, which the `if` below reads as "no match" -- so the negative
+          # assertion would pass without having looked at anything.
+          test -f dist/index.html
+          test -f dist-admin/admin.html
+          if grep -rl "/api/identities" dist/; then
+            echo "::error::admin code reached the LAN bundle — see webapp/app/vite.admin.config.ts"
+            exit 1
+          fi
+          # And prove the needle is still findable, so a rename of the route
+          # cannot turn this gate into one that silently always passes.
+          grep -rq "/api/identities" dist-admin/ || {
+            echo "::error::'/api/identities' is not in the admin bundle — this check no longer proves anything; update the search string"
+            exit 1
+          }
+          echo "LAN bundle clean; admin bundle built"
+        working-directory: webapp/app
+
   build:
     name: Build Package
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ site/
 
 # Web gateway frontend build output
 scpi_control/server/static/
+scpi_control/server/admin/static/
+webapp/app/dist-admin/
 
 # pytest-testmon impact-selection database (local dev only)
 .testmondata*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   raised, so any `except DuplicateTokenName` clause is now an `ImportError` waiting to happen.
 - `TokenStore.names()` now returns distinct names, sorted. It previously returned one entry per
   token, which is one entry per device under the new model.
+- A fresh gateway no longer mints an identity called `default`, and no longer prints a
+  `?token=…` bootstrap URL on first start. Instead it opens a host-only admin panel and asks
+  what to call you, so the first identity is a real person rather than an anonymous credential
+  that ends up owning every session it creates. Existing installations are unaffected — this
+  changes only what happens when the token store is empty.
 
 ### Added
 
@@ -67,6 +72,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the page.
 - A non-owner is now told, in session, that it's read-only and who owns it, with the same Claim
   action the home screen offers. Previously they found out by having a write rejected.
+- The gateway now serves an admin panel on the machine it runs on, at `http://127.0.0.1:8766/`.
+  It lists who has access with device counts and last-seen, issues an invitation showing the
+  link and code together with a countdown, cancels one sent to the wrong person, and revokes
+  someone with a confirmation that names how many devices it signs out. There is no sign-in:
+  the listener binds loopback, so the operating system refuses every non-local connection.
+  `--admin-port` moves it; `--no-admin` switches it off. There is deliberately no flag to bind
+  it to another address.
+- Cancelling a pending invitation is new — previously the only remedy for one sent to the wrong
+  person was waiting ten minutes for it to expire.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The gateway now serves an admin panel on the machine it runs on, at `http://127.0.0.1:8766/`.
   It lists who has access with device counts and last-seen, issues an invitation showing the
   link and code together with a countdown, cancels one sent to the wrong person, and revokes
-  someone with a confirmation that names how many devices it signs out. There is no sign-in:
-  the listener binds loopback, so the operating system refuses every non-local connection.
+  someone with a confirmation that names how many devices it signs out. There is no sign-in,
+  and three independent things stand in for one: the listener binds loopback, so the operating
+  system refuses every non-local connection; requests must carry a `Host` of `127.0.0.1` or
+  `localhost`, which is what stops a DNS-rebound page the bind would let through; and any
+  request carrying a foreign `Origin` is refused, which is what stops an ordinary cross-origin
+  page that satisfies both of the others.
   `--admin-port` moves it; `--no-admin` switches it off. There is deliberately no flag to bind
   it to another address.
 - Cancelling a pending invitation is new — previously the only remedy for one sent to the wrong

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,8 +11,13 @@ include docs/SDS800XHD_Series_ProgrammingGuide_EN11G.pdf
 # Include resources (logos, icons)
 recursive-include resources *.png *.ico *.icns
 
-# Include web gateway frontend build output (when present)
+# Include web gateway frontend build output (when present). Both bundles must
+# be listed: include-package-data sources package data from this manifest, so a
+# static directory missing here is silently absent from the wheel and the sdist
+# even when make webapp-build produced it. tests/test_packaging_manifest.py
+# fails if a new scpi_control/server/**/static directory appears without a rule.
 recursive-include scpi_control/server/static *
+recursive-include scpi_control/server/admin/static *
 
 # Include examples
 recursive-include examples *.py

--- a/Makefile
+++ b/Makefile
@@ -200,12 +200,17 @@ web-server:  ## Run the web gateway (dev, mock-friendly)
 webapp-install:  ## Install webapp dependencies
 	cd webapp/app && npm install
 
-webapp-build:  ## Build the webapp into the server's static dir
+webapp-build:  ## Build both webapp bundles into the server's static dirs
 	cd webapp/app && npm run build
 	rm -rf scpi_control/server/static
 	mkdir -p scpi_control/server/static
 	cp -r webapp/app/dist/* scpi_control/server/static/
-	@echo "✓ Webapp built into scpi_control/server/static/"
+	cd webapp/app && npm run build:admin
+	rm -rf scpi_control/server/admin/static
+	mkdir -p scpi_control/server/admin/static
+	cp -r webapp/app/dist-admin/* scpi_control/server/admin/static/
+	mv scpi_control/server/admin/static/admin.html scpi_control/server/admin/static/index.html
+	@echo "✓ Webapp built into scpi_control/server/static/ and admin/static/"
 
 version:  ## Show package version
 	@python -c "import scpi_control; print(f'SCPI-Instrument-Control v{scpi_control.__version__}')"

--- a/README.md
+++ b/README.md
@@ -632,14 +632,18 @@ scpi-web                                   # prints its URL on every start
 scpi-web invite bob                        # a 10-minute link + code for someone else
 ```
 
-The gateway prints its URL every time it starts; the very first run also mints
-a token and prints it in the URL (`http://127.0.0.1:8765/?token=…`). **Every
-request needs a token**, but nobody except the admin has to handle one:
-`scpi-web invite <name>` prints a link and a six-digit code, either of which
-signs a colleague in, both expiring in ten minutes. For scripts and CI, mint a
-long-lived token with `scpi-web token add <name>`. A name is an identity that
-can hold several devices' tokens, and `scpi-web token revoke <name>` cuts off
-all of them, immediately.
+The gateway prints its URL every time it starts, and serves an **admin panel**
+on the gateway machine only (`http://127.0.0.1:8766/`) for managing who has
+access — invite, revoke, cancel a pending invitation. It has no sign-in because
+it binds loopback: physical access to the machine is the credential. On the very
+first run, when nobody has access yet, the gateway opens that panel so you can
+name yourself; nothing is minted automatically. **Every request to the gateway
+itself needs a token**, but nobody except the admin has to handle one: the
+panel — or `scpi-web invite <name>` — produces a link and a six-digit code,
+either of which signs a colleague in, both expiring in ten minutes. For scripts
+and CI, mint a long-lived token with `scpi-web token add <name>`. A name is an
+identity that can hold several devices' tokens, and
+`scpi-web token revoke <name>` cuts off all of them, immediately.
 
 Sessions can target real scopes by IP or a built-in mock (`mock: true`) for
 hardware-free use. The OpenAPI schema is served at `/api/openapi.json` (token
@@ -652,7 +656,9 @@ instrument session an owner (owner writes, everyone else watches), validates
 outbound connection targets, and caps concurrent sessions. It does **not**
 terminate TLS — put it behind a reverse proxy or keep it on a trusted network.
 See the **[Gateway security guide](docs/gateway/security.md)** for invitations,
-tokens, ownership, claiming, the SSRF gate, and deployment.
+tokens, ownership, claiming, the SSRF gate, and deployment, and the
+**[Admin panel guide](docs/gateway/admin-panel.md)** for the host-only
+management screen and first-run setup.
 
 > **Upgrading from 4.x:** the gateway now requires a token, and reference files
 > saved by 4.x must be converted once with `scpi-web references migrate`. Both
@@ -677,12 +683,13 @@ Full documentation: [Web Gateway guide](https://little-did-I-know.github.io/SCPI
 
 ```bash
 make webapp-install       # once
-make webapp-build         # build the UI into the server
+make webapp-build         # build both bundles (LAN UI + admin panel) into the server
 scpi-web --host 0.0.0.0   # serve API + UI on one port
 ```
 
-Open the URL the gateway prints on startup — tokened on the first run, or use
-a code from `scpi-web invite`. For UI development, run `scpi-web` in one
+Open the URL the gateway prints on startup and sign in with a code or link —
+from the admin panel on the first run, or from `scpi-web invite` after that.
+For UI development, run `scpi-web` in one
 terminal and `cd webapp/app && npm run dev` in another — Vite proxies `/api`
 (HTTP and WebSocket) to the gateway with hot reload; open the dev server with
 an `?invite=…` from `scpi-web invite dev` (or a `?token=…`) so the UI picks up

--- a/README.md
+++ b/README.md
@@ -634,8 +634,10 @@ scpi-web invite bob                        # a 10-minute link + code for someone
 
 The gateway prints its URL every time it starts, and serves an **admin panel**
 on the gateway machine only (`http://127.0.0.1:8766/`) for managing who has
-access — invite, revoke, cancel a pending invitation. It has no sign-in because
-it binds loopback: physical access to the machine is the credential. On the very
+access — invite, revoke, cancel a pending invitation. It has no sign-in: it
+binds loopback, so physical access to the machine is the credential, and it
+refuses any request whose `Host` or `Origin` is not its own, so a web page the
+admin visits cannot reach it either. On the very
 first run, when nobody has access yet, the gateway opens that panel so you can
 name yourself; nothing is minted automatically. **Every request to the gateway
 itself needs a token**, but nobody except the admin has to handle one: the

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   raised, so any `except DuplicateTokenName` clause is now an `ImportError` waiting to happen.
 - `TokenStore.names()` now returns distinct names, sorted. It previously returned one entry per
   token, which is one entry per device under the new model.
+- A fresh gateway no longer mints an identity called `default`, and no longer prints a
+  `?token=…` bootstrap URL on first start. Instead it opens a host-only admin panel and asks
+  what to call you, so the first identity is a real person rather than an anonymous credential
+  that ends up owning every session it creates. Existing installations are unaffected — this
+  changes only what happens when the token store is empty.
 
 ### Added
 
@@ -67,6 +72,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the page.
 - A non-owner is now told, in session, that it's read-only and who owns it, with the same Claim
   action the home screen offers. Previously they found out by having a write rejected.
+- The gateway now serves an admin panel on the machine it runs on, at `http://127.0.0.1:8766/`.
+  It lists who has access with device counts and last-seen, issues an invitation showing the
+  link and code together with a countdown, cancels one sent to the wrong person, and revokes
+  someone with a confirmation that names how many devices it signs out. There is no sign-in:
+  the listener binds loopback, so the operating system refuses every non-local connection.
+  `--admin-port` moves it; `--no-admin` switches it off. There is deliberately no flag to bind
+  it to another address.
+- Cancelling a pending invitation is new — previously the only remedy for one sent to the wrong
+  person was waiting ten minutes for it to expire.
 
 ### Fixed
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -75,8 +75,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The gateway now serves an admin panel on the machine it runs on, at `http://127.0.0.1:8766/`.
   It lists who has access with device counts and last-seen, issues an invitation showing the
   link and code together with a countdown, cancels one sent to the wrong person, and revokes
-  someone with a confirmation that names how many devices it signs out. There is no sign-in:
-  the listener binds loopback, so the operating system refuses every non-local connection.
+  someone with a confirmation that names how many devices it signs out. There is no sign-in,
+  and three independent things stand in for one: the listener binds loopback, so the operating
+  system refuses every non-local connection; requests must carry a `Host` of `127.0.0.1` or
+  `localhost`, which is what stops a DNS-rebound page the bind would let through; and any
+  request carrying a foreign `Origin` is refused, which is what stops an ordinary cross-origin
+  page that satisfies both of the others.
   `--admin-port` moves it; `--no-admin` switches it off. There is deliberately no flag to bind
   it to another address.
 - Cancelling a pending invitation is new — previously the only remedy for one sent to the wrong

--- a/docs/gateway/admin-panel.md
+++ b/docs/gateway/admin-panel.md
@@ -20,8 +20,8 @@ the panel is a second way in, not a replacement.
 ## Why there is no sign-in
 
 The panel asks for no password and no token. That is deliberate, and it rests on
-**two independent defences** — which is worth spelling out, because each one
-looks redundant until you see the attacker the other misses. Removing either
+**three independent defences** — which is worth spelling out, because each one
+looks redundant until you see the attacker the others miss. Removing any of them
 opens the panel up.
 
 **1. The listener binds `127.0.0.1`.** The operating system refuses every
@@ -38,11 +38,42 @@ rebinding — and become same-origin with the panel. The connection then really
 does arrive on loopback, so the bind is satisfied and waves it through; without
 this check that page could quietly issue an invitation and read the redeemable
 link straight back out of the response. A `Host` allowlist breaks it, because
-the request still carries the attacker's hostname. CORS does not help here:
-rebinding defeats it by construction.
+the request still carries the attacker's hostname — which rebinding, by
+construction, cannot launder.
 
-So: **the bind stops the lab; the `Host` check stops the web.** Neither covers
-the other's attacker.
+**3. Requests must carry no `Origin`, or the panel's own.** Rebinding is the
+elaborate attack. The plain one needs none of it: a page on any site the admin
+happens to visit does
+`fetch("http://127.0.0.1:8766/api/invitations", {method: "POST", …})`. The
+socket really is local, so the bind is satisfied; the `Host` really is
+`127.0.0.1:8766`, so the allowlist is too. **Neither of the defences above
+applies at all.** What gives it away is the `Origin` header, which a browser
+attaches to every cross-origin request and a page cannot forge. The panel
+refuses anything whose `Origin` is not `http://127.0.0.1:8766` or
+`http://localhost:8766` (following `--admin-port` if you moved it). Requests
+with no `Origin` — `curl`, scripts, the panel's own same-origin fetches — are
+unaffected, because an `Origin` is precisely what a *cross*-origin request is
+obliged to carry. This also catches the rebinding variant, whose `Origin` would
+name the attacker's host.
+
+So: **the bind stops the lab; the `Host` check stops rebinding; the `Origin`
+check stops the ordinary web page.** None covers the others' attacker.
+
+There is a fourth thing helping, and it is worth naming so nobody mistakes it
+for the plan: the browser's CORS preflight, plus the fact that these endpoints
+read only JSON bodies. A cross-origin page cannot send `application/json`
+without a preflight the panel never answers, and a body it *can* send without
+one — `text/plain`, a form post — is rejected as malformed. That is genuine, and
+it is what stood between the panel and the attack above before the `Origin`
+check existed. But it is a property of the request parsers rather than a
+decision, so it would quietly evaporate the day an endpoint learns to read a
+form body or a `GET` learns to change something. Treat it as a backstop, not a
+defence you are relying on.
+
+If you are hacking on the panel with `npm run dev:admin`, the Vite proxy
+rewrites `Origin` alongside `Host` so the dev server keeps working. Do not
+instead reach for `CORSMiddleware` — adding one is precisely how this boundary
+would be lost.
 
 What this model does *not* survive is someone who can already run a browser on
 the gateway machine as you. If that is in your threat model, do not run the
@@ -73,7 +104,12 @@ the allowlist is too:
 $ ssh -L 8766:127.0.0.1:8766 you@gateway-pc
 ```
 
-Then open `http://localhost:8766/` on your own machine. This does move the
+Then open `http://localhost:8766/` on your own machine. **Forward it to the same
+port number**, as above: your browser's `Origin` carries the local port, so
+`-L 9999:127.0.0.1:8766` would present as `http://localhost:9999` and be refused
+by the `Origin` check.
+
+This does move the
 boundary — anyone who can SSH to the gateway as you can now administer it — but
 that is a boundary you already chose, authenticated by SSH keys rather than by
 an unauthenticated port on the LAN.

--- a/docs/gateway/admin-panel.md
+++ b/docs/gateway/admin-panel.md
@@ -1,0 +1,212 @@
+# Admin panel
+
+Managing who can use the gateway used to mean remembering CLI subcommands. It
+does not any more. The gateway serves a small **admin panel** on the machine it
+runs on, at:
+
+```
+http://127.0.0.1:8766/
+```
+
+Open that in a browser **on the gateway machine** and you get one screen showing
+everyone who has access, with buttons to invite someone or cut them off. The
+`scpi-web invite` and `scpi-web token` commands still work exactly as before —
+the panel is a second way in, not a replacement.
+
+> **This page is for whoever administers the gateway.** If you are a user
+> wanting to sign in, you need a link or a six-digit code from that person;
+> see the [Browser UI tour](browser-ui.md).
+
+## Why there is no sign-in
+
+The panel asks for no password and no token. That is deliberate, and it rests on
+**two independent defences** — which is worth spelling out, because each one
+looks redundant until you see the attacker the other misses. Removing either
+opens the panel up.
+
+**1. The listener binds `127.0.0.1`.** The operating system refuses every
+non-local connection before any gateway code runs. A colleague on the LAN
+pointing a browser at `http://gateway-pc:8766/` does not get a login screen —
+they get a refused connection. **Physical access to the gateway machine is the
+credential**, the same standard as being able to sit down and type
+`scpi-web token revoke bob`.
+
+**2. Requests must carry a `Host` of `127.0.0.1` or `localhost`.** The bind stops
+a non-local *socket*. It does not stop a *browser*. A page the admin visits in
+the ordinary course of a day can point its own hostname at `127.0.0.1` — DNS
+rebinding — and become same-origin with the panel. The connection then really
+does arrive on loopback, so the bind is satisfied and waves it through; without
+this check that page could quietly issue an invitation and read the redeemable
+link straight back out of the response. A `Host` allowlist breaks it, because
+the request still carries the attacker's hostname. CORS does not help here:
+rebinding defeats it by construction.
+
+So: **the bind stops the lab; the `Host` check stops the web.** Neither covers
+the other's attacker.
+
+What this model does *not* survive is someone who can already run a browser on
+the gateway machine as you. If that is in your threat model, do not run the
+panel — see [Turning it off](#turning-it-off).
+
+## Where it is, and moving it
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--admin-port` | `8766` | Port for the admin panel |
+| `--no-admin` | *(off)* | Do not start the admin listener at all |
+
+`--port` and `--admin-port` must differ; the gateway says so and exits rather
+than failing later inside the socket bind.
+
+**There is deliberately no `--admin-host`.** Every argument above depends on the
+listener being on loopback, so making the address configurable would turn a
+guarantee into a footgun — one flag, probably copied from a forum post, and an
+unauthenticated access-management UI is on the LAN. The address is a constant in
+the source, and the gateway asserts it is a loopback address before binding.
+
+If you need the panel from another machine, forward the port over SSH rather
+than rebinding it. The tunnel terminates on the gateway's own loopback, so the
+bind is satisfied honestly, and your browser sends a `Host` of `localhost`, so
+the allowlist is too:
+
+```console
+$ ssh -L 8766:127.0.0.1:8766 you@gateway-pc
+```
+
+Then open `http://localhost:8766/` on your own machine. This does move the
+boundary — anyone who can SSH to the gateway as you can now administer it — but
+that is a boundary you already chose, authenticated by SSH keys rather than by
+an unauthenticated port on the LAN.
+
+## The People screen
+
+There is one screen, because the person administering a gateway sits down to do
+a job, not to navigate.
+
+**Who has access** lists each identity with the number of devices signed in
+under it and when one of them was last seen. This is `scpi-web token list` with
+a **Revoke** button. Revoking asks first, and the confirmation names the
+consequence — *"Revoke bob? This signs out all 2 of their devices"* — because
+the device count is exactly what the CLI cannot easily tell you before you act.
+Revocation takes effect on the next request; there is no restart.
+
+**Invitations** takes a name and creates a ten-minute invitation, showing:
+
+- the **link** to send, which signs a browser in with no typing at all;
+- the **six-digit code** to read down a phone, grouped as `417 902`;
+- a **countdown** to expiry, so you can see whether it is still worth sending.
+
+Both are one invitation with two ways in; whichever is used first consumes it.
+
+**Cancelling a pending invitation is new here.** From the CLI, an invitation
+sent to the wrong person or with a typo in the name could only be waited out —
+ten minutes with a live credential in someone's chat window. The panel lists
+everything still pending and cancels it outright.
+
+### A code can be shown again; a link cannot
+
+Reopen the panel an hour later and a pending invitation still shows its code, so
+an admin who closed the window can read it out without cancelling and starting
+over.
+
+The link is not shown again, and this is not an oversight. Only a **hash** of
+the link's nonce is stored, so the link genuinely exists once, at the moment of
+creation — there is nothing on disk to rebuild it from. If a link is lost,
+cancel the invitation and make a new one.
+
+The code, by contrast, is stored **in the clear**, and that deserves an
+explanation rather than a raised eyebrow. Hashing a secret drawn from a space of
+1,000,000 would be theatre: anyone holding the file could enumerate all
+1,000,000 hashes in well under a second. The code's real defences are that it
+expires in ten minutes and that failed redemptions are rate-limited (see
+[Guessing a join code](security.md#guessing-a-join-code)). Storing it hashed
+would only make it *look* safer than it is.
+
+Storing it in clear is safe **here and nowhere else**: `invitations.json` is
+written `0600` where the platform supports it, and the only thing that ever
+reads a code back out is the host-only panel. It is never served to the LAN app.
+
+## First run
+
+Starting a gateway with an empty token store no longer mints anything. There is
+no auto-created `default` identity and no `?token=…` bootstrap URL — the first
+person to use a gateway should be a named human, not a placeholder that then
+owns every session it touches.
+
+Instead the gateway prints where it is and opens the panel on the host:
+
+```console
+$ scpi-web
+
+Gateway ready at http://127.0.0.1:8765/
+No one has access yet — finish setup at http://127.0.0.1:8766/
+```
+
+The panel shows *"No one has access yet. Invite someone below to get started."*
+Type your own name, press **Invite**, and open the link it gives you. That
+mints an identity for **you**, and from then on the sessions you create are
+owned by your name.
+
+If no browser can be opened — a headless box, an SSH session, a machine with no
+associated browser — the gateway carries on regardless and the printed URL is
+still there to open by hand. A browser problem can never stop a gateway
+starting.
+
+Once anyone has access, every later start prints the ordinary banner:
+
+```console
+$ scpi-web
+
+Gateway ready at http://127.0.0.1:8765/
+Admin panel (this machine only) at http://127.0.0.1:8766/
+Hand out access with: scpi-web invite <name>
+```
+
+## Turning it off
+
+`--no-admin` starts the gateway with no admin listener at all. Nothing else
+changes; the CLI still does everything the panel does, apart from cancelling a
+pending invitation.
+
+On a gateway that **already** has users, that is all you need to know. On a
+**fresh** one it would otherwise be a trap — no panel and no auto-minted token
+means no way in — so the gateway says what to do instead:
+
+```console
+$ scpi-web --no-admin
+
+Gateway ready at http://127.0.0.1:8765/
+No one has access yet, and the admin panel is disabled (--no-admin).
+Create the first identity with: scpi-web invite <name>
+```
+
+That is the path a headless or containerised deployment takes: run
+`scpi-web invite <name>` once, from the same `--config-dir`, and send yourself
+the link.
+
+## For maintainers: the panel is a separate bundle
+
+The admin UI is built and shipped separately from the LAN app, and the two must
+never meet:
+
+- `npm run build:admin` emits to `webapp/app/dist-admin/`, which
+  `make webapp-build` copies to `scpi_control/server/admin/static/`.
+- The LAN app builds to `dist/` and is served from
+  `scpi_control/server/static/`.
+
+They are kept apart because the main app's SPA catch-all serves any real file it
+finds in *its* static directory — so a shared directory would hand the
+access-management UI to every browser in the lab. For the same reason the admin
+app is never mounted under the main app and never shares its router.
+
+CI enforces this by **content, not filename**: it greps the built LAN bundle for
+an admin-only route string and fails if one appears. A check that only looked
+for a file called `admin.*` would miss the case actually worth catching — an
+`import` from `src/admin/*` into the main app's module graph pulls admin code
+into `dist/` while leaving every filename untouched.
+
+## Where to next
+
+- [Gateway security](security.md) — invitations, tokens, session ownership,
+  the SSRF gate, and deployment guidance
+- [Browser UI tour](browser-ui.md) — what the people you invite will see

--- a/docs/gateway/admin-panel.md
+++ b/docs/gateway/admin-panel.md
@@ -105,9 +105,9 @@ everything still pending and cancels it outright.
 
 ### A code can be shown again; a link cannot
 
-Reopen the panel an hour later and a pending invitation still shows its code, so
-an admin who closed the window can read it out without cancelling and starting
-over.
+Reopen the panel five minutes later and a pending invitation still shows its
+code, so an admin who closed the window can read it out without cancelling and
+starting over.
 
 The link is not shown again, and this is not an oversight. Only a **hash** of
 the link's nonce is stored, so the link genuinely exists once, at the moment of

--- a/docs/gateway/api.md
+++ b/docs/gateway/api.md
@@ -22,6 +22,11 @@ is the same whether or not an invitation is live). See the
 invite someone or mint a token, how ownership gates writes, and the WebSocket
 authentication handshake.
 
+The [admin panel](admin-panel.md) has routes of its own — identities and
+invitations — but they belong to a **separate application on a separate,
+loopback-bound port** (`8766` by default) and are not part of this reference.
+They are not reachable from the LAN, and nothing on this page serves them.
+
 ## Sessions & discovery
 
 | Method | Path | Body / params | Response | Errors |

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -28,13 +28,18 @@ python -m scpi_control.server
 ```
 
 By default the gateway listens on `http://127.0.0.1:8765`, and prints that URL
-every time it starts. On the very first run — when no tokens exist yet — it
-also mints one and prints it in the URL (`http://127.0.0.1:8765/?token=…`);
-open that to reach the browser UI.
+every time it starts. Alongside it, on the gateway machine only, it serves an
+[admin panel](admin-panel.md) at `http://127.0.0.1:8766` for managing who has
+access.
 
-To give someone else access, run `scpi-web invite <name>` on the gateway host.
-It prints a link and a six-digit code, both good for ten minutes and for one
-sign-in; send either. Nobody but you needs to handle a raw token.
+On the **very first** run — when nobody has access yet — the gateway opens that
+panel for you. Invite yourself, open the link it gives you, and you are in under
+your own name. Nothing is minted automatically.
+
+To give someone else access, invite them from the panel, or run
+`scpi-web invite <name>` on the gateway host. Either way they get a link and a
+six-digit code, both good for ten minutes and for one sign-in; send either.
+Nobody but you needs to handle a raw token.
 
 ## Security posture
 
@@ -47,6 +52,11 @@ in. Exposing it to the LAN is an explicit choice:
 ```bash
 scpi-web --host 0.0.0.0
 ```
+
+The admin panel is the exception, and a deliberate one: it has no sign-in, and
+it binds `127.0.0.1` unconditionally so that only someone at the gateway machine
+can reach it. See [Admin panel](admin-panel.md) for why that is the boundary and
+how to turn it off.
 
 See the **[Gateway security guide](security.md)** for the full model: tokens,
 session ownership, the SSRF gate that validates outbound connection targets,
@@ -85,6 +95,8 @@ ever plugging in an instrument.
 
 - [Gateway security](security.md) — invitations, tokens, session ownership,
   the SSRF gate, and deployment guidance
+- [Admin panel](admin-panel.md) — the host-only screen for managing who has
+  access, and first-run setup
 - [Browser UI Tour](browser-ui.md) — a walkthrough of the home screen, canvas
   modes, and rail tabs
 - [REST & WebSocket API](api.md) — the complete wire reference, with a curl

--- a/docs/gateway/security.md
+++ b/docs/gateway/security.md
@@ -90,9 +90,8 @@ against the same `--config-dir`.
 ## Inviting someone
 
 Nobody in the lab should ever have to handle a `scpi_…` string. The
-[admin panel](admin-panel.md) does this from a screen — and is the only way to
-*cancel* an invitation you should not have sent. From a terminal, it is one
-command on the gateway host:
+[admin panel](admin-panel.md) does this from a screen; from a terminal, it is
+one command on the gateway host:
 
 ```console
 $ scpi-web invite bob

--- a/docs/gateway/security.md
+++ b/docs/gateway/security.md
@@ -24,48 +24,75 @@ traffic; for that, put the gateway
 behind a reverse proxy or keep it on a network you trust. See
 [Deployment](#deployment) for the specifics.
 
+Everything on this page describes the **gateway** listener, the one your
+colleagues reach. The [admin panel](admin-panel.md) is a second listener with a
+different model: it is unauthenticated, and it is bound to `127.0.0.1` so that
+only someone sitting at the gateway machine can reach it at all. Physical access
+is its credential.
+
 ## Starting the gateway
 
-Every start prints where the gateway can be reached:
+Every start prints where the gateway can be reached, and where to administer it:
 
 ```console
 $ scpi-web
 
 Gateway ready at http://127.0.0.1:8765/
+Admin panel (this machine only) at http://127.0.0.1:8766/
 Hand out access with: scpi-web invite <name>
 ```
 
-The URL is the address you bound to, with one adjustment: a wildcard bind
+The first URL is the address you bound to, with one adjustment: a wildcard bind
 (`--host 0.0.0.0`) prints this machine's LAN address, because `0.0.0.0` is not
 something a colleague can open. A concrete `--host` is used verbatim, and
 loopback stays loopback. The gateway also records this URL in `gateway.json`
 under its config directory, which is how `invite` (below) knows what link to
 print.
 
-The **very first** start is different: with no tokens on disk there is nobody
-to invite you, so the gateway mints a token named `default` and prints a URL
-carrying it:
+The second is the [admin panel](admin-panel.md) — a screen for managing who has
+access, served on a **loopback-bound** listener so it is reachable only from the
+gateway machine itself. Start with `--no-admin` to leave it off entirely.
+
+### The very first start
+
+With no tokens on disk there is nobody to invite you, so the gateway sends you
+to the panel to name yourself:
 
 ```console
 $ scpi-web
 
-Gateway ready. Open:
-
-    http://127.0.0.1:8765/?token=scpi_Qy8…f3A
+Gateway ready at http://127.0.0.1:8765/
+No one has access yet — finish setup at http://127.0.0.1:8766/
 ```
 
-Open that URL. The web UI lifts the token out of the address bar, stores it in
-the browser, and immediately strips it from the URL — so it does not linger in
-your history or leak through the `Referer` header of any link you click. From
-then on the UI sends the token automatically.
+It also tries to open that address in the host's browser. Invite yourself, open
+the link the panel gives you, and you have an identity under your own name.
 
-That `?token=` bootstrap happens only while the token store is empty. Once it
-holds anything, every start prints the plain banner above instead.
+Nothing is minted for you. **There is no auto-created `default` identity and no
+`?token=…` bootstrap URL** — a placeholder identity would end up owning real
+instrument sessions, which makes "who is driving this scope?" unanswerable at
+exactly the moment it matters.
+
+If you started with `--no-admin` there is no panel to send you to, so the
+gateway tells you the other way in instead:
+
+```console
+$ scpi-web --no-admin
+
+Gateway ready at http://127.0.0.1:8765/
+No one has access yet, and the admin panel is disabled (--no-admin).
+Create the first identity with: scpi-web invite <name>
+```
+
+That is the headless and containerised path: run `scpi-web invite <name>` once
+against the same `--config-dir`.
 
 ## Inviting someone
 
-Nobody in the lab should ever have to handle a `scpi_…` string. To give a
-colleague access, run one command on the gateway host:
+Nobody in the lab should ever have to handle a `scpi_…` string. The
+[admin panel](admin-panel.md) does this from a screen — and is the only way to
+*cancel* an invitation you should not have sent. From a terminal, it is one
+command on the gateway host:
 
 ```console
 $ scpi-web invite bob
@@ -86,6 +113,9 @@ sessions from then on.
 - The invitation lives **ten minutes**. That is deliberate: a link pasted into
   a chat channel is worthless long before anyone scrolls back to it.
 - It is good for **one** person. Two colleagues, two `invite` commands.
+- Sent to the wrong person, or with a typo in the name? **Cancel it** in the
+  [admin panel](admin-panel.md). The CLI has no cancel, so from a terminal the
+  only remedy is waiting the ten minutes out.
 - Someone locked out — new laptop, cleared browser, no idea where the token
   went — is the same command again: `scpi-web invite bob`. Their existing
   tokens keep working alongside the new one. If they should not, run
@@ -373,6 +403,7 @@ directory, when you run the command explicitly.
 | Concern | Guidance |
 |---|---|
 | **Bind address** | Defaults to `127.0.0.1` (local only). Use `--host 0.0.0.0` to reach it from the LAN — and only then does the token boundary matter. |
+| **Admin panel** | Always on `127.0.0.1`, whatever `--host` says, and there is deliberately no `--admin-host`. It is unauthenticated, so a non-loopback bind would put access management on the LAN. Reach it from elsewhere with an SSH port-forward, or disable it with `--no-admin`. |
 | **TLS / encryption** | Out of scope for the gateway. Traffic (including the bearer token) is unencrypted. Put the gateway behind a TLS-terminating reverse proxy, or keep it on a trusted network. |
 | **Tokens in transit** | Because traffic is unencrypted, a token on an untrusted network can be captured. This is the main reason TLS-via-proxy is recommended for any non-loopback exposure. |
 | **Token storage** | `~/.siglent/tokens.json`, hashed, written `0600` where the platform supports it. Anyone who can read the *raw* tokens (e.g. from your shell history) can act as you — treat them like passwords. |
@@ -395,6 +426,8 @@ directory, when you run the command explicitly.
 |---|---|---|
 | `--host` | `127.0.0.1` | Bind address; `0.0.0.0` exposes on the LAN |
 | `--port` | `8765` | Listen port |
+| `--admin-port` | `8766` | Port for the host-only [admin panel](admin-panel.md) (must differ from `--port`) |
+| `--no-admin` | *(off)* | Do not start the admin panel listener |
 | `--config-dir` | `~/.siglent` | Where `tokens.json`, `gateway.json` and `invitations.json` live |
 | `--allow-port <n>` | `{5025}` | Extra instrument port(s) the gateway may connect to (repeatable) |
 | `--max-sessions` | `8` | Concurrent instrument-session cap |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -22,12 +22,13 @@ First, install the library:
     scpi-web
     `
 
-    The gateway prints its URL every time it starts; on the very first run
-    that URL carries an access token
-    (`http://127.0.0.1:8765/?token=…`) — open it in your browser. To let a
-    colleague in, run `scpi-web invite <their name>`: it prints a link and a
-    six-digit code, either of which signs them in, both good for ten minutes.
-    See the [Gateway security guide](../gateway/security.md) for details.
+    The gateway prints its URL every time it starts. On the very first run it
+    also opens an [admin panel](../gateway/admin-panel.md) on this machine
+    (`http://127.0.0.1:8766/`) so you can name yourself: type your name, press
+    **Invite**, and open the link it gives you. To let a colleague in, invite
+    them from the same screen or run `scpi-web invite <their name>` — either
+    prints a link and a six-digit code, both good for ten minutes. See the
+    [Gateway security guide](../gateway/security.md) for details.
 
 === "Everything"
 `bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
   - Web Gateway:
       - Overview: gateway/index.md
       - Security: gateway/security.md
+      - Admin Panel: gateway/admin-panel.md
       - Browser UI Tour: gateway/browser-ui.md
       - REST & WebSocket API: gateway/api.md
   - GUI Application:

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -1,16 +1,71 @@
 """Lab gateway entry point: python -m scpi_control.server / scpi-web."""
 
 import argparse
+import asyncio
+import contextlib
+import ipaddress
 import sys
 from pathlib import Path
 
 import uvicorn
 
+from scpi_control.server.admin.app import create_admin_app
 from scpi_control.server.app import create_app
 from scpi_control.server.auth import DEFAULT_CONFIG_DIR, TokenStore
 from scpi_control.server.gateway_url import read_base_url, write_base_url
 from scpi_control.server.invitations import InvitationStore, format_code
 from scpi_control.server.netpolicy import DEFAULT_ALLOWED_PORTS
+
+# The host-only boundary. Not a flag, and deliberately so: the admin app has no
+# authentication because the OS refuses non-local connections before it runs.
+# A configurable host would turn that guarantee into a footgun.
+ADMIN_HOST = "127.0.0.1"
+DEFAULT_ADMIN_PORT = 8766
+
+
+class _QuietServer(uvicorn.Server):
+    """A server that leaves signal handling to the main one.
+
+    Two uvicorn servers on one loop would otherwise both capture SIGINT, and
+    the second registration wins -- so Ctrl+C would stop one server while the
+    other kept the process alive. uvicorn 0.34.3 captures signals through this
+    context manager rather than install_signal_handlers().
+    """
+
+    @contextlib.contextmanager
+    def capture_signals(self):
+        yield
+
+
+def _run_servers(main_app, host: str, port: int, admin_app, admin_port: int) -> None:
+    """Serve the gateway, and the admin app when there is one.
+
+    Both run on one event loop in one process so they can share the token
+    store, the invitation store and the session manager as live objects.
+
+    Only the main server installs signal handlers -- it uses a plain
+    uvicorn.Server, while the admin server uses _QuietServer so its
+    capture_signals() is a no-op. The main server's shutdown sets should_exit
+    on the admin server too, so Ctrl+C stops both.
+    """
+    main_server = uvicorn.Server(uvicorn.Config(main_app, host=host, port=port))
+    if admin_app is None:
+        main_server.run()
+        return
+
+    assert ipaddress.ip_address(ADMIN_HOST).is_loopback, "the admin listener must bind a loopback address"
+    admin_config = uvicorn.Config(admin_app, host=ADMIN_HOST, port=admin_port)
+    admin_server = _QuietServer(admin_config)
+
+    async def _serve_both() -> None:
+        admin_task = asyncio.ensure_future(admin_server.serve())
+        try:
+            await main_server.serve()
+        finally:
+            admin_server.should_exit = True
+            await admin_task
+
+    asyncio.run(_serve_both())
 
 
 def _config_dir(args) -> Path:
@@ -44,6 +99,8 @@ def main(argv=None) -> None:
     parser = argparse.ArgumentParser(prog="scpi-web", description="SCPI Instrument Control web gateway")
     parser.add_argument("--host", default="127.0.0.1", help="bind address (use 0.0.0.0 to expose on the LAN)")
     parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--admin-port", type=int, default=DEFAULT_ADMIN_PORT, help="port for the host-only admin panel (default: 8766)")
+    parser.add_argument("--no-admin", action="store_true", help="do not start the admin panel listener")
     parser.add_argument("--abandon-after", type=float, default=300.0, help="seconds of owner inactivity before another user may claim a session")
     # Registered ONLY on the top-level parser -- see _add_config_dir's docstring
     # for why the same option on a subparser (default=None) would clobber a
@@ -155,11 +212,9 @@ def main(argv=None) -> None:
     else:
         print("\nGateway ready at {0}\nHand out access with: scpi-web invite <name>\n".format(url))
     allowed_ports = frozenset(args.allow_port) | DEFAULT_ALLOWED_PORTS if args.allow_port else None
-    uvicorn.run(
-        create_app(token_store=store, invitation_store=invitations, abandon_after=args.abandon_after, allowed_ports=allowed_ports, max_sessions=args.max_sessions),
-        host=args.host,
-        port=args.port,
-    )
+    main_app = create_app(token_store=store, invitation_store=invitations, abandon_after=args.abandon_after, allowed_ports=allowed_ports, max_sessions=args.max_sessions)
+    admin_app = None if args.no_admin else create_admin_app(token_store=store, invitation_store=invitations, base_url=url)
+    _run_servers(main_app, args.host, args.port, admin_app, args.admin_port)
 
 
 if __name__ == "__main__":

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -65,6 +65,13 @@ def _run_servers(main_app, host: str, port: int, admin_app, admin_port: int) -> 
             admin_server.should_exit = True
             await admin_task
 
+    # Server.run() calls this for the single-server (--no-admin) path above;
+    # asyncio.run() alone skips it, so without this line the default path
+    # (both servers) would silently run on a different event loop
+    # implementation than --no-admin -- uvloop is the installed default on
+    # Linux/macOS with uvicorn[standard], so --no-admin would get uvloop while
+    # the normal path got the stdlib loop.
+    main_server.config.setup_event_loop()
     asyncio.run(_serve_both())
 
 
@@ -193,6 +200,12 @@ def main(argv=None) -> None:
     # a clear message and exits before any of that happens.
     if args.max_sessions < 1:
         parser.error("--max-sessions must be at least 1 (got {0})".format(args.max_sessions))
+
+    # Same reasoning as --max-sessions above: without this check, --port and
+    # --admin-port colliding fails deep inside uvicorn's socket bind with a
+    # bare traceback instead of a sentence explaining the mistake.
+    if not args.no_admin and args.port == args.admin_port:
+        parser.error("--port and --admin-port must differ (both are {0})".format(args.port))
 
     store = _store(args)
     # Built here, not inline in the create_app(...) call below, for the same

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -75,6 +75,21 @@ def _run_servers(main_app, host: str, port: int, admin_app, admin_port: int) -> 
     asyncio.run(_serve_both())
 
 
+def _open_browser(url: str) -> bool:
+    """Open ``url`` in the host's browser. False if that was not possible.
+
+    Never raises: a headless box, an SSH session or a machine with no
+    associated browser must still start a gateway. The caller prints the URL
+    either way.
+    """
+    import webbrowser
+
+    try:
+        return bool(webbrowser.open(url))
+    except Exception:
+        return False
+
+
 def _config_dir(args) -> Path:
     return Path(args.config_dir) if args.config_dir else DEFAULT_CONFIG_DIR
 
@@ -219,11 +234,23 @@ def main(argv=None) -> None:
     except ValueError as exc:
         sys.exit(str(exc))
     url = write_base_url(_config_dir(args), args.host, args.port)
+    admin_url = "http://{0}:{1}/".format(ADMIN_HOST, args.admin_port)
     if store.is_empty():
-        raw = store.mint("default")
-        print("\nGateway ready. Open:\n\n    {0}?token={1}\n".format(url, raw))
-    else:
+        if args.no_admin:
+            print("\nGateway ready at {0}\nNo one has access yet, and the admin panel is disabled (--no-admin).\nCreate the first identity with: scpi-web invite <name>\n".format(url))
+        else:
+            print("\nGateway ready at {0}\nNo one has access yet — finish setup at {1}\n".format(url, admin_url))
+            try:
+                _open_browser(admin_url)
+            except Exception:
+                # _open_browser already swallows what it can; this is the
+                # belt-and-braces guard that a browser problem can never stop a
+                # gateway starting.
+                pass
+    elif args.no_admin:
         print("\nGateway ready at {0}\nHand out access with: scpi-web invite <name>\n".format(url))
+    else:
+        print("\nGateway ready at {0}\nAdmin panel (this machine only) at {1}\nHand out access with: scpi-web invite <name>\n".format(url, admin_url))
     allowed_ports = frozenset(args.allow_port) | DEFAULT_ALLOWED_PORTS if args.allow_port else None
     main_app = create_app(token_store=store, invitation_store=invitations, abandon_after=args.abandon_after, allowed_ports=allowed_ports, max_sessions=args.max_sessions)
     admin_app = None if args.no_admin else create_admin_app(token_store=store, invitation_store=invitations, base_url=url)

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -59,22 +59,33 @@ def _run_servers(main_app, host: str, port: int, admin_app, admin_port: int) -> 
     admin_config = uvicorn.Config(admin_app, host=ADMIN_HOST, port=admin_port)
     admin_server = _QuietServer(admin_config)
 
-    async def _serve_both() -> None:
+    main_serve = main_server.serve
+
+    async def _serve_both(sockets=None) -> None:
         admin_task = asyncio.ensure_future(admin_server.serve())
         try:
-            await main_server.serve()
+            await main_serve(sockets=sockets)
         finally:
             admin_server.should_exit = True
             await admin_task
 
-    # Server.run() calls this for the single-server (--no-admin) path above;
-    # asyncio.run() alone skips it, so without this line the default path
-    # (both servers) would silently run on a different event loop
-    # implementation than --no-admin -- uvloop is the installed default on
-    # Linux/macOS with uvicorn[standard], so --no-admin would get uvloop while
-    # the normal path got the stdlib loop.
-    main_server.config.setup_event_loop()
-    asyncio.run(_serve_both())
+    # Both listeners are driven by the main server's own run(), rather than by
+    # an asyncio.run() call here, because run() is what picks the event loop
+    # implementation -- and it has done that through two incompatible private
+    # Config APIs: setup_event_loop() up to uvicorn 0.35, a loop_factory handed
+    # to asyncio.run from 0.36, where the old name became a method that raises
+    # AttributeError on sight. Naming either one here would pin this module to
+    # a slice of the uvicorn range pyproject.toml declares. Letting run() do it
+    # means the two-server path gets exactly the loop the --no-admin path above
+    # gets (uvloop by default on Linux/macOS with uvicorn[standard]) on every
+    # version, with no version sniffing at all.
+    #
+    # Swapping serve() on the instance is how the pair reaches run(): run()
+    # awaits self.serve(sockets=sockets), so _serve_both stands in for it and
+    # calls the real one via main_serve, captured above. capture_signals() still
+    # wraps only the main server, inside main_serve, exactly as before.
+    main_server.serve = _serve_both
+    main_server.run()
 
 
 def _open_browser(url: str) -> bool:

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import uvicorn
 
-from scpi_control.server.admin.app import create_admin_app
+from scpi_control.server.admin.app import DEFAULT_ADMIN_PORT, create_admin_app
 from scpi_control.server.app import create_app
 from scpi_control.server.auth import DEFAULT_CONFIG_DIR, TokenStore
 from scpi_control.server.gateway_url import read_base_url, write_base_url
@@ -19,8 +19,10 @@ from scpi_control.server.netpolicy import DEFAULT_ALLOWED_PORTS
 # The host-only boundary. Not a flag, and deliberately so: the admin app has no
 # authentication because the OS refuses non-local connections before it runs.
 # A configurable host would turn that guarantee into a footgun.
+# DEFAULT_ADMIN_PORT lives in admin/app.py, not here: the app itself needs it
+# to build the Origin allowlist, and two copies could drift apart into a panel
+# that refuses its own requests.
 ADMIN_HOST = "127.0.0.1"
-DEFAULT_ADMIN_PORT = 8766
 
 
 class _QuietServer(uvicorn.Server):
@@ -253,7 +255,7 @@ def main(argv=None) -> None:
         print("\nGateway ready at {0}\nAdmin panel (this machine only) at {1}\nHand out access with: scpi-web invite <name>\n".format(url, admin_url))
     allowed_ports = frozenset(args.allow_port) | DEFAULT_ALLOWED_PORTS if args.allow_port else None
     main_app = create_app(token_store=store, invitation_store=invitations, abandon_after=args.abandon_after, allowed_ports=allowed_ports, max_sessions=args.max_sessions)
-    admin_app = None if args.no_admin else create_admin_app(token_store=store, invitation_store=invitations, base_url=url)
+    admin_app = None if args.no_admin else create_admin_app(token_store=store, invitation_store=invitations, base_url=url, admin_port=args.admin_port)
     _run_servers(main_app, args.host, args.port, admin_app, args.admin_port)
 
 

--- a/scpi_control/server/admin/api.py
+++ b/scpi_control/server/admin/api.py
@@ -1,0 +1,65 @@
+"""Admin routes. Unauthenticated by design -- see admin/app.py."""
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class InvitationCreate(BaseModel):
+    name: str
+
+
+def _row(entry, link: Optional[str] = None) -> dict:
+    row = {"id": entry["id"], "name": entry["name"], "code": entry["code"], "expires": entry["expires"]}
+    if link is not None:
+        row["link"] = link
+    return row
+
+
+@router.get("/identities")
+async def list_identities(request: Request):
+    return request.app.state.tokens.summary()
+
+
+@router.delete("/identities/{name}", status_code=204)
+async def revoke_identity(name: str, request: Request):
+    if not request.app.state.tokens.revoke(name):
+        raise HTTPException(status_code=404, detail="no identity named {0!r}".format(name))
+    return None
+
+
+@router.get("/invitations")
+async def list_invitations(request: Request):
+    """Live invitations. No link: only the nonce's hash is stored, so a link
+    cannot be reconstructed after creation -- by design. The code is enough to
+    read down a phone, which is what this listing is for."""
+    return [_row(entry) for entry in request.app.state.invitations.pending_list()]
+
+
+@router.post("/invitations")
+async def create_invitation(body: InvitationCreate, request: Request):
+    invitations = request.app.state.invitations
+    # Identify the new row by which id appeared, not by matching on the code.
+    # create() returns (link, code) and not the id, and codes are not checked
+    # for collisions -- two live invitations can share one, in which case
+    # matching by code would attach this link to somebody else's invitation and
+    # hand the caller a credential for the wrong identity. Ids are unique.
+    before = {row["id"] for row in invitations.pending_list()}
+    try:
+        link_nonce, _code = invitations.create(body.name)
+    except ValueError as exc:
+        # An empty or whitespace-only name; mirrors TokenStore.mint's guard.
+        raise HTTPException(status_code=400, detail=str(exc))
+    entry = next(row for row in invitations.pending_list() if row["id"] not in before)
+    base = request.app.state.base_url or "http://127.0.0.1:8765/"
+    return _row(entry, link="{0}?invite={1}".format(base, link_nonce))
+
+
+@router.delete("/invitations/{invitation_id}", status_code=204)
+async def cancel_invitation(invitation_id: str, request: Request):
+    if not request.app.state.invitations.cancel(invitation_id):
+        raise HTTPException(status_code=404, detail="no invitation with that id")
+    return None

--- a/scpi_control/server/admin/app.py
+++ b/scpi_control/server/admin/app.py
@@ -1,24 +1,35 @@
 """The host-only admin app.
 
-This app has no authentication. Two independent things stand in for it, and
-they defend against two different attackers -- neither one is sufficient
-alone:
+This app has no authentication. Three independent things stand in for it, and
+each one covers an attacker the others miss -- none is sufficient alone:
 
 1. It is served on a listener bound to 127.0.0.1, so the operating system
    refuses every non-local *socket* before any of this code runs. Physical
-   access to the gateway machine is the credential.
+   access to the gateway machine is the credential. This stops the LAN and
+   nothing else: a browser on the gateway machine sails straight through it.
 2. TrustedHostMiddleware, below, refuses every request whose Host header is
-   not 127.0.0.1 or localhost. This is what stops a *browser*: a page open
-   on the gateway machine can rebind its own hostname to 127.0.0.1 (DNS
-   rebinding) and become same-origin with this app despite never having a
-   real loopback address of its own. The loopback bind does nothing against
-   that -- the connection really does arrive on 127.0.0.1 -- so without this
-   middleware that page could mint or revoke access with no credential at
-   all. CORS preflight does not help either: rebinding defeats it by
-   construction.
+   not 127.0.0.1 or localhost. This is what stops DNS rebinding: a page open
+   on the gateway machine can point its own hostname at 127.0.0.1 and become
+   same-origin with this app despite never having a real loopback address of
+   its own. The connection really does arrive on 127.0.0.1, so the bind waves
+   it through -- but the request still carries the attacker's hostname, and
+   this check refuses it.
+3. _SameOriginOnlyMiddleware, below, refuses every request carrying an Origin
+   header that is not this panel's own. This is what stops the *plain*
+   cross-origin request, which needs no rebinding at all: a page on any site
+   the admin visits can `fetch("http://127.0.0.1:8766/api/invitations", ...)`
+   and satisfy both defences above -- the socket is genuinely local and the
+   Host genuinely is 127.0.0.1:8766. Only the Origin gives it away. Without
+   this, the sole thing refusing that request is the browser's own CORS
+   preflight plus FastAPI's insistence on application/json, which is a real
+   defence but an accidental one: it would evaporate the day someone accepts
+   a form body, adds a mutating GET, or installs CORSMiddleware to quiet a
+   dev proxy. Requests with no Origin at all (curl, same-origin fetches in
+   browsers that omit it) are allowed -- an Origin is what a cross-origin
+   request is obliged to carry.
 
 Two rules follow from the bind, and breaking either one silently exposes the
-whole surface to the LAN regardless of the Host check above:
+whole surface to the LAN regardless of the checks above:
 
 1. **Never mount this app under the main app**, and never share its router.
    The main app is reachable from the network; this one must not be.
@@ -29,7 +40,7 @@ whole surface to the LAN regardless of the Host check above:
 """
 
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, List, Optional
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse, JSONResponse
@@ -39,9 +50,50 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from scpi_control.server.spa import resolve_spa_path
 
 ADMIN_STATIC_DIR = Path(__file__).parent / "static"
+DEFAULT_ADMIN_PORT = 8766
 
 
-def create_admin_app(token_store, invitation_store, base_url: Optional[str] = None) -> FastAPI:
+def admin_origins(admin_port: int) -> List[str]:
+    """The only Origins the panel may be called from -- itself, by either name.
+
+    Both spellings appear in practice: the printed banner and the auto-opened
+    browser use 127.0.0.1, while an SSH port-forward (documented in
+    docs/gateway/admin-panel.md) reaches it as localhost. TrustedHostMiddleware
+    allows exactly these two hostnames, so this list mirrors it.
+    """
+    return ["http://127.0.0.1:{0}".format(admin_port), "http://localhost:{0}".format(admin_port)]
+
+
+class _SameOriginOnlyMiddleware:
+    """Refuse any request whose Origin is not the panel's own.
+
+    Pure ASGI rather than BaseHTTPMiddleware so the refusal is decided before
+    any body is read, and so nothing downstream -- including the exception
+    handlers, which sit inside the user middleware stack -- can turn it into
+    something else. See the module docstring for the attacker this covers.
+    """
+
+    def __init__(self, app, allowed_origins: Iterable[str]) -> None:
+        self.app = app
+        self.allowed_origins = frozenset(allowed_origins)
+
+    async def __call__(self, scope, receive, send):
+        # Only HTTP: this app serves no websockets, and a websocket to an
+        # unknown path is refused by the router regardless.
+        if scope["type"] == "http":
+            origin = None
+            for name, value in scope["headers"]:
+                if name == b"origin":
+                    origin = value.decode("latin-1")
+                    break
+            if origin is not None and origin not in self.allowed_origins:
+                response = JSONResponse(status_code=403, content={"error": "HTTPException", "detail": "cross-origin request refused"})
+                await response(scope, receive, send)
+                return
+        await self.app(scope, receive, send)
+
+
+def create_admin_app(token_store, invitation_store, base_url: Optional[str] = None, admin_port: int = DEFAULT_ADMIN_PORT) -> FastAPI:
     app = FastAPI(title="SCPI Gateway Admin", docs_url=None, redoc_url=None, openapi_url=None)
     app.state.tokens = token_store
     app.state.invitations = invitation_store
@@ -63,9 +115,10 @@ def create_admin_app(token_store, invitation_store, base_url: Optional[str] = No
                 raise HTTPException(status_code=404, detail="unknown path /{0}".format(full_path))
             return FileResponse(str(resolve_spa_path(ADMIN_STATIC_DIR, full_path)))
 
-    # The second, independent defence described in the module docstring --
-    # see there for why the loopback bind alone is not enough. Added last so
-    # it wraps everything above, including the SPA route.
+    # The second and third independent defences described in the module
+    # docstring -- see there for why the loopback bind alone is not enough.
+    # Added last so they wrap everything above, including the SPA route.
+    app.add_middleware(_SameOriginOnlyMiddleware, allowed_origins=admin_origins(admin_port))
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=["127.0.0.1", "localhost"])
 
     return app

--- a/scpi_control/server/admin/app.py
+++ b/scpi_control/server/admin/app.py
@@ -1,0 +1,58 @@
+"""The host-only admin app.
+
+This app has no authentication, and that is the design rather than an
+oversight. It is served on a listener bound to 127.0.0.1, so the operating
+system refuses every non-local connection before any of this code runs.
+Physical access to the gateway machine is the credential.
+
+Two rules follow, and breaking either one silently exposes the whole surface
+to the LAN:
+
+1. **Never mount this app under the main app**, and never share its router.
+   The main app is reachable from the network; this one must not be.
+2. **Never serve this app's static bundle from the main app's static
+   directory.** The main app's SPA catch-all serves any real file it finds
+   there, so a shared directory would hand the admin UI to every LAN browser.
+   That is why the bundle lives in its own directory.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse, JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+ADMIN_STATIC_DIR = Path(__file__).parent / "static"
+
+
+def create_admin_app(token_store, invitation_store, base_url: Optional[str] = None) -> FastAPI:
+    app = FastAPI(title="SCPI Gateway Admin", docs_url=None, redoc_url=None, openapi_url=None)
+    app.state.tokens = token_store
+    app.state.invitations = invitation_store
+    app.state.base_url = base_url
+
+    from scpi_control.server.admin import api as admin_api
+
+    app.include_router(admin_api.router, prefix="/api")
+
+    @app.exception_handler(StarletteHTTPException)
+    async def _http_error(request, exc):
+        return JSONResponse(status_code=exc.status_code, content={"error": "HTTPException", "detail": exc.detail}, headers=getattr(exc, "headers", None))
+
+    if ADMIN_STATIC_DIR.is_dir():
+        index_file = ADMIN_STATIC_DIR / "index.html"
+        static_root = ADMIN_STATIC_DIR.resolve()
+
+        @app.get("/{full_path:path}", include_in_schema=False)
+        async def spa(full_path: str):
+            if full_path.startswith("api/"):
+                raise HTTPException(status_code=404, detail="unknown path /{0}".format(full_path))
+            candidate = (ADMIN_STATIC_DIR / full_path).resolve()
+            # Same traversal guard as the main app: only serve the resolved
+            # candidate if it is still inside the static root.
+            if full_path and candidate.is_file() and candidate.is_relative_to(static_root):
+                return FileResponse(str(candidate))
+            return FileResponse(str(index_file))
+
+    return app

--- a/scpi_control/server/admin/app.py
+++ b/scpi_control/server/admin/app.py
@@ -1,12 +1,24 @@
 """The host-only admin app.
 
-This app has no authentication, and that is the design rather than an
-oversight. It is served on a listener bound to 127.0.0.1, so the operating
-system refuses every non-local connection before any of this code runs.
-Physical access to the gateway machine is the credential.
+This app has no authentication. Two independent things stand in for it, and
+they defend against two different attackers -- neither one is sufficient
+alone:
 
-Two rules follow, and breaking either one silently exposes the whole surface
-to the LAN:
+1. It is served on a listener bound to 127.0.0.1, so the operating system
+   refuses every non-local *socket* before any of this code runs. Physical
+   access to the gateway machine is the credential.
+2. TrustedHostMiddleware, below, refuses every request whose Host header is
+   not 127.0.0.1 or localhost. This is what stops a *browser*: a page open
+   on the gateway machine can rebind its own hostname to 127.0.0.1 (DNS
+   rebinding) and become same-origin with this app despite never having a
+   real loopback address of its own. The loopback bind does nothing against
+   that -- the connection really does arrive on 127.0.0.1 -- so without this
+   middleware that page could mint or revoke access with no credential at
+   all. CORS preflight does not help either: rebinding defeats it by
+   construction.
+
+Two rules follow from the bind, and breaking either one silently exposes the
+whole surface to the LAN regardless of the Host check above:
 
 1. **Never mount this app under the main app**, and never share its router.
    The main app is reachable from the network; this one must not be.
@@ -22,6 +34,9 @@ from typing import Optional
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse, JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.middleware.trustedhost import TrustedHostMiddleware
+
+from scpi_control.server.spa import resolve_spa_path
 
 ADMIN_STATIC_DIR = Path(__file__).parent / "static"
 
@@ -41,18 +56,16 @@ def create_admin_app(token_store, invitation_store, base_url: Optional[str] = No
         return JSONResponse(status_code=exc.status_code, content={"error": "HTTPException", "detail": exc.detail}, headers=getattr(exc, "headers", None))
 
     if ADMIN_STATIC_DIR.is_dir():
-        index_file = ADMIN_STATIC_DIR / "index.html"
-        static_root = ADMIN_STATIC_DIR.resolve()
 
         @app.get("/{full_path:path}", include_in_schema=False)
         async def spa(full_path: str):
             if full_path.startswith("api/"):
                 raise HTTPException(status_code=404, detail="unknown path /{0}".format(full_path))
-            candidate = (ADMIN_STATIC_DIR / full_path).resolve()
-            # Same traversal guard as the main app: only serve the resolved
-            # candidate if it is still inside the static root.
-            if full_path and candidate.is_file() and candidate.is_relative_to(static_root):
-                return FileResponse(str(candidate))
-            return FileResponse(str(index_file))
+            return FileResponse(str(resolve_spa_path(ADMIN_STATIC_DIR, full_path)))
+
+    # The second, independent defence described in the module docstring --
+    # see there for why the loopback bind alone is not enough. Added last so
+    # it wraps everything above, including the SPA route.
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=["127.0.0.1", "localhost"])
 
     return app

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -14,6 +14,7 @@ from scpi_control.server.api.join import FailureLimiter
 from scpi_control.server.auth import AuthMiddleware, TokenStore
 from scpi_control.server.invitations import InvitationStore
 from scpi_control.server.sessions import SessionError, SessionManager
+from scpi_control.server.spa import resolve_spa_path
 
 STATIC_DIR = Path(__file__).parent / "static"
 
@@ -125,22 +126,16 @@ def create_app(
         return JSONResponse(status_code=exc.status_code, content={"error": "HTTPException", "detail": exc.detail}, headers=getattr(exc, "headers", None))
 
     if STATIC_DIR.is_dir():
-        index_file = STATIC_DIR / "index.html"
-        static_root = STATIC_DIR.resolve()
-
         # Catch-all GET, registered LAST so every API route wins. Serves a real
         # file when one exists (JS/CSS/assets), otherwise index.html so client
         # routes deep-link. /api/* keeps the JSON {error, detail} 404 shape.
+        # The traversal-safe lookup itself lives in server/spa.py, shared with
+        # the admin app -- see that module's docstring for why.
         @app.get("/{full_path:path}", include_in_schema=False)
         async def spa(full_path: str):
             if full_path.startswith("api/"):
                 raise HTTPException(status_code=404, detail="unknown path /{0}".format(full_path))
-            candidate = (STATIC_DIR / full_path).resolve()
-            # Guard against path traversal (e.g. "%2e%2e/secret.txt") escaping
-            # STATIC_DIR: only serve the resolved candidate if it's still inside.
-            if full_path and candidate.is_file() and candidate.is_relative_to(static_root):
-                return FileResponse(str(candidate))
-            return FileResponse(str(index_file))
+            return FileResponse(str(resolve_spa_path(STATIC_DIR, full_path)))
 
     # Added last so it wraps everything above, including the SPA catch-all: pure
     # ASGI middleware (not BaseHTTPMiddleware) so it also guards WebSocket scopes.

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -197,6 +197,11 @@ class TokenStore:
         return None
 
     def revoke(self, name: str) -> bool:
+        # Without this, a stale in-memory snapshot gets rewritten verbatim
+        # (minus `name`) over whatever another process wrote in the
+        # meantime -- silently resurrecting names this process already
+        # thinks are gone, or erasing tokens it never even saw minted.
+        self._reload_if_changed()
         remaining = [entry for entry in self._tokens if entry["name"] != name]
         if len(remaining) == len(self._tokens):
             return False
@@ -214,6 +219,7 @@ class TokenStore:
         last_used is best-effort: verify() updates it in memory only, so it
         reflects this process's view and resets when the store reloads.
         """
+        self._reload_if_changed()
         rows: Dict[str, Dict[str, Any]] = {}
         for entry in self._tokens:
             name = str(entry["name"])

--- a/scpi_control/server/invitations.py
+++ b/scpi_control/server/invitations.py
@@ -79,7 +79,19 @@ class InvitationStore:
             # would be less dangerous than silently discarding tokens, but
             # the surprise -- "I sent Bob a link and it just did not work" --
             # is exactly the failure this whole feature exists to remove.
-            raise ValueError("invitation store {0} is unreadable: {1}".format(self.path, exc))
+            #
+            # Unlike a genuinely corrupt file, an unreadable-but-parseable
+            # file (e.g. one written before the "id" field existed) has an
+            # easy way out, and the operator should not have to guess it:
+            # nothing in here outlives ten minutes, so the file can simply be
+            # deleted and the gateway restarted -- any invitation that was
+            # still pending just needs reissuing.
+            raise ValueError(
+                "invitation store {0} is unreadable: {1}. If this file predates "
+                "an upgrade, it is safe to delete: invitations expire in minutes, "
+                "so nothing in it outlives a restart -- reissue any that were still "
+                "pending.".format(self.path, exc)
+            )
         self._invitations = invitations
         self._stat = stat
 

--- a/scpi_control/server/invitations.py
+++ b/scpi_control/server/invitations.py
@@ -53,7 +53,7 @@ def _normalize_code(value: str) -> str:
 
 
 class InvitationStore:
-    """Pending invitations persisted as {name, link_hash, code, expires}."""
+    """Pending invitations persisted as {id, name, link_hash, code, expires}."""
 
     def __init__(self, path: Optional[str] = None) -> None:
         self.path = Path(path) if path is not None else DEFAULT_CONFIG_DIR / "invitations.json"
@@ -97,6 +97,8 @@ class InvitationStore:
                 raise ValueError('each invitation must have string "name", "link_hash" and "code" keys')
             if not isinstance(entry.get("expires"), (int, float)):
                 raise ValueError('each invitation must have a numeric "expires" key')
+            if not isinstance(entry.get("id"), str):
+                raise ValueError('each invitation must have a string "id" key')
         return entries
 
     def _reload_if_changed(self) -> None:
@@ -125,7 +127,7 @@ class InvitationStore:
         link = secrets.token_urlsafe(32)
         code = "{0:0{1}d}".format(secrets.randbelow(10**CODE_DIGITS), CODE_DIGITS)
         self._prune()
-        self._invitations.append({"name": name, "link_hash": _hash(link), "code": code, "expires": time.time() + ttl})
+        self._invitations.append({"id": secrets.token_hex(4), "name": name, "link_hash": _hash(link), "code": code, "expires": time.time() + ttl})
         self._save()
         return link, code
 
@@ -156,3 +158,35 @@ class InvitationStore:
         self._reload_if_changed()
         self._prune()
         return len(self._invitations)
+
+    def pending_list(self) -> List[Dict[str, Any]]:
+        """Live invitations, soonest to expire first.
+
+        Includes the code. That is safe here and nowhere else: the code is
+        stored in clear (see the module docstring), the file is 0600, and the
+        only consumer is the host-only admin panel. It is what lets the panel
+        re-show an invitation you closed the window on -- the CLI prints once
+        and forgets, so today the only remedy for a lost code is waiting ten
+        minutes.
+        """
+        self._reload_if_changed()
+        self._prune()
+        rows = [{"id": str(entry["id"]), "name": str(entry["name"]), "code": str(entry["code"]), "expires": float(entry["expires"])} for entry in self._invitations]
+        return sorted(rows, key=lambda row: row["expires"])
+
+    def cancel(self, invitation_id: str) -> bool:
+        """Withdraw a pending invitation. True if one was removed.
+
+        Addressed by id rather than by code so a cancellation never puts a live
+        credential in a URL path, and therefore never puts one in the gateway's
+        access log. Name would not work either: one person can hold several
+        pending invitations.
+        """
+        self._reload_if_changed()
+        self._prune()
+        remaining = [entry for entry in self._invitations if entry["id"] != invitation_id]
+        if len(remaining) == len(self._invitations):
+            return False
+        self._invitations = remaining
+        self._save()
+        return True

--- a/scpi_control/server/spa.py
+++ b/scpi_control/server/spa.py
@@ -1,0 +1,32 @@
+"""Shared "serve a static bundle with an SPA fallback" logic.
+
+Both the main app (server/app.py) and the admin app (server/admin/app.py)
+register a catch-all GET route that serves a real static file when one
+exists, and falls back to index.html otherwise so client-side routes
+deep-link. Both need the same guard against path traversal (e.g.
+"%2e%2e/secret.txt" escaping the static directory).
+
+That guard is defined exactly once, here, specifically so the two call
+sites cannot quietly diverge. tests/test_server_spa.py exercises it through
+the main app's HTTP route; the admin app's route calls the same function, so
+the same containment logic is proven for both. Keep it that way -- copying
+this back into either app.py is how the next divergence goes unnoticed, on
+whichever app has no auth in front of it.
+"""
+
+from pathlib import Path
+
+
+def resolve_spa_path(static_dir: Path, full_path: str) -> Path:
+    """Return the file to serve at ``full_path`` under ``static_dir``.
+
+    Returns the resolved candidate if it exists as a file and stays inside
+    ``static_dir``; otherwise returns ``static_dir / "index.html"``. The
+    caller is responsible for rejecting ``/api/*`` before calling this, and
+    for wrapping the result in a FileResponse.
+    """
+    static_root = static_dir.resolve()
+    candidate = (static_dir / full_path).resolve()
+    if full_path and candidate.is_file() and candidate.is_relative_to(static_root):
+        return candidate
+    return static_dir / "index.html"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,35 @@ def _no_real_home(monkeypatch, tmp_path):
     yield fake_home
 
 
+@pytest.fixture(autouse=True)
+def _no_real_browser(monkeypatch):
+    """Never let a test pop a real browser window (or whatever a headless CI
+    runner does when asked to open one).
+
+    Per-test discipline is not enough here, the same lesson as _no_real_home
+    above: scpi_control.server.__main__._open_browser is reachable from any
+    test that calls main() against a fresh (empty) config dir -- a first-run
+    gateway opens the setup screen unless told not to. Two tests already hit
+    this by accident once that path started doing real browser I/O, each
+    stubbing it individually. This is the backstop so a third one cannot slip
+    through the same way ~/.siglent did.
+
+    Patches ``webbrowser.open`` itself, not our own ``_open_browser``
+    wrapper. ``webbrowser.open`` is the actual OS boundary -- patching it
+    also covers any future code path that reaches the stdlib directly,
+    something patching our wrapper could never do -- and it leaves
+    ``_open_browser``'s own try/except doing real work against a stubbed
+    call instead of being bypassed entirely.
+
+    This does not stop a test from asserting its own behaviour: a test can
+    still monkeypatch ``_open_browser`` directly, to capture the URL it was
+    given or to force it to raise. Fixtures run before the test body, so a
+    test's own monkeypatch.setattr on the same or a different target simply
+    layers on top of (or replaces) this one -- it is never overridden by it.
+    """
+    monkeypatch.setattr("webbrowser.open", lambda url, *args, **kwargs: True)
+
+
 @contextmanager
 def ollama_sdk(capabilities=("completion", "tools")):
     """Patch the ollama SDK class so nothing reaches the network.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures shared across the test suite."""
 
+import asyncio
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -8,6 +9,88 @@ import numpy as np
 import pytest
 
 from scpi_control.report_generator.models.report_data import WaveformData
+
+
+def _event_loop_state():
+    """(holder, loop, set_called) for this thread's current-event-loop state.
+
+    ``asyncio`` exposes no way to *read* the current loop without creating one:
+    ``asyncio.get_event_loop()`` is the only getter, and on a pristine main
+    thread it installs a brand new loop as a side effect. Snapshotting through
+    it would therefore mean creating a loop for every one of the ~2100 tests in
+    this suite, and would destroy the very pristine-ness we want to restore.
+
+    So this reads the policy's thread-local holder directly. Both attributes
+    have lived on ``asyncio.BaseDefaultEventLoopPolicy._Local`` since 3.4 and
+    are still there on 3.14; uvloop's policy subclasses it and has them too.
+    They are private, which is why ``test_the_event_loop_guard_is_in_force``
+    (tests/test_server_admin_listener.py) exists -- if a future Python moves
+    them, that test fails loudly instead of the guard silently doing nothing.
+
+    Returns ``(None, None, False)`` for an exotic policy without the holder, so
+    the guard degrades to a no-op rather than damaging state it cannot read.
+    """
+    holder = getattr(asyncio.get_event_loop_policy(), "_local", None)
+    if holder is None:
+        return None, None, False
+    return holder, getattr(holder, "_loop", None), getattr(holder, "_set_called", False)
+
+
+@contextmanager
+def preserved_event_loop_state():
+    """Restore the current-event-loop state that ``asyncio.run()`` destroys.
+
+    ``asyncio.run()`` ends with ``events.set_event_loop(None)``, which leaves
+    the policy holding ``_set_called = True`` and ``_loop = None``. In that
+    state ``asyncio.get_event_loop()`` no longer creates a loop on demand -- it
+    raises ``RuntimeError: There is no current event loop in thread
+    'MainThread'``. That is process-global, so a test calling ``asyncio.run()``
+    breaks whatever runs *next* in the same worker, not itself.
+
+    This is not hypothetical: it took down three tests in
+    tests/test_server_stream_ws.py on CI, a file nobody had touched, on Python
+    3.9 only. 3.9 caps at fastapi 0.128.8, and that older starlette stack calls
+    ``get_event_loop()`` where newer releases do not, so 3.10-3.14 stayed green
+    while the oldest supported Python failed.
+
+    Snapshot-and-restore rather than "install a fresh loop": for the vast
+    majority of tests nothing changed and the teardown is two comparisons and
+    no allocation. Nothing here creates a loop, and nothing closes one -- a
+    loop a test opened is that test's to close.
+    """
+    holder, loop, set_called = _event_loop_state()
+    try:
+        yield
+    finally:
+        if holder is not None:
+            _, now_loop, now_set_called = _event_loop_state()
+            if now_loop is not loop or now_set_called != set_called:
+                holder._loop = loop
+                holder._set_called = set_called
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_event_loop():
+    """Never let one test's ``asyncio.run()`` break the next test in the worker.
+
+    The third guard of its kind here, and for the third time because per-test
+    discipline had already failed: ``_no_real_home`` after a test minted a live
+    token into the developer's real ~/.siglent, ``_no_real_browser`` after
+    tests started opening real browser windows, and now this. Two tests on this
+    branch call ``asyncio.run()`` -- one directly, one via a real
+    ``uvicorn.Server.run()``, which *is* ``asyncio.run()`` -- and the damage
+    they do lands somewhere else entirely, on one Python version, in whichever
+    file the worker happens to pick up next. Asking the next person who writes
+    an ``asyncio.run()`` in a test to remember this is exactly the discipline
+    that has already failed twice.
+
+    Async tests are unaffected: both pytest-asyncio and anyio create and hold
+    their own loop for the test rather than adopting the ambient one, and
+    anyio's blocking portal (what starlette's TestClient uses) runs its loop in
+    a worker thread whose state this fixture never reads or writes.
+    """
+    with preserved_event_loop_state():
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_packaging_manifest.py
+++ b/tests/test_packaging_manifest.py
@@ -1,0 +1,47 @@
+"""MANIFEST.in must cover every frontend bundle the server serves.
+
+`include-package-data = true` means setuptools takes package data from
+MANIFEST.in. A static directory that exists on disk but has no rule here is
+dropped from the wheel and the sdist without any error: `make webapp-build`
+succeeds, `python -m build` succeeds, and the installed package serves a JSON
+404 where the UI should be. That is exactly what happened to the admin bundle,
+so this guard is written against directories on disk rather than a hardcoded
+list -- a future sub-project adding another surface fails here instead of
+shipping an empty one.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / "MANIFEST.in"
+SERVER = REPO_ROOT / "scpi_control" / "server"
+
+
+def _manifest_rules():
+    lines = []
+    for raw in MANIFEST.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line and not line.startswith("#"):
+            lines.append(line)
+    return lines
+
+
+def _static_dirs():
+    """Every static directory under the server package, as posix paths."""
+    found = [SERVER / "static"] if (SERVER / "static").is_dir() else []
+    found += sorted(path for path in SERVER.rglob("static") if path.is_dir() and path.parent != SERVER)
+    return [path.relative_to(REPO_ROOT).as_posix() for path in found]
+
+
+def test_every_server_static_dir_is_in_the_manifest():
+    rules = _manifest_rules()
+    missing = [directory for directory in _static_dirs() if "recursive-include {0} *".format(directory) not in rules]
+    assert not missing, "MANIFEST.in has no recursive-include for {0}; the bundle would be absent from the wheel".format(missing)
+
+
+def test_the_admin_bundle_is_named_explicitly():
+    # The regression this file exists for. _static_dirs() only sees directories
+    # that were actually built, so on a checkout with no bundles the test above
+    # passes vacuously; this one does not.
+    assert "recursive-include scpi_control/server/admin/static *" in _manifest_rules()
+    assert "recursive-include scpi_control/server/static *" in _manifest_rules()

--- a/tests/test_server_admin_api.py
+++ b/tests/test_server_admin_api.py
@@ -13,7 +13,10 @@ def admin(tmp_path):
     tokens = TokenStore(str(tmp_path / "tokens.json"))
     invitations = InvitationStore(str(tmp_path / "invitations.json"))
     app = create_admin_app(token_store=tokens, invitation_store=invitations, base_url="http://192.168.1.50:8765/")
-    with TestClient(app) as client:
+    # base_url is 127.0.0.1, not the httpx default "testserver": TrustedHostMiddleware
+    # only allows 127.0.0.1/localhost, and the Host header httpx sends is derived
+    # from base_url unless a test overrides it.
+    with TestClient(app, base_url="http://127.0.0.1") as client:
         yield client, tokens, invitations
 
 
@@ -112,3 +115,50 @@ def test_every_route_answers_without_a_token(admin):
     tokens.mint("bob")
     assert client.get("/api/identities").status_code == 200
     assert client.get("/api/invitations").status_code == 200
+
+
+def test_a_spoofed_host_header_is_rejected(admin):
+    # The loopback bind stops non-local sockets, not a browser: a page open
+    # on the gateway machine can rebind its own hostname to 127.0.0.1 and
+    # become same-origin with this unauthenticated app. TrustedHostMiddleware
+    # is the second, independent defence -- it must reject anything that does
+    # not present as this host, regardless of what socket it arrived on.
+    client, _tokens, _invitations = admin
+    response = client.get("/api/identities", headers={"Host": "evil.example"})
+    assert response.status_code == 400
+
+
+def test_localhost_and_loopback_hosts_still_work(admin):
+    client, _tokens, _invitations = admin
+    assert client.get("/api/identities", headers={"Host": "127.0.0.1"}).status_code == 200
+    assert client.get("/api/identities", headers={"Host": "localhost"}).status_code == 200
+
+
+def test_admin_spa_traversal_is_contained(tmp_path):
+    # admin/static/ does not exist yet (no bundle has been built), so the
+    # SPA route -- including its path-traversal guard -- has never actually
+    # run in this test file. Build a throwaway static dir and monkeypatch it
+    # in, mirroring tests/test_server_spa.py::test_encoded_traversal_is_contained
+    # for the main app, so the admin app's own wiring gets the same proof.
+    import scpi_control.server.admin.app as admin_app_module
+
+    secret = tmp_path / "outside" / "secret.txt"
+    secret.parent.mkdir()
+    secret.write_text("TOP SECRET", encoding="utf-8")
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "index.html").write_text("<!doctype html><title>admin</title>", encoding="utf-8")
+
+    original = admin_app_module.ADMIN_STATIC_DIR
+    admin_app_module.ADMIN_STATIC_DIR = static_dir
+    try:
+        tokens = TokenStore(str(tmp_path / "tokens.json"))
+        invitations = InvitationStore(str(tmp_path / "invitations.json"))
+        app = admin_app_module.create_admin_app(token_store=tokens, invitation_store=invitations)
+        with TestClient(app, base_url="http://127.0.0.1") as client:
+            for payload in ("/%2e%2e/outside/secret.txt", "/../outside/secret.txt", "/%2e%2e%2foutside/secret.txt"):
+                response = client.get(payload)
+                assert response.status_code in (200, 404), payload
+                assert "TOP SECRET" not in response.text, payload
+    finally:
+        admin_app_module.ADMIN_STATIC_DIR = original

--- a/tests/test_server_admin_api.py
+++ b/tests/test_server_admin_api.py
@@ -1,0 +1,114 @@
+"""The host-only admin app: routes, and the absence of auth."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scpi_control.server.admin.app import create_admin_app
+from scpi_control.server.auth import TokenStore
+from scpi_control.server.invitations import InvitationStore
+
+
+@pytest.fixture
+def admin(tmp_path):
+    tokens = TokenStore(str(tmp_path / "tokens.json"))
+    invitations = InvitationStore(str(tmp_path / "invitations.json"))
+    app = create_admin_app(token_store=tokens, invitation_store=invitations, base_url="http://192.168.1.50:8765/")
+    with TestClient(app) as client:
+        yield client, tokens, invitations
+
+
+def test_identities_are_listed_with_device_counts(admin):
+    client, tokens, _invitations = admin
+    tokens.mint("bob")
+    tokens.mint("bob")
+    tokens.mint("robin")
+    rows = {row["name"]: row for row in client.get("/api/identities").json()}
+    assert rows["bob"]["devices"] == 2
+    assert rows["robin"]["devices"] == 1
+
+
+def test_identities_never_expose_hashes(admin):
+    client, tokens, _invitations = admin
+    tokens.mint("bob")
+    assert "hash" not in client.get("/api/identities").text
+
+
+def test_creating_an_invitation_returns_a_link_and_a_code(admin):
+    client, _tokens, invitations = admin
+    body = client.post("/api/invitations", json={"name": "bob"}).json()
+    assert body["name"] == "bob"
+    assert body["code"].isdigit() and len(body["code"]) == 6
+    assert body["link"].startswith("http://192.168.1.50:8765/?invite=")
+    assert invitations.pending() == 1
+
+
+def test_a_created_invitation_actually_redeems(admin):
+    # The panel's whole job is handing out working access. A link that looks
+    # right but does not redeem would be worse than no panel.
+    client, _tokens, invitations = admin
+    body = client.post("/api/invitations", json={"name": "bob"}).json()
+    nonce = body["link"].split("?invite=")[1]
+    assert invitations.redeem(link=nonce) == "bob"
+
+
+def test_an_empty_name_is_rejected(admin):
+    client, _tokens, invitations = admin
+    assert client.post("/api/invitations", json={"name": "   "}).status_code == 400
+    assert invitations.pending() == 0
+
+
+def test_pending_invitations_are_listed_without_a_link(admin):
+    # pending_list stores only the nonce's hash, so a listed invitation cannot
+    # carry a reconstructable link. Asserting it is absent stops someone
+    # "helpfully" inventing one from the id later.
+    client, _tokens, _invitations = admin
+    client.post("/api/invitations", json={"name": "bob"})
+    row = client.get("/api/invitations").json()[0]
+    assert row["name"] == "bob"
+    assert row["code"].isdigit()
+    assert row.get("link") in (None, "")
+
+
+def test_cancelling_an_invitation_stops_it_redeeming(admin):
+    client, _tokens, invitations = admin
+    code = client.post("/api/invitations", json={"name": "bob"}).json()["code"]
+    invitation_id = client.get("/api/invitations").json()[0]["id"]
+    assert client.delete("/api/invitations/{0}".format(invitation_id)).status_code == 204
+    assert invitations.redeem(code=code) is None
+
+
+def test_cancelling_an_unknown_invitation_is_404(admin):
+    client, _tokens, _invitations = admin
+    assert client.delete("/api/invitations/deadbeef").status_code == 404
+
+
+def test_revoking_an_identity_removes_every_device(admin):
+    client, tokens, _invitations = admin
+    laptop = tokens.mint("bob")
+    tablet = tokens.mint("bob")
+    assert client.delete("/api/identities/bob").status_code == 204
+    assert tokens.verify(laptop) is None
+    assert tokens.verify(tablet) is None
+
+
+def test_revoking_an_unknown_identity_is_404(admin):
+    client, _tokens, _invitations = admin
+    assert client.delete("/api/identities/ghost").status_code == 404
+
+
+def test_the_admin_app_has_no_auth_middleware(admin):
+    # The boundary is the loopback bind, not a credential. If AuthMiddleware
+    # ever appears here it means someone mounted the admin app under the main
+    # one, which would also make it reachable from the LAN.
+    from scpi_control.server.auth import AuthMiddleware
+
+    client, _tokens, _invitations = admin
+    installed = [middleware.cls for middleware in client.app.user_middleware]
+    assert AuthMiddleware not in installed
+
+
+def test_every_route_answers_without_a_token(admin):
+    client, tokens, _invitations = admin
+    tokens.mint("bob")
+    assert client.get("/api/identities").status_code == 200
+    assert client.get("/api/invitations").status_code == 200

--- a/tests/test_server_admin_api.py
+++ b/tests/test_server_admin_api.py
@@ -138,6 +138,37 @@ def test_localhost_and_loopback_hosts_still_work(admin):
     assert client.get("/api/identities", headers={"Host": "localhost"}).status_code == 200
 
 
+def test_the_main_app_serves_no_admin_routes(tmp_path):
+    # The mirror image of test_the_admin_app_has_no_auth_middleware, and the
+    # more important half: that one checks the admin app for auth, which is not
+    # where the mistake gets made. The mistake gets made in create_app, as one
+    # stray `app.include_router(admin_api.router, prefix="/api")` -- and it
+    # passes the entire suite and the CI bundle gate, while handing every LAN
+    # token-holder the power to mint invitations for arbitrary names and revoke
+    # arbitrary identities. That is a straight escalation from "every token is
+    # equal" to admin, so it is asserted in the language it would be written in.
+    from scpi_control.server.app import create_app
+
+    tokens = TokenStore(str(tmp_path / "tokens.json"))
+    invitations = InvitationStore(str(tmp_path / "invitations.json"))
+    app = create_app(token_store=tokens, invitation_store=invitations)
+    paths = {route.path for route in app.routes}
+    leaked = sorted(path for path in paths if path.startswith("/api/identities") or path.startswith("/api/invitations"))
+    assert not leaked, "create_app serves admin routes: {0}".format(leaked)
+
+
+def test_the_two_apps_never_share_a_static_directory(tmp_path):
+    # The second rule in admin/app.py's docstring. The main app's SPA catch-all
+    # serves any real file it finds in its own static dir, so pointing the two
+    # at one directory would hand the access-management UI to every LAN browser
+    # without changing a single route.
+    import scpi_control.server.admin.app as admin_app_module
+    import scpi_control.server.app as app_module
+
+    assert app_module.STATIC_DIR != admin_app_module.ADMIN_STATIC_DIR
+    assert admin_app_module.ADMIN_STATIC_DIR not in app_module.STATIC_DIR.parents
+
+
 def test_a_foreign_origin_is_rejected_on_a_read(admin):
     # The attack neither the bind nor the Host allowlist touches: a page on any
     # site the admin visits does fetch("http://127.0.0.1:8766/api/identities").

--- a/tests/test_server_admin_api.py
+++ b/tests/test_server_admin_api.py
@@ -167,6 +167,13 @@ def test_the_two_apps_never_share_a_static_directory(tmp_path):
 
     assert app_module.STATIC_DIR != admin_app_module.ADMIN_STATIC_DIR
     assert admin_app_module.ADMIN_STATIC_DIR not in app_module.STATIC_DIR.parents
+    # Both directions, and this is the one that bites: if ADMIN_STATIC_DIR ever
+    # moved *under* STATIC_DIR (server/static/admin, say), the two paths would
+    # still differ and neither of the assertions above would notice -- while the
+    # main app's catch-all happily served the admin bundle to the whole LAN.
+    # The reverse nesting is the harmless direction; it would only expose the
+    # LAN bundle to the loopback panel.
+    assert app_module.STATIC_DIR not in admin_app_module.ADMIN_STATIC_DIR.parents
 
 
 def test_a_foreign_origin_is_rejected_on_a_read(admin):

--- a/tests/test_server_admin_api.py
+++ b/tests/test_server_admin_api.py
@@ -9,9 +9,13 @@ from scpi_control.server.invitations import InvitationStore
 
 
 @pytest.fixture
-def admin(tmp_path):
-    tokens = TokenStore(str(tmp_path / "tokens.json"))
-    invitations = InvitationStore(str(tmp_path / "invitations.json"))
+def admin_stores(tmp_path):
+    return TokenStore(str(tmp_path / "tokens.json")), InvitationStore(str(tmp_path / "invitations.json"))
+
+
+@pytest.fixture
+def admin(admin_stores):
+    tokens, invitations = admin_stores
     app = create_admin_app(token_store=tokens, invitation_store=invitations, base_url="http://192.168.1.50:8765/")
     # base_url is 127.0.0.1, not the httpx default "testserver": TrustedHostMiddleware
     # only allows 127.0.0.1/localhost, and the Host header httpx sends is derived
@@ -132,6 +136,76 @@ def test_localhost_and_loopback_hosts_still_work(admin):
     client, _tokens, _invitations = admin
     assert client.get("/api/identities", headers={"Host": "127.0.0.1"}).status_code == 200
     assert client.get("/api/identities", headers={"Host": "localhost"}).status_code == 200
+
+
+def test_a_foreign_origin_is_rejected_on_a_read(admin):
+    # The attack neither the bind nor the Host allowlist touches: a page on any
+    # site the admin visits does fetch("http://127.0.0.1:8766/api/identities").
+    # The socket is genuinely local and the Host genuinely is 127.0.0.1, so both
+    # of the other defences wave it through. Only the Origin gives it away.
+    client, tokens, _invitations = admin
+    tokens.mint("bob")
+    response = client.get("/api/identities", headers={"Origin": "http://evil.example"})
+    assert response.status_code == 403
+    assert "bob" not in response.text
+
+
+def test_a_foreign_origin_is_rejected_on_a_write(admin):
+    client, _tokens, invitations = admin
+    response = client.post("/api/invitations", json={"name": "bob"}, headers={"Origin": "http://evil.example"})
+    assert response.status_code == 403
+    # The refusal must happen before the handler, not merely hide its output.
+    assert invitations.pending() == 0
+
+
+def test_a_rebound_origin_on_the_panels_own_port_is_rejected(admin):
+    # The rebinding variant: the attacker's page reaches the panel on the right
+    # port, so its Origin carries the panel's port but the attacker's hostname.
+    client, _tokens, invitations = admin
+    assert client.post("/api/invitations", json={"name": "bob"}, headers={"Origin": "http://evil.example:8766"}).status_code == 403
+    assert invitations.pending() == 0
+
+
+def test_the_panels_own_origin_is_accepted(admin):
+    # Both spellings TrustedHostMiddleware allows: the banner opens 127.0.0.1,
+    # an SSH port-forward reaches the same panel as localhost.
+    client, _tokens, _invitations = admin
+    for origin in ("http://127.0.0.1:8766", "http://localhost:8766"):
+        assert client.get("/api/identities", headers={"Origin": origin}).status_code == 200, origin
+        assert client.post("/api/invitations", json={"name": "bob"}, headers={"Origin": origin}).status_code == 200, origin
+
+
+def test_a_request_with_no_origin_is_accepted(admin):
+    # curl, scripts, and same-origin browser fetches that omit the header. An
+    # Origin is what a *cross*-origin request is obliged to carry; refusing its
+    # absence would break the panel itself.
+    client, _tokens, invitations = admin
+    assert client.get("/api/identities").status_code == 200
+    assert client.post("/api/invitations", json={"name": "bob"}).status_code == 200
+    assert invitations.pending() == 1
+
+
+def test_the_origin_allowlist_follows_the_configured_admin_port(admin_stores):
+    # The port is not hardcoded: run the panel on --admin-port 9001 and 9001 is
+    # what its own Origin must be, while the default 8766 becomes foreign.
+    tokens, invitations = admin_stores
+    app = create_admin_app(token_store=tokens, invitation_store=invitations, admin_port=9001)
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        assert client.get("/api/identities", headers={"Origin": "http://127.0.0.1:9001"}).status_code == 200
+        assert client.get("/api/identities", headers={"Origin": "http://127.0.0.1:8766"}).status_code == 403
+
+
+def test_a_safelisted_content_type_cannot_create_an_invitation(admin):
+    # The third defence's other half, pinned so it stops being accidental. A
+    # form/text body is what a cross-origin page can send with no preflight at
+    # all; FastAPI's JSON-only body parsing is what refuses it. If someone
+    # teaches this endpoint to read form bodies, this test fails before the
+    # Origin check is the only thing left standing.
+    client, _tokens, invitations = admin
+    for content_type in ("text/plain;charset=UTF-8", "application/x-www-form-urlencoded", "multipart/form-data; boundary=x"):
+        response = client.post("/api/invitations", content=b'{"name": "bob"}', headers={"Content-Type": content_type})
+        assert response.status_code != 200, content_type
+    assert invitations.pending() == 0
 
 
 def test_admin_spa_traversal_is_contained(tmp_path):

--- a/tests/test_server_admin_api.py
+++ b/tests/test_server_admin_api.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from scpi_control.server.admin.app import create_admin_app
 from scpi_control.server.auth import TokenStore
 from scpi_control.server.invitations import InvitationStore
+from tests.route_introspection import iter_http_routes
 
 
 @pytest.fixture
@@ -138,7 +139,7 @@ def test_localhost_and_loopback_hosts_still_work(admin):
     assert client.get("/api/identities", headers={"Host": "localhost"}).status_code == 200
 
 
-def test_the_main_app_serves_no_admin_routes(tmp_path):
+def test_the_main_app_serves_no_admin_routes(gateway_auth, tmp_path):
     # The mirror image of test_the_admin_app_has_no_auth_middleware, and the
     # more important half: that one checks the admin app for auth, which is not
     # where the mistake gets made. The mistake gets made in create_app, as one
@@ -149,12 +150,34 @@ def test_the_main_app_serves_no_admin_routes(tmp_path):
     # equal" to admin, so it is asserted in the language it would be written in.
     from scpi_control.server.app import create_app
 
-    tokens = TokenStore(str(tmp_path / "tokens.json"))
+    store, headers, _raw = gateway_auth
     invitations = InvitationStore(str(tmp_path / "invitations.json"))
-    app = create_app(token_store=tokens, invitation_store=invitations)
-    paths = {route.path for route in app.routes}
-    leaked = sorted(path for path in paths if path.startswith("/api/identities") or path.startswith("/api/invitations"))
+    app = create_app(token_store=store, invitation_store=invitations)
+
+    # Enumerated through tests/route_introspection.py, NOT as
+    # `{route.path for route in app.routes}` -- and emphatically not via the
+    # `getattr(route, "path", "")` that silences the AttributeError that
+    # spelling started raising. From Starlette 1.x each include_router() call
+    # leaves one opaque _IncludedRouter in app.routes that has no .path and
+    # holds the real routes inside itself, so skipping the objects without a
+    # .path would skip every included router: the guard would go blind to
+    # precisely the one-line mistake it exists to catch, and pass on the three
+    # routes create_app declares inline. iter_http_routes reads the generated
+    # schema instead, which reports full paths whatever the nesting.
+    leaked = sorted({path for _method, path in iter_http_routes(app) if path.startswith("/api/identities") or path.startswith("/api/invitations")})
     assert not leaked, "create_app serves admin routes: {0}".format(leaked)
+
+    # The same question put to the running app, which no route-object or schema
+    # representation can misreport: an inclusion carrying include_in_schema=False
+    # would be invisible above and still answer here. 404 is create_app's own
+    # shape for an unknown /api/ path; a 200 means the admin surface is live on
+    # the LAN-facing port. The client is authenticated on purpose -- an
+    # unauthenticated request is refused by AuthMiddleware before routing, so it
+    # would return the same 401 whether or not the routes existed.
+    with TestClient(app) as client:
+        client.headers.update(headers)
+        assert client.get("/api/identities").status_code == 404
+        assert client.get("/api/invitations").status_code == 404
 
 
 def test_the_two_apps_never_share_a_static_directory(tmp_path):

--- a/tests/test_server_admin_listener.py
+++ b/tests/test_server_admin_listener.py
@@ -171,3 +171,47 @@ def test_the_admin_server_leaves_signal_handling_alone():
     with server.capture_signals():
         assert signal.getsignal(signal.SIGINT) is handler
     assert signal.getsignal(signal.SIGINT) is handler
+
+
+def test_uvicorn_run_still_delegates_to_self_serve(monkeypatch):
+    # _run_servers never names a uvicorn private API (Config.setup_event_loop()
+    # up to 0.35, Config.get_loop_factory() from 0.36) to stay valid across the
+    # uvicorn[standard]>=0.30 range pyproject.toml declares. Instead it swaps
+    # `serve` on the main Server instance and lets run() call it -- which only
+    # works because uvicorn.Server.run() is `asyncio.run(self.serve(...))`. If
+    # a future uvicorn routes run() straight to self._serve(...) instead (that
+    # method already exists on 0.51), this delegation silently stops: the
+    # process starts the LAN-facing gateway alone, `run()` still returns
+    # cleanly, and the admin panel that first-run setup just printed and
+    # opened a browser to (http://127.0.0.1:8766/) simply never exists. This
+    # test drives a *real* uvicorn.Server, not the FakeServer used above, so a
+    # uvicorn upgrade that breaks this contract fails here instead of in a
+    # user's terminal.
+    #
+    # No socket may be bound while proving that: the sentinel replaces serve()
+    # entirely, so Server.startup() (the thing that actually listens, via
+    # loop.create_server(...)) should never run. Assert that directly rather
+    # than trust it, by making listener creation explode if anything on this
+    # path still reaches for one. (Patching socket.socket itself is too broad
+    # here -- on Windows, asyncio's own ProactorEventLoop opens a loopback
+    # socket pair for its internal self-pipe before our code runs at all, so
+    # that would fail for a reason unrelated to what this test checks.)
+    def _no_listeners_allowed(*args, **kwargs):
+        raise AssertionError("run() reached loop.create_server(); serve() was not overridden")
+
+    monkeypatch.setattr(asyncio.base_events.BaseEventLoop, "create_server", _no_listeners_allowed)
+
+    # loop="asyncio" keeps Config's event-loop setup from installing the
+    # uvloop policy process-wide on Linux/macOS, which would otherwise leak
+    # into whichever test runs next in this worker.
+    server = uvicorn.Server(uvicorn.Config(FastAPI(), host="127.0.0.1", port=0, loop="asyncio"))
+
+    calls = []
+
+    async def sentinel(sockets=None):
+        calls.append(sockets)
+
+    server.serve = sentinel
+    server.run()
+
+    assert calls == [None]

--- a/tests/test_server_admin_listener.py
+++ b/tests/test_server_admin_listener.py
@@ -1,10 +1,13 @@
 """The admin listener: where it binds, and that it can be switched off."""
 
 import asyncio
+import signal
 
 import pytest
+import uvicorn
+from fastapi import FastAPI
 
-from scpi_control.server.__main__ import ADMIN_HOST, main
+from scpi_control.server.__main__ import ADMIN_HOST, _QuietServer, main
 
 
 @pytest.fixture
@@ -47,6 +50,22 @@ def test_there_is_no_admin_host_flag(tmp_path):
         main(["--config-dir", str(tmp_path), "--admin-host", "0.0.0.0"])
 
 
+def test_port_colliding_with_admin_port_exits_cleanly(captured, tmp_path):
+    # Without this check, --port and --admin-port landing on the same number
+    # fails deep inside uvicorn's socket bind with a bare traceback instead of
+    # a sentence explaining the operator's typo.
+    with pytest.raises(SystemExit):
+        main(["--config-dir", str(tmp_path), "--port", "8766"])
+
+
+def test_port_colliding_with_admin_port_is_fine_under_no_admin(captured, tmp_path):
+    # The collision only matters when the admin listener is actually going to
+    # start on that port.
+    main(["--config-dir", str(tmp_path), "--port", "8766", "--no-admin"])
+    assert captured["port"] == 8766
+    assert captured["admin_app"] is None
+
+
 # --- Ctrl+C: both servers actually stop -------------------------------------
 #
 # The tests above cover binding and flags but not the thing most likely to be
@@ -82,17 +101,53 @@ def test_main_server_returning_stops_the_admin_server_too(monkeypatch):
                 await asyncio.sleep(0)
                 return
             # The admin server: keep "running" until told to stop, exactly
-            # like the real server would while waiting on should_exit.
-            while not self.should_exit:
+            # like the real server would while waiting on should_exit. Bounded
+            # rather than an unconditional while loop: a missing should_exit
+            # propagation then fails in milliseconds with a clear message
+            # instead of hanging the test session (the @pytest.mark.timeout
+            # above is only a backstop).
+            for _ in range(1000):
+                if self.should_exit:
+                    break
                 await asyncio.sleep(0)
+            else:
+                raise AssertionError("should_exit was never set")
+            # One more yield before marking exited: if _run_servers stopped
+            # awaiting this task after setting should_exit, asyncio.run's own
+            # cleanup would cancel it while it's asleep here, and exited would
+            # never become True. That turns "forgot to await admin_task" into
+            # a real assertion failure instead of passing by accident.
+            await asyncio.sleep(0.05)
             self.exited = True
 
     monkeypatch.setattr(mod.uvicorn, "Server", FakeServer)
     monkeypatch.setattr(mod, "_QuietServer", FakeServer)
 
-    mod._run_servers(main_app=object(), host="127.0.0.1", port=1234, admin_app=object(), admin_port=5678)
+    # The main host deliberately differs from ADMIN_HOST so the config
+    # assertions below can tell "the admin server got its own host" apart
+    # from "it got whatever host the main server got".
+    mod._run_servers(main_app=object(), host="0.0.0.0", port=1234, admin_app=object(), admin_port=5678)
 
     assert len(created) == 2
     main_server, admin_server = created
     assert admin_server.should_exit is True
     assert admin_server.exited is True
+    # The line that decides the security boundary: uvicorn.Config(admin_app,
+    # host=ADMIN_HOST, ...). If that ever regresses to host=host, this is the
+    # only thing in the suite that would notice.
+    assert admin_server.config.host == ADMIN_HOST
+    assert main_server.config.host == "0.0.0.0"
+
+
+def test_the_admin_server_leaves_signal_handling_alone():
+    # The brief's original approach (assigning install_signal_handlers) was a
+    # silent no-op on uvicorn 0.34.3, which captures signals through a context
+    # manager instead. This asserts the override actually overrides
+    # something, so a future uvicorn that restructures signal capture fails
+    # here rather than leaving both servers fighting over SIGINT.
+    assert "capture_signals" in vars(uvicorn.Server)
+    handler = signal.getsignal(signal.SIGINT)
+    server = _QuietServer(uvicorn.Config(FastAPI(), host="127.0.0.1", port=0))
+    with server.capture_signals():
+        assert signal.getsignal(signal.SIGINT) is handler
+    assert signal.getsignal(signal.SIGINT) is handler

--- a/tests/test_server_admin_listener.py
+++ b/tests/test_server_admin_listener.py
@@ -17,10 +17,9 @@ def captured(monkeypatch):
         "scpi_control.server.__main__._run_servers",
         lambda main_app, host, port, admin_app, admin_port: calls.update(host=host, port=port, admin_app=admin_app, admin_port=admin_port),
     )
-    # These tests use a fresh, empty tmp_path store, which now opens the
-    # setup screen in a real browser unless stubbed -- see
-    # tests/test_server_first_run.py for the behaviour itself.
-    monkeypatch.setattr("scpi_control.server.__main__._open_browser", lambda url: True)
+    # Some of these tests use a fresh, empty tmp_path store, which opens the
+    # setup screen -- conftest.py's autouse _no_real_browser fixture keeps
+    # that from popping a real browser window.
     return calls
 
 

--- a/tests/test_server_admin_listener.py
+++ b/tests/test_server_admin_listener.py
@@ -1,0 +1,98 @@
+"""The admin listener: where it binds, and that it can be switched off."""
+
+import asyncio
+
+import pytest
+
+from scpi_control.server.__main__ import ADMIN_HOST, main
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(
+        "scpi_control.server.__main__._run_servers",
+        lambda main_app, host, port, admin_app, admin_port: calls.update(host=host, port=port, admin_app=admin_app, admin_port=admin_port),
+    )
+    return calls
+
+
+def test_the_admin_listener_binds_loopback_only(captured, tmp_path):
+    # The host-only boundary IS this constant. If it ever becomes 0.0.0.0 the
+    # entire admin surface -- minting and revoking access -- is exposed to the
+    # LAN with no credential of any kind.
+    assert ADMIN_HOST == "127.0.0.1"
+
+
+def test_serving_starts_an_admin_app_by_default(captured, tmp_path):
+    main(["--config-dir", str(tmp_path), "--port", "9999"])
+    assert captured["admin_app"] is not None
+    assert captured["admin_port"] == 8766
+
+
+def test_admin_port_is_configurable(captured, tmp_path):
+    main(["--config-dir", str(tmp_path), "--admin-port", "9100"])
+    assert captured["admin_port"] == 9100
+
+
+def test_no_admin_starts_only_the_main_listener(captured, tmp_path):
+    main(["--config-dir", str(tmp_path), "--no-admin"])
+    assert captured["admin_app"] is None
+
+
+def test_there_is_no_admin_host_flag(tmp_path):
+    # Deliberate: the only knob is the port. A host flag would let someone bind
+    # the admin surface wide, which no amount of documentation would undo.
+    with pytest.raises(SystemExit):
+        main(["--config-dir", str(tmp_path), "--admin-host", "0.0.0.0"])
+
+
+# --- Ctrl+C: both servers actually stop -------------------------------------
+#
+# The tests above cover binding and flags but not the thing most likely to be
+# quietly wrong: two uvicorn servers sharing one event loop, where only the
+# main one installs signal handlers. If the shutdown wiring in _run_servers is
+# missing or backwards, Ctrl+C stops one server while the other keeps the
+# process alive -- a bug that never shows up in a "does it start" test. This
+# drives the real _run_servers with fake Server-like objects (no real socket
+# binding) standing in for uvicorn.Server, so the exact shutdown-propagation
+# logic in _serve_both runs for real.
+
+
+@pytest.mark.timeout(10)
+def test_main_server_returning_stops_the_admin_server_too(monkeypatch):
+    from scpi_control.server import __main__ as mod
+
+    created = []
+
+    class FakeServer:
+        """Stands in for uvicorn.Server: no sockets, just should_exit/serve."""
+
+        def __init__(self, config):
+            self.config = config
+            self.should_exit = False
+            self.exited = False
+            created.append(self)
+
+        async def serve(self):
+            if self is created[0]:
+                # The main server: simulate Ctrl+C by returning right away,
+                # the way uvicorn's serve() returns once it has handled
+                # SIGINT and torn its own server down.
+                await asyncio.sleep(0)
+                return
+            # The admin server: keep "running" until told to stop, exactly
+            # like the real server would while waiting on should_exit.
+            while not self.should_exit:
+                await asyncio.sleep(0)
+            self.exited = True
+
+    monkeypatch.setattr(mod.uvicorn, "Server", FakeServer)
+    monkeypatch.setattr(mod, "_QuietServer", FakeServer)
+
+    mod._run_servers(main_app=object(), host="127.0.0.1", port=1234, admin_app=object(), admin_port=5678)
+
+    assert len(created) == 2
+    main_server, admin_server = created
+    assert admin_server.should_exit is True
+    assert admin_server.exited is True

--- a/tests/test_server_admin_listener.py
+++ b/tests/test_server_admin_listener.py
@@ -17,6 +17,10 @@ def captured(monkeypatch):
         "scpi_control.server.__main__._run_servers",
         lambda main_app, host, port, admin_app, admin_port: calls.update(host=host, port=port, admin_app=admin_app, admin_port=admin_port),
     )
+    # These tests use a fresh, empty tmp_path store, which now opens the
+    # setup screen in a real browser unless stubbed -- see
+    # tests/test_server_first_run.py for the behaviour itself.
+    monkeypatch.setattr("scpi_control.server.__main__._open_browser", lambda url: True)
     return calls
 
 

--- a/tests/test_server_admin_listener.py
+++ b/tests/test_server_admin_listener.py
@@ -88,15 +88,25 @@ def test_main_server_returning_stops_the_admin_server_too(monkeypatch):
     created = []
 
     class FakeServer:
-        """Stands in for uvicorn.Server: no sockets, just should_exit/serve."""
+        """Stands in for uvicorn.Server: no sockets, just should_exit/serve/run."""
 
         def __init__(self, config):
             self.config = config
             self.should_exit = False
             self.exited = False
+            self.ran = False
             created.append(self)
 
-        async def serve(self):
+        def run(self, sockets=None):
+            # Real uvicorn.Server.run() is asyncio.run(self.serve(...)) plus the
+            # event-loop selection this fake has no use for. Keeping the
+            # self.serve() indirection is the point: _run_servers substitutes
+            # its own serve() on the instance, so driving the pair through
+            # run() is what proves the substitution actually reaches it.
+            self.ran = True
+            return asyncio.run(self.serve(sockets=sockets))
+
+        async def serve(self, sockets=None):
             if self is created[0]:
                 # The main server: simulate Ctrl+C by returning right away,
                 # the way uvicorn's serve() returns once it has handled
@@ -133,6 +143,13 @@ def test_main_server_returning_stops_the_admin_server_too(monkeypatch):
 
     assert len(created) == 2
     main_server, admin_server = created
+    # The pair must be driven by the main server's own run(): that is the only
+    # thing in either uvicorn generation that selects the event loop
+    # implementation, and the --no-admin path gets it for free. A revert to a
+    # bare asyncio.run() here would still pass every assertion below while
+    # silently putting the default path on a different loop than --no-admin.
+    assert main_server.ran is True
+    assert admin_server.ran is False
     assert admin_server.should_exit is True
     assert admin_server.exited is True
     # The line that decides the security boundary: uvicorn.Config(admin_app,

--- a/tests/test_server_admin_listener.py
+++ b/tests/test_server_admin_listener.py
@@ -215,3 +215,52 @@ def test_uvicorn_run_still_delegates_to_self_serve(monkeypatch):
     server.run()
 
     assert calls == [None]
+
+
+def test_the_event_loop_guard_is_in_force(request):
+    """Proves the autouse `_no_leaked_event_loop` guard in conftest.py actually
+    works, the same role test_no_argument_defaults_never_touch_the_real_home
+    (tests/test_server_auth_store.py) plays for `_no_real_home` and
+    test_the_no_real_browser_guard_is_in_force (tests/test_server_first_run.py)
+    plays for `_no_real_browser`.
+
+    This file is where that guard earns its keep: the two tests above both end
+    up inside `asyncio.run()`, which clears the thread's current event loop on
+    the way out. Without the guard that lands on whatever runs next in the
+    worker -- on CI it was three tests in tests/test_server_stream_ws.py, on
+    Python 3.9 only, in a file neither test has anything to do with.
+
+    Two things are asserted, because either alone would pass vacuously: that
+    the guard is wired up as autouse (this test never requests it), and that
+    its restore logic really restores. The middle assertion pins the damage
+    itself, so if a future Python stops leaking here, this says so rather than
+    quietly passing.
+    """
+    from tests.conftest import preserved_event_loop_state
+
+    assert "_no_leaked_event_loop" in request.fixturenames
+
+    # Start from an explicitly set loop rather than whatever ambient state this
+    # worker is in. A pristine main thread behaves differently across the
+    # supported range -- get_event_loop() creates a loop on 3.9-3.13 and raises
+    # on 3.14 -- whereas a loop that has been set is returned by every version,
+    # which keeps the assertions below meaningful on all of them.
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        assert asyncio.get_event_loop() is loop
+
+        with preserved_event_loop_state():
+            asyncio.run(asyncio.sleep(0))
+            # The leak, reproduced in one line: asyncio.run() does not put back
+            # what it found.
+            with pytest.raises(RuntimeError):
+                asyncio.get_event_loop()
+
+        # ...and the guard does. Identity, not merely "a loop exists": an
+        # implementation that installed a fresh loop instead of restoring the
+        # old one would satisfy the weaker check.
+        assert asyncio.get_event_loop() is loop
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -351,13 +351,21 @@ def test_cli_parses_defaults(tmp_path, monkeypatch):
         create_app_calls.append(kwargs)
         return object()
 
-    def fake_run(app, host, port, **kwargs):
+    def fake_run_servers(main_app, host, port, admin_app, admin_port):
         captured.update(host=host, port=port)
 
     # --config-dir points at tmp_path so this never touches the developer's real
     # ~/.siglent/tokens.json; create_app is stubbed so no real ASGI app is built.
+    #
+    # _run_servers is the seam, NOT uvicorn.run: since the admin listener landed,
+    # serving goes through uvicorn.Server(uvicorn.Config(...)).run() and
+    # asyncio.run(), and uvicorn.run() is never called. Stubbing uvicorn.run here
+    # therefore intercepted nothing -- cli.main() bound real sockets on 8765 and
+    # 8766 and served forever, so this test did not fail, it HUNG, taking the
+    # whole run with it. Every other CLI test in the suite patches _run_servers;
+    # this one was missed.
     monkeypatch.setattr(cli, "create_app", fake_create_app)
-    monkeypatch.setattr(cli.uvicorn, "run", fake_run)
+    monkeypatch.setattr(cli, "_run_servers", fake_run_servers)
     cli.main(["--config-dir", str(tmp_path)])
     assert captured == {"host": "127.0.0.1", "port": 8765}
     assert isinstance(create_app_calls[0]["token_store"], TokenStore)

--- a/tests/test_server_auth_store.py
+++ b/tests/test_server_auth_store.py
@@ -325,3 +325,41 @@ def test_summary_counts_devices_without_revealing_secrets(tmp_path):
     assert rows["robin"]["devices"] == 1
     assert rows["bob"]["last_used"] is not None
     assert "hash" not in rows["bob"]
+
+
+def test_summary_sees_a_token_minted_by_another_process(tmp_path):
+    # summary() used to read self._tokens directly, with no reload -- fine
+    # while only the CLI called it, but the admin app's GET /api/identities
+    # is the first caller living inside the same running server process that
+    # a second process (the CLI minting/revoking) writes past. Without a
+    # reload here, the admin panel would render a roster missing tokens
+    # minted after this process started.
+    path = str(tmp_path / "tokens.json")
+    gateway = TokenStore(path)
+    gateway.mint("robin")
+
+    TokenStore(path).mint("bob")
+
+    names = {row["name"] for row in gateway.summary()}
+    assert names == {"robin", "bob"}
+
+
+def test_revoke_does_not_resurrect_a_token_minted_by_another_process(tmp_path):
+    # revoke() used to read and rewrite self._tokens with no reload first.
+    # Instance A revoking "robin" while stale would _save() its own outdated
+    # in-memory list -- silently erasing the token instance B minted for
+    # "bob" in between, even though this revoke has nothing to do with bob.
+    path = str(tmp_path / "tokens.json")
+    instance_a = TokenStore(path)
+    raw_robin = instance_a.mint("robin")
+
+    instance_b = TokenStore(path)
+    raw_bob = instance_b.mint("bob")
+
+    assert instance_a.revoke("robin") is True
+
+    # bob's token, minted by instance_b after instance_a's snapshot, must
+    # still verify -- instance_a's revoke() must not have overwritten it.
+    fresh = TokenStore(path)
+    assert fresh.verify(raw_bob) == "bob"
+    assert fresh.verify(raw_robin) is None

--- a/tests/test_server_cli_invite.py
+++ b/tests/test_server_cli_invite.py
@@ -32,9 +32,8 @@ def test_the_printed_code_actually_redeems(tmp_path, capsys):
 
 def test_invite_uses_the_url_the_gateway_recorded(tmp_path, capsys, monkeypatch):
     monkeypatch.setattr("scpi_control.server.__main__._run_servers", lambda main_app, host, port, admin_app, admin_port: None)
-    # The store is empty here, so main() would otherwise try to open a real
-    # browser on the setup screen -- stub it the same as the first-run tests do.
-    monkeypatch.setattr("scpi_control.server.__main__._open_browser", lambda url: True)
+    # The store is empty here, so main() opens the setup screen; conftest.py's
+    # autouse _no_real_browser fixture keeps that from popping a real browser.
     main(["--config-dir", str(tmp_path), "--host", "192.168.1.50", "--port", "9000"])
     capsys.readouterr()
     main(["invite", "bob", "--config-dir", str(tmp_path)])

--- a/tests/test_server_cli_invite.py
+++ b/tests/test_server_cli_invite.py
@@ -32,6 +32,9 @@ def test_the_printed_code_actually_redeems(tmp_path, capsys):
 
 def test_invite_uses_the_url_the_gateway_recorded(tmp_path, capsys, monkeypatch):
     monkeypatch.setattr("scpi_control.server.__main__._run_servers", lambda main_app, host, port, admin_app, admin_port: None)
+    # The store is empty here, so main() would otherwise try to open a real
+    # browser on the setup screen -- stub it the same as the first-run tests do.
+    monkeypatch.setattr("scpi_control.server.__main__._open_browser", lambda url: True)
     main(["--config-dir", str(tmp_path), "--host", "192.168.1.50", "--port", "9000"])
     capsys.readouterr()
     main(["invite", "bob", "--config-dir", str(tmp_path)])
@@ -85,7 +88,15 @@ def test_a_corrupt_invitation_file_stops_serve_before_a_token_is_minted(tmp_path
 
 
 def test_serve_prints_the_url_every_time_not_just_the_first(tmp_path, capsys, monkeypatch):
+    # "The first" used to mean "the bootstrap mint": the store started empty
+    # and the first main() call minted "default" into it, so a second call
+    # was needed to reach the established-store branch. There is no more
+    # auto-mint, so a store established by scpi-web invite/token add is set
+    # up directly here, and both calls exercise the same (only) established
+    # branch -- the regression this guards against is a run silently
+    # dropping the URL, whichever call it is.
     monkeypatch.setattr("scpi_control.server.__main__._run_servers", lambda main_app, host, port, admin_app, admin_port: None)
+    TokenStore(str(tmp_path / "tokens.json")).mint("robin")
     main(["--config-dir", str(tmp_path), "--port", "9999"])
     capsys.readouterr()
     main(["--config-dir", str(tmp_path), "--port", "9999"])

--- a/tests/test_server_cli_invite.py
+++ b/tests/test_server_cli_invite.py
@@ -31,7 +31,7 @@ def test_the_printed_code_actually_redeems(tmp_path, capsys):
 
 
 def test_invite_uses_the_url_the_gateway_recorded(tmp_path, capsys, monkeypatch):
-    monkeypatch.setattr("uvicorn.run", lambda app, host, port: None)
+    monkeypatch.setattr("scpi_control.server.__main__._run_servers", lambda main_app, host, port, admin_app, admin_port: None)
     main(["--config-dir", str(tmp_path), "--host", "192.168.1.50", "--port", "9000"])
     capsys.readouterr()
     main(["invite", "bob", "--config-dir", str(tmp_path)])
@@ -72,7 +72,10 @@ def test_a_corrupt_invitation_file_stops_serve_before_a_token_is_minted(tmp_path
     # started AND left a live token behind -- and because the token store was
     # no longer empty, no later start would ever print that URL again. Exiting
     # is not enough to assert: the token is the damage.
-    monkeypatch.setattr("uvicorn.run", lambda app, host, port: pytest.fail("uvicorn should not have started"))
+    monkeypatch.setattr(
+        "scpi_control.server.__main__._run_servers",
+        lambda main_app, host, port, admin_app, admin_port: pytest.fail("uvicorn should not have started"),
+    )
     (tmp_path / "invitations.json").write_text("{ not json")
     with pytest.raises(SystemExit) as excinfo:
         main(["--config-dir", str(tmp_path)])
@@ -82,7 +85,7 @@ def test_a_corrupt_invitation_file_stops_serve_before_a_token_is_minted(tmp_path
 
 
 def test_serve_prints_the_url_every_time_not_just_the_first(tmp_path, capsys, monkeypatch):
-    monkeypatch.setattr("uvicorn.run", lambda app, host, port: None)
+    monkeypatch.setattr("scpi_control.server.__main__._run_servers", lambda main_app, host, port, admin_app, admin_port: None)
     main(["--config-dir", str(tmp_path), "--port", "9999"])
     capsys.readouterr()
     main(["--config-dir", str(tmp_path), "--port", "9999"])

--- a/tests/test_server_cli_tokens.py
+++ b/tests/test_server_cli_tokens.py
@@ -37,7 +37,10 @@ def test_revoking_unknown_name_exits_nonzero(tmp_path):
 
 def test_serve_bootstraps_a_token_and_prints_url(tmp_path, capsys, monkeypatch):
     started = {}
-    monkeypatch.setattr("uvicorn.run", lambda app, host, port: started.update(host=host, port=port))
+    monkeypatch.setattr(
+        "scpi_control.server.__main__._run_servers",
+        lambda main_app, host, port, admin_app, admin_port: started.update(host=host, port=port),
+    )
     main(["--config-dir", str(tmp_path), "--port", "9999"])
     printed = capsys.readouterr().out
     assert "?token=scpi_" in printed
@@ -46,7 +49,7 @@ def test_serve_bootstraps_a_token_and_prints_url(tmp_path, capsys, monkeypatch):
 
 
 def test_serve_does_not_remint_when_tokens_exist(tmp_path, capsys, monkeypatch):
-    monkeypatch.setattr("uvicorn.run", lambda app, host, port: None)
+    monkeypatch.setattr("scpi_control.server.__main__._run_servers", lambda main_app, host, port, admin_app, admin_port: None)
     main(["token", "add", "robin", "--config-dir", str(tmp_path)])
     capsys.readouterr()
     main(["--config-dir", str(tmp_path)])
@@ -124,7 +127,7 @@ def test_config_dir_before_bare_serve_bootstraps_into_given_directory(tmp_path, 
     position to appear in -- but it must still land in tmp_path, not the
     real ~/.siglent, and this asserts that directly rather than trusting a
     zero exit code."""
-    monkeypatch.setattr("uvicorn.run", lambda app, host, port: None)
+    monkeypatch.setattr("scpi_control.server.__main__._run_servers", lambda main_app, host, port, admin_app, admin_port: None)
     main(["--config-dir", str(tmp_path), "--port", "9999"])
     assert (tmp_path / "tokens.json").exists()
     assert TokenStore(str(tmp_path / "tokens.json")).names() == ["default"]

--- a/tests/test_server_cli_tokens.py
+++ b/tests/test_server_cli_tokens.py
@@ -35,26 +35,14 @@ def test_revoking_unknown_name_exits_nonzero(tmp_path):
     assert excinfo.value.code != 0
 
 
-def test_serve_bootstraps_a_token_and_prints_url(tmp_path, capsys, monkeypatch):
-    started = {}
-    monkeypatch.setattr(
-        "scpi_control.server.__main__._run_servers",
-        lambda main_app, host, port, admin_app, admin_port: started.update(host=host, port=port),
-    )
-    main(["--config-dir", str(tmp_path), "--port", "9999"])
-    printed = capsys.readouterr().out
-    assert "?token=scpi_" in printed
-    assert started["port"] == 9999
-    assert TokenStore(str(tmp_path / "tokens.json")).names() == ["default"]
-
-
-def test_serve_does_not_remint_when_tokens_exist(tmp_path, capsys, monkeypatch):
+def test_serve_never_mints_a_token(tmp_path, capsys, monkeypatch):
+    # The old behaviour bootstrapped an identity literally called "default"
+    # on an empty store; an empty store now mints nothing at all -- see
+    # tests/test_server_first_run.py for what actually happens instead.
     monkeypatch.setattr("scpi_control.server.__main__._run_servers", lambda main_app, host, port, admin_app, admin_port: None)
-    main(["token", "add", "robin", "--config-dir", str(tmp_path)])
-    capsys.readouterr()
+    monkeypatch.setattr("scpi_control.server.__main__._open_browser", lambda url: True)
     main(["--config-dir", str(tmp_path)])
-    assert TokenStore(str(tmp_path / "tokens.json")).names() == ["robin"]
-    assert "?token=" not in capsys.readouterr().out
+    assert TokenStore(str(tmp_path / "tokens.json")).names() == []
 
 
 # --- --config-dir ordering regressions -------------------------------------
@@ -120,17 +108,6 @@ def test_config_dir_after_subcommand_is_used_for_token_revoke(tmp_path):
     main(["token", "add", "robin", "--config-dir", str(tmp_path)])
     main(["token", "revoke", "robin", "--config-dir", str(tmp_path)])
     assert TokenStore(str(tmp_path / "tokens.json")).names() == []
-
-
-def test_config_dir_before_bare_serve_bootstraps_into_given_directory(tmp_path, capsys, monkeypatch):
-    """The bare serve path has no subcommand, so --config-dir only has one
-    position to appear in -- but it must still land in tmp_path, not the
-    real ~/.siglent, and this asserts that directly rather than trusting a
-    zero exit code."""
-    monkeypatch.setattr("scpi_control.server.__main__._run_servers", lambda main_app, host, port, admin_app, admin_port: None)
-    main(["--config-dir", str(tmp_path), "--port", "9999"])
-    assert (tmp_path / "tokens.json").exists()
-    assert TokenStore(str(tmp_path / "tokens.json")).names() == ["default"]
 
 
 def test_token_add_twice_adds_a_device_instead_of_failing(tmp_path, capsys):

--- a/tests/test_server_cli_tokens.py
+++ b/tests/test_server_cli_tokens.py
@@ -39,8 +39,9 @@ def test_serve_never_mints_a_token(tmp_path, capsys, monkeypatch):
     # The old behaviour bootstrapped an identity literally called "default"
     # on an empty store; an empty store now mints nothing at all -- see
     # tests/test_server_first_run.py for what actually happens instead.
+    # (conftest.py's autouse _no_real_browser fixture keeps the empty-store
+    # path here from popping a real browser window.)
     monkeypatch.setattr("scpi_control.server.__main__._run_servers", lambda main_app, host, port, admin_app, admin_port: None)
-    monkeypatch.setattr("scpi_control.server.__main__._open_browser", lambda url: True)
     main(["--config-dir", str(tmp_path)])
     assert TokenStore(str(tmp_path / "tokens.json")).names() == []
 

--- a/tests/test_server_first_run.py
+++ b/tests/test_server_first_run.py
@@ -16,11 +16,13 @@ def served(monkeypatch):
     return calls
 
 
-def test_an_empty_store_mints_nothing(served, tmp_path, monkeypatch):
+def test_an_empty_store_mints_nothing(served, tmp_path):
     # The old behaviour minted an identity literally called "default", which
     # then showed up as the owner of every session created from it. Setup mints
     # a real name instead.
-    monkeypatch.setattr("scpi_control.server.__main__._open_browser", lambda url: True)
+    # (The conftest.py autouse _no_real_browser fixture keeps this from
+    # popping a real browser window; nothing here needs the URL or to force a
+    # failure, so there is nothing more to stub.)
     main(["--config-dir", str(tmp_path)])
     assert TokenStore(str(tmp_path / "tokens.json")).names() == []
 
@@ -62,7 +64,27 @@ def test_no_admin_on_an_empty_store_points_at_the_cli(served, tmp_path, capsys):
     assert TokenStore(str(tmp_path / "tokens.json")).names() == []
 
 
-def test_no_token_url_is_printed_any_more(served, tmp_path, monkeypatch, capsys):
-    monkeypatch.setattr("scpi_control.server.__main__._open_browser", lambda url: True)
+def test_no_token_url_is_printed_any_more(served, tmp_path, capsys):
     main(["--config-dir", str(tmp_path)])
     assert "?token=" not in capsys.readouterr().out
+
+
+def test_the_no_real_browser_guard_is_in_force():
+    """Proves the autouse `_no_real_browser` guard in conftest.py actually
+    works, the same role test_no_argument_defaults_never_touch_the_real_home
+    (tests/test_server_auth_store.py) plays for `_no_real_home`.
+
+    Every test above that reaches the empty-store setup-screen path without
+    stubbing `_open_browser` itself relies on this. If this assertion ever
+    starts failing, the guard fixture has broken and any test anywhere in
+    the suite that reaches that path is one missed per-test stub away from
+    popping a real browser window again.
+    """
+    import webbrowser
+
+    # The real stdlib webbrowser.open is defined in the webbrowser module
+    # itself; the guard fixture replaces it with a lambda defined in
+    # conftest.py. Comparing __module__ needs no pristine "before" reference
+    # to compare against -- by the time any test body runs, the autouse
+    # fixture has already patched the only webbrowser.open there is.
+    assert webbrowser.open.__module__ != "webbrowser"

--- a/tests/test_server_first_run.py
+++ b/tests/test_server_first_run.py
@@ -1,0 +1,68 @@
+"""First run: no auto-minted identity, and a route to the setup screen."""
+
+import pytest
+
+from scpi_control.server.__main__ import main
+from scpi_control.server.auth import TokenStore
+
+
+@pytest.fixture
+def served(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(
+        "scpi_control.server.__main__._run_servers",
+        lambda main_app, host, port, admin_app, admin_port: calls.update(admin_app=admin_app, admin_port=admin_port),
+    )
+    return calls
+
+
+def test_an_empty_store_mints_nothing(served, tmp_path, monkeypatch):
+    # The old behaviour minted an identity literally called "default", which
+    # then showed up as the owner of every session created from it. Setup mints
+    # a real name instead.
+    monkeypatch.setattr("scpi_control.server.__main__._open_browser", lambda url: True)
+    main(["--config-dir", str(tmp_path)])
+    assert TokenStore(str(tmp_path / "tokens.json")).names() == []
+
+
+def test_an_empty_store_opens_the_admin_panel(served, tmp_path, monkeypatch):
+    opened = {}
+    monkeypatch.setattr("scpi_control.server.__main__._open_browser", lambda url: opened.setdefault("url", url) or True)
+    main(["--config-dir", str(tmp_path), "--admin-port", "9100"])
+    assert opened["url"] == "http://127.0.0.1:9100/"
+
+
+def test_a_configured_store_does_not_open_a_browser(served, tmp_path, monkeypatch):
+    # Opening a window on every restart of a working gateway would be
+    # obnoxious; the setup screen is for the first run only.
+    opened = {}
+    monkeypatch.setattr("scpi_control.server.__main__._open_browser", lambda url: opened.setdefault("url", url) or True)
+    TokenStore(str(tmp_path / "tokens.json")).mint("robin")
+    main(["--config-dir", str(tmp_path)])
+    assert opened == {}
+
+
+def test_a_browser_that_will_not_open_does_not_fail_the_start(served, tmp_path, monkeypatch, capsys):
+    def boom(url):
+        raise OSError("no display")
+
+    monkeypatch.setattr("scpi_control.server.__main__._open_browser", boom)
+    main(["--config-dir", str(tmp_path)])
+    printed = capsys.readouterr().out
+    assert "8766" in printed
+    assert served["admin_app"] is not None
+
+
+def test_no_admin_on_an_empty_store_points_at_the_cli(served, tmp_path, capsys):
+    # Without this branch the combination is a running gateway nobody can ever
+    # reach: no auto-minted token, and no panel to make one.
+    main(["--config-dir", str(tmp_path), "--no-admin"])
+    printed = capsys.readouterr().out
+    assert "scpi-web invite" in printed
+    assert TokenStore(str(tmp_path / "tokens.json")).names() == []
+
+
+def test_no_token_url_is_printed_any_more(served, tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("scpi_control.server.__main__._open_browser", lambda url: True)
+    main(["--config-dir", str(tmp_path)])
+    assert "?token=" not in capsys.readouterr().out

--- a/tests/test_server_invitations.py
+++ b/tests/test_server_invitations.py
@@ -129,6 +129,25 @@ def test_a_corrupt_invitation_file_is_not_silently_empty(tmp_path):
         InvitationStore(str(path))
 
 
+def test_a_pre_id_invitation_file_fails_loudly_with_a_way_out(tmp_path):
+    # A legacy file -- valid JSON, valid old schema, just missing "id" -- is
+    # not corrupt, but strict validation still refuses to load it, and
+    # _validate runs before _prune, so even entries that have long since
+    # expired cannot rescue the load. That is a deliberate choice, not an
+    # oversight: this feature is unreleased, the file is only ever created by
+    # running `scpi-web invite`, and a tolerant load or migration path was
+    # considered and declined as speculative work for a population of
+    # approximately zero existing files. What is not optional is that the
+    # operator who hits this be told what to do about it: delete the file and
+    # restart, since nothing in it outlives ten minutes anyway.
+    path = tmp_path / "invitations.json"
+    legacy_entry = {"name": "bob", "link_hash": "x" * 64, "code": "417902", "expires": 1.0}
+    path.write_text(json.dumps({"invitations": [legacy_entry]}))
+    with pytest.raises(ValueError) as excinfo:
+        InvitationStore(str(path))
+    assert "delete" in str(excinfo.value)
+
+
 def test_a_store_corrupted_while_running_keeps_failing(tmp_path):
     # The same ordering guard TokenStore needed: if _load() commits the stat
     # key before the read succeeds, a corrupt file raises loudly exactly once

--- a/tests/test_server_invitations.py
+++ b/tests/test_server_invitations.py
@@ -148,3 +148,74 @@ def test_redeem_without_a_credential_returns_none(tmp_path):
     store = InvitationStore(str(tmp_path / "invitations.json"))
     store.create("bob")
     assert store.redeem() is None
+
+
+def test_pending_list_reports_live_invitations(tmp_path):
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    _link, code = store.create("bob")
+    rows = store.pending_list()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "bob"
+    assert rows[0]["code"] == code
+    assert rows[0]["id"]
+    assert rows[0]["expires"] > 0
+
+
+def test_pending_list_omits_expired_invitations(tmp_path):
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    store.create("stale", ttl=-1.0)
+    store.create("bob")
+    assert [row["name"] for row in store.pending_list()] == ["bob"]
+
+
+def test_pending_list_is_ordered_by_expiry(tmp_path):
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    store.create("later", ttl=600.0)
+    store.create("sooner", ttl=60.0)
+    assert [row["name"] for row in store.pending_list()] == ["sooner", "later"]
+
+
+def test_cancel_removes_the_invitation(tmp_path):
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    _link, code = store.create("bob")
+    invitation_id = store.pending_list()[0]["id"]
+    assert store.cancel(invitation_id) is True
+    assert store.pending_list() == []
+    assert store.redeem(code=code) is None
+
+
+def test_cancel_is_idempotent_and_reports_unknown_ids(tmp_path):
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    store.create("bob")
+    invitation_id = store.pending_list()[0]["id"]
+    assert store.cancel(invitation_id) is True
+    assert store.cancel(invitation_id) is False
+    assert store.cancel("deadbeef") is False
+
+
+def test_cancel_only_removes_the_named_invitation(tmp_path):
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    store.create("bob")
+    store.create("bob")  # one person, two pending invitations -- id must discriminate
+    first = store.pending_list()[0]["id"]
+    store.cancel(first)
+    remaining = store.pending_list()
+    assert len(remaining) == 1
+    assert remaining[0]["id"] != first
+
+
+def test_an_id_is_not_the_code(tmp_path):
+    # The id exists so cancellation can address an invitation without putting a
+    # live credential in a URL path -- and therefore in the host's access log.
+    # If the id ever becomes the code, that protection silently evaporates.
+    store = InvitationStore(str(tmp_path / "invitations.json"))
+    _link, code = store.create("bob")
+    assert store.pending_list()[0]["id"] != code
+
+
+def test_a_cancelled_invitation_is_gone_for_another_process(tmp_path):
+    path = str(tmp_path / "invitations.json")
+    store = InvitationStore(path)
+    _link, code = store.create("bob")
+    store.cancel(store.pending_list()[0]["id"])
+    assert InvitationStore(path).redeem(code=code) is None

--- a/webapp/app/admin.html
+++ b/webapp/app/admin.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SCPI Gateway Admin</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/admin/main.tsx"></script>
+  </body>
+</html>

--- a/webapp/app/package.json
+++ b/webapp/app/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && tsc --noEmit -p tsconfig.node.json && vite build",
+    "build:admin": "vite build --config vite.admin.config.ts",
+    "dev:admin": "vite --config vite.admin.config.ts",
     "preview": "vite preview",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/webapp/app/src/admin/App.tsx
+++ b/webapp/app/src/admin/App.tsx
@@ -1,0 +1,16 @@
+import { GroupBox } from "../ds/GroupBox";
+import { People } from "./People";
+
+/**
+ * Admin app shell. There is exactly one screen -- the person who administers
+ * the gateway sits down at the bench PC to manage access, not to navigate.
+ */
+export function App() {
+  return (
+    <div style={{ padding: "var(--space-4)", fontFamily: "var(--font-ui)", maxWidth: "960px", margin: "0 auto" }}>
+      <GroupBox title="SCPI Gateway Admin">
+        <People />
+      </GroupBox>
+    </div>
+  );
+}

--- a/webapp/app/src/admin/Countdown.tsx
+++ b/webapp/app/src/admin/Countdown.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+/** Time left until `expires` (epoch seconds), as m:ss. */
+export function Countdown({ expires }: { expires: number }) {
+  const [now, setNow] = useState(() => Date.now() / 1000);
+
+  useEffect(() => {
+    // One interval per mounted countdown, cleared on unmount. Pending
+    // invitations come and go as they are created and cancelled, so a leaked
+    // timer here accumulates for as long as the panel stays open.
+    const timer = setInterval(() => setNow(Date.now() / 1000), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const left = Math.max(0, Math.floor(expires - now));
+  if (left === 0) return <span>expired</span>;
+  const minutes = Math.floor(left / 60);
+  const seconds = String(left % 60).padStart(2, "0");
+  return <span>{`${minutes}:${seconds}`}</span>;
+}

--- a/webapp/app/src/admin/People.test.tsx
+++ b/webapp/app/src/admin/People.test.tsx
@@ -126,6 +126,35 @@ describe("People", () => {
     await waitFor(() => expect(screen.queryByRole("button", { name: /cancel invitation/i })).not.toBeInTheDocument());
   });
 
+  it("re-shows a pending invitation's code without re-creating it", async () => {
+    // The code is what the admin reads down a phone, and the panel is the only
+    // way to get it back: the CLI prints once and forgets, and the link cannot
+    // be reconstructed because only its hash is stored. GET /api/invitations
+    // returns the code for exactly this reason, so a listing that renders the
+    // name and countdown but drops the code makes that response pointless and
+    // leaves "cancel and re-invite" as the only remedy for a mislaid code.
+    // This asserts a *pending* invitation loaded on mount -- not one this
+    // browser session just created, which is a different code path.
+    vi.spyOn(adminApi, "identities").mockResolvedValue([]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([invitation("a1b2c3d4", "bob")]);
+    const create = vi.spyOn(adminApi, "createInvitation");
+    render(<People />);
+    expect(await screen.findByText(/417 902/)).toBeInTheDocument();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("does not offer a link for a pending invitation, only a code", async () => {
+    // Only the nonce's hash is stored, so the link genuinely exists once, at
+    // creation. Rendering a link here would mean somebody had reconstructed
+    // one -- which could only be a wrong one.
+    vi.spyOn(adminApi, "identities").mockResolvedValue([]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([invitation("a1b2c3d4", "bob")]);
+    render(<People />);
+    await screen.findByText(/417 902/);
+    expect(screen.queryByText(/\?invite=/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /copy link/i })).not.toBeInTheDocument();
+  });
+
   it("reports a failure instead of silently doing nothing", async () => {
     vi.spyOn(adminApi, "identities").mockResolvedValue([]);
     vi.spyOn(adminApi, "invitations").mockResolvedValue([]);

--- a/webapp/app/src/admin/People.test.tsx
+++ b/webapp/app/src/admin/People.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { People } from "./People";
@@ -38,6 +38,31 @@ describe("People", () => {
     expect(revoke).not.toHaveBeenCalled();
   });
 
+  it("revokes the identity and reloads the roster when the confirmation is accepted", async () => {
+    // The identities() stub returns bob on mount, then an empty list on the
+    // reload that must follow a successful revoke. A local optimistic splice
+    // (removing bob from state without calling the server again) would leave
+    // the call count flat, so that assertion catches it even though the
+    // screen would look right either way.
+    const identities = vi
+      .spyOn(adminApi, "identities")
+      .mockResolvedValueOnce([identity("bob", 2)])
+      .mockResolvedValueOnce([]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
+    const revoke = vi.spyOn(adminApi, "revokeIdentity").mockResolvedValue(undefined);
+    render(<People />);
+    await screen.findByText(/bob/);
+    const callsAfterMount = identities.mock.calls.length;
+
+    await userEvent.click(screen.getByRole("button", { name: /revoke/i }));
+    const dialog = screen.getByRole("alertdialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /revoke/i }));
+
+    expect(revoke).toHaveBeenCalledWith("bob");
+    await waitFor(() => expect(identities.mock.calls.length).toBeGreaterThan(callsAfterMount));
+    expect(await screen.findByText(/no one has access yet/i)).toBeInTheDocument();
+  });
+
   it("shows the link and the code after inviting", async () => {
     vi.spyOn(adminApi, "identities").mockResolvedValue([]);
     vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
@@ -49,6 +74,28 @@ describe("People", () => {
     expect(screen.getByText(/\?invite=xyz/)).toBeInTheDocument();
   });
 
+  it("reloads invitations from the server after creating one", async () => {
+    // invitations() returns nothing on mount, then the new invite on the
+    // reload that must follow a successful create. If create only appended
+    // the returned invitation to local state instead of reloading, the call
+    // count would stay flat even though the row would still appear.
+    vi.spyOn(adminApi, "identities").mockResolvedValue([]);
+    const invitations = vi
+      .spyOn(adminApi, "invitations")
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([invitation("a1", "bob")]);
+    vi.spyOn(adminApi, "createInvitation").mockResolvedValue({ ...invitation("a1", "bob"), link: "http://192.168.1.50:8765/?invite=xyz" });
+    render(<People />);
+    await screen.findByLabelText(/name/i);
+    const callsAfterMount = invitations.mock.calls.length;
+
+    await userEvent.type(screen.getByLabelText(/name/i), "bob");
+    await userEvent.click(screen.getByRole("button", { name: /invite/i }));
+
+    await waitFor(() => expect(invitations.mock.calls.length).toBeGreaterThan(callsAfterMount));
+    expect(await screen.findByRole("button", { name: /cancel invitation/i })).toBeInTheDocument();
+  });
+
   it("cancels a pending invitation by id", async () => {
     vi.spyOn(adminApi, "identities").mockResolvedValue([]);
     vi.spyOn(adminApi, "invitations").mockResolvedValue([invitation("a1b2c3d4", "bob")]);
@@ -56,6 +103,27 @@ describe("People", () => {
     render(<People />);
     await userEvent.click(await screen.findByRole("button", { name: /cancel invitation/i }));
     expect(cancel).toHaveBeenCalledWith("a1b2c3d4");
+  });
+
+  it("reloads invitations from the server after cancelling one", async () => {
+    // invitations() returns bob's pending invite on mount, then an empty
+    // list on the reload that must follow a successful cancel. A local
+    // splice would leave the call count flat even though the row would
+    // still disappear.
+    vi.spyOn(adminApi, "identities").mockResolvedValue([]);
+    const invitations = vi
+      .spyOn(adminApi, "invitations")
+      .mockResolvedValueOnce([invitation("a1b2c3d4", "bob")])
+      .mockResolvedValueOnce([]);
+    vi.spyOn(adminApi, "cancelInvitation").mockResolvedValue(undefined);
+    render(<People />);
+    await screen.findByRole("button", { name: /cancel invitation/i });
+    const callsAfterMount = invitations.mock.calls.length;
+
+    await userEvent.click(screen.getByRole("button", { name: /cancel invitation/i }));
+
+    await waitFor(() => expect(invitations.mock.calls.length).toBeGreaterThan(callsAfterMount));
+    await waitFor(() => expect(screen.queryByRole("button", { name: /cancel invitation/i })).not.toBeInTheDocument());
   });
 
   it("reports a failure instead of silently doing nothing", async () => {

--- a/webapp/app/src/admin/People.test.tsx
+++ b/webapp/app/src/admin/People.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { People } from "./People";
+import { adminApi } from "./api";
+
+const identity = (name: string, devices: number) => ({ name, devices, last_used: null });
+const invitation = (id: string, name: string) => ({ id, name, code: "417902", expires: Date.now() / 1000 + 600 });
+
+describe("People", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("lists identities with their device counts", async () => {
+    vi.spyOn(adminApi, "identities").mockResolvedValue([identity("bob", 2)]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
+    render(<People />);
+    expect(await screen.findByText(/bob/)).toBeInTheDocument();
+    expect(screen.getByText(/2 devices/)).toBeInTheDocument();
+  });
+
+  it("names the consequence before revoking", async () => {
+    // Revoking signs out every device that identity holds. The count is the
+    // thing the CLI cannot easily tell you before you act, so the panel must.
+    vi.spyOn(adminApi, "identities").mockResolvedValue([identity("bob", 2)]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
+    render(<People />);
+    await userEvent.click(await screen.findByRole("button", { name: /revoke/i }));
+    expect(screen.getByRole("alertdialog")).toHaveTextContent(/all 2 of their devices/i);
+  });
+
+  it("does not revoke until the confirmation is accepted", async () => {
+    vi.spyOn(adminApi, "identities").mockResolvedValue([identity("bob", 2)]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
+    const revoke = vi.spyOn(adminApi, "revokeIdentity").mockResolvedValue(undefined);
+    render(<People />);
+    await userEvent.click(await screen.findByRole("button", { name: /revoke/i }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(revoke).not.toHaveBeenCalled();
+  });
+
+  it("shows the link and the code after inviting", async () => {
+    vi.spyOn(adminApi, "identities").mockResolvedValue([]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
+    vi.spyOn(adminApi, "createInvitation").mockResolvedValue({ ...invitation("a1", "bob"), link: "http://192.168.1.50:8765/?invite=xyz" });
+    render(<People />);
+    await userEvent.type(await screen.findByLabelText(/name/i), "bob");
+    await userEvent.click(screen.getByRole("button", { name: /invite/i }));
+    expect(await screen.findByText(/417 902/)).toBeInTheDocument();
+    expect(screen.getByText(/\?invite=xyz/)).toBeInTheDocument();
+  });
+
+  it("cancels a pending invitation by id", async () => {
+    vi.spyOn(adminApi, "identities").mockResolvedValue([]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([invitation("a1b2c3d4", "bob")]);
+    const cancel = vi.spyOn(adminApi, "cancelInvitation").mockResolvedValue(undefined);
+    render(<People />);
+    await userEvent.click(await screen.findByRole("button", { name: /cancel invitation/i }));
+    expect(cancel).toHaveBeenCalledWith("a1b2c3d4");
+  });
+
+  it("reports a failure instead of silently doing nothing", async () => {
+    vi.spyOn(adminApi, "identities").mockResolvedValue([]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
+    vi.spyOn(adminApi, "createInvitation").mockRejectedValue(new Error("name must not be empty"));
+    render(<People />);
+    await userEvent.type(await screen.findByLabelText(/name/i), "x");
+    await userEvent.click(screen.getByRole("button", { name: /invite/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/must not be empty/i);
+  });
+
+  it("shows the setup screen when nobody has access yet", async () => {
+    vi.spyOn(adminApi, "identities").mockResolvedValue([]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
+    render(<People />);
+    expect(await screen.findByText(/no one has access yet/i)).toBeInTheDocument();
+  });
+});

--- a/webapp/app/src/admin/People.tsx
+++ b/webapp/app/src/admin/People.tsx
@@ -215,9 +215,22 @@ export function People() {
                 style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}
               >
                 <span>{invite.name}</span>
+                {/*
+                  The code is shown again here, not just on the invitation you
+                  happen to have just created. GET /api/invitations returns it
+                  for exactly this reason: an admin who closed the window, or
+                  who is back at the bench an hour later, would otherwise have
+                  no way to recover it and would have to cancel and re-invite.
+                  The link is deliberately absent -- only the nonce's hash is
+                  stored, so it cannot be reconstructed after creation.
+                */}
+                <code style={{ fontFamily: "var(--font-mono)", letterSpacing: "0.1em" }}>{groupCode(invite.code)}</code>
                 <span>
                   <Countdown expires={invite.expires} />
                 </span>
+                <Button size="sm" onClick={() => void copyToClipboard(invite.code)}>
+                  Copy code
+                </Button>
                 <Button size="sm" onClick={() => void cancelInvite(invite.id)}>
                   Cancel invitation
                 </Button>

--- a/webapp/app/src/admin/People.tsx
+++ b/webapp/app/src/admin/People.tsx
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
+import { Button } from "../ds/Button";
+import { DataTable } from "../ds/DataTable";
+import { GroupBox } from "../ds/GroupBox";
+import { Countdown } from "./Countdown";
+import { adminApi, type Identity, type Invitation } from "./api";
+
+function formatDevices(count: number): string {
+  return `${count} device${count === 1 ? "" : "s"}`;
+}
+
+/** Coarse "N units ago" for a last-used timestamp. `null` means never used. */
+function formatLastUsed(lastUsed: string | null): string {
+  if (!lastUsed) return "never";
+  const then = Date.parse(lastUsed);
+  if (Number.isNaN(then)) return "unknown";
+  const seconds = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
+/** "417902" -> "417 902". Splits evenly; codes are an even length by construction. */
+function groupCode(code: string): string {
+  const mid = Math.ceil(code.length / 2);
+  return `${code.slice(0, mid)} ${code.slice(mid)}`;
+}
+
+async function copyToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    // Clipboard access can be denied or unavailable (permissions, insecure
+    // context). There's nothing more to do here -- the value is already on
+    // screen as plain text for the admin to select by hand.
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "Something went wrong.";
+}
+
+export function People() {
+  const [identities, setIdentities] = useState<Identity[] | null>(null);
+  const [invitations, setInvitations] = useState<Invitation[] | null>(null);
+  const [error, setError] = useState("");
+
+  const [revokeTarget, setRevokeTarget] = useState<Identity | null>(null);
+  const [revoking, setRevoking] = useState(false);
+
+  const [inviteName, setInviteName] = useState("");
+  const [inviting, setInviting] = useState(false);
+  const [created, setCreated] = useState<Invitation | null>(null);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const loadIdentities = useCallback(async () => {
+    setIdentities(await adminApi.identities());
+  }, []);
+  const loadInvitations = useCallback(async () => {
+    setInvitations(await adminApi.invitations());
+  }, []);
+
+  useEffect(() => {
+    void loadIdentities();
+    void loadInvitations();
+  }, [loadIdentities, loadInvitations]);
+
+  // Move focus into the confirmation so keyboard and screen-reader users land
+  // on it rather than having to hunt for a dialog that appeared elsewhere.
+  useEffect(() => {
+    if (revokeTarget) dialogRef.current?.focus();
+  }, [revokeTarget]);
+
+  const confirmRevoke = async () => {
+    if (!revokeTarget) return;
+    setError("");
+    setRevoking(true);
+    try {
+      await adminApi.revokeIdentity(revokeTarget.name);
+      setRevokeTarget(null);
+      await loadIdentities();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setRevoking(false);
+    }
+  };
+
+  const submitInvite = async (event: FormEvent) => {
+    event.preventDefault();
+    const name = inviteName.trim();
+    if (!name) return;
+    setError("");
+    setInviting(true);
+    try {
+      const invite = await adminApi.createInvitation(name);
+      setCreated(invite);
+      setInviteName("");
+      await loadInvitations();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setInviting(false);
+    }
+  };
+
+  const cancelInvite = async (id: string) => {
+    setError("");
+    try {
+      await adminApi.cancelInvitation(id);
+      setCreated((current) => (current?.id === id ? null : current));
+      await loadInvitations();
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+      {error ? (
+        <p role="alert" style={{ color: "var(--danger)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </p>
+      ) : null}
+
+      <GroupBox title="Who has access">
+        {identities === null ? (
+          <p>Loading…</p>
+        ) : identities.length === 0 ? (
+          <p>No one has access yet. Invite someone below to get started.</p>
+        ) : (
+          <DataTable
+            columns={["Name", "Devices", "Last used", ""]}
+            rows={identities.map((identity) => [
+              identity.name,
+              formatDevices(identity.devices),
+              formatLastUsed(identity.last_used),
+              <Button
+                size="sm"
+                variant="danger"
+                disabled={revokeTarget !== null}
+                onClick={() => setRevokeTarget(identity)}
+              >
+                Revoke
+              </Button>,
+            ])}
+          />
+        )}
+      </GroupBox>
+
+      <GroupBox title="Invitations">
+        <form
+          onSubmit={(event) => void submitInvite(event)}
+          style={{ display: "flex", gap: "var(--space-2)", alignItems: "flex-end", marginBottom: "var(--space-3)" }}
+        >
+          <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+            <label htmlFor="invite-name" style={{ fontSize: "var(--text-sm)", color: "var(--lc-text)" }}>
+              Name
+            </label>
+            <input
+              id="invite-name"
+              value={inviteName}
+              onChange={(event) => setInviteName(event.target.value)}
+              style={{
+                padding: "6px 8px",
+                fontSize: "var(--text-sm)",
+                border: "1px solid var(--lc-border-strong)",
+                borderRadius: "var(--lc-radius-sm)",
+                background: "var(--lc-control)",
+                color: "var(--lc-text)",
+              }}
+            />
+          </div>
+          <Button type="submit" variant="primary" disabled={inviting || !inviteName.trim()}>
+            Invite
+          </Button>
+        </form>
+
+        {created ? (
+          <div style={{ marginBottom: "var(--space-3)", display: "flex", flexDirection: "column", gap: "6px" }}>
+            <p>
+              Invitation created for <strong>{created.name}</strong> — expires in <Countdown expires={created.expires} />.
+            </p>
+            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+              <code style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-lg)", letterSpacing: "0.1em" }}>
+                {groupCode(created.code)}
+              </code>
+              <Button size="sm" onClick={() => void copyToClipboard(created.code)}>
+                Copy code
+              </Button>
+            </div>
+            {created.link ? (
+              <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                <code style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-xs)", wordBreak: "break-all" }}>
+                  {created.link}
+                </code>
+                <Button size="sm" onClick={() => void copyToClipboard(created.link as string)}>
+                  Copy link
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {invitations && invitations.length > 0 ? (
+          <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "6px" }}>
+            {invitations.map((invite) => (
+              <li
+                key={invite.id}
+                style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}
+              >
+                <span>{invite.name}</span>
+                <span>
+                  <Countdown expires={invite.expires} />
+                </span>
+                <Button size="sm" onClick={() => void cancelInvite(invite.id)}>
+                  Cancel invitation
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </GroupBox>
+
+      {revokeTarget ? (
+        <div
+          role="alertdialog"
+          aria-label={`Revoke ${revokeTarget.name}?`}
+          aria-modal="true"
+          tabIndex={-1}
+          ref={dialogRef}
+          style={{
+            border: "1px solid var(--lc-border-strong)",
+            borderRadius: "var(--lc-radius)",
+            background: "var(--lc-panel)",
+            boxShadow: "var(--lc-elev-1)",
+            padding: "var(--space-3)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--space-2)",
+            maxWidth: "360px",
+          }}
+        >
+          <p>
+            Revoke {revokeTarget.name}? This signs out all {revokeTarget.devices} of their devices.
+          </p>
+          <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end" }}>
+            <Button disabled={revoking} onClick={() => setRevokeTarget(null)}>
+              Cancel
+            </Button>
+            <Button variant="danger" disabled={revoking} onClick={() => void confirmRevoke()}>
+              Revoke
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/webapp/app/src/admin/People.tsx
+++ b/webapp/app/src/admin/People.tsx
@@ -219,8 +219,9 @@ export function People() {
                   The code is shown again here, not just on the invitation you
                   happen to have just created. GET /api/invitations returns it
                   for exactly this reason: an admin who closed the window, or
-                  who is back at the bench an hour later, would otherwise have
-                  no way to recover it and would have to cancel and re-invite.
+                  who steps away and comes back a few minutes later, would
+                  otherwise have no way to recover it and would have to cancel
+                  and re-invite.
                   The link is deliberately absent -- only the nonce's hash is
                   stored, so it cannot be reconstructed after creation.
                 */}

--- a/webapp/app/src/admin/api.test.ts
+++ b/webapp/app/src/admin/api.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { adminApi } from "./api";
+
+describe("adminApi", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("lists identities", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify([{ name: "bob", devices: 2, last_used: null }]), { status: 200 })));
+    await expect(adminApi.identities()).resolves.toEqual([{ name: "bob", devices: 2, last_used: null }]);
+  });
+
+  it("sends no Authorization header", async () => {
+    // The admin app has no auth. Sending a bearer token would be harmless but
+    // misleading -- it would imply a credential model that does not exist.
+    const fetchMock = vi.fn().mockResolvedValue(new Response("[]", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await adminApi.identities();
+    const headers = new Headers(fetchMock.mock.calls[0][1]?.headers ?? {});
+    expect(headers.get("authorization")).toBeNull();
+  });
+
+  it("surfaces the server's message on failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "HTTPException", detail: "no identity named 'ghost'" }), { status: 404 })));
+    await expect(adminApi.revokeIdentity("ghost")).rejects.toThrow(/ghost/);
+  });
+
+  it("cancels by id, never by code", async () => {
+    // A code in the URL path lands in the host's access log. The id exists to
+    // keep it out.
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await adminApi.cancelInvitation("a1b2c3d4");
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/invitations/a1b2c3d4");
+  });
+});

--- a/webapp/app/src/admin/api.ts
+++ b/webapp/app/src/admin/api.ts
@@ -1,0 +1,35 @@
+export type Identity = { name: string; devices: number; last_used: string | null };
+export type Invitation = { id: string; name: string; code: string; expires: number; link?: string };
+
+/**
+ * Admin API client. Deliberately does NOT attach a bearer token: this app is
+ * served only on a loopback-bound listener, and the boundary is that bind.
+ * Sending a credential would imply a permission model that does not exist.
+ */
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(path, init);
+  if (!response.ok) {
+    let detail = "request failed";
+    try {
+      detail = (await response.json()).detail ?? detail;
+    } catch {
+      // non-JSON error body: keep the default
+    }
+    throw new Error(detail);
+  }
+  return response.status === 204 ? (undefined as T) : ((await response.json()) as T);
+}
+
+const json = (method: string, body: unknown): RequestInit => ({
+  method,
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+});
+
+export const adminApi = {
+  identities: () => request<Identity[]>("/api/identities"),
+  invitations: () => request<Invitation[]>("/api/invitations"),
+  createInvitation: (name: string) => request<Invitation>("/api/invitations", json("POST", { name })),
+  cancelInvitation: (id: string) => request<void>(`/api/invitations/${id}`, { method: "DELETE" }),
+  revokeIdentity: (name: string) => request<void>(`/api/identities/${encodeURIComponent(name)}`, { method: "DELETE" }),
+};

--- a/webapp/app/src/admin/main.tsx
+++ b/webapp/app/src/admin/main.tsx
@@ -4,6 +4,12 @@ import "@design/styles.css";
 import "../ds/ds.css";
 import { App } from "./App";
 
+// No captureTokenFromUrl() and no <TokenGate> here, unlike the LAN app's
+// main.tsx -- that is deliberate, not an omission. This bundle is served only
+// by the admin listener, which binds 127.0.0.1, so there is no credential to
+// collect: reaching this page at all is the proof of access. A gate here would
+// only imply a permission model that does not exist. See
+// scpi_control/server/admin/app.py for the two defences that do the work.
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />

--- a/webapp/app/src/admin/main.tsx
+++ b/webapp/app/src/admin/main.tsx
@@ -2,16 +2,10 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "@design/styles.css";
 import "../ds/ds.css";
-
-// Placeholder root: the admin screens (People, invitations, etc.) are built in
-// a later task. This entry point exists so the build in this task is
-// verifiable end-to-end -- see webapp/app/vite.admin.config.ts.
-function AdminPlaceholder() {
-  return <div style={{ padding: "var(--space-3)", fontFamily: "var(--font-ui)" }}>SCPI Gateway Admin</div>;
-}
+import { App } from "./App";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <AdminPlaceholder />
+    <App />
   </React.StrictMode>,
 );

--- a/webapp/app/src/admin/main.tsx
+++ b/webapp/app/src/admin/main.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "@design/styles.css";
+import "../ds/ds.css";
+
+// Placeholder root: the admin screens (People, invitations, etc.) are built in
+// a later task. This entry point exists so the build in this task is
+// verifiable end-to-end -- see webapp/app/vite.admin.config.ts.
+function AdminPlaceholder() {
+  return <div style={{ padding: "var(--space-3)", fontFamily: "var(--font-ui)" }}>SCPI Gateway Admin</div>;
+}
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <AdminPlaceholder />
+  </React.StrictMode>,
+);

--- a/webapp/app/vite.admin.config.ts
+++ b/webapp/app/vite.admin.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
+// A separate config, and a separate outDir, so the admin bundle never lands in
+// the main app's static directory -- whose SPA catch-all would serve it to any
+// LAN browser that asked.
+export default defineConfig({
+  plugins: [react()],
+  resolve: { alias: { "@design": resolve(__dirname, "../design") } },
+  server: {
+    proxy: { "/api": { target: "http://127.0.0.1:8766", changeOrigin: true } },
+  },
+  build: {
+    outDir: "dist-admin",
+    emptyOutDir: true,
+    rollupOptions: { input: resolve(__dirname, "admin.html") },
+  },
+});

--- a/webapp/app/vite.admin.config.ts
+++ b/webapp/app/vite.admin.config.ts
@@ -9,7 +9,18 @@ export default defineConfig({
   plugins: [react()],
   resolve: { alias: { "@design": resolve(__dirname, "../design") } },
   server: {
-    proxy: { "/api": { target: "http://127.0.0.1:8766", changeOrigin: true } },
+    // changeOrigin rewrites Host so the gateway's TrustedHost allowlist is
+    // satisfied; headers.Origin does the same for its Origin allowlist, which
+    // otherwise sees this dev server (localhost:5173) and refuses every write.
+    // Rewrite it here rather than relaxing the check in the app: the whole
+    // point of that check is that it does not have a hole for convenience.
+    proxy: {
+      "/api": {
+        target: "http://127.0.0.1:8766",
+        changeOrigin: true,
+        headers: { Origin: "http://127.0.0.1:8766" },
+      },
+    },
   },
   build: {
     outDir: "dist-admin",


### PR DESCRIPTION
Administering the gateway meant remembering CLI subcommands, and a fresh gateway minted an identity literally called `default` — which then showed up as the owner of every session created from it.

This adds an admin panel on the machine the gateway runs on.

```console
$ scpi-web
Gateway ready at http://192.168.1.50:8765/
Admin panel (this machine only) at http://127.0.0.1:8766/
Hand out access with: scpi-web invite <name>
```

## What it does

**Who has access** — a row per identity: `bob · 2 devices · 4 minutes ago`. Revoke has a confirmation that names the consequence — "Revoke bob? This signs out all 2 of their devices" — because that count is the thing the CLI cannot tell you *before* you act.

**Invitations** — a name field. On submit the link and code appear together with copy buttons and a live countdown. Pending invitations list with time remaining and a **Cancel** button. Cancelling is new capability: the CLI has no way to withdraw an invitation sent to the wrong person, so today the only remedy is waiting ten minutes. A pending invitation's code can also be re-shown after you close the window — the CLI prints once and forgets.

**First run** — an empty store now mints nothing. No `default` identity, no `?token=` bootstrap URL. The gateway opens the panel on the host and asks what to call you, so the first identity is a real person rather than an anonymous credential that ends up owning every session. `--no-admin` on an empty store prints a banner pointing at `scpi-web invite <name>`, which is what a headless deployment hits.

## Why there is no sign-in — three defences, none sufficient alone

This is the part worth reviewing carefully. The panel has **no authentication at all**, by design.

1. **The listener binds `127.0.0.1`**, so the OS refuses non-local connections before any of our code runs. `ADMIN_HOST` is a module constant and there is deliberately **no `--admin-host` flag** — a configurable host would let someone bind an unauthenticated, credential-issuing API to the world.
2. **A `Host` allowlist** (`127.0.0.1`, `localhost`). The bind stops a non-local *socket*; it does not stop a *browser*. A page you visit could otherwise rebind its hostname to 127.0.0.1, become same-origin, issue an invitation and read the redeemable link back.
3. **An `Origin` refusal.** A plain cross-origin `fetch` needs no rebinding and satisfies both defences above — the socket arrives on loopback and `Host` is `127.0.0.1:8766`. Foreign origins are now refused outright, which also kills the rebinding variant.

Each is documented with what it *misses*, in the module docstring and in `docs/gateway/admin-panel.md`, specifically so none of them is later deleted as redundant.

Other boundaries: the admin app has no `AuthMiddleware`, is never mounted under the main app, and its frontend is a **separate bundle** in its own directory so the LAN app can never serve it. A CI gate greps the built LAN bundle's *contents* for `/api/identities` — not filenames, because a cross-import would leave filenames unchanged.

## Breaking changes

Marked ⚠️ in the changelog; folds into the queued **6.0.0** alongside the invitations work:

- A fresh gateway no longer mints `default` and no longer prints a `?token=…` bootstrap URL. Existing installations are unaffected — this changes only what happens when the token store is empty.

## Testing

2092 passed / 19 skipped (Python), 305 passed (frontend), typecheck clean.

Five defects were caught during development that are worth knowing about, because every one came from the implementation plan rather than from writing the code wrong:

1. **A CI gate that would have passed vacuously.** `if grep -r needle missing_dir/` exits 2, which `if` reads as "clean" — so the separation gate would have reported success on a build that never ran.
2. **A signal-handling line that was a silent no-op.** uvicorn 0.34.3 captures signals through a context manager, not `install_signal_handlers`, so both servers would have kept capturing SIGINT and Ctrl+C would have stopped one while the other held the process open.
3. **A test that would have hung CI on all six Python versions.** It stubbed `uvicorn.run`, but the serve path moved to `uvicorn.Server(...).run()`, so it bound real sockets and served forever. CI has no per-test timeout.
4. **A packaging rule that would have shipped 6.0.0 without its flagship feature.** `MANIFEST.in` covered `server/static` and not `server/admin/static`, so `pip install` + `scpi-web` would have opened a browser at the panel and served a raw JSON 404.
5. **Four guards that read as proof of things they did not test** — most seriously, nothing asserted the admin listener's `Config` actually received the loopback host, so changing one token would have published the unauthenticated API to the LAN with a green suite. Each is now mutation-tested: the guard is shown failing when its target bug is reintroduced.

## Known gap, documented rather than fixed

Revocation still does not tear down an **already-open WebSocket** — the stream authenticates once at handshake. The revoke dialog's copy is accurate about the next request, and the behavioural fix is queued for the next sub-project (Sessions, Health and Instruments panels), which is where force-release belongs.
