### PR TITLE
feat(server): revocation cuts live streams and releases owned sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   what to call you, so the first identity is a real person rather than an anonymous credential
   that ends up owning every session it creates. Existing installations are unaffected — this
   changes only what happens when the token store is empty.
+- Revoking an identity now also closes that identity's live streams and releases the sessions
+  they owned. A revoked colleague mid-capture loses their view, and their session becomes
+  immediately claimable. The revoke route's response code has changed from 204 to 200 with a
+  body carrying `{"devices", "streams", "sessions"}` counts — a wire-visible change for anyone
+  scripting against it.
 
 ### Added
 
@@ -85,6 +90,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it to another address.
 - Cancelling a pending invitation is new — previously the only remedy for one sent to the wrong
   person was waiting ten minutes for it to expire.
+- A Sessions screen in the admin panel lists every open session with its owner, viewer count and
+  idle time. Release clears the owner, making the session immediately claimable by anyone, with
+  no confirmation. Close ends the session after confirming, and warns when that session is
+  recording so an active capture is not lost accidentally.
 
 ### Fixed
 
@@ -99,6 +108,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The home screen's no-instruments-found message no longer singles out "start a Mock scope" — it
   points at the mock button for whichever instrument kind, since a mock power supply and mock
   function generator are just as available.
+- A revoked credential no longer keeps streaming to a client with an active token, and no longer
+  blocks a new user from claiming the session. A periodic liveness check in each stream catches
+  a revocation in a different process (default every 5 seconds), and closes the client's WebSocket
+  with code 4403 to signal that the credential was revoked rather than the session ending (4410).
 
 ## [5.8.0] - 2026-07-27
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   what to call you, so the first identity is a real person rather than an anonymous credential
   that ends up owning every session it creates. Existing installations are unaffected — this
   changes only what happens when the token store is empty.
+- Revoking an identity now also closes that identity's live streams and releases the sessions
+  they owned. A revoked colleague mid-capture loses their view, and their session becomes
+  immediately claimable. The revoke route's response code has changed from 204 to 200 with a
+  body carrying `{"devices", "streams", "sessions"}` counts — a wire-visible change for anyone
+  scripting against it.
 
 ### Added
 
@@ -85,6 +90,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it to another address.
 - Cancelling a pending invitation is new — previously the only remedy for one sent to the wrong
   person was waiting ten minutes for it to expire.
+- A Sessions screen in the admin panel lists every open session with its owner, viewer count and
+  idle time. Release clears the owner, making the session immediately claimable by anyone, with
+  no confirmation. Close ends the session after confirming, and warns when that session is
+  recording so an active capture is not lost accidentally.
 
 ### Fixed
 
@@ -99,6 +108,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The home screen's no-instruments-found message no longer singles out "start a Mock scope" — it
   points at the mock button for whichever instrument kind, since a mock power supply and mock
   function generator are just as available.
+- A revoked credential no longer keeps streaming to a client with an active token, and no longer
+  blocks a new user from claiming the session. A periodic liveness check in each stream catches
+  a revocation in a different process (default every 5 seconds), and closes the client's WebSocket
+  with code 4403 to signal that the credential was revoked rather than the session ending (4410).
 
 ## [5.8.0] - 2026-07-27
 

--- a/docs/gateway/admin-panel.md
+++ b/docs/gateway/admin-panel.md
@@ -9,9 +9,10 @@ http://127.0.0.1:8766/
 ```
 
 Open that in a browser **on the gateway machine** and you get one screen showing
-everyone who has access, with buttons to invite someone or cut them off. The
-`scpi-web invite` and `scpi-web token` commands still work exactly as before —
-the panel is a second way in, not a replacement.
+everyone who has access and every session currently open, with buttons to
+invite someone, cut them off, or free up or end a session. The `scpi-web
+invite` and `scpi-web token` commands still work exactly as before — the panel
+is a second way in, not a replacement.
 
 > **This page is for whoever administers the gateway.** If you are a user
 > wanting to sign in, you need a link or a six-digit code from that person;
@@ -121,10 +122,17 @@ a job, not to navigate.
 
 **Who has access** lists each identity with the number of devices signed in
 under it and when one of them was last seen. This is `scpi-web token list` with
-a **Revoke** button. Revoking asks first, and the confirmation names the
-consequence — *"Revoke bob? This signs out all 2 of their devices"* — because
-the device count is exactly what the CLI cannot easily tell you before you act.
-Revocation takes effect on the next request; there is no restart.
+a **Revoke** button. Revoking is one action that does three things at once —
+signs out every device under that name, cuts any live stream it is watching
+right now, and frees any session it owns for anyone else to claim immediately —
+and the confirmation names all three before you commit: *"Revoke bob? This
+signs out all 2 of their devices, cuts any live stream they're watching right
+now, and frees any session they own for anyone to claim immediately — if
+they're mid-capture, they lose their view the moment you confirm."* Once you
+confirm, the panel reports back what actually happened — how many devices,
+streams, and sessions — rather than a bare "done", because the CLI cannot
+easily tell you any of that before you act. Revocation takes effect on the next
+request; there is no restart.
 
 **Invitations** takes a name and creates a ten-minute invitation, showing:
 
@@ -161,6 +169,29 @@ would only make it *look* safer than it is.
 Storing it in clear is safe **here and nowhere else**: `invitations.json` is
 written `0600` where the platform supports it, and the only thing that ever
 reads a code back out is the host-only panel. It is never served to the LAN app.
+
+## The Sessions screen
+
+**Live sessions** lists every open instrument session — the instrument (its
+label, and address or `(Mock)`), who owns it, how many viewers are watching,
+and how long the owner has been idle. Each row has two buttons:
+
+- **Release** clears the session's owner right away, with no confirmation. It
+  is not destructive — the instrument keeps running and every viewer keeps
+  watching — it just makes the session unowned, so the next person to claim it
+  gets it immediately instead of waiting out `--abandon-after`. This is the
+  same release an owner can already do on themselves (see
+  [Handing off explicitly](security.md#handing-off-explicitly)); the panel just
+  lets an admin do it to someone else's session.
+- **Close** ends the session outright, so it asks first. The confirmation
+  names the consequence — *"Close *label*? This ends the session immediately,
+  and anyone viewing it loses their view right now."* — and adds a second
+  warning when the session is currently recording, because closing it stops
+  that capture too.
+
+Revoking an identity on the People screen above reaches this same list: every
+session the revoked name owned is released the same way Release does here, so
+you never have to open Sessions afterward to clean up what Revoke left behind.
 
 ## First run
 

--- a/docs/gateway/api.md
+++ b/docs/gateway/api.md
@@ -181,7 +181,7 @@ All paths under `/api/sessions/{id}/scope/`.
 | `error` | `{"type": "error", "detail": "connection lost"}` |
 | `closed` | `{"type": "closed"}` |
 
-The connection closes with code **4404** if the session ID does not exist, and **4410** when the session itself closes (after which the socket receives a final `closed` message). The server-side outbox is bounded (256 frames); under sustained backpressure it drops the oldest queued `waveform` frame to make room rather than growing unbounded — `state`/`error`/`closed` control frames are never dropped.
+The connection closes with code **4404** if the session ID does not exist, **4410** when the session itself closes (after which the socket receives a final `closed` message), and **4403** if the identity that opened the socket is revoked while it is still connected — distinct from 4410 because the session is untouched; only the viewer's credential is gone (see [Gateway security](security.md#tokens)). The server-side outbox is bounded (256 frames); under sustained backpressure it drops the oldest queued `waveform` frame to make room rather than growing unbounded — `state`/`error`/`closed` control frames are never dropped.
 
 ## Errors
 

--- a/docs/gateway/security.md
+++ b/docs/gateway/security.md
@@ -170,16 +170,24 @@ revoked 'alice'
 
 **Revocation takes effect immediately.** The gateway watches `tokens.json` and
 reloads it when it changes on disk, so a token revoked from another terminal
-stops working on the very next request — no restart needed.
+stops working on the very next request — no restart needed. Revoking a name
+is also more than a lock on new requests: it cuts any live stream that name is
+watching right now, and releases any session it owns so someone else can claim
+it immediately — see [Ownership](#ownership-owner-writes-everyone-watches) for
+what that release means.
 
-> **One exception: a live-stream WebSocket already open.** A stream
-> authenticates once, at the handshake, and nothing re-checks it afterwards, so
-> revoking the token does not tear the connection down — it keeps receiving
-> waveform data until it closes. Worse, a watching stream marks its session as
-> owner-watching, and that *refuses* a claim outright however long the owner has
-> been idle, so the revoked tab also keeps you from taking over the session it
-> is holding. If you need a leaked credential cut off mid-capture, close that
-> stream (or restart the gateway); revoking the token alone is not enough.
+> **A live-stream WebSocket already open is torn down too.** A stream
+> authenticates once, at the handshake, but revocation still reaches it: the
+> socket closes with code **4403** (`CLOSE_IDENTITY_REVOKED`), distinct from
+> **4410** (the session ended) — here the *session* is untouched, the viewer
+> just lost their credential. Two independent triggers make this land even
+> when the revocation happens outside the serving process — `scpi-web token
+> revoke` is a separate command invocation and has no way to signal a running
+> gateway directly: the admin panel signals the stream the moment you click
+> Revoke, and every stream also checks its own identity on its own, every few
+> seconds (5 by default), as a backstop that catches a revocation made any
+> other way. Either path clears out within a handful of seconds; neither
+> requires closing the tab yourself or restarting the gateway.
 
 Every token is equal: there are no roles or scopes. Anyone with a valid token can
 create sessions and read any session; ownership (below) governs who may *write*.

--- a/docs/gateway/security.md
+++ b/docs/gateway/security.md
@@ -119,7 +119,9 @@ sessions from then on.
   went — is the same command again: `scpi-web invite bob`. Their existing
   tokens keep working alongside the new one. If they should not, run
   `scpi-web token revoke bob` **first**, then invite: revoking a name cuts off
-  every token it holds, including one you just issued.
+  every token it holds, including one you just issued. One corner case if Bob
+  has a **live stream** open at that moment — see the note on the liveness
+  check below.
 
 The link's host and port come from the URL the gateway recorded when it last
 started, so what `invite` prints is openable as-is. If no gateway has ever
@@ -188,6 +190,18 @@ what that release means.
 > seconds (5 by default), as a backstop that catches a revocation made any
 > other way. Either path clears out within a handful of seconds; neither
 > requires closing the tab yourself or restarting the gateway.
+>
+> **One limitation, worth knowing before you lean on it.** The backstop asks
+> whether the *name* still exists, not whether the particular token that
+> opened the socket does. So if the name comes back before that stream's next
+> check — `scpi-web token add bob` a second after `token revoke bob`, or Bob
+> redeeming a fresh invitation that quickly — the check sees a live "bob"
+> again and concludes nothing happened, and the stream opened on the revoked
+> credential keeps running until it closes for some other reason. New requests
+> from it are still refused; it is the already-open socket that lingers. If
+> you are re-issuing to someone who is watching a live capture, give the
+> gateway a few seconds in between, or revoke from the admin panel instead: it
+> signals every open stream the moment you click Revoke and is not affected.
 
 Every token is equal: there are no roles or scopes. Anyone with a valid token can
 create sessions and read any session; ownership (below) governs who may *write*.
@@ -457,3 +471,4 @@ directory, when you run the command explicitly.
 | **409** on create | Session cap reached |
 | **400** on session create | Target address/port refused by the SSRF gate |
 | **WS close 1008** | WebSocket handshake was not authenticated |
+| **WS close 4403** | The identity that opened the stream was revoked while it was open (the session itself is untouched) |

--- a/scpi_control/server/__main__.py
+++ b/scpi_control/server/__main__.py
@@ -266,7 +266,18 @@ def main(argv=None) -> None:
         print("\nGateway ready at {0}\nAdmin panel (this machine only) at {1}\nHand out access with: scpi-web invite <name>\n".format(url, admin_url))
     allowed_ports = frozenset(args.allow_port) | DEFAULT_ALLOWED_PORTS if args.allow_port else None
     main_app = create_app(token_store=store, invitation_store=invitations, abandon_after=args.abandon_after, allowed_ports=allowed_ports, max_sessions=args.max_sessions)
-    admin_app = None if args.no_admin else create_admin_app(token_store=store, invitation_store=invitations, base_url=url, admin_port=args.admin_port)
+    admin_app = (
+        None
+        if args.no_admin
+        else create_admin_app(
+            token_store=store,
+            invitation_store=invitations,
+            manager=main_app.state.manager,
+            stream_registry=main_app.state.stream_registry,
+            base_url=url,
+            admin_port=args.admin_port,
+        )
+    )
     _run_servers(main_app, args.host, args.port, admin_app, args.admin_port)
 
 

--- a/scpi_control/server/admin/api.py
+++ b/scpi_control/server/admin/api.py
@@ -1,9 +1,12 @@
 """Admin routes. Unauthenticated by design -- see admin/app.py."""
 
+import time
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
+
+from scpi_control.server.schemas import session_out
 
 router = APIRouter()
 
@@ -62,4 +65,33 @@ async def create_invitation(body: InvitationCreate, request: Request):
 async def cancel_invitation(invitation_id: str, request: Request):
     if not request.app.state.invitations.cancel(invitation_id):
         raise HTTPException(status_code=404, detail="no invitation with that id")
+    return None
+
+
+@router.get("/sessions")
+async def list_sessions(request: Request):
+    """Every open session. Reuses the gateway's own serializer plus idle time.
+
+    NOTE: this is a *different* /api/sessions from the gateway's authenticated
+    one -- same path, different app, different port. Do not "share" the router:
+    tests/test_server_admin_api.py::test_the_main_app_serves_no_admin_routes
+    exists because doing so would hand every LAN token-holder admin powers.
+    """
+    now = time.monotonic()
+    return [dict(session_out(session), idle_seconds=round(now - session.owner_last_active, 1)) for session in request.app.state.manager.list()]
+
+
+@router.post("/sessions/{session_id}/release", status_code=204)
+async def release_session(session_id: str, request: Request):
+    session = request.app.state.manager.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="no session with that id")
+    session.owner = ""
+    return None
+
+
+@router.delete("/sessions/{session_id}", status_code=204)
+async def close_session(session_id: str, request: Request):
+    if not request.app.state.manager.delete(session_id):
+        raise HTTPException(status_code=404, detail="no session with that id")
     return None

--- a/scpi_control/server/admin/api.py
+++ b/scpi_control/server/admin/api.py
@@ -13,6 +13,25 @@ from scpi_control.server.schemas import session_out
 router = APIRouter()
 
 
+def _is_recording(session) -> bool:
+    """True only for a scope session whose TrendRecorder is currently recording.
+
+    Matches the exact comparison already used by api/scope.py and adapters.py
+    (``recorder.state == "recording"``) rather than inventing a new notion.
+
+    PSU and AWG sessions have no recorder at all -- InstrumentSession.recorder
+    is a thin property delegating to ``self.adapter.recorder``, and only
+    ScopeAdapter sets that attribute (sessions.py's own docstring: "touching
+    one of these on a non-scope session raises AttributeError from its
+    adapter, which is the honest answer"). getattr's default here treats
+    "we can't tell" as "not recording" -- an unconditional warning for every
+    kind is exactly what adding this field is meant to replace -- rather than
+    letting one row's AttributeError take down the whole listing.
+    """
+    recorder = getattr(session, "recorder", None)
+    return recorder is not None and recorder.state == "recording"
+
+
 class InvitationCreate(BaseModel):
     name: str
 
@@ -83,7 +102,8 @@ async def cancel_invitation(invitation_id: str, request: Request):
 
 @router.get("/sessions")
 async def list_sessions(request: Request):
-    """Every open session. Reuses the gateway's own serializer plus idle time.
+    """Every open session. Reuses the gateway's own serializer plus idle time
+    and whether it's currently recording (see _is_recording).
 
     NOTE: this is a *different* /api/sessions from the gateway's authenticated
     one -- same path, different app, different port. Do not "share" the router:
@@ -91,7 +111,7 @@ async def list_sessions(request: Request):
     exists because doing so would hand every LAN token-holder admin powers.
     """
     now = time.monotonic()
-    return [dict(session_out(session), idle_seconds=round(now - session.owner_last_active, 1)) for session in request.app.state.manager.list()]
+    return [dict(session_out(session), idle_seconds=round(now - session.owner_last_active, 1), recording=_is_recording(session)) for session in request.app.state.manager.list()]
 
 
 @router.post("/sessions/{session_id}/release", status_code=204)

--- a/scpi_control/server/admin/api.py
+++ b/scpi_control/server/admin/api.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel
 
+from scpi_control.server import revocation
 from scpi_control.server.schemas import session_out
 
 router = APIRouter()
@@ -28,11 +29,22 @@ async def list_identities(request: Request):
     return request.app.state.tokens.summary()
 
 
-@router.delete("/identities/{name}", status_code=204)
+@router.delete("/identities/{name}")
 async def revoke_identity(name: str, request: Request):
-    if not request.app.state.tokens.revoke(name):
+    # Not offloaded to the threadpool, unlike close_session below: revoke_
+    # identity's own asyncio.Event.set() calls (via StreamRegistry.revoke)
+    # are not thread-safe and must run on this event loop (see revocation.py
+    # and the module note on Task 4). Splitting the token store's blocking
+    # file I/O out from that Event.set() would duplicate revocation logic
+    # into this route, which is the one thing Task 1 exists to prevent. The
+    # blocking window this leaves on the loop is a single small JSON file
+    # read/write on an unauthenticated, loopback-only, human-operated panel --
+    # nothing like close_session's up-to-10s thread join, which is why that
+    # one is offloaded and this one is not.
+    result = revocation.revoke_identity(request.app.state.tokens, request.app.state.manager, request.app.state.stream_registry, name)
+    if result is None:
         raise HTTPException(status_code=404, detail="no identity named {0!r}".format(name))
-    return None
+    return result
 
 
 @router.get("/invitations")

--- a/scpi_control/server/admin/api.py
+++ b/scpi_control/server/admin/api.py
@@ -4,6 +4,7 @@ import time
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel
 
 from scpi_control.server.schemas import session_out
@@ -92,6 +93,14 @@ async def release_session(session_id: str, request: Request):
 
 @router.delete("/sessions/{session_id}", status_code=204)
 async def close_session(session_id: str, request: Request):
-    if not request.app.state.manager.delete(session_id):
+    # SessionManager.delete() calls session.close(), which joins the session's
+    # worker thread (up to a 10s timeout) -- a blocking call that must not run
+    # on the event loop this app shares with the main gateway (__main__.py's
+    # "Both run on one event loop in one process"). Offloaded to the threadpool
+    # the same way scpi_control/server/api/sessions.py's own delete route does;
+    # the handler itself stays async def per the thread-safety constraint on
+    # asyncio.Event (see revocation.py) even though this route doesn't touch
+    # the registry directly.
+    if not await run_in_threadpool(request.app.state.manager.delete, session_id):
         raise HTTPException(status_code=404, detail="no session with that id")
     return None

--- a/scpi_control/server/admin/app.py
+++ b/scpi_control/server/admin/app.py
@@ -47,6 +47,8 @@ from fastapi.responses import FileResponse, JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
+from scpi_control.server.revocation import StreamRegistry
+from scpi_control.server.sessions import SessionManager
 from scpi_control.server.spa import resolve_spa_path
 
 ADMIN_STATIC_DIR = Path(__file__).parent / "static"
@@ -93,7 +95,19 @@ class _SameOriginOnlyMiddleware:
         await self.app(scope, receive, send)
 
 
-def create_admin_app(token_store, invitation_store, manager=None, stream_registry=None, base_url: Optional[str] = None, admin_port: int = DEFAULT_ADMIN_PORT) -> FastAPI:
+def create_admin_app(token_store, invitation_store, *, manager: SessionManager, stream_registry: StreamRegistry, base_url: Optional[str] = None, admin_port: int = DEFAULT_ADMIN_PORT) -> FastAPI:
+    """Build the panel. ``manager`` and ``stream_registry`` are required.
+
+    They are keyword-only and have no defaults on purpose. They used to default
+    to None, which let a caller written against the pre-6.0.0 signature build an
+    app that looked fine and then half-completed a revocation: DELETE
+    /api/identities/{name} destroys the tokens *first* (on disk, irreversibly)
+    and only then walks the registry, so a None registry meant the credential
+    was gone while the streams it authenticated stayed open and the sessions it
+    owned stayed unclaimable -- and the panel reported a 500, i.e. "nothing
+    happened". A TypeError at construction is the only place that mistake can
+    still be caught before it costs somebody their revocation.
+    """
     app = FastAPI(title="SCPI Gateway Admin", docs_url=None, redoc_url=None, openapi_url=None)
     app.state.tokens = token_store
     app.state.invitations = invitation_store

--- a/scpi_control/server/admin/app.py
+++ b/scpi_control/server/admin/app.py
@@ -93,10 +93,15 @@ class _SameOriginOnlyMiddleware:
         await self.app(scope, receive, send)
 
 
-def create_admin_app(token_store, invitation_store, base_url: Optional[str] = None, admin_port: int = DEFAULT_ADMIN_PORT) -> FastAPI:
+def create_admin_app(token_store, invitation_store, manager=None, stream_registry=None, base_url: Optional[str] = None, admin_port: int = DEFAULT_ADMIN_PORT) -> FastAPI:
     app = FastAPI(title="SCPI Gateway Admin", docs_url=None, redoc_url=None, openapi_url=None)
     app.state.tokens = token_store
     app.state.invitations = invitation_store
+    # The gateway's own instances, not private copies -- see __main__.py:269
+    # (main_app.state.manager / .stream_registry). A second SessionManager here
+    # would give the panel an empty, disconnected view of the world.
+    app.state.manager = manager
+    app.state.stream_registry = stream_registry
     app.state.base_url = base_url
 
     from scpi_control.server.admin import api as admin_api

--- a/scpi_control/server/api/stream.py
+++ b/scpi_control/server/api/stream.py
@@ -80,11 +80,18 @@ async def _watch_for_revocation(token_store, identity: str, revoked: "asyncio.Ev
     The backstop for a revocation made in another process -- `scpi-web token
     revoke` -- where nothing in this process receives an event. Sets the same
     event the registry does, so there is one teardown path rather than two that
-    have to agree.
+    have to agree. A store read can raise (TokenStore._load() surfaces a
+    corrupt file or a transient OSError as ValueError) -- that costs this tick,
+    not the whole backstop, so we retry on the next one instead of letting the
+    task die silently and leaving a revoked identity streaming forever.
     """
     while True:
         await asyncio.sleep(interval)
-        if not identity_is_live(token_store, identity):
+        try:
+            live = identity_is_live(token_store, identity)
+        except Exception:
+            continue  # an unreadable store is transient; re-check next tick
+        if not live:
             revoked.set()
             return
 

--- a/scpi_control/server/api/stream.py
+++ b/scpi_control/server/api/stream.py
@@ -5,6 +5,7 @@ import contextlib
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from scpi_control.server.auth import WS_ACCEPT_SUBPROTOCOL
+from scpi_control.server.revocation import identity_is_live
 
 router = APIRouter(tags=["stream"])
 
@@ -15,6 +16,11 @@ OUTBOX_MAXSIZE = 256
 # Distinct from 4404 (unknown session) and 4410 (session ended): the socket was
 # accepted but this session's adapter could not produce its opening frame.
 CLOSE_INITIAL_FRAME_FAILED = 4500
+
+# The identity that opened this socket was revoked. Distinct from 4410 (the
+# session ended) because nothing happened to the session -- the viewer lost
+# their credential.
+CLOSE_IDENTITY_REVOKED = 4403
 
 
 def _enqueue(outbox: "asyncio.Queue", message) -> None:
@@ -68,6 +74,21 @@ async def _send_from_outbox(websocket: WebSocket, outbox: "asyncio.Queue") -> No
         return
 
 
+async def _watch_for_revocation(token_store, identity: str, revoked: "asyncio.Event", interval: float) -> None:
+    """Set ``revoked`` once ``identity`` stops existing.
+
+    The backstop for a revocation made in another process -- `scpi-web token
+    revoke` -- where nothing in this process receives an event. Sets the same
+    event the registry does, so there is one teardown path rather than two that
+    have to agree.
+    """
+    while True:
+        await asyncio.sleep(interval)
+        if not identity_is_live(token_store, identity):
+            revoked.set()
+            return
+
+
 @router.websocket("/sessions/{session_id}/stream")
 async def stream(websocket: WebSocket, session_id: str):
     session = websocket.app.state.manager.get(session_id)
@@ -95,8 +116,12 @@ async def stream(websocket: WebSocket, session_id: str):
     # abnormal disconnect releases it just like a clean close does.
     identity = getattr(websocket.state, "identity", "")
     unmark_owner_watching = session.mark_owner_watching(identity)
+    revoked = asyncio.Event()
+    unregister_stream = websocket.app.state.stream_registry.add(identity, revoked)
+    watcher = asyncio.ensure_future(_watch_for_revocation(websocket.app.state.tokens, identity, revoked, websocket.app.state.stream_revocation_interval))
     receiver = None
     sender = None
+    revocation = None
     try:
         # The initial frame must match whatever shape this session's adapter
         # publishes on every subsequent tick, so the adapter -- not a `kind`
@@ -120,7 +145,14 @@ async def stream(websocket: WebSocket, session_id: str):
         # finishes first tears the connection down.
         receiver = asyncio.ensure_future(_receive_until_disconnect(websocket))
         sender = asyncio.ensure_future(_send_from_outbox(websocket, outbox))
-        await asyncio.wait({receiver, sender}, return_when=asyncio.FIRST_COMPLETED)
+        revocation = asyncio.ensure_future(revoked.wait())
+        await asyncio.wait({receiver, sender, revocation}, return_when=asyncio.FIRST_COMPLETED)
+        if revoked.is_set():
+            # Say why. A client that just sees the socket vanish cannot tell a
+            # revocation from a network blip, and this one should send the user
+            # back to the sign-in screen rather than retrying forever.
+            with contextlib.suppress(Exception):
+                await websocket.close(code=CLOSE_IDENTITY_REVOKED)
     except WebSocketDisconnect:
         pass
     except Exception:
@@ -129,7 +161,8 @@ async def stream(websocket: WebSocket, session_id: str):
     finally:
         unmark_owner_watching()
         unsubscribe()
-        for task in (receiver, sender):
+        unregister_stream()
+        for task in (receiver, sender, watcher, revocation):
             if task is not None:
                 task.cancel()
                 with contextlib.suppress(Exception, asyncio.CancelledError):

--- a/scpi_control/server/api/stream.py
+++ b/scpi_control/server/api/stream.py
@@ -124,12 +124,24 @@ async def stream(websocket: WebSocket, session_id: str):
     identity = getattr(websocket.state, "identity", "")
     unmark_owner_watching = session.mark_owner_watching(identity)
     revoked = asyncio.Event()
-    unregister_stream = websocket.app.state.stream_registry.add(identity, revoked)
-    watcher = asyncio.ensure_future(_watch_for_revocation(websocket.app.state.tokens, identity, revoked, websocket.app.state.stream_revocation_interval))
+    unregister_stream = None
+    watcher = None
     receiver = None
     sender = None
     revocation = None
     try:
+        # Inside the try, not above it. mark_owner_watching() has already run,
+        # so anything that raises between there and the finally leaves the
+        # owner marked as watching forever and the session permanently
+        # unclaimable -- the exact bug this whole sub-project exists to kill,
+        # arriving through a different door. Only create_app mounts this
+        # router, so today both lookups are guaranteed to be there; an app
+        # assembled some other way (an embedder, a future second mount) would
+        # raise AttributeError here, and that must cost the connection, not the
+        # bench. The names are bound to None above so the finally can tell
+        # "never registered" from "registered", and skip what was never set up.
+        unregister_stream = websocket.app.state.stream_registry.add(identity, revoked)
+        watcher = asyncio.ensure_future(_watch_for_revocation(websocket.app.state.tokens, identity, revoked, websocket.app.state.stream_revocation_interval))
         # The initial frame must match whatever shape this session's adapter
         # publishes on every subsequent tick, so the adapter -- not a `kind`
         # branch here -- decides it. A kind that forgets the hook raises
@@ -168,7 +180,8 @@ async def stream(websocket: WebSocket, session_id: str):
     finally:
         unmark_owner_watching()
         unsubscribe()
-        unregister_stream()
+        if unregister_stream is not None:
+            unregister_stream()
         for task in (receiver, sender, watcher, revocation):
             if task is not None:
                 task.cancel()

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -13,6 +13,7 @@ from scpi_control.exceptions import InvalidParameterError, SiglentError, Siglent
 from scpi_control.server.api.join import FailureLimiter
 from scpi_control.server.auth import AuthMiddleware, TokenStore
 from scpi_control.server.invitations import InvitationStore
+from scpi_control.server.revocation import StreamRegistry
 from scpi_control.server.sessions import SessionError, SessionManager
 from scpi_control.server.spa import resolve_spa_path
 
@@ -28,6 +29,7 @@ def create_app(
     references_dir: Optional[str] = None,
     token_store: Optional[TokenStore] = None,
     invitation_store: Optional[InvitationStore] = None,
+    stream_revocation_interval: float = 5.0,
     abandon_after: float = 300.0,
     allowed_ports: Optional[frozenset] = None,
     max_sessions: Optional[int] = None,
@@ -73,6 +75,14 @@ def create_app(
     # (scpi_control.server.ownership.claim); mutable at runtime so tests can
     # drive it to 0 instead of sleeping for a real timeout.
     app.state.abandon_after = abandon_after
+    # Live streams grouped by identity, so revoking can signal them. Shared by
+    # the admin app, which is why both listeners run in one process.
+    app.state.stream_registry = StreamRegistry()
+    # How often a stream re-checks that its identity still exists. Injectable
+    # because a test that waits five real seconds is a test nobody runs, and
+    # because the registry test has to set it high enough to prove the backstop
+    # could not have been what tore the stream down.
+    app.state.stream_revocation_interval = stream_revocation_interval
 
     from scpi_control.server.api import awg as awg_api
     from scpi_control.server.api import commands as commands_api

--- a/scpi_control/server/auth.py
+++ b/scpi_control/server/auth.py
@@ -210,7 +210,16 @@ class TokenStore:
         return True
 
     def names(self) -> List[str]:
-        """Distinct identities, sorted. One entry per person, not per device."""
+        """Distinct identities, sorted. One entry per person, not per device.
+
+        Reloads first, like every other public reader. This used to be the one
+        exception, which was survivable only because its sole in-server caller
+        ran after AuthMiddleware had already reloaded in the same request.
+        identity_is_live() is called from a long-lived WebSocket that issues no
+        requests at all, so a stale answer there would keep a revoked stream
+        alive indefinitely -- the exact bug this module exists to fix.
+        """
+        self._reload_if_changed()
         return sorted({str(entry["name"]) for entry in self._tokens})
 
     def summary(self) -> List[Dict[str, Any]]:

--- a/scpi_control/server/revocation.py
+++ b/scpi_control/server/revocation.py
@@ -1,0 +1,94 @@
+"""What revocation means, in one place.
+
+Two things tear a live stream down: the admin panel walking a registry, and
+each stream's own periodic liveness check. They must not disagree about what a
+revoked identity is or what happens to one, so both converge on the same
+asyncio.Event per connection -- there is exactly one exit path, and it is the
+one the stream's existing `finally` already cleans up after.
+
+The CLI is why the second trigger exists at all: `scpi-web token revoke` runs
+in a different process, so nothing in the serving process receives an event.
+The liveness check notices because TokenStore reloads when the file changes.
+"""
+
+import asyncio
+from typing import Any, Callable, Dict, List, Optional, Set
+
+
+class StreamRegistry:
+    """Live streams, grouped by the identity that opened them.
+
+    Holds events rather than sockets on purpose. Closing a WebSocket from
+    another task while its send loop is mid-write is a race whose failure mode
+    is a traceback in a lab log; setting an event the owning task already waits
+    on keeps teardown on the task that owns the socket.
+    """
+
+    def __init__(self) -> None:
+        self._events: Dict[str, Set[asyncio.Event]] = {}
+
+    def add(self, identity: str, event: asyncio.Event) -> Callable[[], None]:
+        """Register ``event``; returns an idempotent unregister callable.
+
+        Mirrors InstrumentSession.mark_owner_watching, which hands back an
+        unmark callable for the same reason: the caller's `finally` should not
+        have to know how the bookkeeping works.
+        """
+        self._events.setdefault(identity, set()).add(event)
+
+        def unregister() -> None:
+            events = self._events.get(identity)
+            if events is None:
+                return
+            events.discard(event)
+            if not events:
+                self._events.pop(identity, None)
+
+        return unregister
+
+    def revoke(self, identity: str) -> int:
+        """Signal every stream this identity holds. Returns how many."""
+        events = self._events.get(identity, set())
+        for event in events:
+            event.set()
+        return len(events)
+
+    def count(self, identity: str) -> int:
+        return len(self._events.get(identity, set()))
+
+
+def identity_is_live(token_store: Any, identity: str) -> bool:
+    """True if ``identity`` still exists in the store.
+
+    names() reloads, so this sees a revocation made by any process. An empty
+    identity is never live: it would mean a stream that never passed through
+    AuthMiddleware, which cannot happen today and must not be trusted if it
+    ever does.
+    """
+    if not identity:
+        return False
+    return identity in token_store.names()
+
+
+def revoke_identity(token_store: Any, manager: Any, registry: StreamRegistry, name: str) -> Optional[Dict[str, int]]:
+    """Revoke ``name`` completely: tokens, live streams, owned sessions.
+
+    Returns what it did, so the caller can report it rather than guess, or
+    None if there was no such identity. The order matters: tokens go first, so
+    that a stream whose liveness check fires between the two steps reaches the
+    same conclusion this function is about to enforce.
+    """
+    devices = {row["name"]: row["devices"] for row in token_store.summary()}.get(name)
+    if devices is None:
+        return None
+    token_store.revoke(name)
+    streams = registry.revoke(name)
+    sessions = 0
+    for session in manager.list():
+        if session.owner == name:
+            # Leaving an owner that no longer exists creates a state the rest
+            # of the API reports as a normal owner, and the session stays
+            # unclaimable until the idle threshold passes.
+            session.owner = ""
+            sessions += 1
+    return {"devices": devices, "streams": streams, "sessions": sessions}

--- a/scpi_control/server/revocation.py
+++ b/scpi_control/server/revocation.py
@@ -12,7 +12,7 @@ The liveness check notices because TokenStore reloads when the file changes.
 """
 
 import asyncio
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, Optional, Set
 
 
 class StreamRegistry:

--- a/tests/test_server_admin_api.py
+++ b/tests/test_server_admin_api.py
@@ -1,11 +1,15 @@
 """The host-only admin app: routes, and the absence of auth."""
 
+import asyncio
+
 import pytest
 from fastapi.testclient import TestClient
 
 from scpi_control.server.admin.app import create_admin_app
 from scpi_control.server.auth import TokenStore
 from scpi_control.server.invitations import InvitationStore
+from scpi_control.server.revocation import StreamRegistry
+from scpi_control.server.sessions import SessionManager
 from tests.route_introspection import iter_http_routes
 
 
@@ -23,6 +27,20 @@ def admin(admin_stores):
     # from base_url unless a test overrides it.
     with TestClient(app, base_url="http://127.0.0.1") as client:
         yield client, tokens, invitations
+
+
+@pytest.fixture
+def admin_revocation(tmp_path):
+    # Separate from `admin`: revoke_identity's path touches app.state.manager
+    # and .stream_registry, which the plain `admin` fixture leaves as None
+    # (mirrors tests/test_server_admin_sessions.py's admin_sessions fixture).
+    tokens = TokenStore(str(tmp_path / "tokens.json"))
+    invitations = InvitationStore(str(tmp_path / "invitations.json"))
+    manager = SessionManager()
+    registry = StreamRegistry()
+    app = create_admin_app(token_store=tokens, invitation_store=invitations, manager=manager, stream_registry=registry)
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        yield client, tokens, manager, registry
 
 
 def test_identities_are_listed_with_device_counts(admin):
@@ -90,18 +108,51 @@ def test_cancelling_an_unknown_invitation_is_404(admin):
     assert client.delete("/api/invitations/deadbeef").status_code == 404
 
 
-def test_revoking_an_identity_removes_every_device(admin):
-    client, tokens, _invitations = admin
+def test_revoking_an_identity_removes_every_device(admin_revocation):
+    # The status changes deliberately from 204 to 200: a panel that cannot say
+    # what it did would have to guess. See revoke_identity in revocation.py.
+    client, tokens, _manager, _registry = admin_revocation
     laptop = tokens.mint("bob")
     tablet = tokens.mint("bob")
-    assert client.delete("/api/identities/bob").status_code == 204
+    response = client.delete("/api/identities/bob")
+    assert response.status_code == 200
+    assert response.json() == {"devices": 2, "streams": 0, "sessions": 0}
     assert tokens.verify(laptop) is None
     assert tokens.verify(tablet) is None
 
 
-def test_revoking_an_unknown_identity_is_404(admin):
-    client, _tokens, _invitations = admin
+def test_revoking_an_identity_reports_streams_and_sessions_too(admin_revocation):
+    client, tokens, manager, registry = admin_revocation
+    tokens.mint("bob")
+    manager.create("bench-1", mock=True, owner="bob")
+    registry.add("bob", asyncio.Event())
+    response = client.delete("/api/identities/bob")
+    assert response.status_code == 200
+    assert response.json() == {"devices": 1, "streams": 1, "sessions": 1}
+
+
+def test_revoking_an_identity_releases_only_that_identitys_sessions(admin_revocation):
+    client, tokens, manager, _registry = admin_revocation
+    tokens.mint("bob")
+    tokens.mint("robin")
+    mine = manager.create("bench-1", mock=True, owner="bob")
+    theirs = manager.create("bench-2", mock=True, owner="robin")
+    response = client.delete("/api/identities/bob")
+    assert response.status_code == 200
+    assert response.json()["sessions"] == 1
+    assert manager.get(mine.id).owner == ""
+    assert manager.get(theirs.id).owner == "robin"
+
+
+def test_revoking_an_unknown_identity_is_404(admin_revocation):
+    client, tokens, manager, _registry = admin_revocation
+    tokens.mint("robin")
+    session = manager.create("bench-1", mock=True, owner="robin")
     assert client.delete("/api/identities/ghost").status_code == 404
+    # Changes nothing: the surviving identity's token still verifies and its
+    # session is still owned.
+    assert tokens.names() == ["robin"]
+    assert manager.get(session.id).owner == "robin"
 
 
 def test_the_admin_app_has_no_auth_middleware(admin):

--- a/tests/test_server_admin_api.py
+++ b/tests/test_server_admin_api.py
@@ -231,7 +231,17 @@ def test_the_main_app_serves_no_admin_routes(gateway_auth, tmp_path):
     # precisely the one-line mistake it exists to catch, and pass on the three
     # routes create_app declares inline. iter_http_routes reads the generated
     # schema instead, which reports full paths whatever the nesting.
-    leaked = sorted({path for _method, path in iter_http_routes(app) if path.startswith("/api/identities") or path.startswith("/api/invitations")})
+    #
+    # The filter has to name every admin path that is *distinguishable* from a
+    # gateway one. Two of the three session routes the panel gained collide by
+    # path with legitimate gateway routes -- GET /api/sessions and DELETE
+    # /api/sessions/{session_id} exist on both apps, deliberately (see
+    # admin/api.py:list_sessions) -- so neither can be looked for here without
+    # failing on the honest gateway. /api/sessions/{session_id}/release is the
+    # admin router's one unambiguous fingerprint, and so the only one of the
+    # three that could betray a stray include_router of it.
+    admin_only = ("/api/identities", "/api/invitations", "/api/sessions/{session_id}/release")
+    leaked = sorted({path for _method, path in iter_http_routes(app) if path.startswith(admin_only)})
     assert not leaked, "create_app serves admin routes: {0}".format(leaked)
 
     # The same question put to the running app, which no route-object or schema
@@ -245,6 +255,18 @@ def test_the_main_app_serves_no_admin_routes(gateway_auth, tmp_path):
         client.headers.update(headers)
         assert client.get("/api/identities").status_code == 404
         assert client.get("/api/invitations").status_code == 404
+        # Same reasoning as the filter above: of the three session routes, only
+        # release can be asked for by path without the gateway's own
+        # /api/sessions answering. It is asked against a *real* session, not a
+        # ghost id, because the admin route 404s on a ghost exactly as an
+        # unrouted path does -- the leak would be invisible. On a real one it
+        # answers 204 and unowns it, which the second assertion catches. The
+        # status is 405 when a built SPA bundle's GET catch-all claims the path
+        # and 404 when there is no bundle to claim it; both mean "no POST
+        # handler here".
+        session_id = client.post("/api/sessions", json={"label": "bench", "mock": True}).json()["id"]
+        assert client.post("/api/sessions/{0}/release".format(session_id)).status_code in (404, 405)
+        assert client.get("/api/sessions/{0}".format(session_id)).json()["owner"] == "tester"
 
 
 def test_the_two_apps_never_share_a_static_directory(tmp_path):
@@ -284,6 +306,24 @@ def test_a_foreign_origin_is_rejected_on_a_write(admin):
     assert response.status_code == 403
     # The refusal must happen before the handler, not merely hide its output.
     assert invitations.pending() == 0
+
+
+def test_a_foreign_origin_is_rejected_on_a_bodyless_mutating_route(admin):
+    # The module docstring names "the day someone accepts a form body" as the
+    # day FastAPI's insistence on application/json stops backing the Origin
+    # check up. POST /api/sessions/{id}/release is that day, arriving from the
+    # other direction: it takes no body and no content type at all, so a page
+    # on any site the admin visits can send it with no preflight, and the
+    # Origin check is the only thing standing between that page and every
+    # session on the bench being unowned. The other Origin tests are a GET and
+    # a JSON POST; neither covers this shape.
+    client, _tokens, _invitations = admin
+    manager = client.app.state.manager
+    session = manager.create("bench-1", mock=True, owner="bob")
+    response = client.post("/api/sessions/{0}/release".format(session.id), headers={"Origin": "http://evil.example"})
+    assert response.status_code == 403
+    # Refused before the handler, not merely hidden from the caller.
+    assert manager.get(session.id).owner == "bob"
 
 
 def test_a_rebound_origin_on_the_panels_own_port_is_rejected(admin):

--- a/tests/test_server_admin_api.py
+++ b/tests/test_server_admin_api.py
@@ -20,27 +20,23 @@ def admin_stores(tmp_path):
 
 @pytest.fixture
 def admin(admin_stores):
+    # One fixture for the whole file: create_admin_app now *requires* a manager
+    # and a stream registry, so there is no longer a "plain" admin app that
+    # revocation cannot be tested against. The separate `admin_revocation`
+    # fixture existed only to work around those arguments defaulting to None,
+    # which is the defect this app is built without. Tests that need the
+    # manager or the registry read them back off app.state (below), which also
+    # pins that create_admin_app really did store what it was handed.
     tokens, invitations = admin_stores
-    app = create_admin_app(token_store=tokens, invitation_store=invitations, base_url="http://192.168.1.50:8765/")
+    app = create_admin_app(token_store=tokens, invitation_store=invitations, manager=SessionManager(), stream_registry=StreamRegistry(), base_url="http://192.168.1.50:8765/")
     # base_url is 127.0.0.1, not the httpx default "testserver": TrustedHostMiddleware
     # only allows 127.0.0.1/localhost, and the Host header httpx sends is derived
     # from base_url unless a test overrides it.
     with TestClient(app, base_url="http://127.0.0.1") as client:
         yield client, tokens, invitations
-
-
-@pytest.fixture
-def admin_revocation(tmp_path):
-    # Separate from `admin`: revoke_identity's path touches app.state.manager
-    # and .stream_registry, which the plain `admin` fixture leaves as None
-    # (mirrors tests/test_server_admin_sessions.py's admin_sessions fixture).
-    tokens = TokenStore(str(tmp_path / "tokens.json"))
-    invitations = InvitationStore(str(tmp_path / "invitations.json"))
-    manager = SessionManager()
-    registry = StreamRegistry()
-    app = create_admin_app(token_store=tokens, invitation_store=invitations, manager=manager, stream_registry=registry)
-    with TestClient(app, base_url="http://127.0.0.1") as client:
-        yield client, tokens, manager, registry
+    # Sessions created through the manager start a worker thread each; close
+    # them rather than leaving one per test running for the rest of the session.
+    app.state.manager.close_all()
 
 
 def test_identities_are_listed_with_device_counts(admin):
@@ -108,10 +104,27 @@ def test_cancelling_an_unknown_invitation_is_404(admin):
     assert client.delete("/api/invitations/deadbeef").status_code == 404
 
 
-def test_revoking_an_identity_removes_every_device(admin_revocation):
+def test_the_admin_app_refuses_to_build_without_a_manager_and_registry(admin_stores):
+    # The pre-6.0.0 call site. While those two arguments defaulted to None it
+    # built an app that looked healthy and then half-completed every
+    # revocation: DELETE /api/identities/{name} destroys the tokens on disk
+    # first and only then walks the registry, so the credential was gone, the
+    # live streams and owned sessions were not, and the panel saw a 500 -- "it
+    # failed", about an action that had already partly happened. Refusing at
+    # construction is the only moment that is still catchable.
+    tokens, invitations = admin_stores
+    with pytest.raises(TypeError):
+        create_admin_app(token_store=tokens, invitation_store=invitations, base_url="http://192.168.1.50:8765/")
+    with pytest.raises(TypeError):
+        create_admin_app(token_store=tokens, invitation_store=invitations, manager=SessionManager())
+    with pytest.raises(TypeError):
+        create_admin_app(token_store=tokens, invitation_store=invitations, stream_registry=StreamRegistry())
+
+
+def test_revoking_an_identity_removes_every_device(admin):
     # The status changes deliberately from 204 to 200: a panel that cannot say
     # what it did would have to guess. See revoke_identity in revocation.py.
-    client, tokens, _manager, _registry = admin_revocation
+    client, tokens, _invitations = admin
     laptop = tokens.mint("bob")
     tablet = tokens.mint("bob")
     response = client.delete("/api/identities/bob")
@@ -121,8 +134,9 @@ def test_revoking_an_identity_removes_every_device(admin_revocation):
     assert tokens.verify(tablet) is None
 
 
-def test_revoking_an_identity_reports_streams_and_sessions_too(admin_revocation):
-    client, tokens, manager, registry = admin_revocation
+def test_revoking_an_identity_reports_streams_and_sessions_too(admin):
+    client, tokens, _invitations = admin
+    manager, registry = client.app.state.manager, client.app.state.stream_registry
     tokens.mint("bob")
     manager.create("bench-1", mock=True, owner="bob")
     registry.add("bob", asyncio.Event())
@@ -131,8 +145,9 @@ def test_revoking_an_identity_reports_streams_and_sessions_too(admin_revocation)
     assert response.json() == {"devices": 1, "streams": 1, "sessions": 1}
 
 
-def test_revoking_an_identity_releases_only_that_identitys_sessions(admin_revocation):
-    client, tokens, manager, _registry = admin_revocation
+def test_revoking_an_identity_releases_only_that_identitys_sessions(admin):
+    client, tokens, _invitations = admin
+    manager = client.app.state.manager
     tokens.mint("bob")
     tokens.mint("robin")
     mine = manager.create("bench-1", mock=True, owner="bob")
@@ -144,8 +159,9 @@ def test_revoking_an_identity_releases_only_that_identitys_sessions(admin_revoca
     assert manager.get(theirs.id).owner == "robin"
 
 
-def test_revoking_an_unknown_identity_is_404(admin_revocation):
-    client, tokens, manager, _registry = admin_revocation
+def test_revoking_an_unknown_identity_is_404(admin):
+    client, tokens, _invitations = admin
+    manager = client.app.state.manager
     tokens.mint("robin")
     session = manager.create("bench-1", mock=True, owner="robin")
     assert client.delete("/api/identities/ghost").status_code == 404
@@ -301,7 +317,7 @@ def test_the_origin_allowlist_follows_the_configured_admin_port(admin_stores):
     # The port is not hardcoded: run the panel on --admin-port 9001 and 9001 is
     # what its own Origin must be, while the default 8766 becomes foreign.
     tokens, invitations = admin_stores
-    app = create_admin_app(token_store=tokens, invitation_store=invitations, admin_port=9001)
+    app = create_admin_app(token_store=tokens, invitation_store=invitations, manager=SessionManager(), stream_registry=StreamRegistry(), admin_port=9001)
     with TestClient(app, base_url="http://127.0.0.1") as client:
         assert client.get("/api/identities", headers={"Origin": "http://127.0.0.1:9001"}).status_code == 200
         assert client.get("/api/identities", headers={"Origin": "http://127.0.0.1:8766"}).status_code == 403
@@ -340,7 +356,7 @@ def test_admin_spa_traversal_is_contained(tmp_path):
     try:
         tokens = TokenStore(str(tmp_path / "tokens.json"))
         invitations = InvitationStore(str(tmp_path / "invitations.json"))
-        app = admin_app_module.create_admin_app(token_store=tokens, invitation_store=invitations)
+        app = admin_app_module.create_admin_app(token_store=tokens, invitation_store=invitations, manager=SessionManager(), stream_registry=StreamRegistry())
         with TestClient(app, base_url="http://127.0.0.1") as client:
             for payload in ("/%2e%2e/outside/secret.txt", "/../outside/secret.txt", "/%2e%2e%2foutside/secret.txt"):
                 response = client.get(payload)

--- a/tests/test_server_admin_sessions.py
+++ b/tests/test_server_admin_sessions.py
@@ -1,0 +1,76 @@
+"""The admin app's view of live sessions: list, release, and close.
+
+Unauthenticated by design -- see admin/app.py -- so the listing test asserts
+reachability with no credential explicitly rather than leaving it implied.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scpi_control.server.admin.app import create_admin_app
+from scpi_control.server.auth import TokenStore
+from scpi_control.server.invitations import InvitationStore
+from scpi_control.server.revocation import StreamRegistry
+from scpi_control.server.sessions import SessionManager
+
+
+@pytest.fixture
+def admin_sessions(tmp_path):
+    tokens = TokenStore(str(tmp_path / "tokens.json"))
+    invitations = InvitationStore(str(tmp_path / "invitations.json"))
+    manager = SessionManager()
+    registry = StreamRegistry()
+    app = create_admin_app(token_store=tokens, invitation_store=invitations, manager=manager, stream_registry=registry)
+    # base_url is 127.0.0.1, not the httpx default "testserver": TrustedHostMiddleware
+    # only allows 127.0.0.1/localhost, mirroring tests/test_server_admin_api.py.
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        yield client, manager
+
+
+def test_the_listing_reports_owner_viewers_and_idle_seconds(admin_sessions):
+    client, manager = admin_sessions
+    manager.create("bench-1", mock=True, owner="bob")
+    rows = client.get("/api/sessions").json()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["owner"] == "bob"
+    assert row["viewers"] == 0
+    assert isinstance(row["idle_seconds"], (int, float))
+
+
+def test_the_listing_is_reachable_with_no_credential(admin_sessions):
+    # The point of this app: no auth middleware, no token required. See
+    # admin/app.py's module docstring for what stands in for a credential
+    # instead.
+    client, manager = admin_sessions
+    manager.create("bench-1", mock=True, owner="bob")
+    response = client.get("/api/sessions")
+    assert response.status_code == 200
+    assert response.json()[0]["owner"] == "bob"
+
+
+def test_releasing_a_session_clears_its_owner(admin_sessions):
+    client, manager = admin_sessions
+    session = manager.create("bench-1", mock=True, owner="bob")
+    response = client.post("/api/sessions/{0}/release".format(session.id))
+    assert response.status_code == 204
+    assert manager.get(session.id).owner == ""
+
+
+def test_releasing_an_unknown_session_is_404(admin_sessions):
+    client, _manager = admin_sessions
+    assert client.post("/api/sessions/ghost/release").status_code == 404
+
+
+def test_deleting_a_session_closes_it_and_removes_it(admin_sessions):
+    client, manager = admin_sessions
+    session = manager.create("bench-1", mock=True, owner="bob")
+    response = client.delete("/api/sessions/{0}".format(session.id))
+    assert response.status_code == 204
+    assert session.state == "closed"
+    assert session.id not in {s.id for s in manager.list()}
+
+
+def test_deleting_an_unknown_session_is_404(admin_sessions):
+    client, _manager = admin_sessions
+    assert client.delete("/api/sessions/ghost").status_code == 404

--- a/tests/test_server_admin_sessions.py
+++ b/tests/test_server_admin_sessions.py
@@ -4,6 +4,8 @@ Unauthenticated by design -- see admin/app.py -- so the listing test asserts
 reachability with no credential explicitly rather than leaving it implied.
 """
 
+import time
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -36,6 +38,38 @@ def test_the_listing_reports_owner_viewers_and_idle_seconds(admin_sessions):
     assert row["owner"] == "bob"
     assert row["viewers"] == 0
     assert isinstance(row["idle_seconds"], (int, float))
+
+
+def test_the_listing_reports_recording_true_for_a_recording_session(admin_sessions):
+    client, manager = admin_sessions
+    session = manager.create("bench-1", mock=True, owner="bob")
+    # The real TrendRecorder, started directly rather than through the
+    # start_recording route: that route also requires a non-empty measurement
+    # selection and runs on the session's worker thread via a Future, which
+    # would make this test slow and would exercise ScopeAdapter.start_recording
+    # rather than the admin listing this test is actually about. Calling
+    # recorder.start() directly is the same object api/scope.py's route calls,
+    # just without that surrounding machinery.
+    session.recorder.start([(1, "RMS")], time.time())
+    rows = client.get("/api/sessions").json()
+    assert rows[0]["recording"] is True
+
+
+def test_the_listing_reports_recording_false_for_an_idle_session(admin_sessions):
+    client, manager = admin_sessions
+    manager.create("bench-1", mock=True, owner="bob")
+    rows = client.get("/api/sessions").json()
+    assert rows[0]["recording"] is False
+
+
+def test_the_listing_reports_recording_false_for_a_kind_with_no_recorder(admin_sessions):
+    # PSU and AWG sessions have no recorder at all (only ScopeAdapter sets
+    # one) -- InstrumentSession.recorder raises AttributeError there by
+    # design. This must degrade to False, not take the whole listing down.
+    client, manager = admin_sessions
+    manager.create("supply-1", kind="psu", mock=True, owner="bob")
+    rows = client.get("/api/sessions").json()
+    assert rows[0]["recording"] is False
 
 
 def test_the_listing_is_reachable_with_no_credential(admin_sessions):

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -341,6 +341,8 @@ class TestViewers:
 
 
 def test_cli_parses_defaults(tmp_path, monkeypatch):
+    import types
+
     import scpi_control.server.__main__ as cli
     from scpi_control.server.auth import TokenStore
 
@@ -349,7 +351,10 @@ def test_cli_parses_defaults(tmp_path, monkeypatch):
 
     def fake_create_app(**kwargs):
         create_app_calls.append(kwargs)
-        return object()
+        # main() now reads main_app.state.manager/.stream_registry to wire the
+        # admin app (see __main__.py's create_admin_app call) -- a bare
+        # object() no longer has anywhere to read those from.
+        return types.SimpleNamespace(state=types.SimpleNamespace(manager=object(), stream_registry=object()))
 
     def fake_run_servers(main_app, host, port, admin_app, admin_port):
         captured.update(host=host, port=port)

--- a/tests/test_server_auth_store.py
+++ b/tests/test_server_auth_store.py
@@ -363,3 +363,22 @@ def test_revoke_does_not_resurrect_a_token_minted_by_another_process(tmp_path):
     fresh = TokenStore(path)
     assert fresh.verify(raw_bob) == "bob"
     assert fresh.verify(raw_robin) is None
+
+
+def test_names_sees_an_identity_minted_by_another_process(tmp_path):
+    # names() was the one public reader that never reloaded. That was harmless
+    # while its only caller ran after verify() had already reloaded in the same
+    # request -- identity_is_live() is the first caller for which it is not.
+    path = str(tmp_path / "tokens.json")
+    gateway = TokenStore(path)
+    gateway.mint("robin")
+    TokenStore(path).mint("bob")
+    assert gateway.names() == ["bob", "robin"]
+
+
+def test_names_stops_seeing_an_identity_revoked_by_another_process(tmp_path):
+    path = str(tmp_path / "tokens.json")
+    gateway = TokenStore(path)
+    gateway.mint("bob")
+    TokenStore(path).revoke("bob")
+    assert gateway.names() == []

--- a/tests/test_server_revocation.py
+++ b/tests/test_server_revocation.py
@@ -1,0 +1,104 @@
+"""What revocation means: tokens, streams and owned sessions, in one place."""
+
+import asyncio
+
+from scpi_control.server.auth import TokenStore
+from scpi_control.server.revocation import StreamRegistry, identity_is_live, revoke_identity
+
+
+class _FakeSession:
+    def __init__(self, owner):
+        self.owner = owner
+
+
+class _FakeManager:
+    def __init__(self, sessions):
+        self._sessions = sessions
+
+    def list(self):
+        return list(self._sessions)
+
+
+def test_identity_is_live_tracks_the_store(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    store.mint("bob")
+    assert identity_is_live(store, "bob") is True
+    store.revoke("bob")
+    assert identity_is_live(store, "bob") is False
+
+
+def test_identity_is_live_sees_another_process(tmp_path):
+    # This is the whole reason the backstop exists: `scpi-web token revoke`
+    # runs in a different process, so nothing in this one gets an event.
+    path = str(tmp_path / "tokens.json")
+    gateway = TokenStore(path)
+    gateway.mint("bob")
+    TokenStore(path).revoke("bob")
+    assert identity_is_live(gateway, "bob") is False
+
+
+def test_identity_is_live_is_false_for_an_empty_identity(tmp_path):
+    # A stream whose identity is "" never went through AuthMiddleware. It
+    # cannot happen today, and if it ever does it must not be treated as live.
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    assert identity_is_live(store, "") is False
+
+
+def test_the_registry_sets_every_event_for_one_identity():
+    registry = StreamRegistry()
+    first, second, other = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    registry.add("bob", first)
+    registry.add("bob", second)
+    registry.add("robin", other)
+    assert registry.revoke("bob") == 2
+    assert first.is_set() and second.is_set()
+    assert not other.is_set()
+
+
+def test_unregistering_stops_a_closed_stream_being_signalled():
+    registry = StreamRegistry()
+    event = asyncio.Event()
+    unregister = registry.add("bob", event)
+    unregister()
+    assert registry.revoke("bob") == 0
+    assert not event.is_set()
+
+
+def test_unregistering_twice_is_harmless():
+    registry = StreamRegistry()
+    unregister = registry.add("bob", asyncio.Event())
+    unregister()
+    unregister()
+    assert registry.count("bob") == 0
+
+
+def test_revoking_an_identity_reports_what_it_did(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    store.mint("bob")
+    store.mint("bob")
+    registry = StreamRegistry()
+    registry.add("bob", asyncio.Event())
+    manager = _FakeManager([_FakeSession("bob"), _FakeSession("robin"), _FakeSession("bob")])
+
+    result = revoke_identity(store, manager, registry, "bob")
+
+    assert result == {"devices": 2, "streams": 1, "sessions": 2}
+    assert store.names() == []
+
+
+def test_revoking_releases_only_that_identitys_sessions(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    store.mint("bob")
+    mine, theirs = _FakeSession("bob"), _FakeSession("robin")
+    revoke_identity(store, _FakeManager([mine, theirs]), StreamRegistry(), "bob")
+    assert mine.owner == ""
+    assert theirs.owner == "robin"
+
+
+def test_revoking_an_unknown_identity_reports_none_and_changes_nothing(tmp_path):
+    store = TokenStore(str(tmp_path / "tokens.json"))
+    store.mint("robin")
+    session = _FakeSession("robin")
+    assert revoke_identity(store, _FakeManager([session]), StreamRegistry(), "ghost") is None
+    assert session.owner == "robin"
+    assert store.names() == ["robin"]

--- a/tests/test_server_stream_revocation.py
+++ b/tests/test_server_stream_revocation.py
@@ -2,6 +2,7 @@
 
 import pytest
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from scpi_control.server.app import create_app
 from scpi_control.server.auth import TokenStore
@@ -28,9 +29,10 @@ def test_the_panel_path_closes_a_live_stream(tmp_path):
         with client.websocket_connect("/api/sessions/{0}/stream".format(session_id), subprotocols=["scpi-token.{0}".format(raw), "scpi"]) as ws:
             ws.receive_json()  # initial frame proves the stream is live
             revoke_identity(tokens, app.state.manager, app.state.stream_registry, "bob")
-            with pytest.raises(Exception):
+            with pytest.raises(WebSocketDisconnect) as excinfo:
                 for _ in range(50):
                     ws.receive_json()
+            assert excinfo.value.code == CLOSE_IDENTITY_REVOKED
 
 
 def test_the_backstop_closes_a_stream_revoked_by_another_process(tmp_path):
@@ -43,9 +45,10 @@ def test_the_backstop_closes_a_stream_revoked_by_another_process(tmp_path):
         with client.websocket_connect("/api/sessions/{0}/stream".format(session_id), subprotocols=["scpi-token.{0}".format(raw), "scpi"]) as ws:
             ws.receive_json()
             TokenStore(str(tmp_path / "tokens.json")).revoke("bob")
-            with pytest.raises(Exception):
+            with pytest.raises(WebSocketDisconnect) as excinfo:
                 for _ in range(50):
                     ws.receive_json()
+            assert excinfo.value.code == CLOSE_IDENTITY_REVOKED
 
 
 def test_a_revoked_stream_stops_blocking_the_claim(tmp_path):
@@ -62,9 +65,10 @@ def test_a_revoked_stream_stops_blocking_the_claim(tmp_path):
             session = app.state.manager.list()[0]
             assert session.owner_watching() is True
             TokenStore(str(tmp_path / "tokens.json")).revoke("bob")
-            with pytest.raises(Exception):
+            with pytest.raises(WebSocketDisconnect) as excinfo:
                 for _ in range(50):
                     ws.receive_json()
+            assert excinfo.value.code == CLOSE_IDENTITY_REVOKED
         assert session.owner_watching() is False
 
 

--- a/tests/test_server_stream_revocation.py
+++ b/tests/test_server_stream_revocation.py
@@ -2,10 +2,12 @@
 
 import asyncio
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
+from scpi_control.server.admin.app import create_admin_app
 from scpi_control.server.app import create_app
 from scpi_control.server.auth import TokenStore
 from scpi_control.server.invitations import InvitationStore
@@ -66,6 +68,76 @@ def _revoke_on_the_serving_loop(client, tokens, app, name):
         return revoke_identity(tokens, app.state.manager, app.state.stream_registry, name)
 
     return portal.call(_revoke)
+
+
+def _delete_identity_on_the_panel(client, admin_app, name):
+    """DELETE /api/identities/{name} on the admin app, on the gateway's loop.
+
+    A second ``TestClient`` would be the obvious way to reach the panel, and it
+    would quietly invalidate the test: each TestClient starts its own portal, so
+    the admin route would run on a *second* event loop and set the gateway
+    loop's events from a foreign thread -- the harness reintroducing the very
+    defect ``_revoke_on_the_serving_loop`` exists to keep out of this file, and
+    the opposite of what ships. ``__main__.py`` runs both apps on one loop in
+    one process (``_run_servers``); that shared loop is what makes the panel's
+    ``Event.set()`` safe on a live socket, so a test of that seam has to
+    reproduce it.
+
+    Driving httpx's ASGI transport from inside the gateway client's portal does:
+    one loop, the panel's real middleware stack (TrustedHost, same-Origin) and
+    the real route, arriving at the same registry the open socket registered
+    with. The Host must be 127.0.0.1 because TrustedHostMiddleware allows
+    nothing else, and no Origin is sent -- which is what a same-origin fetch
+    from the panel's own page looks like.
+    """
+    async def _request():
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=admin_app), base_url="http://127.0.0.1") as http:
+            return await http.delete("/api/identities/{0}".format(name))
+
+    return client.portal.call(_request)
+
+
+def test_the_admin_route_closes_a_live_stream_and_frees_the_session(tmp_path):
+    # The seam. Everything either side of it was already covered and the seam
+    # itself was not: the route was tested against a synthetic asyncio.Event
+    # (tests/test_server_admin_api.py) and the teardown was tested by calling
+    # revoke_identity directly (above), so the wiring that joins them -- the
+    # panel and the gateway sharing one manager and one registry, as
+    # __main__.py arranges -- was exercised only by a CLI test, against stubs.
+    # This is the shipped path end to end: click Revoke, socket dies, bench
+    # frees up.
+    tokens = TokenStore(str(tmp_path / "tokens.json"))
+    invitations = InvitationStore(str(tmp_path / "invitations.json"))
+    # 3600s, as in the panel-path test above: the backstop cannot be what tore
+    # this stream down, so only the route can have.
+    gateway = create_app(token_store=tokens, invitation_store=invitations, stream_revocation_interval=3600.0)
+    # Precisely __main__.py's wiring: the panel is handed the gateway's own
+    # manager and registry. Private copies would give it an empty world and
+    # this test would pass while revoking nothing.
+    admin_app = create_admin_app(token_store=tokens, invitation_store=invitations, manager=gateway.state.manager, stream_registry=gateway.state.stream_registry)
+    raw = tokens.mint("bob")
+    with TestClient(gateway) as client:
+        headers = {"Authorization": "Bearer {0}".format(raw)}
+        session_id = client.post("/api/sessions", json={"label": "bench", "mock": True}, headers=headers).json()["id"]
+        with client.websocket_connect("/api/sessions/{0}/stream".format(session_id), subprotocols=["scpi-token.{0}".format(raw), "scpi"]) as ws:
+            ws.receive_json()  # initial frame: the socket is real and live
+            session = gateway.state.manager.get(session_id)
+            assert session.owner_watching() is True
+            response = _delete_identity_on_the_panel(client, admin_app, "bob")
+            assert response.status_code == 200
+            # What the panel tells the operator, from the app that owns the
+            # real state rather than a synthetic one: one device, one stream,
+            # one session.
+            assert response.json() == {"devices": 1, "streams": 1, "sessions": 1}
+            with pytest.raises(WebSocketDisconnect) as excinfo:
+                for _ in range(50):
+                    ws.receive_json()
+            assert excinfo.value.code == CLOSE_IDENTITY_REVOKED
+        # The point of the whole sub-project: not that the socket closed, but
+        # that the bench is usable again. Both halves of "claimable" -- no
+        # owner, and nobody watching on that owner's behalf.
+        assert session.owner == ""
+        assert session.owner_watching() is False
 
 
 def test_the_panel_path_closes_a_live_stream(tmp_path):

--- a/tests/test_server_stream_revocation.py
+++ b/tests/test_server_stream_revocation.py
@@ -193,6 +193,39 @@ def test_a_revoked_stream_stops_blocking_the_claim(tmp_path):
         assert session.owner_watching() is False
 
 
+def test_a_stream_that_cannot_reach_the_registry_still_frees_the_session(tmp_path):
+    # The same bug through a different door. api/stream.py reads
+    # app.state.stream_registry and .stream_revocation_interval *after*
+    # mark_owner_watching() has already run, so those two lookups raising would
+    # skip unmark_owner_watching() and leave the session unclaimable until the
+    # idle threshold -- permanently, while the owner is watching nothing.
+    # Unreachable through create_app, which always sets both; reachable by an
+    # app assembled any other way, which is what deleting the attribute stands
+    # in for. The connection is allowed to die; the bench is not.
+    app, tokens = _client(tmp_path, interval=3600.0)
+    # Claimable-if-idle immediately, so the claim below turns on the one thing
+    # this test is about: claim() refuses while the owner is *watching*,
+    # whatever the idle threshold says (server/ownership.py).
+    app.state.abandon_after = 0.0
+    raw = tokens.mint("bob")
+    robin = tokens.mint("robin")
+    with TestClient(app) as client:
+        headers = {"Authorization": "Bearer {0}".format(raw)}
+        session_id = client.post("/api/sessions", json={"label": "bench", "mock": True}, headers=headers).json()["id"]
+        del app.state.stream_registry
+        # The handshake is accepted before those lookups run, so the socket
+        # really opens and the handler then falls straight through to its
+        # finally. Nothing is received: the handler returns without closing, so
+        # TestClient has nothing to hand back and a receive here would block
+        # forever. Leaving the context is what waits for the handler.
+        with client.websocket_connect("/api/sessions/{0}/stream".format(session_id), subprotocols=["scpi-token.{0}".format(raw), "scpi"]):
+            pass
+        session = app.state.manager.get(session_id)
+        assert session.owner_watching() is False
+        # And claimable for real, not merely clean in the bookkeeping.
+        assert client.post("/api/sessions/{0}/claim".format(session_id), headers={"Authorization": "Bearer {0}".format(robin)}).status_code == 200
+
+
 def test_an_unrelated_identity_keeps_streaming(tmp_path):
     # Over-broad teardown would be worse than none: revoking one person must
     # not drop everyone watching. The mock's frames are deliberately left

--- a/tests/test_server_stream_revocation.py
+++ b/tests/test_server_stream_revocation.py
@@ -1,5 +1,7 @@
 """Revocation tears a live stream down -- by both triggers, proven separately."""
 
+import asyncio
+
 import pytest
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
@@ -11,12 +13,59 @@ from scpi_control.server.revocation import revoke_identity
 
 CLOSE_IDENTITY_REVOKED = 4403
 
+# Every ws.receive_json() here blocks with no deadline of its own, so a
+# revocation that never reaches the socket presents as a HANG rather than a red
+# test -- it would wedge CI instead of reporting. A module-level timeout turns
+# it back into an ordinary failure, the same reason tests/test_server_stream_ws.py
+# carries this mark. 30 s is far above anything here (the slowest backstop poll
+# is 10 ms).
+pytestmark = pytest.mark.timeout(30)
+
 
 def _client(tmp_path, interval):
     tokens = TokenStore(str(tmp_path / "tokens.json"))
     invitations = InvitationStore(str(tmp_path / "invitations.json"))
     app = create_app(token_store=tokens, invitation_store=invitations, stream_revocation_interval=interval)
     return app, tokens
+
+
+def _revoke_on_the_serving_loop(client, tokens, app, name):
+    """Run revoke_identity on the loop the app is actually served on.
+
+    Not a harness detail -- it is the constraint the feature is built around,
+    and a revocation test that gets it wrong is exercising something the shipped
+    code never does. Revocation ends in ``asyncio.Event.set()``
+    (StreamRegistry.revoke), which is not thread-safe: called from the pytest
+    main thread it reaches ``loop.call_soon`` on a loop owned by another thread,
+    which appends the callback to that loop's ``_ready`` deque **without waking
+    its selector**. On an otherwise idle loop the callback simply sits there --
+    measured: a foreign-thread ``set()`` had not run its waiter a full second
+    later, and ran instantly once the loop was poked.
+
+    Under TestClient that is masked, not harmless: ``ws.receive_json()`` is
+    itself a portal call, so the client's own next read wakes the loop and the
+    revocation lands in milliseconds anyway. A green revocation test therefore
+    proves nothing whatever about which thread signalled it -- which is why
+    this helper asserts the affinity outright instead of leaving the next
+    person to infer it from a passing run, and why every revocation test in
+    this file goes through it.
+
+    ``TestClient``'s blocking portal *is* the serving loop, so ``portal.call``
+    runs the whole revocation on it: the same thread the shipped admin route
+    runs on, where ``Event.set()`` is safe. In production the question does not
+    arise -- the panel's route is a coroutine on the one loop that serves both
+    apps.
+    """
+    portal = getattr(client, "portal", None)
+    assert portal is not None, "TestClient no longer exposes .portal; find another way onto the serving loop (see this function's docstring)"
+
+    def _revoke():
+        # Not decoration: get_running_loop() raises RuntimeError anywhere but
+        # the loop thread, so this is the on-loop assertion itself.
+        asyncio.get_running_loop()
+        return revoke_identity(tokens, app.state.manager, app.state.stream_registry, name)
+
+    return portal.call(_revoke)
 
 
 def test_the_panel_path_closes_a_live_stream(tmp_path):
@@ -28,7 +77,7 @@ def test_the_panel_path_closes_a_live_stream(tmp_path):
         session_id = client.post("/api/sessions", json={"label": "bench", "mock": True}, headers={"Authorization": "Bearer {0}".format(raw)}).json()["id"]
         with client.websocket_connect("/api/sessions/{0}/stream".format(session_id), subprotocols=["scpi-token.{0}".format(raw), "scpi"]) as ws:
             ws.receive_json()  # initial frame proves the stream is live
-            revoke_identity(tokens, app.state.manager, app.state.stream_registry, "bob")
+            _revoke_on_the_serving_loop(client, tokens, app, "bob")
             with pytest.raises(WebSocketDisconnect) as excinfo:
                 for _ in range(50):
                     ws.receive_json()
@@ -74,7 +123,8 @@ def test_a_revoked_stream_stops_blocking_the_claim(tmp_path):
 
 def test_an_unrelated_identity_keeps_streaming(tmp_path):
     # Over-broad teardown would be worse than none: revoking one person must
-    # not drop everyone watching.
+    # not drop everyone watching. The mock's frames are deliberately left
+    # running here -- the assertion *is* that one still arrives.
     app, tokens = _client(tmp_path, interval=0.01)
     bob = tokens.mint("bob")
     robin = tokens.mint("robin")
@@ -82,5 +132,5 @@ def test_an_unrelated_identity_keeps_streaming(tmp_path):
         session_id = client.post("/api/sessions", json={"label": "bench", "mock": True}, headers={"Authorization": "Bearer {0}".format(robin)}).json()["id"]
         with client.websocket_connect("/api/sessions/{0}/stream".format(session_id), subprotocols=["scpi-token.{0}".format(robin), "scpi"]) as ws:
             ws.receive_json()
-            revoke_identity(tokens, app.state.manager, app.state.stream_registry, "bob")
+            _revoke_on_the_serving_loop(client, tokens, app, "bob")
             assert ws.receive_json() is not None

--- a/tests/test_server_stream_revocation.py
+++ b/tests/test_server_stream_revocation.py
@@ -1,0 +1,82 @@
+"""Revocation tears a live stream down -- by both triggers, proven separately."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scpi_control.server.app import create_app
+from scpi_control.server.auth import TokenStore
+from scpi_control.server.invitations import InvitationStore
+from scpi_control.server.revocation import revoke_identity
+
+CLOSE_IDENTITY_REVOKED = 4403
+
+
+def _client(tmp_path, interval):
+    tokens = TokenStore(str(tmp_path / "tokens.json"))
+    invitations = InvitationStore(str(tmp_path / "invitations.json"))
+    app = create_app(token_store=tokens, invitation_store=invitations, stream_revocation_interval=interval)
+    return app, tokens
+
+
+def test_the_panel_path_closes_a_live_stream(tmp_path):
+    # Interval is 3600s: if this passes, teardown came from the registry walk
+    # and not from the backstop, which could not have run.
+    app, tokens = _client(tmp_path, interval=3600.0)
+    raw = tokens.mint("bob")
+    with TestClient(app) as client:
+        session_id = client.post("/api/sessions", json={"label": "bench", "mock": True}, headers={"Authorization": "Bearer {0}".format(raw)}).json()["id"]
+        with client.websocket_connect("/api/sessions/{0}/stream".format(session_id), subprotocols=["scpi-token.{0}".format(raw), "scpi"]) as ws:
+            ws.receive_json()  # initial frame proves the stream is live
+            revoke_identity(tokens, app.state.manager, app.state.stream_registry, "bob")
+            with pytest.raises(Exception):
+                for _ in range(50):
+                    ws.receive_json()
+
+
+def test_the_backstop_closes_a_stream_revoked_by_another_process(tmp_path):
+    # No registry involvement: a second TokenStore on the same file is exactly
+    # what `scpi-web token revoke` is, and nothing in this process is told.
+    app, tokens = _client(tmp_path, interval=0.01)
+    raw = tokens.mint("bob")
+    with TestClient(app) as client:
+        session_id = client.post("/api/sessions", json={"label": "bench", "mock": True}, headers={"Authorization": "Bearer {0}".format(raw)}).json()["id"]
+        with client.websocket_connect("/api/sessions/{0}/stream".format(session_id), subprotocols=["scpi-token.{0}".format(raw), "scpi"]) as ws:
+            ws.receive_json()
+            TokenStore(str(tmp_path / "tokens.json")).revoke("bob")
+            with pytest.raises(Exception):
+                for _ in range(50):
+                    ws.receive_json()
+
+
+def test_a_revoked_stream_stops_blocking_the_claim(tmp_path):
+    # The bug that made this whole sub-project necessary: the socket closing is
+    # not the point -- releasing owner_watching is. Assert the session is
+    # claimable, not merely that the connection died.
+    app, tokens = _client(tmp_path, interval=0.01)
+    raw = tokens.mint("bob")
+    with TestClient(app) as client:
+        headers = {"Authorization": "Bearer {0}".format(raw)}
+        session_id = client.post("/api/sessions", json={"label": "bench", "mock": True}, headers=headers).json()["id"]
+        with client.websocket_connect("/api/sessions/{0}/stream".format(session_id), subprotocols=["scpi-token.{0}".format(raw), "scpi"]) as ws:
+            ws.receive_json()
+            session = app.state.manager.list()[0]
+            assert session.owner_watching() is True
+            TokenStore(str(tmp_path / "tokens.json")).revoke("bob")
+            with pytest.raises(Exception):
+                for _ in range(50):
+                    ws.receive_json()
+        assert session.owner_watching() is False
+
+
+def test_an_unrelated_identity_keeps_streaming(tmp_path):
+    # Over-broad teardown would be worse than none: revoking one person must
+    # not drop everyone watching.
+    app, tokens = _client(tmp_path, interval=0.01)
+    bob = tokens.mint("bob")
+    robin = tokens.mint("robin")
+    with TestClient(app) as client:
+        session_id = client.post("/api/sessions", json={"label": "bench", "mock": True}, headers={"Authorization": "Bearer {0}".format(robin)}).json()["id"]
+        with client.websocket_connect("/api/sessions/{0}/stream".format(session_id), subprotocols=["scpi-token.{0}".format(robin), "scpi"]) as ws:
+            ws.receive_json()
+            revoke_identity(tokens, app.state.manager, app.state.stream_registry, "bob")
+            assert ws.receive_json() is not None

--- a/webapp/app/src/admin/App.tsx
+++ b/webapp/app/src/admin/App.tsx
@@ -1,5 +1,6 @@
 import { GroupBox } from "../ds/GroupBox";
 import { People } from "./People";
+import { Sessions } from "./Sessions";
 
 /**
  * Admin app shell. There is exactly one screen -- the person who administers
@@ -10,6 +11,9 @@ export function App() {
     <div style={{ padding: "var(--space-4)", fontFamily: "var(--font-ui)", maxWidth: "960px", margin: "0 auto" }}>
       <GroupBox title="SCPI Gateway Admin">
         <People />
+        <div style={{ marginTop: "var(--space-4)" }}>
+          <Sessions />
+        </div>
       </GroupBox>
     </div>
   );

--- a/webapp/app/src/admin/People.test.tsx
+++ b/webapp/app/src/admin/People.test.tsx
@@ -28,10 +28,26 @@ describe("People", () => {
     expect(screen.getByRole("alertdialog")).toHaveTextContent(/all 2 of their devices/i);
   });
 
+  it("names all three consequences of revoking before it happens", async () => {
+    // Devices, live streams, and owned sessions are the three things
+    // revoke_identity() actually tears down (scpi_control/server/revocation.py).
+    // A colleague mid-capture loses their view and their session becomes
+    // immediately claimable by anyone -- the confirmation must not undersell
+    // that by mentioning only the device count.
+    vi.spyOn(adminApi, "identities").mockResolvedValue([identity("bob", 2)]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
+    render(<People />);
+    await userEvent.click(await screen.findByRole("button", { name: /revoke/i }));
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveTextContent(/device/i);
+    expect(dialog).toHaveTextContent(/live stream/i);
+    expect(dialog).toHaveTextContent(/session/i);
+  });
+
   it("does not revoke until the confirmation is accepted", async () => {
     vi.spyOn(adminApi, "identities").mockResolvedValue([identity("bob", 2)]);
     vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
-    const revoke = vi.spyOn(adminApi, "revokeIdentity").mockResolvedValue(undefined);
+    const revoke = vi.spyOn(adminApi, "revokeIdentity").mockResolvedValue({ devices: 2, streams: 1, sessions: 1 });
     render(<People />);
     await userEvent.click(await screen.findByRole("button", { name: /revoke/i }));
     await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
@@ -49,7 +65,7 @@ describe("People", () => {
       .mockResolvedValueOnce([identity("bob", 2)])
       .mockResolvedValueOnce([]);
     vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
-    const revoke = vi.spyOn(adminApi, "revokeIdentity").mockResolvedValue(undefined);
+    const revoke = vi.spyOn(adminApi, "revokeIdentity").mockResolvedValue({ devices: 2, streams: 1, sessions: 1 });
     render(<People />);
     await screen.findByText(/bob/);
     const callsAfterMount = identities.mock.calls.length;
@@ -61,6 +77,25 @@ describe("People", () => {
     expect(revoke).toHaveBeenCalledWith("bob");
     await waitFor(() => expect(identities.mock.calls.length).toBeGreaterThan(callsAfterMount));
     expect(await screen.findByText(/no one has access yet/i)).toBeInTheDocument();
+  });
+
+  it("surfaces the counts the revoke route returns", async () => {
+    // revoke_identity() reports what it actually tore down -- the panel must
+    // show that, not a generic "done" message, since the counts are the only
+    // way an admin learns whether a live viewer or session was affected.
+    vi.spyOn(adminApi, "identities")
+      .mockResolvedValueOnce([identity("bob", 2)])
+      .mockResolvedValueOnce([]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
+    vi.spyOn(adminApi, "revokeIdentity").mockResolvedValue({ devices: 2, streams: 1, sessions: 1 });
+    render(<People />);
+    await userEvent.click(await screen.findByRole("button", { name: /revoke/i }));
+    const dialog = screen.getByRole("alertdialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /revoke/i }));
+
+    const notice = await screen.findByText(/2 devices/i);
+    expect(notice).toHaveTextContent(/1 live stream/i);
+    expect(notice).toHaveTextContent(/1 session/i);
   });
 
   it("shows the link and the code after inviting", async () => {

--- a/webapp/app/src/admin/People.tsx
+++ b/webapp/app/src/admin/People.tsx
@@ -3,7 +3,7 @@ import { Button } from "../ds/Button";
 import { DataTable } from "../ds/DataTable";
 import { GroupBox } from "../ds/GroupBox";
 import { Countdown } from "./Countdown";
-import { adminApi, type Identity, type Invitation } from "./api";
+import { adminApi, type Identity, type Invitation, type RevocationResult } from "./api";
 
 function formatDevices(count: number): string {
   return `${count} device${count === 1 ? "" : "s"}`;
@@ -44,6 +44,21 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : "Something went wrong.";
 }
 
+function formatStreams(count: number): string {
+  return `${count} live stream${count === 1 ? "" : "s"}`;
+}
+
+function formatSessions(count: number): string {
+  return `${count} session${count === 1 ? "" : "s"}`;
+}
+
+/** What DELETE /api/identities/{name} actually tore down -- reported so the
+ * admin learns whether a live viewer or an owned session was affected,
+ * instead of a generic "done". */
+function formatRevocationResult(name: string, result: RevocationResult): string {
+  return `Revoked ${name}: signed out ${formatDevices(result.devices)}, closed ${formatStreams(result.streams)}, and freed ${formatSessions(result.sessions)}.`;
+}
+
 export function People() {
   const [identities, setIdentities] = useState<Identity[] | null>(null);
   const [invitations, setInvitations] = useState<Invitation[] | null>(null);
@@ -51,6 +66,7 @@ export function People() {
 
   const [revokeTarget, setRevokeTarget] = useState<Identity | null>(null);
   const [revoking, setRevoking] = useState(false);
+  const [revoked, setRevoked] = useState("");
 
   const [inviteName, setInviteName] = useState("");
   const [inviting, setInviting] = useState(false);
@@ -81,8 +97,10 @@ export function People() {
     setError("");
     setRevoking(true);
     try {
-      await adminApi.revokeIdentity(revokeTarget.name);
+      const name = revokeTarget.name;
+      const result = await adminApi.revokeIdentity(name);
       setRevokeTarget(null);
+      setRevoked(formatRevocationResult(name, result));
       await loadIdentities();
     } catch (err) {
       setError(errorMessage(err));
@@ -129,6 +147,7 @@ export function People() {
       ) : null}
 
       <GroupBox title="Who has access">
+        {revoked ? <p style={{ fontSize: "var(--text-sm)" }}>{revoked}</p> : null}
         {identities === null ? (
           <p>Loading…</p>
         ) : identities.length === 0 ? (
@@ -261,7 +280,10 @@ export function People() {
           }}
         >
           <p>
-            Revoke {revokeTarget.name}? This signs out all {revokeTarget.devices} of their devices.
+            Revoke {revokeTarget.name}? This signs out all {revokeTarget.devices} of their devices,
+            cuts any live stream they're watching right now, and frees any session they own for
+            anyone to claim immediately -- if they're mid-capture, they lose their view the moment
+            you confirm.
           </p>
           <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end" }}>
             <Button disabled={revoking} onClick={() => setRevokeTarget(null)}>

--- a/webapp/app/src/admin/Sessions.test.tsx
+++ b/webapp/app/src/admin/Sessions.test.tsx
@@ -18,6 +18,7 @@ const session = (overrides: Partial<SessionRow> = {}): SessionRow => ({
   viewers: 0,
   owner: "",
   idle_seconds: 12.3,
+  recording: false,
   ...overrides,
 });
 
@@ -80,22 +81,36 @@ describe("Sessions", () => {
   });
 
   it("shows a confirmation naming the instrument before closing, and sends nothing until confirmed", async () => {
-    vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ id: "s1", label: "bench-1" })]);
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ id: "s1", label: "bench-1", recording: false })]);
     const close = vi.spyOn(adminApi, "closeSession").mockResolvedValue(undefined);
     render(<Sessions />);
     await userEvent.click(await screen.findByRole("button", { name: /close/i }));
 
     const dialog = screen.getByRole("alertdialog");
     expect(dialog).toHaveTextContent(/bench-1/);
-    // The listing has no field for "is this session recording" (session_out's
-    // `state` is only ever connecting/connected/closed/error), so the warning
-    // can't be conditioned on that -- it applies to every close, honestly.
-    expect(dialog).toHaveTextContent(/capture in progress/i);
     expect(close).not.toHaveBeenCalled();
 
     await userEvent.click(within(dialog).getByRole("button", { name: /cancel/i }));
     expect(close).not.toHaveBeenCalled();
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("warns that the session is recording when it is", async () => {
+    // Backed by /api/sessions' `recording` field (admin/api.py::_is_recording),
+    // which mirrors the same recorder.state == "recording" comparison used by
+    // api/scope.py and adapters.py -- not a new notion of recording.
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ id: "s1", label: "bench-1", recording: true })]);
+    render(<Sessions />);
+    await userEvent.click(await screen.findByRole("button", { name: /close/i }));
+    expect(screen.getByRole("alertdialog")).toHaveTextContent(/recording/i);
+  });
+
+  it("does not warn about recording when the session is not recording", async () => {
+    // Asserting only the positive branch would let a hardcoded warning pass.
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ id: "s1", label: "bench-1", recording: false })]);
+    render(<Sessions />);
+    await userEvent.click(await screen.findByRole("button", { name: /close/i }));
+    expect(screen.getByRole("alertdialog")).not.toHaveTextContent(/recording/i);
   });
 
   it("closes a session only after the confirmation is accepted, and reloads the listing", async () => {

--- a/webapp/app/src/admin/Sessions.test.tsx
+++ b/webapp/app/src/admin/Sessions.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Sessions } from "./Sessions";
+import { adminApi, type Session as SessionRow } from "./api";
+
+const session = (overrides: Partial<SessionRow> = {}): SessionRow => ({
+  id: "s1",
+  label: "bench-1",
+  kind: "scope",
+  mock: true,
+  address: null,
+  state: "connected",
+  idn: "Mock,Scope,1,1.0",
+  model: "Mock Scope",
+  dialect: "generic",
+  num_channels: 4,
+  viewers: 0,
+  owner: "",
+  idle_seconds: 12.3,
+  ...overrides,
+});
+
+describe("Sessions", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("lists sessions with instrument, owner, viewers and idle time", async () => {
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([
+      session({ id: "s1", mock: true, owner: "bob", viewers: 2, idle_seconds: 5.5 }),
+    ]);
+    render(<Sessions />);
+    expect(await screen.findByText(/mock/i)).toBeInTheDocument();
+    expect(screen.getByText(/bob/)).toBeInTheDocument();
+    expect(screen.getByText(/2/)).toBeInTheDocument();
+    expect(screen.getByText(/5\.5/)).toBeInTheDocument();
+  });
+
+  it("renders an address instead of Mock for a real instrument", async () => {
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([
+      session({ id: "s1", mock: false, address: "192.168.1.20:5025" }),
+    ]);
+    render(<Sessions />);
+    expect(await screen.findByText(/192\.168\.1\.20:5025/)).toBeInTheDocument();
+  });
+
+  it("shows a dash for an unowned session", async () => {
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ id: "s1", owner: "" })]);
+    render(<Sessions />);
+    await screen.findByText(/bench-1/);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("renders an error state when the listing fails", async () => {
+    vi.spyOn(adminApi, "sessions").mockRejectedValue(new Error("gateway unreachable"));
+    render(<Sessions />);
+    expect(await screen.findByRole("alert")).toHaveTextContent(/gateway unreachable/i);
+  });
+
+  it("releases a session without confirmation and reloads the listing", async () => {
+    // sessions() returns bob's session on mount, then an unowned one on the
+    // reload that must follow a successful release. A local optimistic patch
+    // (clearing owner in state without calling the server again) would leave
+    // the call count flat, so that assertion catches it even though the
+    // screen would look right either way.
+    const sessions = vi
+      .spyOn(adminApi, "sessions")
+      .mockResolvedValueOnce([session({ id: "s1", owner: "bob" })])
+      .mockResolvedValueOnce([session({ id: "s1", owner: "" })]);
+    const release = vi.spyOn(adminApi, "releaseSession").mockResolvedValue(undefined);
+    render(<Sessions />);
+    await screen.findByText(/bob/);
+    const callsAfterMount = sessions.mock.calls.length;
+
+    await userEvent.click(screen.getByRole("button", { name: /release/i }));
+
+    expect(release).toHaveBeenCalledWith("s1");
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    await waitFor(() => expect(sessions.mock.calls.length).toBeGreaterThan(callsAfterMount));
+    expect(await screen.findByText("—")).toBeInTheDocument();
+  });
+
+  it("shows a confirmation naming the instrument before closing, and sends nothing until confirmed", async () => {
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ id: "s1", label: "bench-1" })]);
+    const close = vi.spyOn(adminApi, "closeSession").mockResolvedValue(undefined);
+    render(<Sessions />);
+    await userEvent.click(await screen.findByRole("button", { name: /close/i }));
+
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveTextContent(/bench-1/);
+    // The listing has no field for "is this session recording" (session_out's
+    // `state` is only ever connecting/connected/closed/error), so the warning
+    // can't be conditioned on that -- it applies to every close, honestly.
+    expect(dialog).toHaveTextContent(/capture in progress/i);
+    expect(close).not.toHaveBeenCalled();
+
+    await userEvent.click(within(dialog).getByRole("button", { name: /cancel/i }));
+    expect(close).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("closes a session only after the confirmation is accepted, and reloads the listing", async () => {
+    const sessions = vi
+      .spyOn(adminApi, "sessions")
+      .mockResolvedValueOnce([session({ id: "s1", label: "bench-1" })])
+      .mockResolvedValueOnce([]);
+    const close = vi.spyOn(adminApi, "closeSession").mockResolvedValue(undefined);
+    render(<Sessions />);
+    await screen.findByText(/bench-1/);
+    const callsAfterMount = sessions.mock.calls.length;
+
+    await userEvent.click(screen.getByRole("button", { name: /close/i }));
+    const dialog = screen.getByRole("alertdialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /close/i }));
+
+    expect(close).toHaveBeenCalledWith("s1");
+    await waitFor(() => expect(sessions.mock.calls.length).toBeGreaterThan(callsAfterMount));
+    expect(await screen.findByText(/no live sessions/i)).toBeInTheDocument();
+  });
+
+  it("reports the server's message when closing fails", async () => {
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ id: "s1", label: "bench-1" })]);
+    vi.spyOn(adminApi, "closeSession").mockRejectedValue(new Error("session already closing"));
+    render(<Sessions />);
+    await userEvent.click(await screen.findByRole("button", { name: /close/i }));
+    const dialog = screen.getByRole("alertdialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /close/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/session already closing/i);
+  });
+});

--- a/webapp/app/src/admin/Sessions.tsx
+++ b/webapp/app/src/admin/Sessions.tsx
@@ -137,8 +137,9 @@ export function Sessions() {
           }}
         >
           <p>
-            Close {closeTarget.label}? This ends the session immediately. Anyone viewing it loses
-            their view right now, and any capture in progress stops.
+            Close {closeTarget.label}? This ends the session immediately, and anyone viewing it
+            loses their view right now.
+            {closeTarget.recording ? " This session is recording -- closing it stops that capture." : null}
           </p>
           <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end" }}>
             <Button disabled={closing} onClick={() => setCloseTarget(null)}>

--- a/webapp/app/src/admin/Sessions.tsx
+++ b/webapp/app/src/admin/Sessions.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "../ds/Button";
+import { DataTable } from "../ds/DataTable";
+import { GroupBox } from "../ds/GroupBox";
+import { adminApi, type Session } from "./api";
+
+/** What identifies the instrument in a row: its address, or "Mock" when it isn't real hardware. */
+function formatInstrument(session: Session): string {
+  return session.mock ? `${session.label} (Mock)` : `${session.label} (${session.address})`;
+}
+
+function formatIdle(seconds: number): string {
+  return `${seconds}s idle`;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "Something went wrong.";
+}
+
+export function Sessions() {
+  const [sessions, setSessions] = useState<Session[] | null>(null);
+  const [error, setError] = useState("");
+
+  const [closeTarget, setCloseTarget] = useState<Session | null>(null);
+  const [closing, setClosing] = useState(false);
+  const [releasingId, setReleasingId] = useState<string | null>(null);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const loadSessions = useCallback(async () => {
+    try {
+      setError("");
+      setSessions(await adminApi.sessions());
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSessions();
+  }, [loadSessions]);
+
+  // Move focus into the confirmation so keyboard and screen-reader users land
+  // on it rather than having to hunt for a dialog that appeared elsewhere.
+  useEffect(() => {
+    if (closeTarget) dialogRef.current?.focus();
+  }, [closeTarget]);
+
+  const release = async (session: Session) => {
+    setError("");
+    setReleasingId(session.id);
+    try {
+      await adminApi.releaseSession(session.id);
+      await loadSessions();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setReleasingId(null);
+    }
+  };
+
+  const confirmClose = async () => {
+    if (!closeTarget) return;
+    setError("");
+    setClosing(true);
+    try {
+      await adminApi.closeSession(closeTarget.id);
+      setCloseTarget(null);
+      await loadSessions();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setClosing(false);
+    }
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+      {error ? (
+        <p role="alert" style={{ color: "var(--danger)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </p>
+      ) : null}
+
+      <GroupBox title="Live sessions">
+        {sessions === null ? (
+          <p>Loading…</p>
+        ) : sessions.length === 0 ? (
+          <p>No live sessions.</p>
+        ) : (
+          <DataTable
+            columns={["Instrument", "Owner", "Viewers", "Idle", ""]}
+            rows={sessions.map((session) => [
+              formatInstrument(session),
+              session.owner || "—",
+              session.viewers,
+              formatIdle(session.idle_seconds),
+              <div style={{ display: "flex", gap: "var(--space-2)" }}>
+                <Button
+                  size="sm"
+                  disabled={closeTarget !== null || releasingId !== null}
+                  onClick={() => void release(session)}
+                >
+                  Release
+                </Button>
+                <Button
+                  size="sm"
+                  variant="danger"
+                  disabled={closeTarget !== null || releasingId !== null}
+                  onClick={() => setCloseTarget(session)}
+                >
+                  Close
+                </Button>
+              </div>,
+            ])}
+          />
+        )}
+      </GroupBox>
+
+      {closeTarget ? (
+        <div
+          role="alertdialog"
+          aria-label={`Close ${closeTarget.label}?`}
+          aria-modal="true"
+          tabIndex={-1}
+          ref={dialogRef}
+          style={{
+            border: "1px solid var(--lc-border-strong)",
+            borderRadius: "var(--lc-radius)",
+            background: "var(--lc-panel)",
+            boxShadow: "var(--lc-elev-1)",
+            padding: "var(--space-3)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--space-2)",
+            maxWidth: "360px",
+          }}
+        >
+          <p>
+            Close {closeTarget.label}? This ends the session immediately. Anyone viewing it loses
+            their view right now, and any capture in progress stops.
+          </p>
+          <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end" }}>
+            <Button disabled={closing} onClick={() => setCloseTarget(null)}>
+              Cancel
+            </Button>
+            <Button variant="danger" disabled={closing} onClick={() => void confirmClose()}>
+              Close
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/webapp/app/src/admin/api.ts
+++ b/webapp/app/src/admin/api.ts
@@ -2,7 +2,10 @@ export type Identity = { name: string; devices: number; last_used: string | null
 export type Invitation = { id: string; name: string; code: string; expires: number; link?: string };
 export type RevocationResult = { devices: number; streams: number; sessions: number };
 
-/** The gateway's own session_out() payload, plus idle_seconds (see admin/api.py::list_sessions). */
+/** The gateway's own session_out() payload, plus idle_seconds and recording
+ * (see admin/api.py::list_sessions and its _is_recording helper). `recording`
+ * is `false` for any session whose kind has no recorder (PSU, AWG) -- it
+ * means "not known to be recording", not "definitely not". */
 export type Session = {
   id: string;
   label: string;
@@ -17,6 +20,7 @@ export type Session = {
   viewers: number;
   owner: string;
   idle_seconds: number;
+  recording: boolean;
 };
 
 /**

--- a/webapp/app/src/admin/api.ts
+++ b/webapp/app/src/admin/api.ts
@@ -1,5 +1,23 @@
 export type Identity = { name: string; devices: number; last_used: string | null };
 export type Invitation = { id: string; name: string; code: string; expires: number; link?: string };
+export type RevocationResult = { devices: number; streams: number; sessions: number };
+
+/** The gateway's own session_out() payload, plus idle_seconds (see admin/api.py::list_sessions). */
+export type Session = {
+  id: string;
+  label: string;
+  kind: string;
+  mock: boolean;
+  address: string | null;
+  state: string;
+  idn: string;
+  model: string;
+  dialect: string;
+  num_channels: number;
+  viewers: number;
+  owner: string;
+  idle_seconds: number;
+};
 
 /**
  * Admin API client. Deliberately does NOT attach a bearer token: this app is
@@ -31,5 +49,10 @@ export const adminApi = {
   invitations: () => request<Invitation[]>("/api/invitations"),
   createInvitation: (name: string) => request<Invitation>("/api/invitations", json("POST", { name })),
   cancelInvitation: (id: string) => request<void>(`/api/invitations/${id}`, { method: "DELETE" }),
-  revokeIdentity: (name: string) => request<void>(`/api/identities/${encodeURIComponent(name)}`, { method: "DELETE" }),
+  // 200 with the torn-down counts, not 204 -- so the panel can report what
+  // revoking actually did instead of a generic "done".
+  revokeIdentity: (name: string) => request<RevocationResult>(`/api/identities/${encodeURIComponent(name)}`, { method: "DELETE" }),
+  sessions: () => request<Session[]>("/api/sessions"),
+  releaseSession: (id: string) => request<void>(`/api/sessions/${id}/release`, { method: "POST" }),
+  closeSession: (id: string) => request<void>(`/api/sessions/${id}`, { method: "DELETE" }),
 };


### PR DESCRIPTION
## Description

Revoking a credential now actually takes effect on a running gateway.

Previously, revoking someone's token left their already-open live-stream WebSocket running and kept the session they owned unclaimable until an idle timeout. The credential was gone, but the person was still watching and still holding the instrument. `docs/gateway/security.md` documented this as a known limitation.

Revocation is now one complete action: it removes the identity's tokens, closes its live streams, and releases the sessions it owned so anyone can claim them immediately.

## Related Issues

<!-- No tracking issue -->

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [x] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [x] Test coverage improvement

## Changes Made

- **`scpi_control/server/revocation.py` (new)** — one place that defines what revocation means: tokens, live streams, owned sessions. `StreamRegistry` maps an identity to the set of `asyncio.Event`s its streams wait on; `identity_is_live()` answers whether an identity still exists; `revoke_identity()` does the whole job and reports what it did. `TokenStore.names()` is now reload-aware so it sees another process's writes.
- **The stream tears itself down.** `api/stream.py` races a third waiter — an `asyncio.Event` — alongside its existing receive/send tasks, so teardown reuses the `finally` that already unmarks ownership and unsubscribes. There is exactly one exit path, not two that have to agree. A revoked viewer's socket closes with **4403**, distinct from 4410 (session ended) because nothing happened to the session — they lost their credential.
- **Two independent triggers set that event:** the admin panel walking the registry, and each connection's own liveness poll (default 5s). The second exists because `scpi-web token revoke` runs in a *different process*, so nothing in the serving process receives an event.
- **The admin app sees sessions.** `GET /api/sessions` (with `owner`, `viewers`, `idle_seconds` and `recording`), `POST /api/sessions/{id}/release`, `DELETE /api/sessions/{id}`, wired to the gateway's own `SessionManager` and `StreamRegistry` — not private copies.
- **`DELETE /api/identities/{name}` now returns 200** with `{"devices", "streams", "sessions"}` instead of 204, so the panel can report what a revocation actually did rather than guess.
- **A Sessions panel** in the admin UI: every open session with owner, viewer count and idle time. **Release** clears the owner (non-destructive, no confirmation); **Close** ends the session (destructive, confirms first, and warns when that session is recording).
- **Docs corrected.** The blockquote in `docs/gateway/security.md` that stated the old limitation is now false and has been replaced; `docs/gateway/api.md` gained the 4403 close code; `docs/gateway/admin-panel.md` documents the new screen.

### ⚠️ Breaking changes

- Revoking an identity now also closes its live streams and releases the sessions it owned. A revoked colleague mid-capture loses their view, and their session becomes immediately claimable.
- `DELETE /api/identities/{name}` returns **200 with a JSON body** where it returned **204**. Wire-visible for anything scripting against the admin app.
- `create_admin_app()`'s `manager` and `stream_registry` are now **required keyword arguments**. They previously defaulted to `None`, which let a caller build an app that looked fine and then half-completed a revocation — tokens destroyed on disk first, then a 500 before the streams or sessions were touched. A `TypeError` at construction is the only place that mistake can still be caught.

## Testing

- [x] Tests pass locally (`make test` or `pytest tests/`)
- [x] Added tests for new functionality
- [ ] Tested with real hardware (if applicable)
- [ ] All CI checks pass

### Test Details

**Test environment:**

- OS: Windows 11 Pro (CI runs Linux)
- Python version: 3.12.7 (floor is 3.9)
- Oscilloscope model (if applicable): none — mock adapters only

**Test results:**

```
2124 passed, 19 skipped, 0 failed
(-m "not slow" -n 8, Ollama test files excluded)

webapp/app: 317 passed, typecheck clean
mkdocs build --strict: 71 warnings (all pre-existing), 0 new
```

Notes on what the tests actually pin, since two triggers producing one outcome is easy to test badly:

- **The two teardown triggers are proven separately by mutation.** A test asserting only "the stream closed" would pass with either mechanism deleted. The registry test sets the poll interval to 3600s so the backstop provably cannot contribute; the backstop test never touches the registry. Commenting out `registry.revoke()` fails only the panel test; commenting out the watcher fails only the two backstop tests.
- **The close code is asserted, not assumed** — `pytest.raises(WebSocketDisconnect)` plus `excinfo.value.code == CLOSE_IDENTITY_REVOKED`. Without it, changing the close to 4410 left every test green.
- **The revoke is driven through the serving event loop**, not the pytest main thread. `asyncio.Event` is not thread-safe, and a foreign-thread `set()` only worked because the mock adapter happens to publish a frame every 250ms — a latent hang rather than a failure.
- **One end-to-end test** builds both apps over the same manager and registry, opens a real stream, calls the admin route, and asserts the socket closes with 4403 *and* the session becomes claimable.

## Code Quality

- [x] Code follows the project style guidelines (`make lint` passes)
- [x] Code is formatted with Black (`make format`)
- [x] Self-reviewed the code
- [x] Commented complex code sections
- [x] Updated docstrings for modified functions/classes
- [x] No new linting warnings introduced

## Documentation

- [ ] Updated README.md (if needed)
- [x] Updated CHANGELOG.md with changes
- [x] Added/updated docstrings
- [ ] Added/updated examples (if applicable)
- [x] Updated type hints

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation

## Additional Notes

**Known limitation, now documented rather than hidden:** the liveness backstop keys on the identity *name*, not the credential. `security.md` recommends `token revoke bob` followed by re-inviting bob; if both happen inside the 5s poll window via the CLI, the old socket's next check sees "bob" alive again and that stream survives. The panel path is unaffected — it signals immediately. This is recorded in `docs/gateway/security.md`.

**Deferred, and deliberately out of scope:** the design spec listed an `error` field on session rows that the implementation plan never asked for, so an errored session currently looks the same as a healthy one in the Sessions panel. Worth folding into a later panel change rather than widening this one.

**Separate issue found while verifying, not addressed here:** `scpi_control/server/admin/static/` is gitignored — a local build artifact rebuilt by `make webapp-build`. CI runs `npm run build:admin` only to prove the bundle compiles, never that the checked-out one is current, and `MANIFEST.in` ships whatever is on disk. A wheel cut from a stale working tree therefore ships a stale admin panel silently. Tracked for follow-up.

No version bump — this folds into the queued 6.0.0.
