### PR TITLE
fix(webapp): make the admin panel's confirmations modal and its data current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   idle time. Release clears the owner, making the session immediately claimable by anyone, with
   no confirmation. Close ends the session after confirming, and warns when that session is
   recording so an active capture is not lost accidentally.
+- The admin panel gained a page header.
+- The live-session list in the Sessions screen now displays readable right-aligned numeric columns
+  for Viewers and Idle time.
 
 ### Fixed
 
@@ -112,6 +115,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   blocks a new user from claiming the session. A periodic liveness check in each stream catches
   a revocation in a different process (default every 5 seconds), and closes the client's WebSocket
   with code 4403 to signal that the credential was revoked rather than the session ending (4410).
+- The admin panel's Close and Revoke confirmations are now genuinely modal: a backdrop over the
+  page, focus trapped inside, dismissible by Escape or a backdrop click, and focus returned to the
+  triggering button when closed. Previously they appeared as inline panels below the table, so on a
+  long list they could render below the fold and appear not to work.
+- Acting on one session (releasing or revoking) no longer disables the action buttons on every
+  other row — each row's actions are now independent.
+- The live-session list refreshes every 10 seconds, so the Idle column stays current instead of
+  being a snapshot from page load. Refreshes pause while a Close confirmation is open, so the list
+  cannot reshuffle under a question you are reading, and a failed refresh leaves the previous rows
+  visible rather than blanking the table.
+- The gateway serves `index.html` with `Cache-Control: no-store` on both the gateway and admin
+  panel, so a rebuilt webapp appears on an ordinary reload instead of requiring a hard refresh and
+  cache clear.
 
 ## [5.8.0] - 2026-07-27
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -94,6 +94,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   idle time. Release clears the owner, making the session immediately claimable by anyone, with
   no confirmation. Close ends the session after confirming, and warns when that session is
   recording so an active capture is not lost accidentally.
+- The admin panel gained a page header.
+- The live-session list in the Sessions screen now displays readable right-aligned numeric columns
+  for Viewers and Idle time.
 
 ### Fixed
 
@@ -112,6 +115,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   blocks a new user from claiming the session. A periodic liveness check in each stream catches
   a revocation in a different process (default every 5 seconds), and closes the client's WebSocket
   with code 4403 to signal that the credential was revoked rather than the session ending (4410).
+- The admin panel's Close and Revoke confirmations are now genuinely modal: a backdrop over the
+  page, focus trapped inside, dismissible by Escape or a backdrop click, and focus returned to the
+  triggering button when closed. Previously they appeared as inline panels below the table, so on a
+  long list they could render below the fold and appear not to work.
+- Acting on one session (releasing or revoking) no longer disables the action buttons on every
+  other row — each row's actions are now independent.
+- The live-session list refreshes every 10 seconds, so the Idle column stays current instead of
+  being a snapshot from page load. Refreshes pause while a Close confirmation is open, so the list
+  cannot reshuffle under a question you are reading, and a failed refresh leaves the previous rows
+  visible rather than blanking the table.
+- The gateway serves `index.html` with `Cache-Control: no-store` on both the gateway and admin
+  panel, so a rebuilt webapp appears on an ordinary reload instead of requiring a hard refresh and
+  cache clear.
 
 ## [5.8.0] - 2026-07-27
 

--- a/docs/gateway/admin-panel.md
+++ b/docs/gateway/admin-panel.md
@@ -203,7 +203,7 @@ dialog: a modal that sits over the page rather than a block of text under the
 table, so it is never scrolled out of view on a long list. It opens with focus
 already on Cancel, keeps Tab from leaving the dialog, and closes on **Escape**
 or a click on the backdrop behind it — all three read as "never mind" and put
-focus back on the button you opened it from. While either confirmation is
+focus back on the button you opened it from. While the Close confirmation is
 open, the ten-second refresh pauses, so the row you are reading about cannot
 reshuffle or disappear out from under the question you are being asked.
 

--- a/docs/gateway/admin-panel.md
+++ b/docs/gateway/admin-panel.md
@@ -174,7 +174,16 @@ reads a code back out is the host-only panel. It is never served to the LAN app.
 
 **Live sessions** lists every open instrument session — the instrument (its
 label, and address or `(Mock)`), who owns it, how many viewers are watching,
-and how long the owner has been idle. Each row has two buttons:
+and how long the owner has been idle. The list refreshes itself every ten
+seconds, so **Idle** keeps counting up instead of freezing at whatever it read
+when the page opened — leave the screen open across a coffee break and it
+still tells the truth. A refresh that fails leaves the rows on screen as they
+were rather than blanking the table, and one row's Release or Close can never
+be stepped on by a slower refresh landing after it: the action always wins.
+Each row's buttons act on that row alone — clearing one session never touches
+the buttons on any other.
+
+Each row has two buttons:
 
 - **Release** clears the session's owner right away, with no confirmation. It
   is not destructive — the instrument keeps running and every viewer keeps
@@ -188,6 +197,15 @@ and how long the owner has been idle. Each row has two buttons:
   and anyone viewing it loses their view right now."* — and adds a second
   warning when the session is currently recording, because closing it stops
   that capture too.
+
+Close's confirmation, and Revoke's on the People screen above, are the same
+dialog: a modal that sits over the page rather than a block of text under the
+table, so it is never scrolled out of view on a long list. It opens with focus
+already on Cancel, keeps Tab from leaving the dialog, and closes on **Escape**
+or a click on the backdrop behind it — all three read as "never mind" and put
+focus back on the button you opened it from. While either confirmation is
+open, the ten-second refresh pauses, so the row you are reading about cannot
+reshuffle or disappear out from under the question you are being asked.
 
 Revoking an identity on the People screen above reaches this same list: every
 session the revoked name owned is released the same way Release does here, so

--- a/scpi_control/server/admin/app.py
+++ b/scpi_control/server/admin/app.py
@@ -43,13 +43,13 @@ from pathlib import Path
 from typing import Iterable, List, Optional
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from scpi_control.server.revocation import StreamRegistry
 from scpi_control.server.sessions import SessionManager
-from scpi_control.server.spa import resolve_spa_path
+from scpi_control.server.spa import spa_response
 
 ADMIN_STATIC_DIR = Path(__file__).parent / "static"
 DEFAULT_ADMIN_PORT = 8766
@@ -132,7 +132,7 @@ def create_admin_app(token_store, invitation_store, *, manager: SessionManager, 
         async def spa(full_path: str):
             if full_path.startswith("api/"):
                 raise HTTPException(status_code=404, detail="unknown path /{0}".format(full_path))
-            return FileResponse(str(resolve_spa_path(ADMIN_STATIC_DIR, full_path)))
+            return spa_response(ADMIN_STATIC_DIR, full_path)
 
     # The second and third independent defences described in the module
     # docstring -- see there for why the loopback bind alone is not enough.

--- a/scpi_control/server/app.py
+++ b/scpi_control/server/app.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from scpi_control.exceptions import InvalidParameterError, SiglentError, SiglentTimeoutError
@@ -15,7 +15,7 @@ from scpi_control.server.auth import AuthMiddleware, TokenStore
 from scpi_control.server.invitations import InvitationStore
 from scpi_control.server.revocation import StreamRegistry
 from scpi_control.server.sessions import SessionError, SessionManager
-from scpi_control.server.spa import resolve_spa_path
+from scpi_control.server.spa import spa_response
 
 STATIC_DIR = Path(__file__).parent / "static"
 
@@ -145,7 +145,7 @@ def create_app(
         async def spa(full_path: str):
             if full_path.startswith("api/"):
                 raise HTTPException(status_code=404, detail="unknown path /{0}".format(full_path))
-            return FileResponse(str(resolve_spa_path(STATIC_DIR, full_path)))
+            return spa_response(STATIC_DIR, full_path)
 
     # Added last so it wraps everything above, including the SPA catch-all: pure
     # ASGI middleware (not BaseHTTPMiddleware) so it also guards WebSocket scopes.

--- a/scpi_control/server/spa.py
+++ b/scpi_control/server/spa.py
@@ -24,8 +24,9 @@ def resolve_spa_path(static_dir: Path, full_path: str) -> Path:
 
     Returns the resolved candidate if it exists as a file and stays inside
     ``static_dir``; otherwise returns ``static_dir / "index.html"``. The
-    caller is responsible for rejecting ``/api/*`` before calling this, and
-    for wrapping the result in a FileResponse.
+    caller is responsible for rejecting ``/api/*`` before calling this.
+    Wrapping the result in a response is `spa_response`'s job below -- it is
+    the only caller of this function.
     """
     static_root = static_dir.resolve()
     candidate = (static_dir / full_path).resolve()

--- a/scpi_control/server/spa.py
+++ b/scpi_control/server/spa.py
@@ -16,6 +16,8 @@ whichever app has no auth in front of it.
 
 from pathlib import Path
 
+from fastapi.responses import FileResponse
+
 
 def resolve_spa_path(static_dir: Path, full_path: str) -> Path:
     """Return the file to serve at ``full_path`` under ``static_dir``.
@@ -30,3 +32,22 @@ def resolve_spa_path(static_dir: Path, full_path: str) -> Path:
     if full_path and candidate.is_file() and candidate.is_relative_to(static_root):
         return candidate
     return static_dir / "index.html"
+
+
+def spa_response(static_dir: Path, full_path: str) -> FileResponse:
+    """Serve the SPA file for ``full_path``, with index.html made uncacheable.
+
+    The asset filenames are content-hashed, so they invalidate themselves.
+    index.html is the file that *names* those hashes, and nothing invalidates
+    it -- so a browser holding a cached copy keeps requesting a bundle the last
+    build deleted, and the page silently stays at the previous version until
+    somebody clears their cache by hand. That cost two debugging sessions.
+
+    Keyed on the resolved path, not on full_path: an unknown path falls back to
+    index.html, and that response needs the same treatment or a deep-linked
+    client route caches a stale document under its own URL.
+    """
+    path = resolve_spa_path(static_dir, full_path)
+    if path.name == "index.html":
+        return FileResponse(str(path), headers={"Cache-Control": "no-store"})
+    return FileResponse(str(path))

--- a/tests/test_server_admin_api.py
+++ b/tests/test_server_admin_api.py
@@ -19,6 +19,29 @@ def admin_stores(tmp_path):
 
 
 @pytest.fixture
+def admin_static_client(tmp_path, monkeypatch, admin_stores):
+    # The `admin` fixture above never points ADMIN_STATIC_DIR at a real
+    # directory (no bundle has been built), so it cannot exercise the SPA
+    # route's cache headers. Build a throwaway static dir and monkeypatch it
+    # in, mirroring test_server_spa.py's static_client fixture, rather than
+    # weakening `admin` for the many tests that don't need a static bundle.
+    import scpi_control.server.admin.app as admin_app_module
+
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "index.html").write_text("<!doctype html><title>admin</title>", encoding="utf-8")
+    (static_dir / "app.js").write_text("console.log('x')", encoding="utf-8")
+    monkeypatch.setattr(admin_app_module, "ADMIN_STATIC_DIR", static_dir)
+
+    tokens, invitations = admin_stores
+    manager = SessionManager()
+    app = admin_app_module.create_admin_app(token_store=tokens, invitation_store=invitations, manager=manager, stream_registry=StreamRegistry(), base_url="http://192.168.1.50:8765/")
+    with TestClient(app, base_url="http://127.0.0.1") as client:
+        yield client
+    manager.close_all()
+
+
+@pytest.fixture
 def admin(admin_stores):
     # One fixture for the whole file: create_admin_app now *requires* a manager
     # and a stream registry, so there is no longer a "plain" admin app that
@@ -374,6 +397,28 @@ def test_a_safelisted_content_type_cannot_create_an_invitation(admin):
         response = client.post("/api/invitations", content=b'{"name": "bob"}', headers={"Content-Type": content_type})
         assert response.status_code != 200, content_type
     assert invitations.pending() == 0
+
+
+def test_the_admin_index_is_never_cached(admin_static_client):
+    # index.html names the content-hashed asset files, so it is the one file a
+    # rebuild cannot invalidate. Cached, it keeps asking for a bundle that no
+    # longer exists and the page appears frozen at the previous build.
+    response = admin_static_client.get("/")
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_the_admin_spa_fallback_is_never_cached(admin_static_client):
+    # An unknown path falls back to index.html; that response needs the same
+    # treatment or a deep-linked client route caches a stale document.
+    response = admin_static_client.get("/sessions/abc123")
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_admin_hashed_assets_stay_cacheable(admin_static_client):
+    # Their names change when their contents do, so making them uncacheable
+    # would trade the staleness bug for a slower panel.
+    response = admin_static_client.get("/app.js")
+    assert response.headers.get("cache-control") != "no-store"
 
 
 def test_admin_spa_traversal_is_contained(tmp_path):

--- a/tests/test_server_spa.py
+++ b/tests/test_server_spa.py
@@ -74,3 +74,25 @@ def test_encoded_traversal_is_contained(tmp_path, monkeypatch, gateway_auth):
             assert response.status_code in (200, 404), payload
             assert "TOP SECRET" not in response.text, payload
     manager.close_all()
+
+
+def test_index_is_never_cached(static_client):
+    # index.html names the content-hashed asset files, so it is the one file a
+    # rebuild cannot invalidate. Cached, it keeps asking for a bundle that no
+    # longer exists and the page appears frozen at the previous build.
+    response = static_client.get("/")
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_the_spa_fallback_is_never_cached(static_client):
+    # An unknown path falls back to index.html; that response needs the same
+    # treatment or a deep-linked client route caches a stale document.
+    response = static_client.get("/sessions/abc123")
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_hashed_assets_stay_cacheable(static_client):
+    # Their names change when their contents do, so making them uncacheable
+    # would trade the staleness bug for a slower panel.
+    response = static_client.get("/app.js")
+    assert response.headers.get("cache-control") != "no-store"

--- a/webapp/app/src/admin/App.tsx
+++ b/webapp/app/src/admin/App.tsx
@@ -9,7 +9,13 @@ import { Sessions } from "./Sessions";
 export function App() {
   return (
     <div style={{ padding: "var(--space-4)", fontFamily: "var(--font-ui)", maxWidth: "960px", margin: "0 auto" }}>
-      <GroupBox title="SCPI Gateway Admin">
+      <header style={{ marginBottom: "var(--space-4)" }}>
+        <h1 style={{ margin: 0, fontSize: "var(--text-lg)", fontWeight: "var(--weight-bold)" }}>SCPI Gateway Admin</h1>
+        <p style={{ margin: "var(--space-1) 0 0", color: "var(--text-muted)", fontSize: "var(--text-sm)" }}>
+          Access and live sessions for the gateway on this machine.
+        </p>
+      </header>
+      <GroupBox>
         <People />
         <div style={{ marginTop: "var(--space-4)" }}>
           <Sessions />

--- a/webapp/app/src/admin/People.test.tsx
+++ b/webapp/app/src/admin/People.test.tsx
@@ -207,6 +207,33 @@ describe("People", () => {
     expect(await screen.findByText(/no one has access yet/i)).toBeInTheDocument();
   });
 
+  it("leaves other rows usable while one identity's revoke is in flight", async () => {
+    // Mirrors Sessions' equivalent test: the old code disabled every row's
+    // Revoke button whenever any revoke was targeted, so acting on one
+    // identity greyed out the whole roster.
+    vi.spyOn(adminApi, "identities").mockResolvedValue([identity("bob", 2), identity("alice", 1)]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
+    let resolveRevoke: (result: { devices: number; streams: number; sessions: number }) => void = () => {};
+    vi.spyOn(adminApi, "revokeIdentity").mockReturnValue(
+      new Promise((resolve) => {
+        resolveRevoke = resolve;
+      }),
+    );
+    render(<People />);
+
+    const rows = await screen.findAllByRole("row");
+    const rowBob = within(rows[1]);
+    const rowAlice = within(rows[2]);
+    await userEvent.click(rowBob.getByRole("button", { name: /revoke/i }));
+    const dialog = screen.getByRole("alertdialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /revoke/i }));
+
+    expect(rowBob.getByRole("button", { name: /revoke/i })).toBeDisabled();
+    expect(rowAlice.getByRole("button", { name: /revoke/i })).toBeEnabled();
+
+    resolveRevoke({ devices: 2, streams: 0, sessions: 0 });
+  });
+
   it("confirms a revoke in a modal that traps focus", async () => {
     // Same dialog as Sessions: the promise of aria-modal has to be true here too.
     vi.spyOn(adminApi, "identities").mockResolvedValue([identity("bob", 2)]);

--- a/webapp/app/src/admin/People.test.tsx
+++ b/webapp/app/src/admin/People.test.tsx
@@ -206,4 +206,21 @@ describe("People", () => {
     render(<People />);
     expect(await screen.findByText(/no one has access yet/i)).toBeInTheDocument();
   });
+
+  it("confirms a revoke in a modal that traps focus", async () => {
+    // Same dialog as Sessions: the promise of aria-modal has to be true here too.
+    vi.spyOn(adminApi, "identities").mockResolvedValue([identity("bob", 2)]);
+    vi.spyOn(adminApi, "invitations").mockResolvedValue([]);
+    const revoke = vi.spyOn(adminApi, "revokeIdentity");
+    render(<People />);
+    await userEvent.click(await screen.findByRole("button", { name: /revoke/i }));
+
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    expect(revoke).not.toHaveBeenCalled();
+  });
 });

--- a/webapp/app/src/admin/People.tsx
+++ b/webapp/app/src/admin/People.tsx
@@ -155,7 +155,7 @@ export function People() {
               <Button
                 size="sm"
                 variant="danger"
-                disabled={revokeTarget !== null}
+                disabled={revokeTarget?.name === identity.name}
                 onClick={() => setRevokeTarget(identity)}
               >
                 Revoke

--- a/webapp/app/src/admin/People.tsx
+++ b/webapp/app/src/admin/People.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { Button } from "../ds/Button";
+import { ConfirmDialog } from "../ds/ConfirmDialog";
 import { DataTable } from "../ds/DataTable";
 import { GroupBox } from "../ds/GroupBox";
 import { Countdown } from "./Countdown";
@@ -72,8 +73,6 @@ export function People() {
   const [inviting, setInviting] = useState(false);
   const [created, setCreated] = useState<Invitation | null>(null);
 
-  const dialogRef = useRef<HTMLDivElement>(null);
-
   const loadIdentities = useCallback(async () => {
     setIdentities(await adminApi.identities());
   }, []);
@@ -85,12 +84,6 @@ export function People() {
     void loadIdentities();
     void loadInvitations();
   }, [loadIdentities, loadInvitations]);
-
-  // Move focus into the confirmation so keyboard and screen-reader users land
-  // on it rather than having to hunt for a dialog that appeared elsewhere.
-  useEffect(() => {
-    if (revokeTarget) dialogRef.current?.focus();
-  }, [revokeTarget]);
 
   const confirmRevoke = async () => {
     if (!revokeTarget) return;
@@ -261,39 +254,20 @@ export function People() {
       </GroupBox>
 
       {revokeTarget ? (
-        <div
-          role="alertdialog"
-          aria-label={`Revoke ${revokeTarget.name}?`}
-          aria-modal="true"
-          tabIndex={-1}
-          ref={dialogRef}
-          style={{
-            border: "1px solid var(--lc-border-strong)",
-            borderRadius: "var(--lc-radius)",
-            background: "var(--lc-panel)",
-            boxShadow: "var(--lc-elev-1)",
-            padding: "var(--space-3)",
-            display: "flex",
-            flexDirection: "column",
-            gap: "var(--space-2)",
-            maxWidth: "360px",
-          }}
-        >
-          <p>
-            Revoke {revokeTarget.name}? This signs out all {revokeTarget.devices} of their devices,
-            cuts any live stream they're watching right now, and frees any session they own for
-            anyone to claim immediately -- if they're mid-capture, they lose their view the moment
-            you confirm.
-          </p>
-          <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end" }}>
-            <Button disabled={revoking} onClick={() => setRevokeTarget(null)}>
-              Cancel
-            </Button>
-            <Button variant="danger" disabled={revoking} onClick={() => void confirmRevoke()}>
-              Revoke
-            </Button>
-          </div>
-        </div>
+        <ConfirmDialog
+          title={`Revoke ${revokeTarget.name}?`}
+          confirmLabel="Revoke"
+          busy={revoking}
+          onCancel={() => setRevokeTarget(null)}
+          onConfirm={() => void confirmRevoke()}
+          body={
+            <>
+              This signs out all {revokeTarget.devices} of their devices, cuts any live stream
+              they're watching right now, and frees any session they own for anyone to claim
+              immediately — if they're mid-capture, they lose their view the moment you confirm.
+            </>
+          }
+        />
       ) : null}
     </div>
   );

--- a/webapp/app/src/admin/Sessions.test.tsx
+++ b/webapp/app/src/admin/Sessions.test.tsx
@@ -187,66 +187,129 @@ describe("Sessions", () => {
 
   it("refreshes on a timer so the idle column cannot go stale", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    vi.spyOn(adminApi, "sessions")
-      .mockResolvedValueOnce([session({ idle_seconds: 4 })])
-      .mockResolvedValueOnce([session({ idle_seconds: 14 })]);
-    render(<Sessions />);
-    expect(await screen.findByText("4s idle")).toBeInTheDocument();
+    try {
+      vi.spyOn(adminApi, "sessions")
+        .mockResolvedValueOnce([session({ idle_seconds: 4 })])
+        .mockResolvedValueOnce([session({ idle_seconds: 14 })]);
+      render(<Sessions />);
+      expect(await screen.findByText("4s idle")).toBeInTheDocument();
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(10_000);
-    });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
 
-    expect(await screen.findByText("14s idle")).toBeInTheDocument();
-    vi.useRealTimers();
+      expect(await screen.findByText("14s idle")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not refresh while a confirmation is open", async () => {
     // The list must not reshuffle under a confirmation the operator is reading.
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    const list = vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ id: "aaa", label: "bench-a" })]);
-    render(<Sessions />);
-    await userEvent.click(await screen.findByRole("button", { name: "Close" }));
-    const callsWhenOpened = list.mock.calls.length;
+    try {
+      const list = vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ id: "aaa", label: "bench-a" })]);
+      render(<Sessions />);
+      await userEvent.click(await screen.findByRole("button", { name: "Close" }));
+      const callsWhenOpened = list.mock.calls.length;
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(60_000);
-    });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
 
-    expect(list.mock.calls.length).toBe(callsWhenOpened);
-    vi.useRealTimers();
+      expect(list.mock.calls.length).toBe(callsWhenOpened);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps the last good rows when a refresh fails", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    vi.spyOn(adminApi, "sessions")
-      .mockResolvedValueOnce([session({ label: "bench-a" })])
-      .mockRejectedValueOnce(new Error("gateway unreachable"));
-    render(<Sessions />);
-    expect(await screen.findByText(/bench-a/)).toBeInTheDocument();
+    try {
+      vi.spyOn(adminApi, "sessions")
+        .mockResolvedValueOnce([session({ label: "bench-a" })])
+        .mockRejectedValueOnce(new Error("gateway unreachable"));
+      render(<Sessions />);
+      expect(await screen.findByText(/bench-a/)).toBeInTheDocument();
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(10_000);
-    });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
 
-    expect(await screen.findByRole("alert")).toHaveTextContent("gateway unreachable");
-    expect(screen.getByText(/bench-a/)).toBeInTheDocument();
-    vi.useRealTimers();
+      expect(await screen.findByRole("alert")).toHaveTextContent("gateway unreachable");
+      expect(screen.getByText(/bench-a/)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("stops polling once unmounted", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    const list = vi.spyOn(adminApi, "sessions").mockResolvedValue([session()]);
-    const { unmount } = render(<Sessions />);
-    await screen.findByRole("table");
-    unmount();
-    const callsAtUnmount = list.mock.calls.length;
+    try {
+      const list = vi.spyOn(adminApi, "sessions").mockResolvedValue([session()]);
+      const { unmount } = render(<Sessions />);
+      await screen.findByRole("table");
+      unmount();
+      const callsAtUnmount = list.mock.calls.length;
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(60_000);
-    });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
 
-    expect(list.mock.calls.length).toBe(callsAtUnmount);
-    vi.useRealTimers();
+      expect(list.mock.calls.length).toBe(callsAtUnmount);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let a stale poll response overwrite a newer release reload", async () => {
+    // A release fires its own reload; if an in-flight poll tick's older
+    // response resolves after it, the released session must not reappear.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      let resolvePoll: (rows: SessionRow[]) => void = () => {};
+      let resolveReleaseReload: (rows: SessionRow[]) => void = () => {};
+      const list = vi
+        .spyOn(adminApi, "sessions")
+        .mockResolvedValueOnce([session({ id: "aaa", label: "bench-a", owner: "bob" })])
+        // The poll tick's request, kicked off while the release is in flight.
+        .mockImplementationOnce(
+          () => new Promise<SessionRow[]>((resolve) => (resolvePoll = resolve)),
+        )
+        // The release's own reload, requested after the poll tick above.
+        .mockImplementationOnce(
+          () => new Promise<SessionRow[]>((resolve) => (resolveReleaseReload = resolve)),
+        );
+      vi.spyOn(adminApi, "releaseSession").mockResolvedValue(undefined);
+      render(<Sessions />);
+      await screen.findByText(/bob/);
+
+      // Trigger the poll tick: its request goes in flight but does not resolve yet.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(list.mock.calls.length).toBe(2);
+
+      // Now release, which fires its own (third) reload request.
+      await user.click(screen.getByRole("button", { name: "Release" }));
+      await vi.waitFor(() => expect(list.mock.calls.length).toBe(3));
+
+      // The release's reload resolves first, clearing the owner...
+      await act(async () => {
+        resolveReleaseReload([session({ id: "aaa", label: "bench-a", owner: "" })]);
+      });
+      expect(await screen.findByText("—")).toBeInTheDocument();
+
+      // ...then the stale poll response resolves late, with the old owner.
+      // It must be discarded rather than winning because it landed last.
+      await act(async () => {
+        resolvePoll([session({ id: "aaa", label: "bench-a", owner: "bob" })]);
+      });
+      expect(screen.getByText("—")).toBeInTheDocument();
+      expect(screen.queryByText(/bob/)).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/webapp/app/src/admin/Sessions.test.tsx
+++ b/webapp/app/src/admin/Sessions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Sessions } from "./Sessions";
@@ -183,5 +183,70 @@ describe("Sessions", () => {
     await userEvent.keyboard("{Escape}");
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
     expect(close).not.toHaveBeenCalled();
+  });
+
+  it("refreshes on a timer so the idle column cannot go stale", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.spyOn(adminApi, "sessions")
+      .mockResolvedValueOnce([session({ idle_seconds: 4 })])
+      .mockResolvedValueOnce([session({ idle_seconds: 14 })]);
+    render(<Sessions />);
+    expect(await screen.findByText("4s idle")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(await screen.findByText("14s idle")).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it("does not refresh while a confirmation is open", async () => {
+    // The list must not reshuffle under a confirmation the operator is reading.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const list = vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ id: "aaa", label: "bench-a" })]);
+    render(<Sessions />);
+    await userEvent.click(await screen.findByRole("button", { name: "Close" }));
+    const callsWhenOpened = list.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(list.mock.calls.length).toBe(callsWhenOpened);
+    vi.useRealTimers();
+  });
+
+  it("keeps the last good rows when a refresh fails", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.spyOn(adminApi, "sessions")
+      .mockResolvedValueOnce([session({ label: "bench-a" })])
+      .mockRejectedValueOnce(new Error("gateway unreachable"));
+    render(<Sessions />);
+    expect(await screen.findByText(/bench-a/)).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("gateway unreachable");
+    expect(screen.getByText(/bench-a/)).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it("stops polling once unmounted", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const list = vi.spyOn(adminApi, "sessions").mockResolvedValue([session()]);
+    const { unmount } = render(<Sessions />);
+    await screen.findByRole("table");
+    unmount();
+    const callsAtUnmount = list.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(list.mock.calls.length).toBe(callsAtUnmount);
+    vi.useRealTimers();
   });
 });

--- a/webapp/app/src/admin/Sessions.test.tsx
+++ b/webapp/app/src/admin/Sessions.test.tsx
@@ -141,4 +141,47 @@ describe("Sessions", () => {
     await userEvent.click(within(dialog).getByRole("button", { name: /close/i }));
     expect(await screen.findByRole("alert")).toHaveTextContent(/session already closing/i);
   });
+
+  it("leaves other rows usable while one row is releasing", async () => {
+    // The old code disabled every button on every row whenever any action was in
+    // flight, so acting on one bench greyed out the whole panel.
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([
+      session({ id: "aaa", label: "bench-a" }),
+      session({ id: "bbb", label: "bench-b" }),
+    ]);
+    let resolveRelease: () => void = () => {};
+    vi.spyOn(adminApi, "releaseSession").mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRelease = resolve;
+      }),
+    );
+    render(<Sessions />);
+
+    const rows = await screen.findAllByRole("row");
+    const rowA = within(rows[1]);
+    const rowB = within(rows[2]);
+    await userEvent.click(rowA.getByRole("button", { name: "Release" }));
+
+    expect(rowA.getByRole("button", { name: "Release" })).toBeDisabled();
+    expect(rowB.getByRole("button", { name: "Release" })).toBeEnabled();
+    expect(rowB.getByRole("button", { name: "Close" })).toBeEnabled();
+
+    resolveRelease();
+  });
+
+  it("puts the close confirmation in a modal that traps focus", async () => {
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ id: "aaa", label: "bench-a" })]);
+    const close = vi.spyOn(adminApi, "closeSession").mockResolvedValue(undefined);
+    render(<Sessions />);
+    await userEvent.click(await screen.findByRole("button", { name: "Close" }));
+
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+    expect(close).not.toHaveBeenCalled();
+
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    expect(close).not.toHaveBeenCalled();
+  });
 });

--- a/webapp/app/src/admin/Sessions.test.tsx
+++ b/webapp/app/src/admin/Sessions.test.tsx
@@ -36,6 +36,29 @@ describe("Sessions", () => {
     expect(screen.getByText(/5\.5/)).toBeInTheDocument();
   });
 
+  it("right-aligns the numeric columns in a mono face", async () => {
+    // Viewer counts and idle times are scanned down a column, not read as prose.
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ idle_seconds: 5.5 })]);
+    render(<Sessions />);
+    const cell = await screen.findByText("5.5s idle");
+    expect(cell.closest("td")).toHaveStyle({ textAlign: "right" });
+  });
+
+  it("keeps the destructive action visually secondary", async () => {
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([session()]);
+    render(<Sessions />);
+    const close = await screen.findByRole("button", { name: "Close" });
+    const release = screen.getByRole("button", { name: "Release" });
+    expect(close).toHaveAttribute("data-variant", "danger");
+    expect(release).not.toHaveAttribute("data-variant", "danger");
+  });
+
+  it("explains an empty list rather than just stating it", async () => {
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([]);
+    render(<Sessions />);
+    expect(await screen.findByText(/Sessions appear here when someone opens an instrument/)).toBeInTheDocument();
+  });
+
   it("renders an address instead of Mock for a real instrument", async () => {
     vi.spyOn(adminApi, "sessions").mockResolvedValue([
       session({ id: "s1", mock: false, address: "192.168.1.20:5025" }),

--- a/webapp/app/src/admin/Sessions.test.tsx
+++ b/webapp/app/src/admin/Sessions.test.tsx
@@ -165,6 +165,23 @@ describe("Sessions", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(/session already closing/i);
   });
 
+  it("keeps a failed close's error inside the modal, not hidden behind the backdrop", async () => {
+    // Before this fix, a failed close's message rendered in the page-level
+    // banner, which sits underneath the backdrop while the dialog stays
+    // open (confirmClose only clears closeTarget on success) -- so the
+    // only evidence of the failure was invisible to the operator reading
+    // the still-open dialog.
+    vi.spyOn(adminApi, "sessions").mockResolvedValue([session({ id: "s1", label: "bench-1" })]);
+    vi.spyOn(adminApi, "closeSession").mockRejectedValue(new Error("session already closing"));
+    render(<Sessions />);
+    await userEvent.click(await screen.findByRole("button", { name: /close/i }));
+    const dialog = screen.getByRole("alertdialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /close/i }));
+
+    expect(await within(dialog).findByRole("alert")).toHaveTextContent(/session already closing/i);
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+  });
+
   it("leaves other rows usable while one row is releasing", async () => {
     // The old code disabled every button on every row whenever any action was in
     // flight, so acting on one bench greyed out the whole panel.
@@ -331,6 +348,83 @@ describe("Sessions", () => {
       });
       expect(screen.getByText("—")).toBeInTheDocument();
       expect(screen.queryByText(/bob/)).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not clear an existing error banner before a poll's own response arrives", async () => {
+    // The old code called setError("") synchronously at the top of every
+    // loadSessions -- including a poll tick -- before the network call even
+    // resolved, so a banner from an earlier failure vanished the instant the
+    // next tick fired, regardless of what that tick's own request did.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      let resolvePoll: (rows: SessionRow[]) => void = () => {};
+      vi.spyOn(adminApi, "sessions")
+        .mockRejectedValueOnce(new Error("gateway unreachable"))
+        .mockImplementationOnce(() => new Promise<SessionRow[]>((resolve) => (resolvePoll = resolve)));
+      render(<Sessions />);
+      expect(await screen.findByRole("alert")).toHaveTextContent(/gateway unreachable/i);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      // The tick's own request is in flight but unresolved: the earlier
+      // banner must still be visible, not cleared the instant the tick fired.
+      expect(screen.getByRole("alert")).toHaveTextContent(/gateway unreachable/i);
+
+      await act(async () => {
+        resolvePoll([session()]);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let a stale poll rejection raise an error banner over fresh rows", async () => {
+    // Mirrors the stale-response test above, but for the error path: the old
+    // catch block's setError() had no generation guard at all, so a
+    // superseded request's rejection could paint a banner over rows a newer,
+    // successful request had already delivered.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      let rejectPoll: (err: Error) => void = () => {};
+      let resolveReleaseReload: (rows: SessionRow[]) => void = () => {};
+      const list = vi
+        .spyOn(adminApi, "sessions")
+        .mockResolvedValueOnce([session({ id: "aaa", label: "bench-a", owner: "bob" })])
+        // The poll tick's request, kicked off while the release is in flight.
+        .mockImplementationOnce(() => new Promise<SessionRow[]>((_resolve, reject) => (rejectPoll = reject)))
+        // The release's own reload, requested after the poll tick above.
+        .mockImplementationOnce(
+          () => new Promise<SessionRow[]>((resolve) => (resolveReleaseReload = resolve)),
+        );
+      vi.spyOn(adminApi, "releaseSession").mockResolvedValue(undefined);
+      render(<Sessions />);
+      await screen.findByText(/bob/);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(list.mock.calls.length).toBe(2);
+
+      await user.click(screen.getByRole("button", { name: "Release" }));
+      await vi.waitFor(() => expect(list.mock.calls.length).toBe(3));
+
+      await act(async () => {
+        resolveReleaseReload([session({ id: "aaa", label: "bench-a", owner: "" })]);
+      });
+      expect(await screen.findByText("—")).toBeInTheDocument();
+
+      // The stale poll tick's rejection resolves late. It must be discarded,
+      // not painted over the fresh (successful) rows above.
+      await act(async () => {
+        rejectPoll(new Error("stale gateway blip"));
+      });
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }

--- a/webapp/app/src/admin/Sessions.tsx
+++ b/webapp/app/src/admin/Sessions.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "../ds/Button";
 import { ConfirmDialog } from "../ds/ConfirmDialog";
 import { DataTable } from "../ds/DataTable";
@@ -30,10 +30,14 @@ export function Sessions() {
   const [closing, setClosing] = useState(false);
   const [releasingId, setReleasingId] = useState<string | null>(null);
 
+  const requestId = useRef(0);
+
   const loadSessions = useCallback(async () => {
+    const id = ++requestId.current;
     try {
       setError("");
-      setSessions(await adminApi.sessions());
+      const rows = await adminApi.sessions();
+      if (id === requestId.current) setSessions(rows);
     } catch (err) {
       setError(errorMessage(err));
     }

--- a/webapp/app/src/admin/Sessions.tsx
+++ b/webapp/app/src/admin/Sessions.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "../ds/Button";
+import { ConfirmDialog } from "../ds/ConfirmDialog";
 import { DataTable } from "../ds/DataTable";
 import { GroupBox } from "../ds/GroupBox";
 import { adminApi, type Session } from "./api";
@@ -25,8 +26,6 @@ export function Sessions() {
   const [closing, setClosing] = useState(false);
   const [releasingId, setReleasingId] = useState<string | null>(null);
 
-  const dialogRef = useRef<HTMLDivElement>(null);
-
   const loadSessions = useCallback(async () => {
     try {
       setError("");
@@ -39,12 +38,6 @@ export function Sessions() {
   useEffect(() => {
     void loadSessions();
   }, [loadSessions]);
-
-  // Move focus into the confirmation so keyboard and screen-reader users land
-  // on it rather than having to hunt for a dialog that appeared elsewhere.
-  useEffect(() => {
-    if (closeTarget) dialogRef.current?.focus();
-  }, [closeTarget]);
 
   const release = async (session: Session) => {
     setError("");
@@ -96,19 +89,10 @@ export function Sessions() {
               session.viewers,
               formatIdle(session.idle_seconds),
               <div style={{ display: "flex", gap: "var(--space-2)" }}>
-                <Button
-                  size="sm"
-                  disabled={closeTarget !== null || releasingId !== null}
-                  onClick={() => void release(session)}
-                >
+                <Button size="sm" disabled={releasingId === session.id} onClick={() => void release(session)}>
                   Release
                 </Button>
-                <Button
-                  size="sm"
-                  variant="danger"
-                  disabled={closeTarget !== null || releasingId !== null}
-                  onClick={() => setCloseTarget(session)}
-                >
+                <Button size="sm" variant="danger" disabled={releasingId === session.id} onClick={() => setCloseTarget(session)}>
                   Close
                 </Button>
               </div>,
@@ -118,38 +102,19 @@ export function Sessions() {
       </GroupBox>
 
       {closeTarget ? (
-        <div
-          role="alertdialog"
-          aria-label={`Close ${closeTarget.label}?`}
-          aria-modal="true"
-          tabIndex={-1}
-          ref={dialogRef}
-          style={{
-            border: "1px solid var(--lc-border-strong)",
-            borderRadius: "var(--lc-radius)",
-            background: "var(--lc-panel)",
-            boxShadow: "var(--lc-elev-1)",
-            padding: "var(--space-3)",
-            display: "flex",
-            flexDirection: "column",
-            gap: "var(--space-2)",
-            maxWidth: "360px",
-          }}
-        >
-          <p>
-            Close {closeTarget.label}? This ends the session immediately, and anyone viewing it
-            loses their view right now.
-            {closeTarget.recording ? " This session is recording -- closing it stops that capture." : null}
-          </p>
-          <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end" }}>
-            <Button disabled={closing} onClick={() => setCloseTarget(null)}>
-              Cancel
-            </Button>
-            <Button variant="danger" disabled={closing} onClick={() => void confirmClose()}>
-              Close
-            </Button>
-          </div>
-        </div>
+        <ConfirmDialog
+          title={`Close ${closeTarget.label}?`}
+          confirmLabel="Close"
+          busy={closing}
+          onCancel={() => setCloseTarget(null)}
+          onConfirm={() => void confirmClose()}
+          body={
+            <>
+              This ends the session immediately, and anyone viewing it loses their view right now.
+              {closeTarget.recording ? " This session is recording — closing it stops that capture." : null}
+            </>
+          }
+        />
       ) : null}
     </div>
   );

--- a/webapp/app/src/admin/Sessions.tsx
+++ b/webapp/app/src/admin/Sessions.tsx
@@ -93,12 +93,14 @@ export function Sessions() {
 
       <GroupBox title="Live sessions">
         {sessions === null ? (
-          <p>Loading…</p>
+          <p style={{ color: "var(--text-muted)" }}>Loading…</p>
         ) : sessions.length === 0 ? (
-          <p>No live sessions.</p>
+          <p style={{ color: "var(--text-muted)" }}>
+            No live sessions. Sessions appear here when someone opens an instrument.
+          </p>
         ) : (
           <DataTable
-            columns={["Instrument", "Owner", "Viewers", "Idle", ""]}
+            columns={["Instrument", "Owner", { label: "Viewers", width: "5.5rem", align: "right", mono: true }, { label: "Idle", width: "7rem", align: "right", mono: true }, ""]}
             rows={sessions.map((session) => [
               formatInstrument(session),
               session.owner || "—",

--- a/webapp/app/src/admin/Sessions.tsx
+++ b/webapp/app/src/admin/Sessions.tsx
@@ -18,6 +18,10 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : "Something went wrong.";
 }
 
+// Idle time is the one value whose entire purpose is freshness, so it is
+// refetched rather than left at whatever it was when the page loaded.
+const POLL_INTERVAL_MS = 10_000;
+
 export function Sessions() {
   const [sessions, setSessions] = useState<Session[] | null>(null);
   const [error, setError] = useState("");
@@ -38,6 +42,14 @@ export function Sessions() {
   useEffect(() => {
     void loadSessions();
   }, [loadSessions]);
+
+  // Paused while a confirmation is open: re-sorting the list under someone who
+  // is reading "Close bench-a?" is how the wrong session gets closed.
+  useEffect(() => {
+    if (closeTarget) return;
+    const timer = setInterval(() => void loadSessions(), POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [closeTarget, loadSessions]);
 
   const release = async (session: Session) => {
     setError("");

--- a/webapp/app/src/admin/Sessions.tsx
+++ b/webapp/app/src/admin/Sessions.tsx
@@ -28,6 +28,7 @@ export function Sessions() {
 
   const [closeTarget, setCloseTarget] = useState<Session | null>(null);
   const [closing, setClosing] = useState(false);
+  const [closeError, setCloseError] = useState("");
   const [releasingId, setReleasingId] = useState<string | null>(null);
 
   const requestId = useRef(0);
@@ -35,11 +36,13 @@ export function Sessions() {
   const loadSessions = useCallback(async () => {
     const id = ++requestId.current;
     try {
-      setError("");
       const rows = await adminApi.sessions();
-      if (id === requestId.current) setSessions(rows);
+      if (id === requestId.current) {
+        setSessions(rows);
+        setError("");
+      }
     } catch (err) {
-      setError(errorMessage(err));
+      if (id === requestId.current) setError(errorMessage(err));
     }
   }, []);
 
@@ -70,14 +73,17 @@ export function Sessions() {
 
   const confirmClose = async () => {
     if (!closeTarget) return;
-    setError("");
+    setCloseError("");
     setClosing(true);
     try {
       await adminApi.closeSession(closeTarget.id);
       setCloseTarget(null);
       await loadSessions();
     } catch (err) {
-      setError(errorMessage(err));
+      // Reported through the dialog's own error slot, not the page-level
+      // banner: the dialog stays open for a retry, and the banner would be
+      // hidden behind its backdrop anyway.
+      setCloseError(errorMessage(err));
     } finally {
       setClosing(false);
     }
@@ -110,7 +116,15 @@ export function Sessions() {
                 <Button size="sm" disabled={releasingId === session.id} onClick={() => void release(session)}>
                   Release
                 </Button>
-                <Button size="sm" variant="danger" disabled={releasingId === session.id} onClick={() => setCloseTarget(session)}>
+                <Button
+                  size="sm"
+                  variant="danger"
+                  disabled={releasingId === session.id}
+                  onClick={() => {
+                    setCloseTarget(session);
+                    setCloseError("");
+                  }}
+                >
                   Close
                 </Button>
               </div>,
@@ -124,7 +138,11 @@ export function Sessions() {
           title={`Close ${closeTarget.label}?`}
           confirmLabel="Close"
           busy={closing}
-          onCancel={() => setCloseTarget(null)}
+          error={closeError}
+          onCancel={() => {
+            setCloseTarget(null);
+            setCloseError("");
+          }}
           onConfirm={() => void confirmClose()}
           body={
             <>

--- a/webapp/app/src/ds/Button.tsx
+++ b/webapp/app/src/ds/Button.tsx
@@ -125,6 +125,7 @@ export function Button({
       onMouseDown={() => setState("active")}
       onMouseUp={() => setState("hover")}
       style={{ ...base, ...variants[variant], ...dyn, ...style }}
+      data-variant={variant}
       {...rest}
     >
       {icon && <span style={{ display: "inline-flex", fontSize: "1.05em" }}>{icon}</span>}

--- a/webapp/app/src/ds/ConfirmDialog.test.tsx
+++ b/webapp/app/src/ds/ConfirmDialog.test.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+function setup(overrides: Partial<React.ComponentProps<typeof ConfirmDialog>> = {}) {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+  render(<ConfirmDialog title="Close bench?" body="This ends the session." confirmLabel="Close" onConfirm={onConfirm} onCancel={onCancel} {...overrides} />);
+  return { onConfirm, onCancel };
+}
+
+describe("ConfirmDialog", () => {
+  it("names itself and renders its body and actions", () => {
+    setup();
+    const dialog = screen.getByRole("alertdialog", { name: "Close bench?" });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(screen.getByText("This ends the session.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+  });
+
+  it("focuses Cancel, not the confirming action", () => {
+    // A destructive confirmation should treat a stray Enter as "cancel".
+    setup();
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+  });
+
+  it("cancels on Escape", async () => {
+    const { onCancel } = setup();
+    await userEvent.keyboard("{Escape}");
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels on a backdrop click", async () => {
+    const { onCancel } = setup();
+    await userEvent.click(screen.getByTestId("confirm-backdrop"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cancel on a click inside the panel", async () => {
+    const { onCancel } = setup();
+    await userEvent.click(screen.getByText("This ends the session."));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("ignores Escape and backdrop clicks while busy", async () => {
+    // A half-dismissed dialog during a slow close would leave the operator
+    // unsure whether the action went through.
+    const { onCancel } = setup({ busy: true });
+    await userEvent.keyboard("{Escape}");
+    await userEvent.click(screen.getByTestId("confirm-backdrop"));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("confirms when the confirming action is pressed", async () => {
+    const { onConfirm } = setup();
+    await userEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps Tab inside the dialog", async () => {
+    setup();
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    const confirm = screen.getByRole("button", { name: "Close" });
+    expect(cancel).toHaveFocus();
+    await userEvent.tab();
+    expect(confirm).toHaveFocus();
+    await userEvent.tab();
+    expect(cancel).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(confirm).toHaveFocus();
+  });
+
+  it("returns focus to whatever opened it", async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open</button>
+          {open ? <ConfirmDialog title="Close bench?" body="body" confirmLabel="Close" onConfirm={() => setOpen(false)} onCancel={() => setOpen(false)} /> : null}
+        </>
+      );
+    }
+    render(<Harness />);
+    const opener = screen.getByRole("button", { name: "Open" });
+    await userEvent.click(opener);
+    await userEvent.keyboard("{Escape}");
+    expect(opener).toHaveFocus();
+  });
+});

--- a/webapp/app/src/ds/ConfirmDialog.test.tsx
+++ b/webapp/app/src/ds/ConfirmDialog.test.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ConfirmDialog } from "./ConfirmDialog";
 
@@ -70,6 +70,58 @@ describe("ConfirmDialog", () => {
     expect(cancel).toHaveFocus();
     await userEvent.tab({ shift: true });
     expect(confirm).toHaveFocus();
+  });
+
+  it("keeps Tab inside the dialog while busy, even though both buttons are disabled", async () => {
+    // Both buttons are disabled while busy, so the focusable-elements query
+    // that the trap relies on comes back empty. Without a fallback, Tab is
+    // never preventDefault-ed and escapes straight to the page behind the
+    // backdrop -- exactly the state a slow Close or Revoke sits in.
+    setup({ busy: true });
+    const dialog = screen.getByRole("alertdialog");
+    await userEvent.tab();
+    expect(dialog.contains(document.activeElement)).toBe(true);
+    await userEvent.tab();
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+
+  it("re-traps Tab after a click inside the panel blurs focus off the end buttons", async () => {
+    // Clicking the dialog's non-focusable body text can blur focus away
+    // from Cancel/Close, landing document.activeElement somewhere that
+    // matches neither "at first, shift+Tab" nor "at last, Tab" -- so
+    // without a contained-in-panel check, Tab falls through to native
+    // order and can land on a focusable element on the page behind the
+    // dialog (here, one that renders earlier in the document).
+    render(
+      <>
+        <button>Other row action</button>
+        <ConfirmDialog title="Close bench?" body="This ends the session." confirmLabel="Close" onConfirm={vi.fn()} onCancel={vi.fn()} />
+      </>,
+    );
+    const other = screen.getByRole("button", { name: "Other row action" });
+    await userEvent.click(screen.getByText("This ends the session."));
+
+    const dialog = screen.getByRole("alertdialog");
+    await userEvent.tab();
+    expect(dialog.contains(document.activeElement)).toBe(true);
+    expect(other).not.toHaveFocus();
+  });
+
+  it("wires the accessible name and description so a screen reader announces the consequence", () => {
+    setup();
+    const dialog = screen.getByRole("alertdialog");
+    const labelledBy = dialog.getAttribute("aria-labelledby");
+    const describedBy = dialog.getAttribute("aria-describedby");
+    expect(labelledBy).toBeTruthy();
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(labelledBy as string)).toHaveTextContent("Close bench?");
+    expect(document.getElementById(describedBy as string)).toHaveTextContent("This ends the session.");
+  });
+
+  it("renders a passed-in error inside the panel, as an alert", () => {
+    setup({ error: "session already closing" });
+    const dialog = screen.getByRole("alertdialog");
+    expect(within(dialog).getByRole("alert")).toHaveTextContent("session already closing");
   });
 
   it("returns focus to whatever opened it", async () => {

--- a/webapp/app/src/ds/ConfirmDialog.tsx
+++ b/webapp/app/src/ds/ConfirmDialog.tsx
@@ -1,0 +1,118 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { Button, type ButtonVariant } from "./Button";
+
+export type ConfirmDialogProps = {
+  title: string;
+  body: React.ReactNode;
+  confirmLabel: string;
+  variant?: ButtonVariant;
+  busy?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+const FOCUSABLE = "button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])";
+
+/**
+ * ConfirmDialog — a modal confirmation for a destructive action.
+ *
+ * Portalled to document.body rather than rendered in place: both call sites sit
+ * inside a GroupBox fieldset, and an in-flow dialog can land below the fold on a
+ * long list, so the operator clicks a destructive button and sees nothing happen.
+ *
+ * Hand-rolled rather than a native <dialog>: this project tests components under
+ * jsdom, which has no showModal(), so a native dialog would make every test
+ * exercise a polyfill instead of the component.
+ */
+export function ConfirmDialog({ title, body, confirmLabel, variant = "danger", busy = false, onConfirm, onCancel }: ConfirmDialogProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const openerRef = useRef<HTMLElement | null>(null);
+
+  // Focus lands on Cancel, and returns to the opener on unmount -- without the
+  // latter a keyboard user is dropped back at the top of the document.
+  useEffect(() => {
+    openerRef.current = document.activeElement as HTMLElement | null;
+    panelRef.current?.querySelector<HTMLElement>("[data-confirm-cancel]")?.focus();
+    return () => openerRef.current?.focus?.();
+  }, []);
+
+  const dismiss = useCallback(() => {
+    if (!busy) onCancel();
+  }, [busy, onCancel]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        dismiss();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusable = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE));
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [dismiss]);
+
+  return createPortal(
+    <div
+      data-testid="confirm-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) dismiss();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0, 0, 0, 0.45)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "var(--space-4)",
+        zIndex: 1000,
+      }}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-label={title}
+        ref={panelRef}
+        style={{
+          border: "1px solid var(--lc-border-strong)",
+          borderRadius: "var(--lc-radius)",
+          background: "var(--lc-panel)",
+          boxShadow: "var(--lc-elev-1)",
+          padding: "var(--space-3)",
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-2)",
+          maxWidth: "360px",
+        }}
+      >
+        <strong style={{ fontFamily: "var(--font-ui)", fontSize: "var(--text-sm)" }}>{title}</strong>
+        <div style={{ fontFamily: "var(--font-ui)" }}>{body}</div>
+        <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end" }}>
+          <Button data-confirm-cancel="" disabled={busy} onClick={dismiss}>
+            Cancel
+          </Button>
+          <Button variant={variant} disabled={busy} onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/webapp/app/src/ds/ConfirmDialog.tsx
+++ b/webapp/app/src/ds/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useId, useRef } from "react";
 import { createPortal } from "react-dom";
 import { Button, type ButtonVariant } from "./Button";
 
@@ -8,6 +8,10 @@ export type ConfirmDialogProps = {
   confirmLabel: string;
   variant?: ButtonVariant;
   busy?: boolean;
+  /** A failure from the action this dialog confirms (e.g. a rejected close).
+   * Rendered inside the panel so it stays where the operator is looking,
+   * rather than behind the backdrop in a page-level banner. */
+  error?: string;
   onConfirm: () => void;
   onCancel: () => void;
 };
@@ -25,9 +29,11 @@ const FOCUSABLE = "button:not([disabled]), [href], input:not([disabled]), select
  * jsdom, which has no showModal(), so a native dialog would make every test
  * exercise a polyfill instead of the component.
  */
-export function ConfirmDialog({ title, body, confirmLabel, variant = "danger", busy = false, onConfirm, onCancel }: ConfirmDialogProps) {
+export function ConfirmDialog({ title, body, confirmLabel, variant = "danger", busy = false, error, onConfirm, onCancel }: ConfirmDialogProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const openerRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+  const bodyId = useId();
 
   // Focus lands on Cancel, and returns to the opener on unmount -- without the
   // latter a keyboard user is dropped back at the top of the document.
@@ -52,13 +58,36 @@ export function ConfirmDialog({ title, body, confirmLabel, variant = "danger", b
       const panel = panelRef.current;
       if (!panel) return;
       const focusable = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE));
-      if (focusable.length === 0) return;
+
+      // Both buttons are disabled while busy, so there is nothing in the
+      // ordinary Tab cycle to hold focus -- without this the trap goes
+      // fully open for the length of the async action. Keep focus on the
+      // panel itself, which is a valid (if inert) place for it to sit.
+      if (focusable.length === 0) {
+        event.preventDefault();
+        panel.focus();
+        return;
+      }
+
       const first = focusable[0];
       const last = focusable[focusable.length - 1];
-      if (event.shiftKey && document.activeElement === first) {
+      const active = document.activeElement;
+
+      // Focus can land outside panelRef's contents entirely -- e.g. a click
+      // on the (non-focusable) body text blurs to <body>. Neither the
+      // shift+Tab-from-first nor Tab-from-last branch below matches that,
+      // so without this, Tab falls through to native order and escapes to
+      // the page behind the backdrop.
+      if (!panel.contains(active)) {
+        event.preventDefault();
+        first.focus();
+        return;
+      }
+
+      if (event.shiftKey && active === first) {
         event.preventDefault();
         last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
+      } else if (!event.shiftKey && active === last) {
         event.preventDefault();
         first.focus();
       }
@@ -87,8 +116,10 @@ export function ConfirmDialog({ title, body, confirmLabel, variant = "danger", b
       <div
         role="alertdialog"
         aria-modal="true"
-        aria-label={title}
+        aria-labelledby={titleId}
+        aria-describedby={bodyId}
         ref={panelRef}
+        tabIndex={-1}
         style={{
           border: "1px solid var(--lc-border-strong)",
           borderRadius: "var(--lc-radius)",
@@ -101,8 +132,13 @@ export function ConfirmDialog({ title, body, confirmLabel, variant = "danger", b
           maxWidth: "360px",
         }}
       >
-        <strong style={{ fontFamily: "var(--font-ui)", fontSize: "var(--text-sm)" }}>{title}</strong>
-        <div style={{ fontFamily: "var(--font-ui)" }}>{body}</div>
+        <strong id={titleId} style={{ fontFamily: "var(--font-ui)", fontSize: "var(--text-sm)" }}>{title}</strong>
+        <div id={bodyId} style={{ fontFamily: "var(--font-ui)" }}>{body}</div>
+        {error ? (
+          <p role="alert" style={{ color: "var(--danger)", fontSize: "var(--text-sm)", margin: 0 }}>
+            {error}
+          </p>
+        ) : null}
         <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end" }}>
           <Button data-confirm-cancel="" disabled={busy} onClick={dismiss}>
             Cancel


### PR DESCRIPTION
## Description

Polish for the host-only admin panel, in two sequenced phases: behaviour first, then appearance.

The panel worked, but two things made it feel unfinished and one made it look broken. Both admin panels hand-rolled the *same* confirmation dialog, and both set `role="alertdialog"` and `aria-modal="true"` on a plain `<div>` rendered inline below the table — no backdrop, no focus trap, no Escape handler. The ARIA claim was false in both places, and on a long session list the confirmation could render below the fold, so clicking **Close** appeared to do nothing at all.

Separately, `index.html` names the content-hashed asset files but was itself served with no cache headers, making it the one file a rebuild could not invalidate. A cached copy kept requesting a bundle the last build had deleted, the SPA fallback returned `index.html` for it, the browser refused it as a module on a MIME mismatch, and `#root` stayed empty. That cost two debugging sessions in one day and needed a manual hard refresh plus cache clear to escape.

## Related Issues

<!-- No tracking issue -->

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [x] Test coverage improvement

## Changes Made

**Phase A — behaviour**

- **`ds/ConfirmDialog` (new)** — one modal confirmation shared by both panels, replacing two hand-rolled copies. Portalled to `document.body` so it cannot be clipped by the `fieldset` its callers sit inside. Focus moves to **Cancel** on open, not to the container: for a destructive confirmation a stray Enter should cancel, not destroy. Tab and Shift+Tab cycle within the dialog, Escape and a backdrop click both cancel, both are suppressed while the action is in flight, and focus returns to the button that opened it.
- **Hand-rolled rather than a native `<dialog>`**, on evidence: this project tests components under jsdom 29.1.1, where `showModal` is `undefined` and calling it throws. A native dialog would have made every test exercise a polyfill instead of the component.
- **Per-row action state.** The global "disable every row's buttons while any action is in flight" lock is gone from both panels — it only existed to compensate for the dialog not being modal.
- **The live-session list refreshes every 10 seconds**, so `Idle` stays current instead of being a snapshot from page load. It pauses while the **Close** confirmation is open, so the list cannot reshuffle under the question you are reading. A failed refresh leaves the previous rows on screen rather than blanking the table.
- **A request-generation guard** in `loadSessions`, so a slow poll resolving after a just-completed release cannot resurrect the released session for up to 10 seconds.
- **`index.html` is served `Cache-Control: no-store`** on both the gateway and the admin app, via a shared `spa_response()` in `server/spa.py`. It keys on the **resolved** path, so the SPA fallback for a deep-linked client route inherits the header too — a `full_path` check would have missed exactly that case. Content-hashed assets keep normal caching; they are immutable by construction.

**Phase B — visual**

- A page header, so the panel has a document outline rather than a `GroupBox` legend standing in for one.
- Right-aligned monospaced `Viewers` and `Idle` columns — `ds/DataTable` already supported per-column `width`/`align`/`mono`, so this passes options rather than adding component code.
- Muted, self-explaining empty and loading states.
- `data-variant` on `ds/Button`, so button hierarchy is assertable without matching on colour values.

## Testing

- [x] Tests pass locally (`make test` or `pytest tests/`)
- [x] Added tests for new functionality
- [ ] Tested with real hardware (if applicable)
- [ ] All CI checks pass

### Test Details

**Test environment:**

- OS: Windows 11 Pro (CI runs Linux)
- Python version: 3.12.7 (floor is 3.9)
- Oscilloscope model (if applicable): none — the admin panel is instrument-agnostic

**Test results:**

```
webapp/app: 345 passed (54 files), typecheck clean
pytest tests/test_server_spa.py tests/test_server_admin_api.py
  tests/test_server_admin_sessions.py tests/test_server_api.py: 124 passed
mkdocs build --strict: 71 warnings (all pre-existing), 0 new
```

Notes on what the tests actually pin, since a modal dialog is easy to test in ways that pass while being wrong:

- **The focus trap is tested in the state that breaks it.** While the action is in flight both buttons are `disabled`, so a selector excluding disabled buttons matches nothing and Tab would fall through to the page behind the backdrop — where the other rows' buttons are focusable. There is a test for exactly that.
- **The poll's pause is mutation-checked:** deleting `if (closeTarget) return;` fails only the test that names it, and nothing else.
- **The stale-poll guard is proven by an ordered test**, not by luck: two in-flight responses are held by explicit resolvers and released newest-first, so it fails if the generation check is removed.
- **The `no-store` header is keyed on the resolved path**, with tests on both apps for `/`, for a deep-linked fallback, and for a hashed asset staying cacheable.

## Code Quality

- [x] Code follows the project style guidelines (`make lint` passes)
- [x] Code is formatted with Black (`make format`)
- [x] Self-reviewed the code
- [x] Commented complex code sections
- [x] Updated docstrings for modified functions/classes
- [x] No new linting warnings introduced

## Documentation

- [ ] Updated README.md (if needed)
- [x] Updated CHANGELOG.md with changes
- [x] Added/updated docstrings
- [ ] Added/updated examples (if applicable)
- [x] Updated type hints

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation

## Additional Notes

**Two residuals, parked deliberately rather than silently:**

1. **A dead branch in the focus trap.** The escape where `document.activeElement` is neither the first nor last focusable element is genuinely fixed, but by the panel's `tabIndex={-1}` interacting with tab-destination ordering — *not* by the `!panel.contains(active)` conditional that was added for it. `Node.contains` is self-inclusive, and the backdrop dismisses any true outside click, so that conditional is unreachable. The symptom is gone; the code carries a misleading comment. Follow-up: force `activeElement` to an external node by direct DOM manipulation to exercise it, or delete the branch.
2. **A successful poll still clears an action error.** The fix stopped the *premature* clear and the stale-rejection case, but a successful 10-second tick still runs `setError("")`, so a failed Release's banner can vanish without user action. Properly fixing it means separating action-error state from fetch-error state, which is a design change rather than a fix. The prescription was the incomplete part here, not the implementation — it was flagged rather than quietly extended.

**`aria-modal` is now defensible rather than absolute.** Nothing sets `inert` or `aria-hidden` on the app root, so assistive technology that ignores `aria-modal` could still reach background content. Plainly: this branch substantially delivers modality — real backdrop, real focus management, real Escape, focus restore — rather than fully delivering it. One `inert` attribute would close the gap.

**Not addressed here, found while verifying:** the admin bundle is a gitignored build artifact rebuilt by `make webapp-build`, and nothing warns when it is stale. That is what made the panel look broken at the start of this work, and it belongs in its own change.

No version bump — this folds into the queued 6.0.0.
