### PR TITLE
Make the live view correct against real hardware, and fix what probing it exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,12 +130,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A channel whose display query failed is now logged instead of silently failing. Previously a
   poll-path failure made a channel appear 'off': no waveform, no error message, a gateway that
   appeared healthy and did nothing.
-- A thinned waveform read that comes back short now fails loudly instead of returning a truncated
-  trace. On modern Siglent instruments the live view asks for every Nth point, and the driver
-  scaled however many points arrived without checking that against the count the instrument's own
-  preamble promised. If another program sharing the scope (EasyScopeX, a LabVIEW driver) had left
-  a `:WAVeform:POINt` window cap set, every frame lost its tail while its time axis still looked
-  perfectly correct — a silently wrong measurement rather than a visible failure.
 - The timebase control's stepper no longer moves in 0.1 s jumps or hides sub-microsecond sweeps
   under a six-decimal display. It previously lived in the Trigger panel with 100 ms increments —
   one click from 1 ms/div landed on 0.101 s/div — and made sub-microsecond sweeps effectively

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,9 +97,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The admin panel gained a page header.
 - The live-session list in the Sessions screen now displays readable right-aligned numeric columns
   for Viewers and Idle time.
+- A Horizontal panel in the oscilloscope controls, containing a new timebase stepper that steps
+  in a 1-2-5 ladder (1 ms → 2 ms → 5 ms → 10 ms) with engineering-unit labels, making both slow
+  sweeps and sub-microsecond settings easily reachable.
+- `capture.csv` gained an optional `max_points` parameter for parity with the JSON export,
+  allowing an oversized record to be trimmed to a smaller sample count before export.
+
+### Changed
+
+- The CSV and JSON exports now stream instead of loading into memory; when a waveform is too large
+  to export safely, the endpoints return an error naming the actual point count and showing how to
+  proceed with `max_points`. On dialects that cannot report record length in advance, the export
+  proceeds unguarded and logs a warning if it oversizes — nothing is ever silently truncated or
+  decimated.
 
 ### Fixed
 
+- The gateway no longer freezes while a long capture is in progress. The oscilloscope poll
+  previously fetched a waveform on a timer without checking whether the instrument had finished
+  acquiring — at slow sweep rates this meant requesting much faster than the scope could produce
+  frames, blocking the read until the acquisition was complete, and freezing every control in the
+  web UI (since the session's only worker thread also services commands). The poll now checks
+  whether a new acquisition has landed before fetching, and requests only the display points
+  rather than transferring the entire record and then discarding most of it.
+- The live view updates once per completed acquisition. At slow sweep rates, a single update
+  every 14 seconds (at 1 s/div, for example) is expected behaviour — it matches the instrument's
+  own display rate — and is not a defect or regression.
+- A channel whose display query failed is now logged instead of silently failing. Previously a
+  poll-path failure made a channel appear 'off': no waveform, no error message, a gateway that
+  appeared healthy and did nothing.
+- The timebase control's stepper no longer moves in 0.1 s jumps or hides sub-microsecond sweeps
+  under a six-decimal display. It previously lived in the Trigger panel with 100 ms increments —
+  one click from 1 ms/div landed on 0.101 s/div — and made sub-microsecond sweeps effectively
+  unreachable.
 - Revoking a token now takes effect immediately. The gateway reloads its token store when the file
   changes, so `scpi-web token revoke` no longer requires restarting the server to lock someone out
   — which meant the documented remedy for a leaked credential silently did nothing until someone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A channel whose display query failed is now logged instead of silently failing. Previously a
   poll-path failure made a channel appear 'off': no waveform, no error message, a gateway that
   appeared healthy and did nothing.
+- A thinned live view on a modern Siglent instrument no longer reports a time axis that is too
+  short by the thinning factor. When the live view asks the scope for every Nth point, the
+  instrument keeps reporting the *acquisition's* sample spacing rather than the spacing between
+  the points it actually sends — so a trace thinned 7:1 claimed to cover a seventh of the sweep
+  it really covered, with `sample_rate` wrong by the same factor. Measurements and exports were
+  never affected (they are never thinned); the live view's x-axis was. Verified against an
+  SDS824X HD.
+- A thinned read that comes back short now fails loudly instead of returning a truncated trace
+  scaled onto a time axis that looks correct, and a deep record that fits comfortably once
+  thinned is no longer refused as too large for one transfer.
 - The timebase control's stepper no longer moves in 0.1 s jumps or hides sub-microsecond sweeps
   under a six-decimal display. It previously lived in the Trigger panel with 100 ms increments —
   one click from 1 ms/div landed on 0.101 s/div — and made sub-microsecond sweeps effectively

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A thinned read that comes back short now fails loudly instead of returning a truncated trace
   scaled onto a time axis that looks correct, and a deep record that fits comfortably once
   thinned is no longer refused as too large for one transfer.
+- **Waveforms captured from a high-resolution Siglent instrument in the default 8-bit transfer
+  mode were 256 times too small.** These scopes report one code-per-division figure for their
+  native 16-bit samples and reuse it unchanged for an 8-bit transfer, where the instrument sends
+  only the high byte — so a 3.07 V signal was read back as 0.012 V. Every default waveform read
+  on an SDS800X HD was affected: live view, exports, saved records and any analysis derived from
+  them. 16-bit (`WORD`) captures were always correct. Verified against an SDS824X HD by comparing
+  both transfer widths against the instrument's own measurement of the same channel. **Waveform
+  data captured from an HD instrument before this release should be treated as unusable rather
+  than rescaled**, since the 8-bit path also discarded the low byte.
+- The live view's new-acquisition check never actually ran on a modern Siglent instrument. The
+  scope answers that query with a response header (`INR 8193`) rather than a bare number, which
+  the driver could not read, so it concluded the instrument had no such capability — silently, on
+  every poll, with nothing in the log. The poll therefore always fell back to timing-based
+  backoff, which is the very thing the check exists to avoid.
+- A measurement the instrument cannot compute yet is no longer reported as a failure. Modern
+  Siglent scopes answer `****` for an item that has no value at that moment; that surfaced as a
+  parse error and, in the gateway, as a `poll query failed` warning for an entirely routine
+  condition. It now raises the new `MeasurementUnavailableError` (a `CommandError` subclass, so
+  existing handlers keep working) and the gateway reports the reading as unavailable without
+  logging an alarm.
 - The timebase control's stepper no longer moves in 0.1 s jumps or hides sub-microsecond sweeps
   under a six-decimal display. It previously lived in the Trigger panel with 100 ms increments —
   one click from 1 ms/div landed on 0.101 s/div — and made sub-microsecond sweeps effectively

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- On modern Siglent instruments, the gateway now asks the instrument to thin the waveform record
+  to the points the display needs, rather than transferring everything and discarding most of it
+  client-side — no change to what you see on screen. Dialects without the interval command
+  continue to transfer the full record and thin on the server.
 - The CSV and JSON exports now stream instead of loading into memory; when a waveform is too large
   to export safely, the endpoints return an error naming the actual point count and showing how to
   proceed with `max_points`. On dialects that cannot report record length in advance, the export
@@ -117,12 +121,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previously fetched a waveform on a timer without checking whether the instrument had finished
   acquiring — at slow sweep rates this meant requesting much faster than the scope could produce
   frames, blocking the read until the acquisition was complete, and freezing every control in the
-  web UI (since the session's only worker thread also services commands). The poll now checks
-  whether a new acquisition has landed before fetching, and requests only the display points
-  rather than transferring the entire record and then discarding most of it.
-- The live view updates once per completed acquisition. At slow sweep rates, a single update
-  every 14 seconds (at 1 s/div, for example) is expected behaviour — it matches the instrument's
-  own display rate — and is not a defect or regression.
+  web UI (since the session's only worker thread also services commands). On modern Siglent
+  instruments, the poll now checks whether a new acquisition has landed before fetching; other
+  dialects use adaptive timing-based backoff to prevent the freeze.
+- On modern Siglent instruments, the live view updates once per completed acquisition. At slow
+  sweep rates, a single update every 14 seconds (at 1 s/div, for example) is expected behaviour —
+  it matches the instrument's own display rate — and is not a defect or regression.
 - A channel whose display query failed is now logged instead of silently failing. Previously a
   poll-path failure made a channel appear 'off': no waveform, no error message, a gateway that
   appeared healthy and did nothing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   condition. It now raises the new `MeasurementUnavailableError` (a `CommandError` subclass, so
   existing handlers keep working) and the gateway reports the reading as unavailable without
   logging an alarm.
+- A mock oscilloscope now reports its own acquisition length, like a real one. `:ACQuire:POINts?`
+  had no mock answer, so the query failed and the driver concluded the record length was unknown
+  — which meant the live view's frame-thinning was never exercised against a mock at all, on any
+  dialect. A mock session's live view now thins its frames the same way a real instrument's does.
 - The timebase control's stepper no longer moves in 0.1 s jumps or hides sub-microsecond sweeps
   under a six-decimal display. It previously lived in the Trigger panel with 100 ms increments —
   one click from 1 ms/div landed on 0.101 s/div — and made sub-microsecond sweeps effectively

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A channel whose display query failed is now logged instead of silently failing. Previously a
   poll-path failure made a channel appear 'off': no waveform, no error message, a gateway that
   appeared healthy and did nothing.
+- A thinned waveform read that comes back short now fails loudly instead of returning a truncated
+  trace. On modern Siglent instruments the live view asks for every Nth point, and the driver
+  scaled however many points arrived without checking that against the count the instrument's own
+  preamble promised. If another program sharing the scope (EasyScopeX, a LabVIEW driver) had left
+  a `:WAVeform:POINt` window cap set, every frame lost its tail while its time axis still looked
+  perfectly correct — a silently wrong measurement rather than a visible failure.
 - The timebase control's stepper no longer moves in 0.1 s jumps or hides sub-microsecond sweeps
   under a six-decimal display. It previously lived in the Trigger panel with 100 ms increments —
   one click from 1 ms/div landed on 0.101 s/div — and made sub-microsecond sweeps effectively

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -130,12 +130,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A channel whose display query failed is now logged instead of silently failing. Previously a
   poll-path failure made a channel appear 'off': no waveform, no error message, a gateway that
   appeared healthy and did nothing.
-- A thinned waveform read that comes back short now fails loudly instead of returning a truncated
-  trace. On modern Siglent instruments the live view asks for every Nth point, and the driver
-  scaled however many points arrived without checking that against the count the instrument's own
-  preamble promised. If another program sharing the scope (EasyScopeX, a LabVIEW driver) had left
-  a `:WAVeform:POINt` window cap set, every frame lost its tail while its time axis still looked
-  perfectly correct — a silently wrong measurement rather than a visible failure.
 - The timebase control's stepper no longer moves in 0.1 s jumps or hides sub-microsecond sweeps
   under a six-decimal display. It previously lived in the Trigger panel with 100 ms increments —
   one click from 1 ms/div landed on 0.101 s/div — and made sub-microsecond sweeps effectively

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -97,9 +97,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The admin panel gained a page header.
 - The live-session list in the Sessions screen now displays readable right-aligned numeric columns
   for Viewers and Idle time.
+- A Horizontal panel in the oscilloscope controls, containing a new timebase stepper that steps
+  in a 1-2-5 ladder (1 ms → 2 ms → 5 ms → 10 ms) with engineering-unit labels, making both slow
+  sweeps and sub-microsecond settings easily reachable.
+- `capture.csv` gained an optional `max_points` parameter for parity with the JSON export,
+  allowing an oversized record to be trimmed to a smaller sample count before export.
+
+### Changed
+
+- The CSV and JSON exports now stream instead of loading into memory; when a waveform is too large
+  to export safely, the endpoints return an error naming the actual point count and showing how to
+  proceed with `max_points`. On dialects that cannot report record length in advance, the export
+  proceeds unguarded and logs a warning if it oversizes — nothing is ever silently truncated or
+  decimated.
 
 ### Fixed
 
+- The gateway no longer freezes while a long capture is in progress. The oscilloscope poll
+  previously fetched a waveform on a timer without checking whether the instrument had finished
+  acquiring — at slow sweep rates this meant requesting much faster than the scope could produce
+  frames, blocking the read until the acquisition was complete, and freezing every control in the
+  web UI (since the session's only worker thread also services commands). The poll now checks
+  whether a new acquisition has landed before fetching, and requests only the display points
+  rather than transferring the entire record and then discarding most of it.
+- The live view updates once per completed acquisition. At slow sweep rates, a single update
+  every 14 seconds (at 1 s/div, for example) is expected behaviour — it matches the instrument's
+  own display rate — and is not a defect or regression.
+- A channel whose display query failed is now logged instead of silently failing. Previously a
+  poll-path failure made a channel appear 'off': no waveform, no error message, a gateway that
+  appeared healthy and did nothing.
+- The timebase control's stepper no longer moves in 0.1 s jumps or hides sub-microsecond sweeps
+  under a six-decimal display. It previously lived in the Trigger panel with 100 ms increments —
+  one click from 1 ms/div landed on 0.101 s/div — and made sub-microsecond sweeps effectively
+  unreachable.
 - Revoking a token now takes effect immediately. The gateway reloads its token store when the file
   changes, so `scpi-web token revoke` no longer requires restarting the server to lock someone out
   — which meant the documented remedy for a leaked credential silently did nothing until someone

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -130,6 +130,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A channel whose display query failed is now logged instead of silently failing. Previously a
   poll-path failure made a channel appear 'off': no waveform, no error message, a gateway that
   appeared healthy and did nothing.
+- A thinned live view on a modern Siglent instrument no longer reports a time axis that is too
+  short by the thinning factor. When the live view asks the scope for every Nth point, the
+  instrument keeps reporting the *acquisition's* sample spacing rather than the spacing between
+  the points it actually sends — so a trace thinned 7:1 claimed to cover a seventh of the sweep
+  it really covered, with `sample_rate` wrong by the same factor. Measurements and exports were
+  never affected (they are never thinned); the live view's x-axis was. Verified against an
+  SDS824X HD.
+- A thinned read that comes back short now fails loudly instead of returning a truncated trace
+  scaled onto a time axis that looks correct, and a deep record that fits comfortably once
+  thinned is no longer refused as too large for one transfer.
 - The timebase control's stepper no longer moves in 0.1 s jumps or hides sub-microsecond sweeps
   under a six-decimal display. It previously lived in the Trigger panel with 100 ms increments —
   one click from 1 ms/div landed on 0.101 s/div — and made sub-microsecond sweeps effectively

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -140,6 +140,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A thinned read that comes back short now fails loudly instead of returning a truncated trace
   scaled onto a time axis that looks correct, and a deep record that fits comfortably once
   thinned is no longer refused as too large for one transfer.
+- **Waveforms captured from a high-resolution Siglent instrument in the default 8-bit transfer
+  mode were 256 times too small.** These scopes report one code-per-division figure for their
+  native 16-bit samples and reuse it unchanged for an 8-bit transfer, where the instrument sends
+  only the high byte — so a 3.07 V signal was read back as 0.012 V. Every default waveform read
+  on an SDS800X HD was affected: live view, exports, saved records and any analysis derived from
+  them. 16-bit (`WORD`) captures were always correct. Verified against an SDS824X HD by comparing
+  both transfer widths against the instrument's own measurement of the same channel. **Waveform
+  data captured from an HD instrument before this release should be treated as unusable rather
+  than rescaled**, since the 8-bit path also discarded the low byte.
+- The live view's new-acquisition check never actually ran on a modern Siglent instrument. The
+  scope answers that query with a response header (`INR 8193`) rather than a bare number, which
+  the driver could not read, so it concluded the instrument had no such capability — silently, on
+  every poll, with nothing in the log. The poll therefore always fell back to timing-based
+  backoff, which is the very thing the check exists to avoid.
+- A measurement the instrument cannot compute yet is no longer reported as a failure. Modern
+  Siglent scopes answer `****` for an item that has no value at that moment; that surfaced as a
+  parse error and, in the gateway, as a `poll query failed` warning for an entirely routine
+  condition. It now raises the new `MeasurementUnavailableError` (a `CommandError` subclass, so
+  existing handlers keep working) and the gateway reports the reading as unavailable without
+  logging an alarm.
 - The timebase control's stepper no longer moves in 0.1 s jumps or hides sub-microsecond sweeps
   under a six-decimal display. It previously lived in the Trigger panel with 100 ms increments —
   one click from 1 ms/div landed on 0.101 s/div — and made sub-microsecond sweeps effectively

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -105,6 +105,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- On modern Siglent instruments, the gateway now asks the instrument to thin the waveform record
+  to the points the display needs, rather than transferring everything and discarding most of it
+  client-side — no change to what you see on screen. Dialects without the interval command
+  continue to transfer the full record and thin on the server.
 - The CSV and JSON exports now stream instead of loading into memory; when a waveform is too large
   to export safely, the endpoints return an error naming the actual point count and showing how to
   proceed with `max_points`. On dialects that cannot report record length in advance, the export
@@ -117,12 +121,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previously fetched a waveform on a timer without checking whether the instrument had finished
   acquiring — at slow sweep rates this meant requesting much faster than the scope could produce
   frames, blocking the read until the acquisition was complete, and freezing every control in the
-  web UI (since the session's only worker thread also services commands). The poll now checks
-  whether a new acquisition has landed before fetching, and requests only the display points
-  rather than transferring the entire record and then discarding most of it.
-- The live view updates once per completed acquisition. At slow sweep rates, a single update
-  every 14 seconds (at 1 s/div, for example) is expected behaviour — it matches the instrument's
-  own display rate — and is not a defect or regression.
+  web UI (since the session's only worker thread also services commands). On modern Siglent
+  instruments, the poll now checks whether a new acquisition has landed before fetching; other
+  dialects use adaptive timing-based backoff to prevent the freeze.
+- On modern Siglent instruments, the live view updates once per completed acquisition. At slow
+  sweep rates, a single update every 14 seconds (at 1 s/div, for example) is expected behaviour —
+  it matches the instrument's own display rate — and is not a defect or regression.
 - A channel whose display query failed is now logged instead of silently failing. Previously a
   poll-path failure made a channel appear 'off': no waveform, no error message, a gateway that
   appeared healthy and did nothing.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -160,6 +160,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   condition. It now raises the new `MeasurementUnavailableError` (a `CommandError` subclass, so
   existing handlers keep working) and the gateway reports the reading as unavailable without
   logging an alarm.
+- A mock oscilloscope now reports its own acquisition length, like a real one. `:ACQuire:POINts?`
+  had no mock answer, so the query failed and the driver concluded the record length was unknown
+  — which meant the live view's frame-thinning was never exercised against a mock at all, on any
+  dialect. A mock session's live view now thins its frames the same way a real instrument's does.
 - The timebase control's stepper no longer moves in 0.1 s jumps or hides sub-microsecond sweeps
   under a six-decimal display. It previously lived in the Trigger panel with 100 ms increments —
   one click from 1 ms/div landed on 0.101 s/div — and made sub-microsecond sweeps effectively

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -130,6 +130,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A channel whose display query failed is now logged instead of silently failing. Previously a
   poll-path failure made a channel appear 'off': no waveform, no error message, a gateway that
   appeared healthy and did nothing.
+- A thinned waveform read that comes back short now fails loudly instead of returning a truncated
+  trace. On modern Siglent instruments the live view asks for every Nth point, and the driver
+  scaled however many points arrived without checking that against the count the instrument's own
+  preamble promised. If another program sharing the scope (EasyScopeX, a LabVIEW driver) had left
+  a `:WAVeform:POINt` window cap set, every frame lost its tail while its time axis still looked
+  perfectly correct — a silently wrong measurement rather than a visible failure.
 - The timebase control's stepper no longer moves in 0.1 s jumps or hides sub-microsecond sweeps
   under a six-decimal display. It previously lived in the Trigger panel with 100 ms increments —
   one click from 1 ms/div landed on 0.101 s/div — and made sub-microsecond sweeps effectively

--- a/docs/gateway/api.md
+++ b/docs/gateway/api.md
@@ -117,9 +117,18 @@ All paths under `/api/sessions/{id}/scope/`.
 
 | Method | Path | Params | Response | Errors |
 |---|---|---|---|---|
-| `GET` | `capture.csv` | `?channels=1,2` (comma-separated) | `text/csv` — one `time_s` column plus one `C{n}_V` column per requested channel, aligned to the shortest capture | 400 no/invalid channels; 409 if the session is in an error/closed state |
+| `GET` | `capture.csv` | `?channels=1,2&max_points=N` (comma-separated channels) | `text/csv`, streamed — one `time_s` column plus one `C{n}_V` column per requested channel, aligned to the shortest capture, capped to `max_points` rows (0/omitted = full resolution) | 400 no/invalid channels; 409 if the session is in an error/closed state; 413 record too large (see below) |
 | `GET` | `screenshot.png` | — | `image/png` — the instrument's display | 409 if the session is in an error/closed state |
-| `GET` | `waveform` | `?channels=1,2&max_points=N` | `{"channels": [{channel, t0, dt, sample_rate, voltage_scale, voltage_offset, points}, ...]}` — `points` decimated to `max_points` (0/omitted = full resolution) | 400 no/invalid channels; 409 if the session is in an error/closed state |
+| `GET` | `waveform` | `?channels=1,2&max_points=N` | `{"channels": [{channel, t0, dt, sample_rate, voltage_scale, voltage_offset, points}, ...]}`, streamed — `points` decimated to `max_points` (0/omitted = full resolution) | 400 no/invalid channels; 409 if the session is in an error/closed state; 413 record too large (see below) |
+
+Both routes **refuse rather than truncate** an oversized capture: if the record holds more points than
+`MAX_EXPORT_POINTS` (2,000,000) and no `max_points` (or one still above that cap) was given, the server
+returns **413** naming the actual point count and the `max_points` value that would let the export proceed
+— nothing is ever silently decimated down to a size the caller didn't ask for. This check runs *before* a
+single sample is fetched, by asking the instrument its record length (`:ACQuire:POINts?`). On a dialect that
+doesn't implement that query — legacy Siglent among them — the size can't be checked in advance, so the
+export proceeds unguarded on those dialects exactly as it always has, and the server logs a warning after
+the fact if the fetch turns out to have been oversized.
 
 ## Analysis
 
@@ -181,6 +190,15 @@ All paths under `/api/sessions/{id}/scope/`.
 | `error` | `{"type": "error", "detail": "connection lost"}` |
 | `closed` | `{"type": "closed"}` |
 
+On a Siglent-modern instrument, a `waveform` frame for a real channel (not math/filter) is gated on the
+instrument's own "new acquisition" flag (`INR?` bit 0): the poll loop asks that question every tick, and
+only fetches and publishes a frame when the answer is yes. In practice this means the live view updates
+once per completed acquisition — at a slow sweep that means a slow update, by design, matching what the
+instrument's own display is doing. Every other dialect (legacy Siglent, Tektronix, LeCroy) has no such
+flag to ask — legacy's closest equivalent (`SAST?`) reports a latching trigger state, not an edge on new
+data, so it can't answer the question honestly — and instead falls back to an adaptive poll rate that never
+retries sooner than the previous poll took.
+
 The connection closes with code **4404** if the session ID does not exist, **4410** when the session itself closes (after which the socket receives a final `closed` message), and **4403** if the identity that opened the socket is revoked while it is still connected — distinct from 4410 because the session is untouched; only the viewer's credential is gone (see [Gateway security](security.md#tokens)). The server-side outbox is bounded (256 frames); under sustained backpressure it drops the oldest queued `waveform` frame to make room rather than growing unbounded — `state`/`error`/`closed` control frames are never dropped.
 
 ## Errors
@@ -192,6 +210,7 @@ Every error response is JSON: `{"error": "<ExceptionClassName>", "detail": "<mes
 | 400 | Validation failure — bad/missing parameters, invalid enum value, out-of-range channel |
 | 404 | Unknown resource — session ID, reference name, or (for `log.csv`) no recording ever started |
 | 409 | State conflict — session not accepting jobs (error/closed), already recording, or measurement selection locked while recording |
+| 413 | Export refused — the record (or the requested `max_points`) exceeds what the server will fetch in one go; see [Acquisition & export](#acquisition-export) |
 | 504 | Instrument communication timed out |
 | 500 | Other instrument error |
 

--- a/docs/gateway/browser-ui.md
+++ b/docs/gateway/browser-ui.md
@@ -62,7 +62,13 @@ Once connected, the main canvas toggles between three modes:
 
 - **Time** — live traces. Channels are drawn as solid lines, math traces
   (M1/M2) and filters (F1/F2) as dashed lines, and an active reference
-  waveform as a gray ghost trace overlaid on the live signal.
+  waveform as a gray ghost trace overlaid on the live signal. On a
+  Siglent-modern instrument the trace updates once per completed acquisition,
+  not on a fixed timer — at a slow timebase that means slow updates (a
+  handful of seconds apart at 1 s/div is normal, not stalled), matching what
+  the scope's own screen is doing. Other dialects have no way to ask the
+  instrument whether a new acquisition has landed, so they poll adaptively
+  instead.
 - **Spectrum** — a server-computed FFT of a chosen channel, with peak
   markers and a THD readout. If spectrum analysis is off, the canvas shows
   an **Enable** button instead of a plot.
@@ -77,6 +83,11 @@ The side rail holds one tab per feature area:
 
 - **Channels** — per-channel enable, V/div, offset, coupling, and probe
   ratio.
+- **Horizontal** — the timebase (time/div), on a 1-2-5 ladder from 1 ns/div
+  to 10 s/div with engineering-unit display (`100 µs`, not `0.000100`). A
+  stepper click only ever lands on the next rung, never an arbitrary value —
+  there's no way to nudge the instrument to a setting it wasn't designed to
+  accept.
 - **Trigger** — mode, source, level, slope, and coupling.
 - **Math** — configure the M1/M2 expressions, e.g. `C1 - C2` or `INTG(C1)`.
 - **Analysis** — spectrum configuration (source channel, window function,
@@ -97,6 +108,11 @@ Across the top: Run / Stop / Single / Auto acquisition controls, the canvas
 view-mode toggle, and CSV / JSON / Screenshot export buttons. Disconnect
 lives in the header, not here — see [Header](#header) above, since it applies
 to every session kind, not just an oscilloscope's.
+
+A CSV or JSON export on a very deep record can be refused rather than
+silently cut down to size — see
+[Acquisition & export](api.md#acquisition-export) for the limit and what the
+error tells you to do about it.
 
 ## Power supply session
 

--- a/docs/gateway/security.md
+++ b/docs/gateway/security.md
@@ -394,6 +394,13 @@ the gate entirely — use them for hardware-free work.
 - Full-resolution CSV/JSON serialization of deep-memory captures runs **off the
   event loop**, so one large export does not freeze the gateway for everyone
   else.
+- A capture export (`capture.csv` / `waveform`) above **2,000,000 points** is
+  **refused with 413** rather than fetched and truncated — the response names
+  the actual point count and the `max_points` value that would let it through.
+  This is a fixed safety rail against exhausting server memory, not a tuning
+  knob. See [Acquisition & export](api.md#acquisition-export) for the one
+  documented exception (a dialect that cannot report its record length in
+  advance).
 
 ## Reference file migration
 

--- a/docs/user-guide/scpi-dialects.md
+++ b/docs/user-guide/scpi-dialects.md
@@ -132,6 +132,7 @@ dialect lacks a command, calling the corresponding property or method raises
 | Waveform transfer bit depth | 8-bit only, all dialects | Tektronix's `DATa:WIDth` is pinned to `1` (8-bit) for now; 16-bit transfer is a follow-up. |
 | LeCroy waveform transfer format | lecroy | Uses `C{ch}:WF? ALL` (descriptor + data in one block), scaled from the `WAVEDESC` descriptor's vertical gain/offset and horizontal interval/offset fields, with `CFMT DEF9,{BYTE\|WORD},BIN` and `CORD LO` (LSB-first) pinning the wire encoding — a different transfer path from the Siglent-style `WF? DAT2` used by legacy and modern. |
 | LeCroy bandwidth limit token | lecroy | The public `ON` token maps to the wire value `20MHZ`; LeCroy's `BWL` vocabulary (`OFF`, `20MHZ`, `200MHZ`, ...) has no `ON` token of its own to map onto. |
+| `new_acquisition_ready()` ("has a new acquisition landed?", `INR?` bit 0) | modern (Siglent) only | Legacy's closest equivalent, `SAST?`, reports a latching trigger state rather than an edge on new data, so it cannot answer honestly and is deliberately not wired up here. Tektronix and LeCroy have no equivalent query at all. Every dialect without this gate returns `None` — callers (the web gateway's live view) must treat that as "no gate available," not as "not ready," and fall back to polling adaptively instead of stalling forever. |
 
 A modern-dialect `measure()` call is not side-effect-free: it sends
 `:MEASure ON`, `:MEASure:SIMPle:SOURce`, and `:MEASure:SIMPle:ITEM

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import math
 import re
+import threading
 from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from scpi_control import exceptions
@@ -40,6 +41,13 @@ class MockConnection(BaseConnection):
     bytes are state-coupled synthesis by default (see connection/mock/synth.py),
     driven by each channel's SignalSpec (or a built-in default); explicit
     waveform_payloads bytes for a channel always take precedence.
+
+    `waveform_gate` (default None) makes a waveform-data read block until the
+    gate is set. A real scope cannot answer a waveform-data query until the
+    acquisition it describes has finished; tests use this to reproduce a long
+    capture deterministically -- no sleeping, no wall-clock dependency -- by
+    holding the gate open across the read. Leaving it None (the default)
+    keeps every read instant, exactly as before this parameter existed.
     """
 
     def __init__(
@@ -53,6 +61,7 @@ class MockConnection(BaseConnection):
         voltage_scales: Optional[Dict[int, float]] = None,
         voltage_offsets: Optional[Dict[int, float]] = None,
         waveform_payloads: Optional[Dict[int, bytes]] = None,
+        waveform_gate: Optional[threading.Event] = None,
         signals: Optional[Dict[int, Union["SignalSpec", Callable[[], "SignalSpec"]]]] = None,
         sample_rate: float = 1_000.0,
         timebase: float = 1e-3,
@@ -91,6 +100,10 @@ class MockConnection(BaseConnection):
         # Explicit payloads only; channels without one get state-coupled synthesis
         # (connection/mock/synth.py). The old fixed 4-byte default is gone.
         self._waveform_payloads: Dict[int, bytes] = dict(waveform_payloads) if waveform_payloads else {}
+        # See the class docstring: None (the default) means every read stays
+        # instant, untouched. Consumed only by read_raw()'s waveform-data
+        # response paths (below), via _wait_for_waveform_gate().
+        self._waveform_gate: Optional[threading.Event] = waveform_gate
         self._signals: Dict[int, Union["SignalSpec", Callable[[], "SignalSpec"]]] = dict(signals) if signals else {}
         self._acquisition_counts: Dict[int, int] = {}
         self._channel_coupling: Dict[int, str] = {ch: "D1M" for ch in channels}
@@ -885,6 +898,20 @@ class MockConnection(BaseConnection):
         """Convenience helper to query multiple commands sequentially."""
         return [self.query(cmd) for cmd in commands]
 
+    def _wait_for_waveform_gate(self) -> None:
+        """Block until `waveform_gate` is released, if one is armed.
+
+        A real scope cannot answer a waveform-data query until the
+        acquisition it describes has finished. Tests use this to reproduce a
+        long capture without sleeping, and without depending on wall-clock
+        time. A `None` gate (the default) makes this a no-op, so every caller
+        that omits it is unaffected. Called from read_raw()'s waveform-DATA
+        response paths only -- not the preamble/metadata or screenshot paths,
+        which a real scope answers without waiting on the acquisition.
+        """
+        if self._waveform_gate is not None:
+            self._waveform_gate.wait()
+
     def read_raw(self, size: Optional[int] = None) -> bytes:
         """Return deterministic raw waveform data (or a mock screenshot BMP after SCDP?)."""
         if not self._connected:
@@ -905,6 +932,7 @@ class MockConnection(BaseConnection):
                 payload = siglent.build_waveform_preamble(self)
                 return payload[:size] if size is not None else payload
             if last_write == ":WAVEFORM:DATA?":
+                self._wait_for_waveform_gate()
                 payload = siglent.build_waveform_data(self)
                 return payload[:size] if size is not None else payload
 
@@ -918,6 +946,7 @@ class MockConnection(BaseConnection):
         if self.scope_dialect == "modern":
             raise exceptions.TimeoutError(f"MockConnection ({self.scope_dialect}) has no response for read_raw() after writes={self.writes!r}")
 
+        self._wait_for_waveform_gate()
         personality = _PERSONALITIES.get(self.scope_vendor, siglent)
         payload = personality.build_waveform_response(self)
         return payload[:size] if size is not None else payload

--- a/scpi_control/connection/mock/helpers.py
+++ b/scpi_control/connection/mock/helpers.py
@@ -35,10 +35,15 @@ def _build_ieee_block(payload: bytes) -> bytes:
 def _build_ieee_block_9digit(payload: bytes) -> bytes:
     """Wrap payload in the modern Siglent ":WAVeform:" block: "#9<9-digit-length><payload>".
 
-    SDS Series Programming Guide EN11G p.757 (:WAVeform:DATA? example): the
-    header is always "#9" + nine ASCII digits, e.g. "#9000001000" -- a FIXED
-    9-digit length field, unlike the general IEEE-488.2 form (_build_ieee_block
-    above) whose digit count varies with payload size.
+    SDS Series Programming Guide EN11G p.757 (:WAVeform:DATA? example) shows
+    "#9" + nine ASCII digits, e.g. "#9000001000" -- a FIXED 9-digit length
+    field, unlike the general IEEE-488.2 form (_build_ieee_block above) whose
+    digit count varies with payload size.
+
+    CAUTION: the guide's example does not describe :WAVeform:DATA? on real
+    hardware. Measured on an SDS824X HD (2026-07-30), PREamble? uses this
+    fixed form but DATA? uses the GENERAL one -- 50000 bytes came back as
+    "#550000", not "#9000050000". Only PREamble? should use this builder.
     """
     return b"#9" + f"{len(payload):09d}".encode() + payload
 

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -274,6 +274,21 @@ def handle_query(conn, command: str) -> Optional[str]:
     upper = command.upper()
 
     if conn.scope_dialect == "modern":
+        if upper == ":ACQUIRE:POINTS?":
+            # Bare NR3, as measured on a real SDS824X HD: "1.00E+05".
+            #
+            # There was no handler here, so the query raised, record_length()
+            # caught it and degraded to None ("the dialect can't say"), and the
+            # live view's stride sizing -- driven entirely by record_length() --
+            # was never exercised against the modern mock. Same shape as the
+            # INR? gap above: a query the instrument answers happily, that the
+            # mock could only fail.
+            #
+            # Deliberately the SAME _effective_record_length() the preamble
+            # uses, so the point count and wave_array_count always describe one
+            # record. Sourcing them separately is how a stride gets sized
+            # against a length the transfer does not actually have.
+            return _format_nr3(float(_effective_record_length(conn, _modern_source_channel(conn))))
         if upper == "INR?":
             # The modern personality had NO handler here, so INR? raised and
             # Oscilloscope.new_acquisition_ready() degraded to None in CI just

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -3,6 +3,7 @@ write/query dialects, plus the waveform-response builder."""
 
 from __future__ import annotations
 
+import math
 import re
 import struct
 from typing import Dict, Optional, Tuple
@@ -508,6 +509,18 @@ def build_waveform_preamble(conn) -> bytes:
     transfers are capped. This also (re)populates the per-channel code cache
     that build_waveform_data slices from, since PREamble? is read exactly
     once per capture, before the STARt-driven DATA? loop begins.
+
+    ASSUMPTION, made visible (Task 3 stride follow-up, not yet confirmed
+    against real hardware): wave_array_count/WAVE_ARRAY_1 below report the
+    STRIDED (post-:WAVeform:INTerval) point/byte count, and HORIZ_INTERVAL
+    reports the STRIDED sample spacing, not the full record's. We read it
+    this way because WAVE_ARRAY_1 (addr 60) is documented as "bytes in the
+    TRANSMITTED array", and FIRST_POINT (132)/DATA_INTERVAL (136) exist as
+    their own fields precisely because the transmitted array is a sparse
+    subset of the full record -- there would be nothing for DATA_INTERVAL to
+    describe if wave_array_count were always the unstrided count. If a real
+    SDS800X HD disagrees, this mock and ModernTransfer.acquire's DATA_INTERVAL
+    cross-check (waveform_transfer.py) change together.
     """
     channel = _modern_source_channel(conn)
     word = conn.waveform_width == "WORD"
@@ -516,20 +529,23 @@ def build_waveform_preamble(conn) -> bytes:
     record_length = _effective_record_length(conn, channel)
     conn._modern_waveform_codes[channel] = _synthesize_modern_codes(conn, channel, record_length, word)
 
+    interval = max(1, conn.waveform_interval)
+    strided_length = math.ceil(record_length / interval)
+
     desc = bytearray(_MODERN_WAVEDESC_LEN)
     desc[0:8] = b"WAVEDESC"
     desc[16:23] = b"WAVEACE"
     struct.pack_into("<h", desc, _MODERN_COMM_TYPE, 1 if word else 0)
     struct.pack_into("<h", desc, _MODERN_COMM_ORDER, 0)
     struct.pack_into("<i", desc, _MODERN_WAVE_DESC_LENGTH, _MODERN_WAVEDESC_LEN)
-    struct.pack_into("<i", desc, _MODERN_WAVE_ARRAY_1, record_length * bytes_per_point)
-    struct.pack_into("<i", desc, _MODERN_WAVE_ARRAY_COUNT, record_length)
+    struct.pack_into("<i", desc, _MODERN_WAVE_ARRAY_1, strided_length * bytes_per_point)
+    struct.pack_into("<i", desc, _MODERN_WAVE_ARRAY_COUNT, strided_length)
     struct.pack_into("<i", desc, _MODERN_FIRST_POINT, conn.waveform_start)
     struct.pack_into("<i", desc, _MODERN_DATA_INTERVAL, conn.waveform_interval)
     struct.pack_into("<f", desc, _MODERN_VERTICAL_GAIN, conn._voltage_scales.get(channel, 1.0))
     struct.pack_into("<f", desc, _MODERN_VERTICAL_OFFSET, conn._voltage_offsets.get(channel, 0.0))
     struct.pack_into("<f", desc, _MODERN_CODE_PER_DIV, code_per_div)
-    struct.pack_into("<f", desc, _MODERN_HORIZ_INTERVAL, (1.0 / conn.sample_rate) if conn.sample_rate else 0.0)
+    struct.pack_into("<f", desc, _MODERN_HORIZ_INTERVAL, ((1.0 / conn.sample_rate) * interval) if conn.sample_rate else 0.0)
     struct.pack_into("<d", desc, _MODERN_HORIZ_OFFSET, 0.0)  # mock triggers at the first sample
     return _build_ieee_block_9digit(bytes(desc))
 
@@ -544,12 +560,18 @@ def build_waveform_data(conn) -> bytes:
     exists to make trustworthy -- see wavedesc-reference.md).
 
     Task 19 (deep-memory chunking, guide p.753): window-aware. Returns only
-    codes[start : start + window], where window is capped by BOTH
+    transmitted[start : start + window], where window is capped by BOTH
     :WAVeform:POINt (when set) and :WAVeform:MAXPoint, and never reads past
-    the record's end -- exactly the "read the waveform data in pieces" the
-    guide's own MAXPoint description names. A single-shot capture (record
-    length <= max_points, the common case and every Task 18 test) still
-    returns the whole record in one call, unchanged.
+    the (strided) record's end -- exactly the "read the waveform data in
+    pieces" the guide's own MAXPoint description names. A single-shot capture
+    (record length <= max_points, the common case and every Task 18 test)
+    still returns the whole record in one call, unchanged.
+
+    `transmitted` is codes[::interval] -- see build_waveform_preamble's
+    ASSUMPTION note on why DATA? is read as answering from the strided
+    subset, not the full record. interval=1 (the default, and every read that
+    never sets :WAVeform:INTerval) makes this identical to the pre-stride
+    behavior.
     """
     channel = _modern_source_channel(conn)
     word = conn.waveform_width == "WORD"
@@ -559,9 +581,11 @@ def build_waveform_data(conn) -> bytes:
         # driver uses, but tolerate it (one-shot synthesis, not cached)
         # rather than raising, matching this mock's general leniency.
         codes = _synthesize_modern_codes(conn, channel, _effective_record_length(conn, channel), word)
-    record_length = len(codes)
+    interval = max(1, conn.waveform_interval)
+    transmitted = codes[::interval] if interval > 1 else codes
+    record_length = len(transmitted)
     start = max(0, conn.waveform_start)
     remaining = max(0, record_length - start)
     requested = conn.waveform_point if conn.waveform_point else conn.max_points
     window = max(0, min(requested, conn.max_points, remaining))
-    return _build_ieee_block_9digit(codes[start : start + window].tobytes())
+    return _build_ieee_block_9digit(transmitted[start : start + window].tobytes())

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -274,6 +274,35 @@ def handle_query(conn, command: str) -> Optional[str]:
     upper = command.upper()
 
     if conn.scope_dialect == "modern":
+        if upper == "INR?":
+            # The modern personality had NO handler here, so INR? raised and
+            # Oscilloscope.new_acquisition_ready() degraded to None in CI just
+            # as it did on hardware -- while every gate test injected a bare
+            # "1"/"0" through custom_responses, a shape the instrument never
+            # sends. Nothing could notice the gate was inert.
+            #
+            # HEADER-PREFIXED, as measured on a real SDS824X HD: "INR 8193",
+            # never "8193". Bit 0 is "new signal acquired"; the 8192 seen
+            # alongside it on hardware is an unrelated bit, reproduced here so
+            # a reader that forgets to mask fails.
+            # Bit 0 is always SET, because this mock genuinely does synthesize a
+            # fresh acquisition on every waveform read -- it free-runs no matter
+            # what label `trigger_status` carries. Deriving bit 0 from
+            # trigger_status instead would have the mock answer "no new data"
+            # while still handing out new data on the next read, and since the
+            # gateway's mock scope is built with trigger_status=["Stop"], its
+            # live view would go dark after one frame.
+            #
+            # The read-and-clear latch is deliberately NOT modelled: there is no
+            # acquisition clock here to re-arm it against, so any timing would be
+            # invented rather than observed. Tests that need a specific gate
+            # answer script it through custom_responses (which is consulted
+            # before this handler) or stub new_acquisition_ready() outright.
+            #
+            # 8193 = bit 13 + bit 0, exactly as the instrument answered, so a
+            # reader that forgets to mask bit 0 fails here rather than on
+            # hardware.
+            return "INR 8193"
         if upper == ":TRIGGER:STATUS?":  # enum Arm|Ready|Auto|Trig'd|Stop|Roll, p.483
             if len(conn.trigger_status) > 1:
                 return conn.trigger_status.pop(0)
@@ -439,14 +468,20 @@ _MODERN_CODE_PER_DIV = 164  # float (p.756)
 _MODERN_HORIZ_INTERVAL = 176  # float: 1/sample_rate (p.756)
 _MODERN_HORIZ_OFFSET = 180  # double: trigger offset, seconds (p.756)
 
-# code_per_div the mock encodes with. BYTE mirrors WAVEFORM_CODE_PER_DIV_8BIT
-# (waveform.py); WORD is that value left-shifted 8 bits (256x), matching
-# p.758's note that >8-bit models transmit word samples "left aligned, and
-# the lower bit is zero filled" -- i.e. WAVEFORM_CODE_PER_DIV_16BIT is
-# WAVEFORM_CODE_PER_DIV_8BIT * 256. Restated here (not imported) to avoid a
-# waveform.py <-> connection.mock import edge; kept numerically identical.
-_MODERN_CODE_PER_DIV_BYTE = 25.0
-_MODERN_CODE_PER_DIV_WORD = 25.0 * 256
+# code_per_div the mock encodes with -- ONE value for both transfer widths,
+# MEASURED on a real SDS824X HD (fw 3.8.12.1.1.3.6) 2026-07-30: the preamble
+# reported code_per_div=7680 and Adc_bit=16 under :WAVeform:WIDTh BYTE and
+# under WORD alike. The instrument does NOT hand BYTE its own smaller scale;
+# it sends the HIGH BYTE of the native code and leaves the field untouched.
+#
+# This replaces a 25.0 (BYTE) / 6400.0 (WORD) pair, which scaled the field by
+# 256 across widths where the instrument does not. That pair round-tripped
+# perfectly against a driver making the same assumption while reading real
+# BYTE captures 256x too small -- the self-consistent-but-wrong defect this
+# mock exists to expose, not to reproduce.
+_MODERN_CODE_PER_DIV_NATIVE = 7680.0
+_MODERN_ADC_BIT_VALUE = 16
+_MODERN_ADC_BIT = 172  # short (p.756)
 
 
 def _modern_source_channel(conn) -> int:
@@ -484,14 +519,19 @@ def _synthesize_modern_codes(conn, channel: int, record_length: int, word: bool)
     explicit = conn._waveform_payloads.get(channel)
     if explicit is not None:
         return np.frombuffer(explicit, dtype="<i2" if word else np.int8)
-    code_per_div = _MODERN_CODE_PER_DIV_WORD if word else _MODERN_CODE_PER_DIV_BYTE
     vdiv = conn._voltage_scales.get(channel, 1.0)
     voffset = conn._voltage_offsets.get(channel, 0.0)
     volts = mock_synth.raw_volts(conn, channel, n_override=record_length)
-    codes = np.rint((volts + voffset) * code_per_div / vdiv)
+    # Always encode in the NATIVE (16-bit) code space the preamble advertises,
+    # then, for a BYTE transfer, send the HIGH BYTE of that code -- which is
+    # what the instrument does. code_per_div stays 7680 either way, so a BYTE
+    # reader must divide it by 256 itself; a reader that does not gets volts
+    # 256x too small, exactly as measured on hardware.
+    codes = np.rint((volts + voffset) * _MODERN_CODE_PER_DIV_NATIVE / vdiv)
+    codes = np.clip(codes, -32768, 32767).astype("<i2")
     if word:
-        return np.clip(codes, -32768, 32767).astype("<i2")
-    return np.clip(codes, -128, 127).astype(np.int8)
+        return codes
+    return (codes >> 8).astype(np.int8)
 
 
 def build_waveform_preamble(conn) -> bytes:
@@ -536,7 +576,7 @@ def build_waveform_preamble(conn) -> bytes:
     channel = _modern_source_channel(conn)
     word = conn.waveform_width == "WORD"
     bytes_per_point = 2 if word else 1
-    code_per_div = _MODERN_CODE_PER_DIV_WORD if word else _MODERN_CODE_PER_DIV_BYTE
+    code_per_div = _MODERN_CODE_PER_DIV_NATIVE  # one value for both widths (hardware)
     record_length = _effective_record_length(conn, channel)
     conn._modern_waveform_codes[channel] = _synthesize_modern_codes(conn, channel, record_length, word)
 
@@ -553,12 +593,15 @@ def build_waveform_preamble(conn) -> bytes:
     struct.pack_into("<f", desc, _MODERN_VERTICAL_GAIN, conn._voltage_scales.get(channel, 1.0))
     struct.pack_into("<f", desc, _MODERN_VERTICAL_OFFSET, conn._voltage_offsets.get(channel, 0.0))
     struct.pack_into("<f", desc, _MODERN_CODE_PER_DIV, code_per_div)
+    struct.pack_into("<h", desc, _MODERN_ADC_BIT, _MODERN_ADC_BIT_VALUE)
     # NOT scaled by the interval -- the instrument reports the raw sample
     # spacing at every stride (table above). A reader wanting the spacing
     # BETWEEN DELIVERED POINTS must multiply this by DATA_INTERVAL itself.
     struct.pack_into("<f", desc, _MODERN_HORIZ_INTERVAL, (1.0 / conn.sample_rate) if conn.sample_rate else 0.0)
     struct.pack_into("<d", desc, _MODERN_HORIZ_OFFSET, 0.0)  # mock triggers at the first sample
-    return _build_ieee_block_9digit(bytes(desc))
+    # Fixed 9-digit header plus ONE trailing newline -- measured:
+    # b'#9000000346WAVEDESC...\n'. DATA? below frames itself differently.
+    return _build_ieee_block_9digit(bytes(desc)) + b"\n"
 
 
 def build_waveform_data(conn) -> bytes:
@@ -601,4 +644,9 @@ def build_waveform_data(conn) -> bytes:
     remaining = max(0, transmitted_length - start)
     requested = conn.waveform_point if conn.waveform_point else conn.max_points
     window = max(0, min(requested, conn.max_points, remaining))
-    return _build_ieee_block_9digit(transmitted[start : start + window].tobytes())
+    # The GENERAL variable-width IEEE-488.2 header plus TWO trailing newlines,
+    # not the fixed "#9<9-digits>" of the guide's p.757 example: a real
+    # SDS824X HD answered 50000 bytes as b'#550000...' + b'\n\n'. PREamble?
+    # above really does use the 9-digit form, so the two replies genuinely
+    # disagree and the mock has to reproduce each separately.
+    return _build_ieee_block(transmitted[start : start + window].tobytes()) + b"\n\n"

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -510,17 +510,28 @@ def build_waveform_preamble(conn) -> bytes:
     that build_waveform_data slices from, since PREamble? is read exactly
     once per capture, before the STARt-driven DATA? loop begins.
 
-    ASSUMPTION, made visible (Task 3 stride follow-up, not yet confirmed
-    against real hardware): wave_array_count/WAVE_ARRAY_1 below report the
-    STRIDED (post-:WAVeform:INTerval) point/byte count, and HORIZ_INTERVAL
-    reports the STRIDED sample spacing, not the full record's. We read it
-    this way because WAVE_ARRAY_1 (addr 60) is documented as "bytes in the
-    TRANSMITTED array", and FIRST_POINT (132)/DATA_INTERVAL (136) exist as
-    their own fields precisely because the transmitted array is a sparse
-    subset of the full record -- there would be nothing for DATA_INTERVAL to
-    describe if wave_array_count were always the unstrided count. If a real
-    SDS800X HD disagrees, this mock and ModernTransfer.acquire's DATA_INTERVAL
-    cross-check (waveform_transfer.py) change together.
+    STRIDE (:WAVeform:INTerval), measured on a real SDS824X HD (fw
+    3.8.12.1.1.3.6) on 2026-07-30 at ACQ:POINts=50000:
+
+        INTerval | WAVE_ARRAY_1 | wave_array_count | DATA? pts | horiz_interval
+               1 |        50000 |            50000 |     50000 |        1.0e-08
+               2 |        50000 |            50000 |     25000 |        1.0e-08
+               7 |        50000 |            50000 |      7142 |        1.0e-08
+              10 |        50000 |            50000 |      5000 |        1.0e-08
+
+    So: BOTH count fields stay at the FULL record and HORIZ_INTERVAL keeps
+    reporting the raw sample spacing, no matter the stride. Only DATA_INTERVAL
+    (136) echoes it, and only :WAVeform:DATA? actually shrinks -- by FLOOR
+    division (50000/7 -> 7142, not 7143).
+
+    This reverses the assumption this mock previously carried, which said
+    these fields reported the STRIDED counts and spacing, and which said it
+    would "change together" with ModernTransfer.acquire if hardware
+    disagreed. It disagreed. Note in particular that WAVE_ARRAY_1 stays at
+    the full count even though the guide (p.755) calls it "the number of
+    transmitted bytes" -- the instrument does not honour that description, so
+    NOTHING in the preamble reports the transmitted count and a reader has to
+    compute `record // interval` itself.
     """
     channel = _modern_source_channel(conn)
     word = conn.waveform_width == "WORD"
@@ -529,23 +540,23 @@ def build_waveform_preamble(conn) -> bytes:
     record_length = _effective_record_length(conn, channel)
     conn._modern_waveform_codes[channel] = _synthesize_modern_codes(conn, channel, record_length, word)
 
-    interval = max(1, conn.waveform_interval)
-    strided_length = math.ceil(record_length / interval)
-
     desc = bytearray(_MODERN_WAVEDESC_LEN)
     desc[0:8] = b"WAVEDESC"
     desc[16:23] = b"WAVEACE"
     struct.pack_into("<h", desc, _MODERN_COMM_TYPE, 1 if word else 0)
     struct.pack_into("<h", desc, _MODERN_COMM_ORDER, 0)
     struct.pack_into("<i", desc, _MODERN_WAVE_DESC_LENGTH, _MODERN_WAVEDESC_LEN)
-    struct.pack_into("<i", desc, _MODERN_WAVE_ARRAY_1, strided_length * bytes_per_point)
-    struct.pack_into("<i", desc, _MODERN_WAVE_ARRAY_COUNT, strided_length)
+    struct.pack_into("<i", desc, _MODERN_WAVE_ARRAY_1, record_length * bytes_per_point)
+    struct.pack_into("<i", desc, _MODERN_WAVE_ARRAY_COUNT, record_length)
     struct.pack_into("<i", desc, _MODERN_FIRST_POINT, conn.waveform_start)
     struct.pack_into("<i", desc, _MODERN_DATA_INTERVAL, conn.waveform_interval)
     struct.pack_into("<f", desc, _MODERN_VERTICAL_GAIN, conn._voltage_scales.get(channel, 1.0))
     struct.pack_into("<f", desc, _MODERN_VERTICAL_OFFSET, conn._voltage_offsets.get(channel, 0.0))
     struct.pack_into("<f", desc, _MODERN_CODE_PER_DIV, code_per_div)
-    struct.pack_into("<f", desc, _MODERN_HORIZ_INTERVAL, ((1.0 / conn.sample_rate) * interval) if conn.sample_rate else 0.0)
+    # NOT scaled by the interval -- the instrument reports the raw sample
+    # spacing at every stride (table above). A reader wanting the spacing
+    # BETWEEN DELIVERED POINTS must multiply this by DATA_INTERVAL itself.
+    struct.pack_into("<f", desc, _MODERN_HORIZ_INTERVAL, (1.0 / conn.sample_rate) if conn.sample_rate else 0.0)
     struct.pack_into("<d", desc, _MODERN_HORIZ_OFFSET, 0.0)  # mock triggers at the first sample
     return _build_ieee_block_9digit(bytes(desc))
 
@@ -567,11 +578,13 @@ def build_waveform_data(conn) -> bytes:
     (record length <= max_points, the common case and every Task 18 test)
     still returns the whole record in one call, unchanged.
 
-    `transmitted` is codes[::interval] -- see build_waveform_preamble's
-    ASSUMPTION note on why DATA? is read as answering from the strided
-    subset, not the full record. interval=1 (the default, and every read that
-    never sets :WAVeform:INTerval) makes this identical to the pre-stride
-    behavior.
+    `transmitted` is codes[::interval], truncated to FLOOR(record/interval):
+    the real instrument returned 7142 points for a 50000-point record at
+    interval 7, where a bare codes[::7] yields 7143 (see
+    build_waveform_preamble's hardware table). DATA? is the ONLY response
+    that shrinks with the stride -- the preamble's counts do not.
+    interval=1 (the default, and every read that never sets
+    :WAVeform:INTerval) makes this identical to the pre-stride behavior.
     """
     channel = _modern_source_channel(conn)
     word = conn.waveform_width == "WORD"
@@ -582,10 +595,10 @@ def build_waveform_data(conn) -> bytes:
         # rather than raising, matching this mock's general leniency.
         codes = _synthesize_modern_codes(conn, channel, _effective_record_length(conn, channel), word)
     interval = max(1, conn.waveform_interval)
-    transmitted = codes[::interval] if interval > 1 else codes
-    record_length = len(transmitted)
+    transmitted = codes[::interval][: len(codes) // interval] if interval > 1 else codes
+    transmitted_length = len(transmitted)
     start = max(0, conn.waveform_start)
-    remaining = max(0, record_length - start)
+    remaining = max(0, transmitted_length - start)
     requested = conn.waveform_point if conn.waveform_point else conn.max_points
     window = max(0, min(requested, conn.max_points, remaining))
     return _build_ieee_block_9digit(transmitted[start : start + window].tobytes())

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -3,7 +3,6 @@ write/query dialects, plus the waveform-response builder."""
 
 from __future__ import annotations
 
-import math
 import re
 import struct
 from typing import Dict, Optional, Tuple

--- a/scpi_control/exceptions.py
+++ b/scpi_control/exceptions.py
@@ -25,6 +25,23 @@ class CommandError(SiglentError):
     pass
 
 
+class MeasurementUnavailableError(CommandError):
+    """Raised when the instrument has no value for a measurement right now.
+
+    Distinct from a failed read: the wire worked and the instrument answered,
+    it simply has nothing to report for that item yet. A modern Siglent says
+    so with the literal "****" (measured on an SDS824X HD: MEAN answered
+    while PKPK/MAX/MIN returned "****" on the same live channel).
+
+    Deliberately a CommandError subclass so callers written before it existed
+    keep catching it, while callers that care can tell "not available yet"
+    apart from "the read is broken" -- the difference between a normal
+    transient and something worth alerting on.
+    """
+
+    pass
+
+
 class InvalidParameterError(SiglentError):
     """Raised when invalid parameters are provided."""
 

--- a/scpi_control/measurement.py
+++ b/scpi_control/measurement.py
@@ -129,9 +129,7 @@ class Measurement:
             # an ordinary transient look like an instrument fault in the
             # gateway's poll log.
             if set(reply) == {"*"}:
-                raise exceptions.MeasurementUnavailableError(
-                    f"Instrument reports no value for {wire_type} on channel {channel} right now (answered {reply!r})"
-                )
+                raise exceptions.MeasurementUnavailableError(f"Instrument reports no value for {wire_type} on channel {channel} right now (answered {reply!r})")
             try:
                 return float(reply)
             except ValueError as e:

--- a/scpi_control/measurement.py
+++ b/scpi_control/measurement.py
@@ -120,8 +120,20 @@ class Measurement:
             # p.369: RESPONSE FORMAT is a bare <value> in NR3 ("2.000E+00") -- no
             # parameter name and no unit suffix, so the legacy comma-splitting
             # parser below cannot be reused.
+            reply = response.strip()
+            # "****" is the instrument's "no value for this item right now"
+            # marker, not a malformed reply -- measured on an SDS824X HD, where
+            # MEAN answered a normal NR3 while PKPK/MAX/MIN each returned
+            # "****" on the same live channel. p.369 documents only the bare
+            # NR3 and never mentions it. Reporting this as a parse failure made
+            # an ordinary transient look like an instrument fault in the
+            # gateway's poll log.
+            if set(reply) == {"*"}:
+                raise exceptions.MeasurementUnavailableError(
+                    f"Instrument reports no value for {wire_type} on channel {channel} right now (answered {reply!r})"
+                )
             try:
-                return float(response.strip())
+                return float(reply)
             except ValueError as e:
                 raise exceptions.CommandError(f"Failed to parse measurement: {e}")
 

--- a/scpi_control/oscilloscope.py
+++ b/scpi_control/oscilloscope.py
@@ -381,10 +381,21 @@ class Oscilloscope:
         maximum points a single transfer can carry, not how many the record
         actually holds. A caller sizing a stride from the wrong one would
         under-decimate a deep record.
+
+        A dialect that MAPS the command is not a promise the instrument will
+        answer it: firmware that doesn't implement the query (or errors on it
+        while stopped) makes it fail, and so does the mock, which has no modern
+        handler for it. A raise here reached the gateway's export path as a 504
+        on an otherwise healthy session, so this degrades to None -- "the
+        dialect can't say" -- exactly like waveform_max_points() below, and
+        callers already handle None.
         """
         if not self._has_command("get_acq_points"):
             return None
-        return int(float(self.query(self._get_command("get_acq_points"))))
+        try:
+            return int(float(self.query(self._get_command("get_acq_points"))))
+        except (SiglentError, ValueError):
+            return None
 
     def waveform_max_points(self) -> Optional[int]:
         """The instrument's per-:WAVeform:DATA?-transfer cap, or None if the dialect can't say.

--- a/scpi_control/oscilloscope.py
+++ b/scpi_control/oscilloscope.py
@@ -23,6 +23,31 @@ from scpi_control.waveform import Waveform, WaveformData
 logger = logging.getLogger(__name__)
 
 
+def _parse_inr(response: str) -> int:
+    """Parse an INR? reply, with or without its response header.
+
+    MEASURED on a real SDS824X HD (fw 3.8.12.1.1.3.6) 2026-07-30: the
+    instrument answers "INR 8193", NOT the bare "8193" the guide's example
+    implies. Only the ":"-prefixed modern queries answer bare; legacy-style
+    ones like INR? carry the header.
+
+    That mattered a great deal: new_acquisition_ready() used int() directly,
+    so every real reply raised ValueError, was caught, and became None = "this
+    dialect has no gate" -- silently, every tick. The modern gate never ran on
+    hardware. Both shapes are accepted here because a bare reply is what the
+    mock and the LeCroy dialect send (and what a CHDR OFF instrument would).
+
+    Raises:
+        ValueError: If the remainder is not an integer -- the caller turns
+            that into None ("cannot tell this tick"), which is the right
+            answer for a genuinely unreadable gate.
+    """
+    token = response.strip()
+    if token[:3].upper() == "INR":
+        token = token[3:].strip()
+    return int(token)
+
+
 class Oscilloscope:
     """Main class for controlling Siglent oscilloscopes.
 
@@ -369,7 +394,7 @@ class Oscilloscope:
             return None
         try:
             response = self.query(self._get_command("get_new_data"))
-            return bool(int(response.strip()) & 0x01)
+            return bool(_parse_inr(response) & 0x01)
         except (SiglentError, ValueError):
             # A gate we cannot read is a gate we do not have, for this tick only.
             return None

--- a/scpi_control/oscilloscope.py
+++ b/scpi_control/oscilloscope.py
@@ -374,6 +374,18 @@ class Oscilloscope:
             # A gate we cannot read is a gate we do not have, for this tick only.
             return None
 
+    def record_length(self) -> Optional[int]:
+        """The full acquisition length in points, or None if the dialect can't say.
+
+        This is :ACQuire:POINts?, NOT :WAVeform:MAXPoint? -- the latter is the
+        maximum points a single transfer can carry, not how many the record
+        actually holds. A caller sizing a stride from the wrong one would
+        under-decimate a deep record.
+        """
+        if not self._has_command("get_acq_points"):
+            return None
+        return int(float(self.query(self._get_command("get_acq_points"))))
+
     @property
     def timebase(self) -> float:
         """Get timebase setting in seconds/division."""
@@ -392,7 +404,7 @@ class Oscilloscope:
         """Perform automatic setup."""
         self.write(self._get_command("auto_setup"))
 
-    def get_waveform(self, channel: int, provenance: bool = True) -> WaveformData:
+    def get_waveform(self, channel: int, provenance: bool = True, stride: Optional[int] = None) -> WaveformData:
         """Acquire waveform data from a channel.
 
         Convenience method that calls waveform.acquire().
@@ -401,11 +413,19 @@ class Oscilloscope:
             channel: Channel number (1-4)
             provenance: Snapshot instrument settings alongside the data
                 (default True; pass False on high-rate paths)
+            stride: Ask the instrument to return every Nth point via
+                :WAVeform:INTerval, bounding the transfer instead of pulling
+                the full record and striding it down afterward. This is
+                instrument state, not a per-request argument: every read sets
+                it explicitly, so None means "set it to 1", never "leave it
+                alone" -- otherwise a stride left over from the live view
+                would silently decimate the next export on this session.
+                Ignored on dialects that don't document the command.
 
         Returns:
             WaveformData object with time and voltage arrays
         """
-        return self.waveform.acquire(channel, provenance=provenance)
+        return self.waveform.acquire(channel, provenance=provenance, stride=stride)
 
     @property
     def device_info(self) -> Optional[Dict[str, str]]:

--- a/scpi_control/oscilloscope.py
+++ b/scpi_control/oscilloscope.py
@@ -386,6 +386,25 @@ class Oscilloscope:
             return None
         return int(float(self.query(self._get_command("get_acq_points"))))
 
+    def waveform_max_points(self) -> Optional[int]:
+        """The instrument's per-:WAVeform:DATA?-transfer cap, or None if the dialect can't say.
+
+        This is :WAVeform:MAXPoint? -- the same cap ModernTransfer.acquire
+        (waveform_transfer.py) reads before deciding whether a strided record
+        fits in a single window, raising FeatureNotSupportedError when it
+        doesn't. A caller sizing a stride against a frame budget alone,
+        ignoring this number, can turn that guard into a total live-view
+        outage on a model that reports a cap below the frame budget -- size
+        against min(frame_budget, this value) instead.
+        """
+        if not self._has_command("get_waveform_maxpoint"):
+            return None
+        try:
+            value = int(float(self.query(self._get_command("get_waveform_maxpoint"))))
+        except (SiglentError, ValueError):
+            return None
+        return value if value > 0 else None
+
     @property
     def timebase(self) -> float:
         """Get timebase setting in seconds/division."""

--- a/scpi_control/oscilloscope.py
+++ b/scpi_control/oscilloscope.py
@@ -11,6 +11,7 @@ from scpi_control import exceptions
 from scpi_control.analysis import FFTAnalyzer
 from scpi_control.channel import Channel
 from scpi_control.connection import BaseConnection, SocketConnection
+from scpi_control.exceptions import SiglentError
 from scpi_control.math_channel import MathChannel
 from scpi_control.measurement import Measurement
 from scpi_control.models import ModelCapability, detect_model_from_idn
@@ -351,6 +352,27 @@ class Oscilloscope:
                 return "TRIGD"
             return "AUTO" if mode.endswith("AUTO") else "READY"
         return normalize_status(self.query(self._get_command("get_acq_status")))
+
+    def new_acquisition_ready(self) -> Optional[bool]:
+        """True if a new acquisition has completed since the last check.
+
+        Returns None when the active dialect has no way to tell us, which callers
+        must treat as "no gate available" rather than as False -- a False would
+        stall the live view forever on those dialects.
+
+        The underlying INR? register is READ-AND-CLEAR: reading it consumes the
+        event. This method is therefore the single permitted consumer. Do not read
+        get_new_data anywhere else, and do not call this method twice per tick
+        expecting the same answer.
+        """
+        if not self._has_command("get_new_data"):
+            return None
+        try:
+            response = self.query(self._get_command("get_new_data"))
+            return bool(int(response.strip()) & 0x01)
+        except (SiglentError, ValueError):
+            # A gate we cannot read is a gate we do not have, for this tick only.
+            return None
 
     @property
     def timebase(self) -> float:

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -233,6 +233,13 @@ class SCPICommandSet:
         "set_simple_source": ":MEASure:SIMPle:SOURce C{ch}",  # p.368
         "set_simple_item": ":MEASure:SIMPle:ITEM {param},{state}",  # p.367
         "get_simple_value": ":MEASure:SIMPle:VALue? {param}",  # bare NR3 reply, p.369
+        # INR? bit 0 is a read-and-clear "new signal acquired" latch -- the only
+        # honest "has a new frame landed?" signal on this dialect. The manual's own
+        # example polls exactly this before fetching (SDS800XHD guide p.829).
+        # :TRIGger:STATus? cannot substitute: it reports a state that latches, so
+        # it says TRIGD long after the frame it referred to was consumed.
+        # READ-AND-CLEAR: exactly one consumer, Oscilloscope.new_acquisition_ready().
+        "get_new_data": "INR?",
         # Screen capture (legacy strings accepted on modern scopes today; revisit with screen-capture overhaul)
         "screen_dump": "SCDP",
         "set_hardcopy_format": "HCSU DEV,FORMAT,{format}",

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -221,6 +221,10 @@ class SCPICommandSet:
         # to learn how many :WAVeform:STARt-driven DATA? windows a full
         # record needs.
         "get_waveform_maxpoint": ":WAVeform:MAXPoint?",  # p.753
+        # The record length, i.e. how many points the acquisition holds. NOT
+        # :WAVeform:MAXPoint? (p.753), which is the maximum per transfer -- using
+        # that to size a stride would under-decimate a deep record.
+        "get_acq_points": ":ACQuire:POINts?",  # p.36, p.43
         # Measurements — the :MEASure:SIMPle subsystem (p.335 index). The legacy
         # PAVA? command is deliberately ABSENT: it appears zero times in this
         # guide (exhaustive full-text search), so offering it here made measure()

--- a/scpi_control/server/adapters.py
+++ b/scpi_control/server/adapters.py
@@ -9,6 +9,7 @@ and a subclass that overrides part of a thread or error path by accident is a
 much worse failure than a little indirection.
 """
 
+import logging
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -19,6 +20,8 @@ from scpi_control.server import compute
 from scpi_control.server.netpolicy import validate_target
 from scpi_control.server.recorder import TrendRecorder
 
+logger = logging.getLogger(__name__)
+
 MAX_FRAME_POINTS = 2000
 MEASUREMENT_EVERY_N_POLLS = 4
 
@@ -27,16 +30,46 @@ DEFAULT_MOCK_PSU_IDN = "Siglent Technologies,SPD3303X,SPD123456,1.0"
 DEFAULT_MOCK_AWG_IDN = "Siglent Technologies,SDG1032X,SDG1XXXXX,2.01.01.37R1"
 
 
-def _safe(fn, default=None):
+def _safe(fn, default=None, label=None, state=None):
+    """Run `fn`, degrading to `default` on the exceptions a poll tick must
+    survive. `label`/`state` are both optional and BOTH must be given to opt
+    into logging -- every existing call site that passes neither behaves
+    exactly as before, which is what keeps this signature backward compatible
+    for the many callers that just want the swallow.
+
+    `state` is a dict the caller owns (an adapter's `self._poll_health`,
+    typically), keyed by `label`, holding the last-known-good (True) or
+    last-known-bad (False) status of that one named operation. Passing the
+    SAME dict across calls with DIFFERENT labels is what lets, e.g., a failing
+    channel 1 query and a healthy channel 2 query be tracked independently --
+    otherwise the two would overwrite one shared "is it failing" flag and
+    flap each other's state.
+
+    Logging is once per transition, not once per call: at a 0.25s poll
+    interval, logging every tick of a persistent failure would write four
+    lines a second and bury everything else in the log. A success->failure
+    transition logs one WARNING naming the operation; a failure->success
+    transition logs one recovery record, so a reader can tell an outage in
+    the log actually ended. Steady state -- repeated failures, or repeated
+    successes -- logs nothing.
+    """
     try:
-        return fn()
+        result = fn()
     except (SiglentError, ValueError):
         # ValueError alongside SiglentError: a couple of the callers wrapped
         # here (Oscilloscope.record_length()/waveform_max_points()) parse a
         # numeric response with int(float(...)), which raises ValueError on a
         # malformed reply rather than a SiglentError. Either way, the poll
         # tick is the session heartbeat and must degrade to `default`, not die.
+        if label is not None and state is not None and state.get(label) is not False:
+            logger.warning("poll query failed, degrading to a default: %s", label)
+            state[label] = False
         return default
+    if label is not None and state is not None:
+        if state.get(label) is False:
+            logger.info("poll query recovered: %s", label)
+        state[label] = True
+    return result
 
 
 def _quiet(fn, default=None):
@@ -158,6 +191,10 @@ class ScopeAdapter(InstrumentAdapter):
         # produces a new acquisition, and without this exemption it would show
         # an empty canvas forever instead of its perfectly good last frame.
         self._published_a_frame = False
+        # Last-known-good/bad status per poll-path query, keyed by an
+        # operation label -- see _safe()'s docstring. Worker-thread-only, like
+        # self._shown: nothing else reads or writes it.
+        self._poll_health: Dict[str, bool] = {}
 
     def build(self, address, port, mock, model, allowed_ports, connection):
         if mock:
@@ -189,7 +226,8 @@ class ScopeAdapter(InstrumentAdapter):
         # event and get a meaningless answer. None (dialect has no gate) must
         # never be treated as False, or the live view dies on every
         # non-Siglent scope.
-        ready = _safe(lambda: scope.new_acquisition_ready(), default=None)
+        health = self._poll_health
+        ready = _safe(lambda: scope.new_acquisition_ready(), default=None, label="acquisition ready check", state=health)
         if ready is False and self._published_a_frame:
             return
         # Size the stride from the full record length, capped by whichever is
@@ -199,16 +237,16 @@ class ScopeAdapter(InstrumentAdapter):
         # and turn ModernTransfer's strided-read guard (FeatureNotSupportedError)
         # into a total live-view outage -- capping here makes that guard
         # unreachable by construction.
-        points = _safe(lambda: scope.record_length(), default=None)
+        points = _safe(lambda: scope.record_length(), default=None, label="record length", state=health)
         stride = None
         if points:
-            cap = _safe(lambda: scope.waveform_max_points(), default=None)
+            cap = _safe(lambda: scope.waveform_max_points(), default=None, label="waveform max points", state=health)
             limit = min(MAX_FRAME_POINTS, cap) if cap else MAX_FRAME_POINTS
             stride = max(1, -(-points // limit))
         acquired = {}
         for n in scope.supported_channels:
             ch = scope.get_channel(n)
-            if ch is not None and _safe(lambda: ch.enabled, default=False):
+            if ch is not None and _safe(lambda: ch.enabled, default=False, label="channel {0} enabled".format(n), state=health):
                 data = scope.get_waveform(n, provenance=False, stride=stride)
                 acquired["C{0}".format(n)] = data
                 publish(_decimate_frame(n, data.time, data.voltage))
@@ -216,8 +254,8 @@ class ScopeAdapter(InstrumentAdapter):
         shown_now = set()
         for label, math in (("M1", scope.math1), ("M2", scope.math2)):
             result = None
-            if math is not None and _safe(lambda: math.enabled, default=False):
-                result = _safe(lambda: math.compute(acquired))
+            if math is not None and _safe(lambda: math.enabled, default=False, label="math {0} enabled".format(label), state=health):
+                result = _safe(lambda: math.compute(acquired), label="math {0} compute".format(label), state=health)
             if result is not None:
                 publish(_decimate_frame(label, result.time, result.voltage))
                 shown_now.add(label)
@@ -246,7 +284,7 @@ class ScopeAdapter(InstrumentAdapter):
                 now = time.time()
                 values = []
                 for channel, mtype in self.measurements:
-                    value = _safe(lambda: scope.measurement.measure(mtype, channel))
+                    value = _safe(lambda: scope.measurement.measure(mtype, channel), label="measurement {0} channel {1}".format(mtype, channel), state=health)
                     values.append({"channel": channel, "mtype": mtype, "value": value})
                 publish({"type": "measurements", "values": values, "timestamp": now})
                 self.recorder.append(now, [entry["value"] for entry in values])

--- a/scpi_control/server/adapters.py
+++ b/scpi_control/server/adapters.py
@@ -196,11 +196,13 @@ class ScopeAdapter(InstrumentAdapter):
         self.active_reference: Optional[Dict[str, Any]] = None  # {"name", "channel", "data": {"time","voltage",...}}
         self._shown: set = set()  # trace keys (M1/M2/F1/F2/SPEC) live on subscribers' canvases; worker-thread-only
         self.recorder = TrendRecorder()  # internally locked: worker appends, request threads control/read
-        # Whether a waveform frame has ever been published on this session.
-        # False lets the very first tick fetch unconditionally even when the
-        # gate below says "nothing new" -- a scope sitting in Stop mode never
-        # produces a new acquisition, and without this exemption it would show
-        # an empty canvas forever instead of its perfectly good last frame.
+        # Whether a waveform frame has been published since the most recent
+        # stream was seeded. False lets the next tick fetch unconditionally
+        # even when the gate below says "nothing new" -- a scope sitting in
+        # Stop mode never produces a new acquisition, and without this
+        # exemption it would show an empty canvas forever instead of its
+        # perfectly good last frame. initial_frame() resets it, because the
+        # canvas this protects belongs to a subscriber, not to the session.
         self._published_a_frame = False
         # Last-known-good/bad status per poll-path query, keyed by an
         # operation label -- see _safe()'s docstring. Worker-thread-only, like
@@ -312,6 +314,19 @@ class ScopeAdapter(InstrumentAdapter):
                 publish(compute.reference_stats(reference, acquired))
 
     def initial_frame(self, instrument):
+        # Re-arm the first-tick exemption: a newly-opened stream is a canvas
+        # with nothing on it. The frontend clears every frame on unmount and
+        # this opening frame carries state only, so a viewer that reloads the
+        # page starts empty -- while the flag still said a frame had been
+        # published, which on a scope sitting in Stop (INR? bit 0 never sets
+        # again) left the canvas blank forever with no error and no log line.
+        # That is the exact failure the exemption exists to prevent; the unit
+        # it has to be counted in is a SUBSCRIBER, not a session.
+        #
+        # Race-free without a lock: initial_frame is submitted as a job and so
+        # runs on the same worker thread as poll(), which is the only other
+        # reader/writer of this flag.
+        self._published_a_frame = False
         return {"type": "state", "state": read_state(instrument)}
 
     def close(self, instrument):

--- a/scpi_control/server/adapters.py
+++ b/scpi_control/server/adapters.py
@@ -30,7 +30,12 @@ DEFAULT_MOCK_AWG_IDN = "Siglent Technologies,SDG1032X,SDG1XXXXX,2.01.01.37R1"
 def _safe(fn, default=None):
     try:
         return fn()
-    except SiglentError:
+    except (SiglentError, ValueError):
+        # ValueError alongside SiglentError: a couple of the callers wrapped
+        # here (Oscilloscope.record_length()/waveform_max_points()) parse a
+        # numeric response with int(float(...)), which raises ValueError on a
+        # malformed reply rather than a SiglentError. Either way, the poll
+        # tick is the session heartbeat and must degrade to `default`, not die.
         return default
 
 
@@ -147,6 +152,12 @@ class ScopeAdapter(InstrumentAdapter):
         self.active_reference: Optional[Dict[str, Any]] = None  # {"name", "channel", "data": {"time","voltage",...}}
         self._shown: set = set()  # trace keys (M1/M2/F1/F2/SPEC) live on subscribers' canvases; worker-thread-only
         self.recorder = TrendRecorder()  # internally locked: worker appends, request threads control/read
+        # Whether a waveform frame has ever been published on this session.
+        # False lets the very first tick fetch unconditionally even when the
+        # gate below says "nothing new" -- a scope sitting in Stop mode never
+        # produces a new acquisition, and without this exemption it would show
+        # an empty canvas forever instead of its perfectly good last frame.
+        self._published_a_frame = False
 
     def build(self, address, port, mock, model, allowed_ports, connection):
         if mock:
@@ -170,13 +181,38 @@ class ScopeAdapter(InstrumentAdapter):
     def poll(self, instrument, publish, tick):
         scope = instrument
         shown = self._shown
+        # A read the scope cannot answer yet blocks this worker, and the worker
+        # is also the only thing servicing user commands -- so an unanswerable
+        # read freezes the whole UI for the length of the acquisition. Ask
+        # first, and ask at most once: the underlying register is
+        # read-and-clear, so a second read in this tick would consume a real
+        # event and get a meaningless answer. None (dialect has no gate) must
+        # never be treated as False, or the live view dies on every
+        # non-Siglent scope.
+        ready = _safe(lambda: scope.new_acquisition_ready(), default=None)
+        if ready is False and self._published_a_frame:
+            return
+        # Size the stride from the full record length, capped by whichever is
+        # smaller: our own per-frame budget, or the instrument's own
+        # per-transfer limit (:WAVeform:MAXPoint?, via waveform_max_points()).
+        # Sizing against MAX_FRAME_POINTS alone can still overflow a low cap
+        # and turn ModernTransfer's strided-read guard (FeatureNotSupportedError)
+        # into a total live-view outage -- capping here makes that guard
+        # unreachable by construction.
+        points = _safe(lambda: scope.record_length(), default=None)
+        stride = None
+        if points:
+            cap = _safe(lambda: scope.waveform_max_points(), default=None)
+            limit = min(MAX_FRAME_POINTS, cap) if cap else MAX_FRAME_POINTS
+            stride = max(1, -(-points // limit))
         acquired = {}
         for n in scope.supported_channels:
             ch = scope.get_channel(n)
             if ch is not None and _safe(lambda: ch.enabled, default=False):
-                data = scope.get_waveform(n, provenance=False)
+                data = scope.get_waveform(n, provenance=False, stride=stride)
                 acquired["C{0}".format(n)] = data
                 publish(_decimate_frame(n, data.time, data.voltage))
+                self._published_a_frame = True
         shown_now = set()
         for label, math in (("M1", scope.math1), ("M2", scope.math2)):
             result = None

--- a/scpi_control/server/adapters.py
+++ b/scpi_control/server/adapters.py
@@ -49,9 +49,12 @@ def _safe(fn, default=None, label=None, state=None):
     interval, logging every tick of a persistent failure would write four
     lines a second and bury everything else in the log. A success->failure
     transition logs one WARNING naming the operation; a failure->success
-    transition logs one recovery record, so a reader can tell an outage in
-    the log actually ended. Steady state -- repeated failures, or repeated
-    successes -- logs nothing.
+    transition logs one recovery WARNING (same level, deliberately -- an
+    operator or alert filtering at WARNING must see the outage both begin
+    and end, or the log is exactly as ambiguous as before this fix for that
+    reader), with distinguishable wording so the two can be told apart at a
+    glance. Steady state -- repeated failures, or repeated successes -- logs
+    nothing.
     """
     try:
         result = fn()
@@ -67,7 +70,13 @@ def _safe(fn, default=None, label=None, state=None):
         return default
     if label is not None and state is not None:
         if state.get(label) is False:
-            logger.info("poll query recovered: %s", label)
+            # Also WARNING, not a quieter level: this is the other half of a
+            # matched pair with the failure log above, not "good news" logged
+            # for its own sake. An operator or alert filtering at WARNING --
+            # which is the level the failure logs at -- must see the outage
+            # both begin AND end, or the log is exactly as ambiguous as before
+            # this fix for anyone reading at that level.
+            logger.warning("poll query recovered, no longer degrading to a default: %s", label)
         state[label] = True
     return result
 

--- a/scpi_control/server/adapters.py
+++ b/scpi_control/server/adapters.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from scpi_control import FunctionGenerator, Oscilloscope, PowerSupply
 from scpi_control.connection.mock import MockConnection
-from scpi_control.exceptions import InvalidParameterError, SiglentError
+from scpi_control.exceptions import InvalidParameterError, MeasurementUnavailableError, SiglentError
 from scpi_control.server import compute
 from scpi_control.server.netpolicy import validate_target
 from scpi_control.server.recorder import TrendRecorder
@@ -58,6 +58,15 @@ def _safe(fn, default=None, label=None, state=None):
     """
     try:
         result = fn()
+    except MeasurementUnavailableError:
+        # NOT a failure, so it must not enter the health/transition machinery
+        # below: the instrument answered, it simply has no value for that item
+        # yet ("****" on a modern Siglent). Logging it as "poll query failed"
+        # put a routine, transient condition in the log at WARNING and marked
+        # the operation unhealthy, so the eventual real reading logged a
+        # spurious "recovered" to match. The value still degrades to `default`,
+        # which the UI already renders as an unreadable field.
+        return default
     except SiglentError:
         # SiglentError only, deliberately: the one caller that could raise a
         # ValueError through here (Oscilloscope.record_length(), which parses

--- a/scpi_control/server/adapters.py
+++ b/scpi_control/server/adapters.py
@@ -238,7 +238,15 @@ class ScopeAdapter(InstrumentAdapter):
         # never be treated as False, or the live view dies on every
         # non-Siglent scope.
         health = self._poll_health
-        ready = _safe(lambda: scope.new_acquisition_ready(), default=None, label="acquisition ready check", state=health)
+        # No label/state on the next three _safe calls, unlike the per-channel
+        # reads below: new_acquisition_ready()/record_length()/
+        # waveform_max_points() each catch their own query failure and return
+        # None (see oscilloscope.py), so _safe never sees an exception from
+        # them and its logging branch is unreachable. A label here would only
+        # promise a log line that can never be written. The bare _safe stays as
+        # the last-resort swallow that keeps the session heartbeat alive if one
+        # of them ever raises something unexpected.
+        ready = _safe(lambda: scope.new_acquisition_ready(), default=None)
         if ready is False and self._published_a_frame:
             return
         # Size the stride from the full record length, capped by whichever is
@@ -248,10 +256,10 @@ class ScopeAdapter(InstrumentAdapter):
         # and turn ModernTransfer's strided-read guard (FeatureNotSupportedError)
         # into a total live-view outage -- capping here makes that guard
         # unreachable by construction.
-        points = _safe(lambda: scope.record_length(), default=None, label="record length", state=health)
+        points = _safe(lambda: scope.record_length(), default=None)
         stride = None
         if points:
-            cap = _safe(lambda: scope.waveform_max_points(), default=None, label="waveform max points", state=health)
+            cap = _safe(lambda: scope.waveform_max_points(), default=None)
             limit = min(MAX_FRAME_POINTS, cap) if cap else MAX_FRAME_POINTS
             stride = max(1, -(-points // limit))
         acquired = {}

--- a/scpi_control/server/adapters.py
+++ b/scpi_control/server/adapters.py
@@ -58,12 +58,14 @@ def _safe(fn, default=None, label=None, state=None):
     """
     try:
         result = fn()
-    except (SiglentError, ValueError):
-        # ValueError alongside SiglentError: a couple of the callers wrapped
-        # here (Oscilloscope.record_length()/waveform_max_points()) parse a
-        # numeric response with int(float(...)), which raises ValueError on a
-        # malformed reply rather than a SiglentError. Either way, the poll
-        # tick is the session heartbeat and must degrade to `default`, not die.
+    except SiglentError:
+        # SiglentError only, deliberately: the one caller that could raise a
+        # ValueError through here (Oscilloscope.record_length(), which parses
+        # its reply with int(float(...))) now swallows that itself, like
+        # waveform_max_points() always did. Widening this to ValueError as
+        # well would silently absorb one from the three unlabelled read_state
+        # call sites too, turning probe_ratio/trigger.source into null instead
+        # of surfacing a genuine bug.
         if label is not None and state is not None and state.get(label) is not False:
             logger.warning("poll query failed, degrading to a default: %s", label)
             state[label] = False

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -241,6 +241,9 @@ async def get_measurements(session_id: str, request: Request):
     return {"measurements": [{"channel": c, "mtype": m} for c, m in session.adapter.measurements]}
 
 
+CSV_ROWS_PER_CHUNK = 2000
+
+
 def _build_csv(captures, max_points: Optional[int] = None):
     """Yield CSV lines lazily so the server never holds the whole body in memory.
 
@@ -253,6 +256,18 @@ def _build_csv(captures, max_points: Optional[int] = None):
     When max_points is None this reproduces the pre-streaming implementation's
     output byte-for-byte: joining the same rows with "\\n" and a single
     trailing newline is exactly what "\\n".join(rows) + "\\n" produced.
+
+    Rows are yielded in batches of CSV_ROWS_PER_CHUNK, not one per row.
+    Starlette wraps a sync iterator in iterate_in_threadpool, which awaits
+    anyio.to_thread.run_sync PER ITEM, and StreamingResponse sends one
+    http.response.body message PER ITEM -- so a 2,000,000-point export yielding
+    row by row would do 2M thread round-trips and 2M chunked frames, where the
+    pre-streaming code did one run_in_threadpool and one body. That is an
+    enormous throughput cost on exactly the deep records this endpoint's
+    memory bound exists for. Batching is byte-transparent: the concatenation
+    of the emitted strings is unchanged, which
+    tests/test_server_export_bounds.py::TestByteIdentity pins against a frozen
+    copy of the pre-streaming algorithm.
     """
     n = min(len(w.voltage) for _, w in captures)
     time_axis = captures[0][1].time
@@ -261,8 +276,14 @@ def _build_csv(captures, max_points: Optional[int] = None):
         step = -(-n // max_points)  # ceiling division keeps row count <= max_points
     header = "time_s," + ",".join("C{0}_V".format(c) for c, _ in captures)
     yield header + "\n"
+    buf: List[str] = []
     for i in range(0, n, step):
-        yield "{0:.9g},{1}\n".format(float(time_axis[i]), ",".join("{0:.9g}".format(float(w.voltage[i])) for _, w in captures))
+        buf.append("{0:.9g},{1}\n".format(float(time_axis[i]), ",".join("{0:.9g}".format(float(w.voltage[i])) for _, w in captures)))
+        if len(buf) >= CSV_ROWS_PER_CHUNK:
+            yield "".join(buf)
+            buf = []
+    if buf:
+        yield "".join(buf)
 
 
 @router.get("/sessions/{session_id}/scope/capture.csv")

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -1,11 +1,12 @@
 # scpi_control/server/api/scope.py
+import json
 from dataclasses import replace
 from datetime import datetime
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
-from fastapi.responses import PlainTextResponse, Response
+from fastapi.responses import PlainTextResponse, Response, StreamingResponse
 
 from scpi_control.exceptions import InvalidParameterError
 from scpi_control.server.api.commands import send_command_for
@@ -30,6 +31,64 @@ from scpi_control.server.schemas import (
 from scpi_control.server.sessions import InstrumentSession, SessionError, read_state
 
 router = APIRouter(tags=["scope"])
+
+# Safety rail against an export exhausting server memory, not a tuning knob --
+# no CLI flag or config file for this. A record above it is refused with 413
+# BEFORE it is fetched (see _export_stride); it is never silently decimated.
+MAX_EXPORT_POINTS = 2_000_000
+
+
+def _parse_channel_list(channels: str) -> List[int]:
+    try:
+        channel_list = sorted({int(c) for c in channels.split(",") if c.strip()})
+    except ValueError:
+        raise InvalidParameterError("channels must be a comma-separated list of integers")
+    if not channel_list:
+        raise InvalidParameterError("no channels requested")
+    return channel_list
+
+
+async def _export_stride(session, max_points: int) -> Optional[int]:
+    """Decide the fetch stride for an export, refusing an unbounded one before any fetch happens.
+
+    record_length() (:ACQuire:POINts?) is queried BEFORE get_waveform is ever
+    called, so an oversized record is refused before a single sample crosses
+    the wire -- never after building (or half-building) a response.
+
+    Returns None when no decimation is needed (or, on some dialects, possible):
+    record_length() returns None on dialects with no :ACQuire:POINts? mapping
+    (the legacy dialect is one -- see scpi_commands.py's LEGACY_COMMANDS,
+    which has no "get_acq_points" entry). There the record's size cannot be
+    verified before the fetch at all. This proceeds unstrided and unguarded on
+    those dialects, exactly as every export did before this task, rather than
+    refusing every legacy-dialect export outright -- that would be a blanket
+    regression for every user on those models, not a safety improvement, since
+    they would have no way to learn their own record size to work around it.
+    This is a disclosed, accepted gap (see task-8-report.md), not a silent
+    guess: an operator on an affected dialect gets no guard, same as today.
+
+    When decimation IS needed (an explicit max_points below the actual record
+    size), the stride is sized against whichever is smaller: the caller's own
+    max_points, or the instrument's own per-transfer cap (:WAVeform:MAXPoint?,
+    via waveform_max_points()) -- mirrors ScopeAdapter.poll's sizing
+    (server/adapters.py) so a strided export cannot trip ModernTransfer's
+    single-window ceiling (FeatureNotSupportedError) by construction, instead
+    of discovering that ceiling in production.
+    """
+    cap = max_points if max_points and max_points > 0 else None
+    total = await run_job(session, lambda scope: scope.record_length())
+    if total is None:
+        return None
+    if total > MAX_EXPORT_POINTS and (cap is None or cap > MAX_EXPORT_POINTS):
+        raise HTTPException(
+            status_code=413,
+            detail="record holds {0} points, exceeding MAX_EXPORT_POINTS ({1}); pass max_points={1} to proceed with a decimated export".format(total, MAX_EXPORT_POINTS),
+        )
+    if cap is None or total <= cap:
+        return None
+    transfer_cap = await run_job(session, lambda scope: scope.waveform_max_points())
+    limit = min(cap, transfer_cap) if transfer_cap else cap
+    return max(1, -(-total // limit))
 
 
 async def mutate(session: InstrumentSession, fn: Callable) -> dict:
@@ -133,35 +192,44 @@ async def get_measurements(session_id: str, request: Request):
     return {"measurements": [{"channel": c, "mtype": m} for c, m in session.adapter.measurements]}
 
 
-def _build_csv(captures) -> str:
-    """captures: list of (channel:int, WaveformData). Align to the shortest."""
+def _build_csv(captures, max_points: Optional[int] = None):
+    """Yield CSV lines lazily so the server never holds the whole body in memory.
+
+    captures: list of (channel:int, WaveformData). Align to the shortest.
+    max_points additionally decimates the emitted rows client-side, on top of
+    whatever the fetch stride already achieved -- a safety net for dialects
+    that ignore the stride argument outright (see _export_stride), so the
+    row count is capped regardless of dialect.
+
+    When max_points is None this reproduces the pre-streaming implementation's
+    output byte-for-byte: joining the same rows with "\\n" and a single
+    trailing newline is exactly what "\\n".join(rows) + "\\n" produced.
+    """
     n = min(len(w.voltage) for _, w in captures)
     time_axis = captures[0][1].time
+    step = 1
+    if max_points is not None and max_points > 0 and n > max_points:
+        step = -(-n // max_points)  # ceiling division keeps row count <= max_points
     header = "time_s," + ",".join("C{0}_V".format(c) for c, _ in captures)
-    rows = [header]
-    for i in range(n):
-        rows.append("{0:.9g},{1}".format(float(time_axis[i]), ",".join("{0:.9g}".format(float(w.voltage[i])) for _, w in captures)))
-    return "\n".join(rows) + "\n"
+    yield header + "\n"
+    for i in range(0, n, step):
+        yield "{0:.9g},{1}\n".format(float(time_axis[i]), ",".join("{0:.9g}".format(float(w.voltage[i])) for _, w in captures))
 
 
 @router.get("/sessions/{session_id}/scope/capture.csv")
-async def capture_csv(session_id: str, request: Request, channels: str = "1"):
+async def capture_csv(session_id: str, request: Request, channels: str = "1", max_points: int = 0):
     session = require_session(request, session_id)
     require_kind(session, "scope")
-    try:
-        channel_list = sorted({int(c) for c in channels.split(",") if c.strip()})
-    except ValueError:
-        raise InvalidParameterError("channels must be a comma-separated list of integers")
-    if not channel_list:
-        raise InvalidParameterError("no channels requested")
+    channel_list = _parse_channel_list(channels)
+    stride = await _export_stride(session, max_points)
+    cap = max_points if max_points > 0 else None
 
     def capture(scope):
-        return [(c, scope.get_waveform(c)) for c in channel_list]
+        return [(c, scope.get_waveform(c, stride=stride)) for c in channel_list]
 
     captures = await run_job(session, capture)
-    csv_text = await run_in_threadpool(_build_csv, captures)
     filename = "capture_{0}_C{1}.csv".format(session.id, "-".join(str(c) for c in channel_list))
-    return PlainTextResponse(csv_text, media_type="text/csv", headers={"Content-Disposition": 'attachment; filename="{0}"'.format(filename)})
+    return StreamingResponse(_build_csv(captures, cap), media_type="text/csv", headers={"Content-Disposition": 'attachment; filename="{0}"'.format(filename)})
 
 
 @router.get("/sessions/{session_id}/scope/screenshot.png")
@@ -182,8 +250,21 @@ async def screenshot(session_id: str, request: Request):
     return Response(content=png, media_type="image/png", headers={"Content-Disposition": 'attachment; filename="{0}"'.format(filename)})
 
 
-def _build_waveform_response(captures, max_points) -> dict:
-    return {"channels": [_waveform_json(c, data, max_points) for c, data in captures]}
+def _stream_waveform_json(captures, max_points):
+    """Yield the waveform JSON body incrementally, one channel at a time.
+
+    Each chunk's json.dumps() call covers exactly one channel's (already
+    capped) point list, so the server never assembles the full multi-channel
+    body as a single string. Content-equivalent to the pre-streaming dict
+    response (same keys, same values); unlike the CSV export, byte-for-byte
+    whitespace/order identity is not a requirement here.
+    """
+    yield '{"channels": ['
+    for i, (channel, data) in enumerate(captures):
+        if i:
+            yield ", "
+        yield json.dumps(_waveform_json(channel, data, max_points))
+    yield "]}"
 
 
 def _waveform_json(channel, data, max_points):
@@ -210,19 +291,15 @@ def _waveform_json(channel, data, max_points):
 async def waveform_json(session_id: str, request: Request, channels: str = "1", max_points: int = 0):
     session = require_session(request, session_id)
     require_kind(session, "scope")
-    try:
-        channel_list = sorted({int(c) for c in channels.split(",") if c.strip()})
-    except ValueError:
-        raise InvalidParameterError("channels must be a comma-separated list of integers")
-    if not channel_list:
-        raise InvalidParameterError("no channels requested")
+    channel_list = _parse_channel_list(channels)
+    stride = await _export_stride(session, max_points)
+    cap = max_points if max_points > 0 else None
 
     def capture(scope):
-        return [(c, scope.get_waveform(c)) for c in channel_list]
+        return [(c, scope.get_waveform(c, stride=stride)) for c in channel_list]
 
     captures = await run_job(session, capture)
-    cap = max_points if max_points > 0 else None
-    return await run_in_threadpool(_build_waveform_response, captures, cap)
+    return StreamingResponse(_stream_waveform_json(captures, cap), media_type="application/json")
 
 
 def _math_state(scope):

--- a/scpi_control/server/api/scope.py
+++ b/scpi_control/server/api/scope.py
@@ -1,14 +1,15 @@
 # scpi_control/server/api/scope.py
 import json
+import logging
 from dataclasses import replace
 from datetime import datetime
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Tuple
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import PlainTextResponse, Response, StreamingResponse
 
-from scpi_control.exceptions import InvalidParameterError
+from scpi_control.exceptions import FeatureNotSupportedError, InvalidParameterError
 from scpi_control.server.api.commands import send_command_for
 from scpi_control.server.api.sessions import require_kind, require_session, run_job
 from scpi_control.server.ownership import require_owner
@@ -30,6 +31,8 @@ from scpi_control.server.schemas import (
 )
 from scpi_control.server.sessions import InstrumentSession, SessionError, read_state
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(tags=["scope"])
 
 # Safety rail against an export exhausting server memory, not a tuning knob --
@@ -48,47 +51,93 @@ def _parse_channel_list(channels: str) -> List[int]:
     return channel_list
 
 
-async def _export_stride(session, max_points: int) -> Optional[int]:
+async def _export_stride(session, max_points: int) -> Tuple[Optional[int], bool]:
     """Decide the fetch stride for an export, refusing an unbounded one before any fetch happens.
 
     record_length() (:ACQuire:POINts?) is queried BEFORE get_waveform is ever
     called, so an oversized record is refused before a single sample crosses
     the wire -- never after building (or half-building) a response.
 
-    Returns None when no decimation is needed (or, on some dialects, possible):
-    record_length() returns None on dialects with no :ACQuire:POINts? mapping
-    (the legacy dialect is one -- see scpi_commands.py's LEGACY_COMMANDS,
-    which has no "get_acq_points" entry). There the record's size cannot be
-    verified before the fetch at all. This proceeds unstrided and unguarded on
-    those dialects, exactly as every export did before this task, rather than
-    refusing every legacy-dialect export outright -- that would be a blanket
-    regression for every user on those models, not a safety improvement, since
-    they would have no way to learn their own record size to work around it.
-    This is a disclosed, accepted gap (see task-8-report.md), not a silent
-    guess: an operator on an affected dialect gets no guard, same as today.
+    Returns (stride, size_verified). size_verified is False when
+    record_length() itself returned None -- dialects with no :ACQuire:POINts?
+    mapping (the legacy dialect is one -- see scpi_commands.py's
+    LEGACY_COMMANDS, which has no "get_acq_points" entry). There the record's
+    size cannot be verified before the fetch at all. This proceeds unstrided
+    and unguarded on those dialects, exactly as every export did before this
+    task, rather than refusing every legacy-dialect export outright -- that
+    would be a blanket regression for every user on those models, not a
+    safety improvement, since they would have no way to learn their own
+    record size to work around it. This is a disclosed, accepted gap, not a
+    silent guess -- callers use size_verified to log a post-fetch warning
+    when the eventual fetch turns out to have been oversized after all (see
+    _warn_if_export_was_unverifiable_and_oversized below), since prevention
+    is no longer possible once size_verified is False.
 
     When decimation IS needed (an explicit max_points below the actual record
     size), the stride is sized against whichever is smaller: the caller's own
     max_points, or the instrument's own per-transfer cap (:WAVeform:MAXPoint?,
     via waveform_max_points()) -- mirrors ScopeAdapter.poll's sizing
     (server/adapters.py) so a strided export cannot trip ModernTransfer's
-    single-window ceiling (FeatureNotSupportedError) by construction, instead
-    of discovering that ceiling in production.
+    single-window ceiling (FeatureNotSupportedError) by construction for a
+    *stable* record. record_length() and the later get_waveform() fetch are
+    two separate run_job calls with nothing holding the record between them,
+    so a record that grows in that window can still trip the real ceiling --
+    callers must catch FeatureNotSupportedError around the fetch and turn it
+    into a 413 rather than let it become an uncaught 500 (see
+    _reraise_transfer_cap_trip_as_413 below).
     """
     cap = max_points if max_points and max_points > 0 else None
     total = await run_job(session, lambda scope: scope.record_length())
     if total is None:
-        return None
+        return None, False
     if total > MAX_EXPORT_POINTS and (cap is None or cap > MAX_EXPORT_POINTS):
         raise HTTPException(
             status_code=413,
             detail="record holds {0} points, exceeding MAX_EXPORT_POINTS ({1}); pass max_points={1} to proceed with a decimated export".format(total, MAX_EXPORT_POINTS),
         )
     if cap is None or total <= cap:
-        return None
+        return None, True
     transfer_cap = await run_job(session, lambda scope: scope.waveform_max_points())
     limit = min(cap, transfer_cap) if transfer_cap else cap
-    return max(1, -(-total // limit))
+    return max(1, -(-total // limit)), True
+
+
+def _warn_if_export_was_unverifiable_and_oversized(captures, size_verified: bool) -> None:
+    """Log once the fetch's actual size is known, on a dialect that could not
+    verify it in advance (record_length() returned None -- size_verified is
+    False). Prevention is impossible at this point: the array is already in
+    memory. But an operator whose gateway runs out of memory deserves a log
+    line explaining why, not silence -- silent degradation on this branch has
+    already cost an hour of diagnosis once (Task 6).
+    """
+    if size_verified:
+        return
+    for channel, data in captures:
+        n = len(data.voltage)
+        if n > MAX_EXPORT_POINTS:
+            logger.warning(
+                "export fetched %d points on channel %s, exceeding MAX_EXPORT_POINTS (%d); "
+                "this dialect could not report record_length() in advance, so the size could not be checked before the fetch",
+                n,
+                channel,
+                MAX_EXPORT_POINTS,
+            )
+
+
+def _reraise_transfer_cap_trip_as_413(exc: FeatureNotSupportedError) -> HTTPException:
+    """Translate a strided fetch's single-window ceiling trip into a 413.
+
+    FeatureNotSupportedError subclasses SiglentError, which the app-level
+    handler maps to a plain 500 -- indistinguishable from an unrelated
+    instrument fault, and not machine-actionable the way the oversized-record
+    413 above is. This keeps both refusals on the same status: "this export
+    is too big, here is what would work," not two different statuses for the
+    same operator-facing problem.
+    """
+    return HTTPException(
+        status_code=413,
+        detail="export exceeded this instrument's per-transfer capability while fetching ({0}); pass a smaller max_points and retry".format(exc),
+    )
 
 
 async def mutate(session: InstrumentSession, fn: Callable) -> dict:
@@ -221,13 +270,17 @@ async def capture_csv(session_id: str, request: Request, channels: str = "1", ma
     session = require_session(request, session_id)
     require_kind(session, "scope")
     channel_list = _parse_channel_list(channels)
-    stride = await _export_stride(session, max_points)
+    stride, size_verified = await _export_stride(session, max_points)
     cap = max_points if max_points > 0 else None
 
     def capture(scope):
         return [(c, scope.get_waveform(c, stride=stride)) for c in channel_list]
 
-    captures = await run_job(session, capture)
+    try:
+        captures = await run_job(session, capture)
+    except FeatureNotSupportedError as exc:
+        raise _reraise_transfer_cap_trip_as_413(exc) from exc
+    _warn_if_export_was_unverifiable_and_oversized(captures, size_verified)
     filename = "capture_{0}_C{1}.csv".format(session.id, "-".join(str(c) for c in channel_list))
     return StreamingResponse(_build_csv(captures, cap), media_type="text/csv", headers={"Content-Disposition": 'attachment; filename="{0}"'.format(filename)})
 
@@ -292,13 +345,17 @@ async def waveform_json(session_id: str, request: Request, channels: str = "1", 
     session = require_session(request, session_id)
     require_kind(session, "scope")
     channel_list = _parse_channel_list(channels)
-    stride = await _export_stride(session, max_points)
+    stride, size_verified = await _export_stride(session, max_points)
     cap = max_points if max_points > 0 else None
 
     def capture(scope):
         return [(c, scope.get_waveform(c, stride=stride)) for c in channel_list]
 
-    captures = await run_job(session, capture)
+    try:
+        captures = await run_job(session, capture)
+    except FeatureNotSupportedError as exc:
+        raise _reraise_transfer_cap_trip_as_413(exc) from exc
+    _warn_if_export_was_unverifiable_and_oversized(captures, size_verified)
     return StreamingResponse(_stream_waveform_json(captures, cap), media_type="application/json")
 
 

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -13,7 +13,7 @@ import uuid
 from collections import Counter
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeoutError
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from scpi_control.exceptions import SiglentConnectionError, SiglentError
 
@@ -57,6 +57,16 @@ class InstrumentSession:
         self._subscribers: List[Callable[[Dict[str, Any]], None]] = []
         self._subscribers_lock = threading.Lock()
         self._poll_count = 0
+        # Adaptive backoff (belt and braces beside the adapter's readiness
+        # gate): a tick's own measured duration becomes a floor on how soon
+        # the *next* one may start, so a gate that ever misreports still
+        # degrades to a lower poll rate instead of piling up back-to-back
+        # blocking reads the moment the scope catches up. `poll_log` is a
+        # test seam (see _poll_if_due) recording (tick_number, duration) for
+        # every tick actually run.
+        self._last_poll_duration = 0.0
+        self._next_poll_at = 0.0
+        self.poll_log: List[Tuple[int, float]] = []
         self.owner = ""
         self.owner_last_active = time.monotonic()
         # Live stream watchers, keyed by identity (not by "is this the
@@ -277,7 +287,7 @@ class InstrumentSession:
             try:
                 item = self._queue.get(timeout=self._poll_interval)
             except queue.Empty:
-                self._poll_tick()
+                self._poll_if_due()
                 continue
             if item is _STOP:
                 break
@@ -313,6 +323,30 @@ class InstrumentSession:
             self.adapter.close(self._instrument)
         except SiglentError:
             pass
+
+    def _poll_if_due(self) -> None:
+        """Run `_poll_tick`, but not sooner than `max(poll_interval, last_poll_duration)`
+        after the previous one started.
+
+        The adapter's readiness gate (ScopeAdapter.poll) is what keeps a tick
+        cheap in the common case by never starting a blocking read that
+        isn't needed yet. This is the fallback for when that gate is wrong or
+        unavailable: if a tick genuinely takes longer than `poll_interval`
+        (a real blocking waveform read on a slow acquisition), the next tick
+        is not scheduled until that same duration has elapsed, so a slow
+        scope settles into a lower poll rate instead of queuing up another
+        tick attempt -- and the blocking read that goes with it -- the
+        instant the worker is free again.
+        """
+        now = time.monotonic()
+        if now < self._next_poll_at:
+            return
+        self._poll_tick()
+        end = time.monotonic()
+        duration = end - now
+        self._last_poll_duration = duration
+        self.poll_log.append((self._poll_count, duration))
+        self._next_poll_at = end + max(self._poll_interval, duration)
 
     def _poll_tick(self) -> None:
         with self._subscribers_lock:

--- a/scpi_control/server/sessions.py
+++ b/scpi_control/server/sessions.py
@@ -13,7 +13,7 @@ import uuid
 from collections import Counter
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeoutError
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional
 
 from scpi_control.exceptions import SiglentConnectionError, SiglentError
 
@@ -61,12 +61,9 @@ class InstrumentSession:
         # gate): a tick's own measured duration becomes a floor on how soon
         # the *next* one may start, so a gate that ever misreports still
         # degrades to a lower poll rate instead of piling up back-to-back
-        # blocking reads the moment the scope catches up. `poll_log` is a
-        # test seam (see _poll_if_due) recording (tick_number, duration) for
-        # every tick actually run.
+        # blocking reads the moment the scope catches up.
         self._last_poll_duration = 0.0
         self._next_poll_at = 0.0
-        self.poll_log: List[Tuple[int, float]] = []
         self.owner = ""
         self.owner_last_active = time.monotonic()
         # Live stream watchers, keyed by identity (not by "is this the
@@ -343,10 +340,8 @@ class InstrumentSession:
             return
         self._poll_tick()
         end = time.monotonic()
-        duration = end - now
-        self._last_poll_duration = duration
-        self.poll_log.append((self._poll_count, duration))
-        self._next_poll_at = end + max(self._poll_interval, duration)
+        self._last_poll_duration = end - now
+        self._next_poll_at = end + max(self._poll_interval, self._last_poll_duration)
 
     def _poll_tick(self) -> None:
         with self._subscribers_lock:

--- a/scpi_control/waveform.py
+++ b/scpi_control/waveform.py
@@ -133,7 +133,7 @@ class Waveform:
         """Wire dialect of the parent scope; defaults to legacy before connect."""
         return getattr(self._scope, "dialect", None) or "legacy"
 
-    def acquire(self, channel: int, format: str = "BYTE", provenance: bool = True) -> WaveformData:
+    def acquire(self, channel: int, format: str = "BYTE", provenance: bool = True, stride: Optional[int] = None) -> WaveformData:
         """Acquire waveform data from a channel.
 
         Args:
@@ -141,6 +141,9 @@ class Waveform:
             format: Data format - 'BYTE' or 'WORD' (default: 'BYTE')
             provenance: Snapshot instrument settings alongside the data
                 (default True; pass False on high-rate paths)
+            stride: Forwarded to the transfer's acquire() -- see
+                Oscilloscope.get_waveform for why None still writes 1 rather
+                than skipping the write.
 
         Returns:
             WaveformData object with time and voltage arrays
@@ -155,7 +158,7 @@ class Waveform:
 
         from scpi_control.waveform_transfer import make_transfer
 
-        data = make_transfer(self._scope).acquire(channel, format)
+        data = make_transfer(self._scope).acquire(channel, format, stride=stride)
         if provenance:
             try:
                 data.provenance = AcquisitionProvenance.from_scope(self._scope, channels=[channel])

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -612,13 +612,21 @@ class ModernTransfer:
 
         dtype = np.int16 if meta["comm_type"] == 1 else np.int8
         # wave_array_count (WAVEDESC address 116-119, p.756) is "Number of
-        # data points in the data array". ASSUMPTION (Task 3 stride
-        # follow-up, not yet confirmed against real hardware): when stride >
-        # 1, this is the STRIDED count, not the full record's -- see the
-        # mock's build_waveform_preamble docstring for why. It is still the
-        # FULL record when stride == 1, even when a single :WAVeform:DATA?
-        # transfer cannot carry all of it at once.
+        # data points in the data array" -- the FULL record, at EVERY stride.
+        # Measured on a real SDS824X HD (fw 3.8.12.1.1.3.6) 2026-07-30: with
+        # ACQ:POINts=50000 it reported 50000 at :WAVeform:INTerval 1, 2, 7 and
+        # 10 alike, while DATA? returned 50000/25000/7142/5000. This reverses
+        # the earlier assumption (that it reported the strided count), which
+        # the mock carried too; both changed together, as that assumption's
+        # own note said they would if hardware disagreed.
+        #
+        # WAVE_ARRAY_1 (addr 60) is NOT a substitute: the guide (p.755) calls
+        # it "the number of transmitted bytes" but the instrument leaves it at
+        # the full count as well. Nothing in the preamble reports what DATA?
+        # will actually send, so it has to be computed -- by FLOOR division
+        # (50000/7 -> 7142, not 7143).
         record_length = meta["wave_array_count"]
+        expected_points = record_length // effective_stride
 
         # :WAVeform:MAXPoint? (p.753) is Query-only: the scope reports its own
         # per-transfer cap, there is no setter. int(float(...)) matches this
@@ -670,17 +678,40 @@ class ModernTransfer:
             # is always <= MAX_FRAME_POINTS, far below any real MAXPoint, so a
             # single window covers every case it actually needs; a strided read
             # that would not fit raises instead of mis-assembling.
-            if record_length > max_points:
+            #
+            # The cap applies to what CROSSES THE WIRE, so it is compared
+            # against expected_points (the decimated count), not against the
+            # full record -- decimation is precisely what brings a deep record
+            # under the cap, and comparing the full record here would refuse
+            # reads that fit with room to spare.
+            if expected_points > max_points:
                 raise exceptions.FeatureNotSupportedError(
-                    f"Strided read of {record_length} points (stride={effective_stride}) exceeds "
-                    f"this instrument's per-transfer cap of {max_points} points (:WAVeform:MAXPoint?); "
-                    f"multi-window strided reads are not supported ({data_context})"
+                    f"Strided read of {expected_points} points ({record_length} at stride="
+                    f"{effective_stride}) exceeds this instrument's per-transfer cap of "
+                    f"{max_points} points (:WAVeform:MAXPoint?); multi-window strided reads "
+                    f"are not supported ({data_context})"
                 )
             with scope._connection.lock:
                 scope.write(scope._get_command("set_waveform_start", value=0))
                 scope.write(scope._get_command("get_waveform_data"))
                 data_raw = scope.read_raw()
             codes = parse_ieee_block(data_raw, dtype, error_context=data_context)
+
+            # A short window here is the one failure that would otherwise be
+            # INVISIBLE. Unlike the stride==1 branch nothing loops to collect a
+            # remainder, and the time axis below is sized off whatever did
+            # arrive -- so a truncated record comes back looking perfectly
+            # well-formed, just quietly missing its tail. Nothing in the
+            # preamble reports the transmitted count (see expected_points
+            # above), which is exactly why this has to be checked rather than
+            # read back.
+            if codes.size < expected_points:
+                raise exceptions.CommandError(
+                    f"Strided read returned {codes.size} points, but a {record_length}-point "
+                    f"record at stride {effective_stride} should deliver {expected_points}; "
+                    f"refusing to scale a truncated record into a time axis that would look "
+                    f"correct ({data_context})"
+                )
 
         # SDS Series Programming Guide EN11G p.758 ("Read Waveform Data",
         # analog example, Step 3): "voltage value (V) = code value
@@ -709,17 +740,32 @@ class ModernTransfer:
         # example (delay=1.72E-8, timebase=20E-9, interval=2E-10): the
         # documented first-point time is -8.28E-08 s, which only the
         # delay-(timebase*grid/2) form reproduces.
+        #
+        # HORIZ_INTERVAL is the ACQUISITION's sample spacing and does NOT
+        # track :WAVeform:INTerval -- measured constant at 1.0e-08 across
+        # strides 1/2/7/10 on a real SDS824X HD (see the record_length note
+        # above). Delivered points are therefore `stride` samples apart, and
+        # the spacing between them is horiz_interval * stride. Using
+        # horiz_interval unscaled compresses the trace into 1/stride of the
+        # real sweep: at stride 7 a live frame claimed 7.14e-5 s of a 5.0e-4 s
+        # window, an x-axis wrong by 7x on every thinned frame while looking
+        # entirely well-formed.
         grid = 10
         timebase = scope.waveform._get_timebase()
         n = len(codes)
-        time = meta["horiz_offset"] - (timebase * grid / 2) + np.arange(n) * meta["horiz_interval"]
+        point_interval = meta["horiz_interval"] * effective_stride
+        time = meta["horiz_offset"] - (timebase * grid / 2) + np.arange(n) * point_interval
 
         logger.info(f"Acquired {n} samples from channel {channel} (modern)")
         return WaveformData(
             time=time,
             voltage=voltage,
             channel=channel,
-            sample_rate=(1.0 / meta["horiz_interval"]) if meta["horiz_interval"] else None,
+            # The EFFECTIVE rate of the trace being returned (1/stride of the
+            # acquisition rate on a decimated read), not the acquisition rate
+            # -- this is what a consumer needs to reconstruct `time`, and what
+            # any FFT or frequency-axis built from it depends on.
+            sample_rate=(1.0 / point_interval) if point_interval else None,
             record_length=n,
             timebase=timebase,
             voltage_scale=meta["vertical_gain"],

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -389,6 +389,7 @@ class LeCroyTransfer:
 # dialects must stay independently editable (Task 15 vs Task 18).
 _MODERN_COMM_TYPE = 32  # short: 0=byte, 1=word
 _MODERN_WAVE_ARRAY_COUNT = 116  # long: number of data points
+_MODERN_DATA_INTERVAL = 136  # long: = :WAVeform:INTerval, echoed back (p.755)
 _MODERN_VERTICAL_GAIN = 156  # float: V/div, no probe attenuation
 _MODERN_VERTICAL_OFFSET = 160  # float
 _MODERN_CODE_PER_DIV = 164  # float
@@ -414,6 +415,10 @@ def parse_modern_wavedesc(payload: bytes, *, error_context: str = "") -> dict:
     return {
         "comm_type": struct.unpack_from("<h", payload, _MODERN_COMM_TYPE)[0],
         "wave_array_count": struct.unpack_from("<i", payload, _MODERN_WAVE_ARRAY_COUNT)[0],
+        # Echoed back purely so acquire() can cross-check it against the
+        # stride it actually requested -- see the DATA_INTERVAL mismatch
+        # warning below. Not otherwise used to scale anything.
+        "data_interval": struct.unpack_from("<i", payload, _MODERN_DATA_INTERVAL)[0],
         "vertical_gain": struct.unpack_from("<f", payload, _MODERN_VERTICAL_GAIN)[0],
         "vertical_offset": struct.unpack_from("<f", payload, _MODERN_VERTICAL_OFFSET)[0],
         "code_per_div": struct.unpack_from("<f", payload, _MODERN_CODE_PER_DIV)[0],
@@ -435,6 +440,17 @@ class ModernTransfer:
     is capped at :WAVeform:MAXPoint points; acquire() below reads the
     PREamble's wave_array_count (the FULL record length) and loops
     :WAVeform:STARt in MAXPoint-sized windows until the whole record is read.
+
+    Task 3 stride follow-up: that STARt-driven loop is only correct when
+    stride is 1 (`start` is advanced by the count of points already
+    delivered, which is the same space as :WAVeform:STARt only when nothing
+    is being decimated). A stride > 1 therefore takes a DIFFERENT, narrower
+    path below: a single, unlooped window sized to the (already strided)
+    record length, since the live view's <= MAX_FRAME_POINTS request is far
+    below any real :WAVeform:MAXPoint. If a strided record ever needed more
+    than one window, acquire() raises rather than mis-assemble it -- the
+    general chunking loop is deliberately NOT made stride-aware, so the
+    proven stride=1/export path is untouched.
     """
 
     def __init__(self, scope: "Oscilloscope"):
@@ -467,12 +483,19 @@ class ModernTransfer:
             entire record_length, not just the first window.
 
         Raises:
-            InvalidParameterError: If a non-BYTE/WORD format is requested.
+            InvalidParameterError: If a non-BYTE/WORD format is requested, or
+                stride is not a positive integer.
             CommandError: If either binary block is malformed.
+            FeatureNotSupportedError: If a stride > 1 would need more than one
+                :WAVeform:DATA? window (see the class docstring) -- this is a
+                loud refusal rather than a silently mis-assembled read.
         """
         format = format.upper()
         if format not in ("BYTE", "WORD"):
             raise exceptions.InvalidParameterError(f"Invalid format: {format}")
+        if stride is not None and stride < 1:
+            raise exceptions.InvalidParameterError(f"stride must be a positive integer (got {stride})")
+        effective_stride = stride or 1
         scope = self._scope
 
         # Source (and width) must be selected before PREamble?/DATA? read
@@ -486,8 +509,12 @@ class ModernTransfer:
             # above on interval being instrument state rather than a
             # per-request argument. Guarded so a future dialect without the
             # command (were one ever routed through ModernTransfer) is
-            # unaffected rather than raising KeyError.
-            scope.write(scope._get_command("set_waveform_interval", value=int(stride or 1)))
+            # unaffected rather than raising KeyError. Written BEFORE the
+            # PREamble? read below -- load-bearing, not incidental: the
+            # preamble must be read back under the interval this call asked
+            # for, not whatever a previous caller (e.g. the live view) left
+            # set, or that stride would leak into this read.
+            scope.write(scope._get_command("set_waveform_interval", value=effective_stride))
 
         with scope._connection.lock:
             scope.write(scope._get_command("get_waveform_preamble"))
@@ -499,10 +526,28 @@ class ModernTransfer:
         if meta["code_per_div"] == 0:
             raise exceptions.CommandError(f"Modern WAVEDESC code_per_div is 0 ({preamble_context})")
 
+        # The one thing code cannot settle: whether a real instrument's
+        # DATA_INTERVAL echo (and therefore its HORIZ_INTERVAL scaling, used
+        # below for the time axis) actually reflects the stride we requested.
+        # A mismatch must not be invisible -- log it, but don't raise; a
+        # disagreement here is a scaling risk, not a malformed read.
+        if meta["data_interval"] != effective_stride:
+            logger.warning(
+                "Requested :WAVeform:INTerval %d but PREamble reported DATA_INTERVAL %d (host %s:%s) -- the returned record length/time axis may not be scaled the way this driver assumes.",
+                effective_stride,
+                meta["data_interval"],
+                scope.host,
+                scope.port,
+            )
+
         dtype = np.int16 if meta["comm_type"] == 1 else np.int8
         # wave_array_count (WAVEDESC address 116-119, p.756) is "Number of
-        # data points in the data array" -- the FULL record, even when a
-        # single :WAVeform:DATA? transfer cannot carry all of it at once.
+        # data points in the data array". ASSUMPTION (Task 3 stride
+        # follow-up, not yet confirmed against real hardware): when stride >
+        # 1, this is the STRIDED count, not the full record's -- see the
+        # mock's build_waveform_preamble docstring for why. It is still the
+        # FULL record when stride == 1, even when a single :WAVeform:DATA?
+        # transfer cannot carry all of it at once.
         record_length = meta["wave_array_count"]
 
         # :WAVeform:MAXPoint? (p.753) is Query-only: the scope reports its own
@@ -516,29 +561,56 @@ class ModernTransfer:
             max_points = max(record_length, 1)
 
         data_context = f"host {scope.host}:{scope.port}, command ':WAVeform:DATA?'"
-        chunks = []
-        start = 0
-        while start < record_length:
-            # STARt and DATA? are coupled (DATA? answers "using the source
-            # specified by :WAVeform:SOURce" AND the current STARt window),
-            # so both live under one lock acquisition -- same reasoning as
-            # the preamble read above, extended to cover the write that picks
-            # which window DATA? answers with.
+
+        if effective_stride == 1:
+            # The proven export path: completely unchanged from before
+            # stride existed.
+            chunks = []
+            start = 0
+            while start < record_length:
+                # STARt and DATA? are coupled (DATA? answers "using the source
+                # specified by :WAVeform:SOURce" AND the current STARt window),
+                # so both live under one lock acquisition -- same reasoning as
+                # the preamble read above, extended to cover the write that picks
+                # which window DATA? answers with.
+                with scope._connection.lock:
+                    scope.write(scope._get_command("set_waveform_start", value=start))
+                    scope.write(scope._get_command("get_waveform_data"))
+                    data_raw = scope.read_raw()
+                chunk = parse_ieee_block(data_raw, dtype, error_context=data_context)
+                if chunk.size == 0:
+                    # A well-behaved instrument only returns an empty window at
+                    # end-of-record, which the `while` condition above already
+                    # excludes -- this guards against a non-conformant one
+                    # instead of looping forever.
+                    break
+                chunks.append(chunk)
+                start += chunk.size
+
+            codes = np.concatenate(chunks) if chunks else np.array([], dtype=dtype)
+        else:
+            # Deliberately NOT the general chunking loop, and deliberately not
+            # made stride-aware: `start` there is advanced by chunk.size (points
+            # already delivered, in the STRIDED/transmitted space) but written
+            # to :WAVeform:STARt and compared against record_length -- the same
+            # space as chunk.size only when stride is 1. Beyond one window, a
+            # second iteration would re-request source points the first window
+            # already delivered, silently duplicating a stretch of the record
+            # (and building `time` over the wrong `n`). The live view's request
+            # is always <= MAX_FRAME_POINTS, far below any real MAXPoint, so a
+            # single window covers every case it actually needs; a strided read
+            # that would not fit raises instead of mis-assembling.
+            if record_length > max_points:
+                raise exceptions.FeatureNotSupportedError(
+                    f"Strided read of {record_length} points (stride={effective_stride}) exceeds "
+                    f"this instrument's per-transfer cap of {max_points} points (:WAVeform:MAXPoint?); "
+                    f"multi-window strided reads are not supported ({data_context})"
+                )
             with scope._connection.lock:
-                scope.write(scope._get_command("set_waveform_start", value=start))
+                scope.write(scope._get_command("set_waveform_start", value=0))
                 scope.write(scope._get_command("get_waveform_data"))
                 data_raw = scope.read_raw()
-            chunk = parse_ieee_block(data_raw, dtype, error_context=data_context)
-            if chunk.size == 0:
-                # A well-behaved instrument only returns an empty window at
-                # end-of-record, which the `while` condition above already
-                # excludes -- this guards against a non-conformant one
-                # instead of looping forever.
-                break
-            chunks.append(chunk)
-            start += chunk.size
-
-        codes = np.concatenate(chunks) if chunks else np.array([], dtype=dtype)
+            codes = parse_ieee_block(data_raw, dtype, error_context=data_context)
 
         # SDS Series Programming Guide EN11G p.758 ("Read Waveform Data",
         # analog example, Step 3): "voltage value (V) = code value

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -682,6 +682,34 @@ class ModernTransfer:
                 data_raw = scope.read_raw()
             codes = parse_ieee_block(data_raw, dtype, error_context=data_context)
 
+            # A short window here is the one failure that would otherwise be
+            # INVISIBLE. Unlike the stride==1 branch above, nothing loops to
+            # collect a remainder, and `n = len(codes)` below sizes the time
+            # axis off whatever did arrive -- so a truncated record comes back
+            # looking perfectly well-formed, just quietly missing its tail.
+            # Nothing in this driver writes :WAVeform:POINt, but it is
+            # instrument state like :WAVeform:INTerval, and another program on
+            # the same scope (EasyScopeX, a colleague's LabVIEW driver) can
+            # leave it small. Same principle as the interval write above: this
+            # read verifies the state it depends on rather than trusting it.
+            #
+            # CAUTION: this compares against wave_array_count, which is only
+            # the STRIDED count under the p.756 assumption flagged at
+            # `record_length` above -- still unconfirmed on real hardware. If
+            # a real instrument instead reports the FULL record here, this
+            # raises on every strided frame (a live-view outage, the failure
+            # mode waveform_max_points() warns about) rather than on the
+            # truncation it is meant to catch. That is the FIRST thing to
+            # check against the scope if the live view starts refusing.
+            if codes.size < record_length:
+                raise exceptions.CommandError(
+                    f"Strided read returned {codes.size} points but the preamble's "
+                    f"WAVE_ARRAY_COUNT says {record_length} (stride={effective_stride}); "
+                    f"a :WAVeform:POINt window cap left set by another program is the "
+                    f"likeliest cause -- refusing to scale a truncated record into a "
+                    f"time axis that would look correct ({data_context})"
+                )
+
         # SDS Series Programming Guide EN11G p.758 ("Read Waveform Data",
         # analog example, Step 3): "voltage value (V) = code value
         # *(vdiv /code_per_div) - voffset". vdiv/voffset/code_per_div are the

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -682,34 +682,6 @@ class ModernTransfer:
                 data_raw = scope.read_raw()
             codes = parse_ieee_block(data_raw, dtype, error_context=data_context)
 
-            # A short window here is the one failure that would otherwise be
-            # INVISIBLE. Unlike the stride==1 branch above, nothing loops to
-            # collect a remainder, and `n = len(codes)` below sizes the time
-            # axis off whatever did arrive -- so a truncated record comes back
-            # looking perfectly well-formed, just quietly missing its tail.
-            # Nothing in this driver writes :WAVeform:POINt, but it is
-            # instrument state like :WAVeform:INTerval, and another program on
-            # the same scope (EasyScopeX, a colleague's LabVIEW driver) can
-            # leave it small. Same principle as the interval write above: this
-            # read verifies the state it depends on rather than trusting it.
-            #
-            # CAUTION: this compares against wave_array_count, which is only
-            # the STRIDED count under the p.756 assumption flagged at
-            # `record_length` above -- still unconfirmed on real hardware. If
-            # a real instrument instead reports the FULL record here, this
-            # raises on every strided frame (a live-view outage, the failure
-            # mode waveform_max_points() warns about) rather than on the
-            # truncation it is meant to catch. That is the FIRST thing to
-            # check against the scope if the live view starts refusing.
-            if codes.size < record_length:
-                raise exceptions.CommandError(
-                    f"Strided read returned {codes.size} points but the preamble's "
-                    f"WAVE_ARRAY_COUNT says {record_length} (stride={effective_stride}); "
-                    f"a :WAVeform:POINt window cap left set by another program is the "
-                    f"likeliest cause -- refusing to scale a truncated record into a "
-                    f"time axis that would look correct ({data_context})"
-                )
-
         # SDS Series Programming Guide EN11G p.758 ("Read Waveform Data",
         # analog example, Step 3): "voltage value (V) = code value
         # *(vdiv /code_per_div) - voffset". vdiv/voffset/code_per_div are the

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -438,8 +438,10 @@ def _note_data_interval_mismatch(scope: "Oscilloscope", channel: int, requested:
     so logging every call would write one WARNING per frame, indefinitely, at
     up to four frames a second if real hardware's echo disagreed persistently.
     Same discipline as the poll-path fix in server/adapters.py: one WARNING
-    when the mismatch starts, one recovery record when it stops, nothing
-    while it persists.
+    when the mismatch starts, one recovery WARNING when it stops (same level,
+    deliberately -- an operator or alert filtering at WARNING must see the
+    disagreement both start AND clear, or the log is exactly as ambiguous as
+    it was before this fix for that reader), nothing while it persists.
 
     State is stored ON THE SCOPE INSTANCE, keyed by channel, rather than on
     `self` of the calling Transfer: make_transfer() builds a brand new
@@ -449,6 +451,13 @@ def _note_data_interval_mismatch(scope: "Oscilloscope", channel: int, requested:
     long, and keying by channel keeps a mismatching channel 1 and a healthy
     channel 2 from flapping each other's state.
     """
+    # Sets `scope._data_interval_mismatch_state` (a private dict, keyed by
+    # channel) on the Oscilloscope instance passed in as `scope` -- an
+    # attribute this module injects rather than one declared in
+    # Oscilloscope.__init__. It has to live somewhere that outlives a single
+    # acquire() call, and the ModernTransfer instance calling this function
+    # does not (see the docstring above); the scope instance is the only
+    # object here that does.
     state = getattr(scope, _DATA_INTERVAL_STATE_ATTR, None)
     if state is None:
         state = {}
@@ -465,8 +474,8 @@ def _note_data_interval_mismatch(scope: "Oscilloscope", channel: int, requested:
             channel,
         )
     elif not mismatched and was_mismatched:
-        logger.info(
-            "DATA_INTERVAL now matches the requested :WAVeform:INTerval %d again (host %s:%s, channel %d) -- the prior mismatch warning has cleared.",
+        logger.warning(
+            "DATA_INTERVAL now matches the requested :WAVeform:INTerval %d again (host %s:%s, channel %d) -- the prior mismatch has cleared.",
             requested,
             scope.host,
             scope.port,

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -576,6 +576,17 @@ class ModernTransfer:
             # preamble must be read back under the interval this call asked
             # for, not whatever a previous caller (e.g. the live view) left
             # set, or that stride would leak into this read.
+            #
+            # DO NOT "optimize" this to skip the write when the value hasn't
+            # changed, or when stride is None -- that reintroduces the exact
+            # leak this comment warns about, silently. The guard is
+            # tests/test_oscilloscope_waveform_stride.py::
+            # test_a_stride_left_over_from_a_prior_read_does_not_leak_into_the_next_one,
+            # which pins the observable failure (a strided read followed by a
+            # plain read on the same connection must return the FULL record).
+            # Confirmed by mutation test (Task 7): making this write
+            # conditional on `stride is not None` makes that test fail with
+            # 143 points back instead of 1000.
             scope.write(scope._get_command("set_waveform_interval", value=effective_stride))
 
         with scope._connection.lock:

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -427,6 +427,54 @@ def parse_modern_wavedesc(payload: bytes, *, error_context: str = "") -> dict:
     }
 
 
+_DATA_INTERVAL_STATE_ATTR = "_data_interval_mismatch_state"
+
+
+def _note_data_interval_mismatch(scope: "Oscilloscope", channel: int, requested: int, reported: int) -> None:
+    """Once-per-transition warning for a DATA_INTERVAL echo that disagrees
+    with the stride we asked for (see ModernTransfer.acquire above).
+
+    This runs on every acquire() -- including stride==1 on the export path --
+    so logging every call would write one WARNING per frame, indefinitely, at
+    up to four frames a second if real hardware's echo disagreed persistently.
+    Same discipline as the poll-path fix in server/adapters.py: one WARNING
+    when the mismatch starts, one recovery record when it stops, nothing
+    while it persists.
+
+    State is stored ON THE SCOPE INSTANCE, keyed by channel, rather than on
+    `self` of the calling Transfer: make_transfer() builds a brand new
+    ModernTransfer for every single acquire() call (see waveform.py's
+    Waveform.acquire), so there is no longer-lived Transfer object to carry
+    the previous call's state across. The Oscilloscope instance IS session-
+    long, and keying by channel keeps a mismatching channel 1 and a healthy
+    channel 2 from flapping each other's state.
+    """
+    state = getattr(scope, _DATA_INTERVAL_STATE_ATTR, None)
+    if state is None:
+        state = {}
+        setattr(scope, _DATA_INTERVAL_STATE_ATTR, state)
+    mismatched = reported != requested
+    was_mismatched = state.get(channel, False)
+    if mismatched and not was_mismatched:
+        logger.warning(
+            "Requested :WAVeform:INTerval %d but PREamble reported DATA_INTERVAL %d (host %s:%s, channel %d) -- the returned record length/time axis may not be scaled the way this driver assumes.",
+            requested,
+            reported,
+            scope.host,
+            scope.port,
+            channel,
+        )
+    elif not mismatched and was_mismatched:
+        logger.info(
+            "DATA_INTERVAL now matches the requested :WAVeform:INTerval %d again (host %s:%s, channel %d) -- the prior mismatch warning has cleared.",
+            requested,
+            scope.host,
+            scope.port,
+            channel,
+        )
+    state[channel] = mismatched
+
+
 class ModernTransfer:
     """:WAVeform: SOURce/PREamble/DATA/MAXPoint transfer for modern-dialect Siglent scopes.
 
@@ -535,15 +583,12 @@ class ModernTransfer:
         # DATA_INTERVAL echo (and therefore its HORIZ_INTERVAL scaling, used
         # below for the time axis) actually reflects the stride we requested.
         # A mismatch must not be invisible -- log it, but don't raise; a
-        # disagreement here is a scaling risk, not a malformed read.
-        if meta["data_interval"] != effective_stride:
-            logger.warning(
-                "Requested :WAVeform:INTerval %d but PREamble reported DATA_INTERVAL %d (host %s:%s) -- the returned record length/time axis may not be scaled the way this driver assumes.",
-                effective_stride,
-                meta["data_interval"],
-                scope.host,
-                scope.port,
-            )
+        # disagreement here is a scaling risk, not a malformed read. This runs
+        # on EVERY acquire(), including stride==1 on the export path, so the
+        # cadence has to be once-per-transition rather than once-per-call: a
+        # real instrument that disagreed persistently would otherwise log one
+        # WARNING per frame, indefinitely, at up to four frames a second.
+        _note_data_interval_mismatch(scope, channel, effective_stride, meta["data_interval"])
 
         dtype = np.int16 if meta["comm_type"] == 1 else np.int8
         # wave_array_count (WAVEDESC address 116-119, p.756) is "Number of

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -12,7 +12,7 @@ definite-length block framing is shared by all of them.
 import logging
 import re
 import struct
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
@@ -108,12 +108,16 @@ class SiglentTransfer:
     def __init__(self, scope: "Oscilloscope"):
         self._scope = scope
 
-    def acquire(self, channel: int, format: str = "BYTE") -> WaveformData:
+    def acquire(self, channel: int, format: str = "BYTE", stride: Optional[int] = None) -> WaveformData:
         """Acquire waveform data from a channel via WF? DAT2.
 
         Args:
             channel: Channel number (1-4)
             format: Data format - 'BYTE' or 'WORD' (default: 'BYTE')
+            stride: Unused on this dialect -- legacy Siglent has no documented
+                :WAVeform:INTerval-equivalent command, so nothing is written.
+                Accepted only so callers can pass it uniformly regardless of
+                which transfer make_transfer() selected.
 
         Returns:
             WaveformData object with time and voltage arrays
@@ -227,13 +231,17 @@ class TektronixTransfer:
     def __init__(self, scope: "Oscilloscope"):
         self._scope = scope
 
-    def acquire(self, channel: int, format: str = "BYTE") -> WaveformData:
+    def acquire(self, channel: int, format: str = "BYTE", stride: Optional[int] = None) -> WaveformData:
         """Acquire waveform data from a channel via the CURVe protocol.
 
         Args:
             channel: Channel number (1-4)
             format: Data format - only 'BYTE' (8-bit, DATa:WIDth 1) is
                 supported today; 'WORD' (16-bit) is a follow-up.
+            stride: Unused on this dialect -- no documented Tektronix
+                equivalent to :WAVeform:INTerval. Accepted only so callers
+                can pass it uniformly regardless of which transfer
+                make_transfer() selected.
 
         Returns:
             WaveformData scaled by the WFMOutpre preamble (ymult/yoff/yzero for
@@ -335,7 +343,17 @@ class LeCroyTransfer:
     def __init__(self, scope: "Oscilloscope"):
         self._scope = scope
 
-    def acquire(self, channel: int, format: str = "BYTE") -> WaveformData:
+    def acquire(self, channel: int, format: str = "BYTE", stride: Optional[int] = None) -> WaveformData:
+        """Acquire waveform data from a channel via WF? ALL.
+
+        Args:
+            channel: Channel number (1-4)
+            format: Data format - 'BYTE' or 'WORD'
+            stride: Unused on this dialect -- no documented LeCroy equivalent
+                to :WAVeform:INTerval. Accepted only so callers can pass it
+                uniformly regardless of which transfer make_transfer()
+                selected.
+        """
         scope = self._scope
         fmt = "WORD" if format.upper() == "WORD" else "BYTE"
         scope.write(scope._get_command("set_comm_format", fmt=fmt))
@@ -422,7 +440,7 @@ class ModernTransfer:
     def __init__(self, scope: "Oscilloscope"):
         self._scope = scope
 
-    def acquire(self, channel: int, format: str = "BYTE") -> WaveformData:
+    def acquire(self, channel: int, format: str = "BYTE", stride: Optional[int] = None) -> WaveformData:
         """Acquire waveform data from a channel via :WAVeform:SOURce/PREamble/DATA.
 
         Args:
@@ -430,6 +448,15 @@ class ModernTransfer:
             format: Data format - 'BYTE' or 'WORD' (default: 'BYTE'); sets
                 :WAVeform:WIDTh before the transfer so COMM_TYPE in the
                 preamble matches what DATA? actually sends.
+            stride: Sets :WAVeform:INTerval before the transfer so the
+                instrument returns every Nth point instead of the driver
+                pulling the full record and striding it down after the wire
+                transfer. :WAVeform:INTerval is instrument state, not a
+                per-request argument -- a value left over from a previous
+                caller (e.g. the live view) would silently decimate the next
+                export on this session. So this is ALWAYS written explicitly,
+                including when stride is None, which writes 1 (no
+                decimation) rather than leaving whatever was last set.
 
         Returns:
             WaveformData scaled by the PREamble's vertical_gain/
@@ -453,6 +480,14 @@ class ModernTransfer:
         # :WAVeform:SOURce" (guide p.748/p.754).
         scope.write(scope._get_command("set_waveform_source", ch=channel))
         scope.write(scope._get_command("set_waveform_width", value=format))
+
+        if scope._has_command("set_waveform_interval"):
+            # Always explicit, never inherited: see the stride docstring note
+            # above on interval being instrument state rather than a
+            # per-request argument. Guarded so a future dialect without the
+            # command (were one ever routed through ModernTransfer) is
+            # unaffected rather than raising KeyError.
+            scope.write(scope._get_command("set_waveform_interval", value=int(stride or 1)))
 
         with scope._connection.lock:
             scope.write(scope._get_command("get_waveform_preamble"))

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -495,7 +495,12 @@ class ModernTransfer:
             raise exceptions.InvalidParameterError(f"Invalid format: {format}")
         if stride is not None and stride < 1:
             raise exceptions.InvalidParameterError(f"stride must be a positive integer (got {stride})")
-        effective_stride = stride or 1
+        # int(...), not just `stride or 1`: a float stride (e.g. a caller's
+        # ceil-division producing 2.5 -- or 2.0, benign here but not
+        # guaranteed elsewhere) must not be written to the wire as-is, since
+        # :WAVeform:INTerval is a real SCPI command argument, not a Python
+        # value.
+        effective_stride = int(stride) if stride else 1
         scope = self._scope
 
         # Source (and width) must be selected before PREamble?/DATA? read

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -393,6 +393,7 @@ _MODERN_DATA_INTERVAL = 136  # long: = :WAVeform:INTerval, echoed back (p.755)
 _MODERN_VERTICAL_GAIN = 156  # float: V/div, no probe attenuation
 _MODERN_VERTICAL_OFFSET = 160  # float
 _MODERN_CODE_PER_DIV = 164  # float
+_MODERN_ADC_BIT = 172  # short: front-end resolution (p.756). 16 on an SDS824X HD
 _MODERN_HORIZ_INTERVAL = 176  # float: 1/sample_rate
 _MODERN_HORIZ_OFFSET = 180  # double: trigger offset, seconds
 
@@ -422,6 +423,10 @@ def parse_modern_wavedesc(payload: bytes, *, error_context: str = "") -> dict:
         "vertical_gain": struct.unpack_from("<f", payload, _MODERN_VERTICAL_GAIN)[0],
         "vertical_offset": struct.unpack_from("<f", payload, _MODERN_VERTICAL_OFFSET)[0],
         "code_per_div": struct.unpack_from("<f", payload, _MODERN_CODE_PER_DIV)[0],
+        # Needed to interpret code_per_div: on a >8-bit front end the field
+        # describes the NATIVE code space even when BYTE is the transfer
+        # width -- see the effective_code_per_div note in acquire().
+        "adc_bit": struct.unpack_from("<h", payload, _MODERN_ADC_BIT)[0],
         "horiz_interval": struct.unpack_from("<f", payload, _MODERN_HORIZ_INTERVAL)[0],
         "horiz_offset": struct.unpack_from("<d", payload, _MODERN_HORIZ_OFFSET)[0],
     }
@@ -721,7 +726,23 @@ class ModernTransfer:
         # guide's own worked numbers: code=-11, vdiv=10, code_per_div=30,
         # voffset=14.5 -> -11*(10/30)-14.5 = -18.167 V, matching the guide's
         # own printed "-18.167 V" exactly.
-        voltage = codes.astype(np.float64) * (meta["vertical_gain"] / meta["code_per_div"]) - meta["vertical_offset"]
+        # code_per_div describes the NATIVE code space, not the transferred
+        # one. MEASURED on a real SDS824X HD (fw 3.8.12.1.1.3.6) 2026-07-30:
+        # the preamble reports Adc_bit=16 and code_per_div=7680 under BOTH
+        # :WAVeform:WIDTh BYTE and WORD -- BYTE does not get its own smaller
+        # scale, the instrument just sends the HIGH BYTE of the 16-bit code.
+        # So a BYTE read must divide code_per_div by 256 (7680 -> 30) or every
+        # volt comes back 256x too small: a 3.075 Vpp signal read as 0.0119792
+        # Vpp, while the scope's own :MEASure MEAN (1.45474 V) agreed with the
+        # WORD read (1.45602 V). BYTE is this driver's DEFAULT width, so that
+        # was every default waveform read on an HD instrument.
+        #
+        # Guarded on adc_bit so a genuinely 8-bit front end (which reports its
+        # code_per_div in the 8-bit space already) is untouched.
+        effective_code_per_div = meta["code_per_div"]
+        if meta["comm_type"] == 0 and meta["adc_bit"] > 8:
+            effective_code_per_div /= 256.0
+        voltage = codes.astype(np.float64) * (meta["vertical_gain"] / effective_code_per_div) - meta["vertical_offset"]
 
         # SDS Series Programming Guide EN11G p.759 ("Read Waveform Data",
         # Step 4): "time value(S) = delay-(timebase*grid/2)+index*interval".

--- a/tests/test_mock_connection_gate.py
+++ b/tests/test_mock_connection_gate.py
@@ -1,0 +1,54 @@
+"""A waveform-data read that can block on demand.
+
+No existing test can reproduce the defect this sub-project fixes: the mock
+answers a waveform query instantly, so a poll tick is free and the session's
+single worker thread never contends between the scope poll and a user
+command. `MockConnection(waveform_gate=...)` is the test double that makes
+this reproducible -- a waveform-data read blocks until the test releases the
+gate, deterministically and without sleeping.
+
+The real entry point for a waveform-data read is `write()` followed by
+`read_raw()` (see waveform_transfer.py's SiglentTransfer.acquire, which holds
+the connection lock across exactly this pair). There is no `query_binary` on
+MockConnection -- that name only exists on VisaConnection/SocketConnection --
+so the gate is proven here against the actual pair the driver uses, with the
+legacy dialect's own waveform query string ("C1:WF? DAT2", scpi_commands.py's
+"get_waveform" mapping for the default Siglent dialect).
+"""
+
+import threading
+
+from scpi_control.connection.mock import MockConnection
+
+
+def test_the_waveform_gate_blocks_until_released():
+    gate = threading.Event()
+    conn = MockConnection(waveform_gate=gate)
+    conn.connect()
+    done = threading.Event()
+
+    def read():
+        conn.write("C1:WF? DAT2")
+        conn.read_raw()
+        done.set()
+
+    worker = threading.Thread(target=read, daemon=True)
+    worker.start()
+    try:
+        assert not done.wait(timeout=0.2), "the read returned without the gate being released"
+    finally:
+        # Always release the gate, even if the assertion above fails, so a
+        # broken gate cannot leave the worker thread blocked forever.
+        gate.set()
+    assert done.wait(timeout=2.0), "the read did not return after the gate was released"
+    worker.join(timeout=2.0)
+    assert not worker.is_alive(), "worker thread did not exit after the read returned"
+
+
+def test_no_gate_means_no_blocking():
+    # Every existing test constructs MockConnection without a gate and must be
+    # completely unaffected.
+    conn = MockConnection()
+    conn.connect()
+    conn.write("C1:WF? DAT2")
+    conn.read_raw()

--- a/tests/test_mock_connection_gate.py
+++ b/tests/test_mock_connection_gate.py
@@ -52,3 +52,34 @@ def test_no_gate_means_no_blocking():
     conn.connect()
     conn.write("C1:WF? DAT2")
     conn.read_raw()
+
+
+def test_the_waveform_gate_blocks_the_modern_dialect_too():
+    # The legacy path above and the modern :WAVeform:DATA? path
+    # (base.py's read_raw()) are two wire encodings of the identical logical
+    # query -- both share the one waveform_gate attribute and the one
+    # _wait_for_waveform_gate() call. This pins the modern branch so a future
+    # refactor of the modern preamble/data dispatch can't silently drop the
+    # wait without a test noticing. Same modern IDN Task 1's tests use for the
+    # SDS824X HD, so both files agree on what resolves to the modern dialect.
+    gate = threading.Event()
+    conn = MockConnection(idn="Siglent Technologies,SDS824X HD,SDS08A0X804831,3.8.12.1.1.3.6", waveform_gate=gate)
+    conn.connect()
+    done = threading.Event()
+
+    def read():
+        conn.write(":WAVeform:DATA?")
+        conn.read_raw()
+        done.set()
+
+    worker = threading.Thread(target=read, daemon=True)
+    worker.start()
+    try:
+        assert not done.wait(timeout=0.2), "the read returned without the gate being released"
+    finally:
+        # Always release the gate, even if the assertion above fails, so a
+        # broken gate cannot leave the worker thread blocked forever.
+        gate.set()
+    assert done.wait(timeout=2.0), "the read did not return after the gate was released"
+    worker.join(timeout=2.0)
+    assert not worker.is_alive(), "worker thread did not exit after the read returned"

--- a/tests/test_modern_measure.py
+++ b/tests/test_modern_measure.py
@@ -150,8 +150,7 @@ def test_a_measurement_the_instrument_cannot_compute_is_reported_as_unavailable(
     """
     from scpi_control.exceptions import CommandError, MeasurementUnavailableError
 
-    conn = MockConnection("mock", idn=MODERN_IDN,
-                          custom_responses={":MEASure:SIMPle:VALue? PKPK": "****"})
+    conn = MockConnection("mock", idn=MODERN_IDN, custom_responses={":MEASure:SIMPle:VALue? PKPK": "****"})
     scope = Oscilloscope("mock", connection=conn)
     scope.connect()
 
@@ -160,12 +159,8 @@ def test_a_measurement_the_instrument_cannot_compute_is_reported_as_unavailable(
 
     message = str(excinfo.value)
     assert "PKPK" in message
-    assert "parse" not in message.lower(), (
-        "an unavailable reading is not a parse failure: {0}".format(message)
-    )
-    assert isinstance(excinfo.value, CommandError), (
-        "must stay a CommandError subclass so existing handlers keep catching it"
-    )
+    assert "parse" not in message.lower(), "an unavailable reading is not a parse failure: {0}".format(message)
+    assert isinstance(excinfo.value, CommandError), "must stay a CommandError subclass so existing handlers keep catching it"
     scope.disconnect()
 
 
@@ -173,8 +168,7 @@ def test_a_genuinely_unparseable_measurement_still_fails_as_before():
     # The '****' handling must not swallow real wire corruption.
     from scpi_control.exceptions import CommandError, MeasurementUnavailableError
 
-    conn = MockConnection("mock", idn=MODERN_IDN,
-                          custom_responses={":MEASure:SIMPle:VALue? PKPK": "garbage"})
+    conn = MockConnection("mock", idn=MODERN_IDN, custom_responses={":MEASure:SIMPle:VALue? PKPK": "garbage"})
     scope = Oscilloscope("mock", connection=conn)
     scope.connect()
 

--- a/tests/test_modern_measure.py
+++ b/tests/test_modern_measure.py
@@ -129,3 +129,56 @@ def test_measure_agrees_across_dialects_for_the_same_signal():
     modern = _modern_scope()
     for mtype in ("PKPK", "FREQ", "WID", "NWID", "DUTY"):
         assert modern.measurement.measure(mtype, 1) == pytest.approx(legacy.measurement.measure(mtype, 1)), mtype
+
+
+def test_a_measurement_the_instrument_cannot_compute_is_reported_as_unavailable():
+    """MEASURED on a real SDS824X HD (fw 3.8.12.1.1.3.6), 2026-07-30: with
+    PKPK/MAX/MIN/MEAN all enabled on a live channel, MEAN answered
+    "1.45474E+00" while PKPK, MAX and MIN each answered the literal "****" --
+    the instrument's marker for "no value for this item right now".
+
+    p.369 documents the reply as a bare NR3 and says nothing about "****", so
+    measure() did float("****") and raised "Failed to parse measurement" -- a
+    normal, transient, expected condition surfacing as a parse failure. In the
+    gateway that reaches _safe(), which logs "poll query failed, degrading to
+    a default" at WARNING, so an ordinary unavailable reading looked like an
+    instrument fault in the log.
+
+    It stays an exception (measure() returns float, and inventing a None
+    return would push the check onto every caller), but a DISTINGUISHABLE one,
+    so a caller can tell "not available yet" from "the wire is broken".
+    """
+    from scpi_control.exceptions import CommandError, MeasurementUnavailableError
+
+    conn = MockConnection("mock", idn=MODERN_IDN,
+                          custom_responses={":MEASure:SIMPle:VALue? PKPK": "****"})
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    with pytest.raises(MeasurementUnavailableError) as excinfo:
+        scope.measurement.measure("PKPK", 1)
+
+    message = str(excinfo.value)
+    assert "PKPK" in message
+    assert "parse" not in message.lower(), (
+        "an unavailable reading is not a parse failure: {0}".format(message)
+    )
+    assert isinstance(excinfo.value, CommandError), (
+        "must stay a CommandError subclass so existing handlers keep catching it"
+    )
+    scope.disconnect()
+
+
+def test_a_genuinely_unparseable_measurement_still_fails_as_before():
+    # The '****' handling must not swallow real wire corruption.
+    from scpi_control.exceptions import CommandError, MeasurementUnavailableError
+
+    conn = MockConnection("mock", idn=MODERN_IDN,
+                          custom_responses={":MEASure:SIMPle:VALue? PKPK": "garbage"})
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    with pytest.raises(CommandError) as excinfo:
+        scope.measurement.measure("PKPK", 1)
+    assert not isinstance(excinfo.value, MeasurementUnavailableError)
+    scope.disconnect()

--- a/tests/test_modern_waveform_transfer.py
+++ b/tests/test_modern_waveform_transfer.py
@@ -230,9 +230,7 @@ def test_one_code_per_div_serves_both_widths_on_a_high_resolution_front_end():
     word_meta = _preamble_under(conn, "WORD")
 
     assert byte_meta["adc_bit"] > 8, "an HD front end reports more than 8 ADC bits"
-    assert byte_meta["code_per_div"] == word_meta["code_per_div"], (
-        "the instrument reports one code_per_div regardless of transfer width"
-    )
+    assert byte_meta["code_per_div"] == word_meta["code_per_div"], "the instrument reports one code_per_div regardless of transfer width"
     assert byte_meta["comm_type"] == 0 and word_meta["comm_type"] == 1
 
 
@@ -313,11 +311,6 @@ def test_the_mock_frames_data_the_way_the_instrument_does():
     data = build_waveform_data(conn)
 
     assert data.endswith(b"\n\n"), "DATA? replies carry two trailing newlines"
-    assert data.startswith(b"#41000"), (
-        "1000 bytes must use the general variable-width header (#4 + '1000'), "
-        "not the fixed 9-digit form: {0!r}".format(data[:12])
-    )
+    assert data.startswith(b"#41000"), "1000 bytes must use the general variable-width header (#4 + '1000'), " "not the fixed 9-digit form: {0!r}".format(data[:12])
     assert build_waveform_preamble(conn).endswith(b"\n"), "PREamble? carries one trailing newline"
-    assert build_waveform_preamble(conn).startswith(b"#9000000346"), (
-        "PREamble? does keep the fixed 9-digit header, unlike DATA?"
-    )
+    assert build_waveform_preamble(conn).startswith(b"#9000000346"), "PREamble? does keep the fixed 9-digit header, unlike DATA?"

--- a/tests/test_modern_waveform_transfer.py
+++ b/tests/test_modern_waveform_transfer.py
@@ -72,7 +72,9 @@ def test_round_trip_recovers_known_signal_amplitude():
     """
     amplitude = 2.0
     vdiv = 1.0  # MockConnection's default C1 voltage_scales value
-    code_per_div = 25.0  # mock's BYTE-format code_per_div (siglent.py's _MODERN_CODE_PER_DIV_BYTE)
+    # BYTE carries the HIGH BYTE of the native code, so its effective scale is
+    # _MODERN_CODE_PER_DIV_NATIVE / 256 = 30 codes/div (hardware-measured).
+    code_per_div = 7680.0 / 256
     conn = MockConnection(
         idn=MODERN_IDN,
         timebase=1e-3,
@@ -98,7 +100,7 @@ def test_round_trip_honors_nonzero_offset_and_scale():
     amplitude = 0.3
     vdiv = 0.2
     voffset = 0.5
-    code_per_div = 25.0
+    code_per_div = 7680.0 / 256  # BYTE = high byte of the native code
     conn = MockConnection(
         idn=MODERN_IDN,
         timebase=1e-3,
@@ -145,7 +147,7 @@ def test_deep_memory_chunks_preserve_sample_order_and_values():
     """
     amplitude = 1.0
     vdiv = 1.0  # MockConnection's default C1 voltage_scales value
-    code_per_div = 25.0  # mock's BYTE-format code_per_div
+    code_per_div = 7680.0 / 256  # BYTE = high byte of the native code
     conn = MockConnection(
         idn=MODERN_IDN,
         timebase=1e-3,
@@ -191,8 +193,131 @@ def test_word_format_round_trips_too():
     wf = scope.waveform.acquire(1, format="WORD", provenance=False)
 
     assert ":WAVeform:WIDTh WORD" in conn.writes
-    code_per_div_word = 25.0 * 256
+    code_per_div_word = 7680.0  # WORD uses the native scale as reported
     quantization_step = 1.0 / code_per_div_word
     assert np.max(wf.voltage) == pytest.approx(amplitude, abs=quantization_step * 2)
     assert np.min(wf.voltage) == pytest.approx(-amplitude, abs=quantization_step * 2)
     scope.disconnect()
+
+
+def _preamble_under(conn, width):
+    """What the mock would answer :WAVeform:PREamble? with at this width."""
+    from scpi_control.connection.mock.siglent import build_waveform_preamble
+    from scpi_control.waveform_transfer import parse_ieee_block, parse_modern_wavedesc
+
+    conn.waveform_width = width
+    conn.waveform_source = "C1"
+    payload = parse_ieee_block(build_waveform_preamble(conn), np.uint8).tobytes()
+    return parse_modern_wavedesc(payload)
+
+
+def test_one_code_per_div_serves_both_widths_on_a_high_resolution_front_end():
+    """MEASURED on the real SDS824X HD (fw 3.8.12.1.1.3.6), 2026-07-30:
+    the preamble reports Adc_bit=16 and code_per_div=7680 -- the SAME 7680
+    under :WAVeform:WIDTh BYTE and under WORD. BYTE does not get its own
+    smaller code_per_div; the instrument sends the HIGH BYTE of the native
+    code and leaves the scale field alone.
+
+    The mock used to report 25.0 for BYTE and 6400.0 for WORD, i.e. it scaled
+    the field by 256 across widths where the instrument does not. Because the
+    mock's encoder and the driver's decoder both used that same wrong number
+    they round-tripped perfectly, which is precisely the self-consistent-but-
+    wrong defect this module's docstring says it exists to catch.
+    """
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+
+    byte_meta = _preamble_under(conn, "BYTE")
+    word_meta = _preamble_under(conn, "WORD")
+
+    assert byte_meta["adc_bit"] > 8, "an HD front end reports more than 8 ADC bits"
+    assert byte_meta["code_per_div"] == word_meta["code_per_div"], (
+        "the instrument reports one code_per_div regardless of transfer width"
+    )
+    assert byte_meta["comm_type"] == 0 and word_meta["comm_type"] == 1
+
+
+def test_a_byte_read_is_not_scaled_off_by_the_word_factor():
+    """THE 256x guard. With one code_per_div serving both widths, a decoder
+    that divides BYTE codes by the native (16-bit) code_per_div returns volts
+    256x too small. On the instrument that showed up as a 3.075 Vpp signal
+    read back as 0.0119792 Vpp, with the scope's own :MEASure MEAN
+    (1.45474 V) agreeing with the WORD read (1.45602 V) and not the BYTE one.
+
+    Both widths must recover the same amplitude, to within BYTE's coarser
+    quantization -- that is the whole claim.
+    """
+    amplitude = 2.0
+    conn = MockConnection(
+        idn=MODERN_IDN,
+        timebase=1e-3,
+        sample_rate=20_000.0,
+        signals={1: SignalSpec(kind="sine", frequency=200.0, amplitude=amplitude, noise_rms=0.0)},
+    )
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    wf_byte = scope.waveform.acquire(1, format="BYTE", provenance=False)
+    wf_word = scope.waveform.acquire(1, format="WORD", provenance=False)
+
+    vdiv = 1.0
+    byte_step = vdiv / (7680.0 / 256)  # BYTE carries the high byte: 30 codes/div
+    assert np.max(wf_byte.voltage) == pytest.approx(amplitude, abs=byte_step * 2)
+    assert np.max(wf_byte.voltage) == pytest.approx(np.max(wf_word.voltage), abs=byte_step * 2)
+    assert np.min(wf_byte.voltage) == pytest.approx(np.min(wf_word.voltage), abs=byte_step * 2)
+    scope.disconnect()
+
+
+def test_the_parser_accepts_the_block_shapes_the_instrument_actually_sends():
+    """Byte shapes captured off a real SDS824X HD (fw 3.8.12.1.1.3.6),
+    2026-07-30, at ACQ:POINts=50000:
+
+      :WAVeform:PREamble? -> b'#9000000346WAVEDESC...' + b'\n'
+      :WAVeform:DATA?     -> b'#550000' + 50000 bytes + b'\n\n'
+      empty DATA?         -> b'C1:WF DAT2,#9000000000\n\n'
+
+    Two things the guide does not say. DATA? uses the GENERAL IEEE-488.2 form
+    with a variable digit count ("#5" for 50000 bytes), not the fixed
+    "#9<9-digits>" of p.757's example -- which PREamble? does use. And every
+    reply carries trailing newlines, DATA? two of them. The empty reply also
+    arrives behind a legacy "C1:WF DAT2," response header, on the modern
+    subsystem.
+
+    parse_ieee_block already survives all of this (it scans for "#" and reads
+    the declared length), but nothing pinned it, and the mock emitted none of
+    it -- so the tolerance was accidental rather than guaranteed.
+    """
+    from scpi_control.waveform_transfer import parse_ieee_block
+
+    payload = bytes(range(256)) * 4  # 1024 bytes
+    variable_header = b"#4" + b"1024" + payload + b"\n\n"
+    assert parse_ieee_block(variable_header, np.int8).size == 1024
+
+    fixed_header = b"#9" + b"000001024" + payload + b"\n"
+    assert parse_ieee_block(fixed_header, np.int8).size == 1024
+
+    legacy_prefixed_empty = b"C1:WF DAT2,#9000000000\n\n"
+    assert parse_ieee_block(legacy_prefixed_empty, np.int8).size == 0
+
+
+def test_the_mock_frames_data_the_way_the_instrument_does():
+    """The mock emitted a bare fixed-width "#9..." with no trailing bytes for
+    BOTH replies, so CI never exercised the variable-width header or the
+    trailing newlines that every real transfer carries.
+    """
+    from scpi_control.connection.mock.siglent import build_waveform_data, build_waveform_preamble
+
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+    conn.record_length = 1000
+    conn.waveform_source = "C1"
+    build_waveform_preamble(conn)  # populates the code cache DATA? slices
+    data = build_waveform_data(conn)
+
+    assert data.endswith(b"\n\n"), "DATA? replies carry two trailing newlines"
+    assert data.startswith(b"#41000"), (
+        "1000 bytes must use the general variable-width header (#4 + '1000'), "
+        "not the fixed 9-digit form: {0!r}".format(data[:12])
+    )
+    assert build_waveform_preamble(conn).endswith(b"\n"), "PREamble? carries one trailing newline"
+    assert build_waveform_preamble(conn).startswith(b"#9000000346"), (
+        "PREamble? does keep the fixed 9-digit header, unlike DATA?"
+    )

--- a/tests/test_oscilloscope_acquisition.py
+++ b/tests/test_oscilloscope_acquisition.py
@@ -1,0 +1,50 @@
+"""Tests for Oscilloscope.new_acquisition_ready() -- the cheap "has a new frame
+landed?" gate the live-view poll loop asks before fetching a waveform.
+
+Against a real Siglent SDS824X HD at a long timebase, polling on a timer alone
+means the poll loop asks roughly six times faster than the instrument can
+produce a frame; the read blocks for the rest of the acquisition and, because
+the session's single worker thread also services user commands, every control
+in the web UI hangs for the length of the capture. new_acquisition_ready() is
+the cheap question asked first, before paying for that blocking read.
+"""
+
+from scpi_control import Oscilloscope
+from scpi_control.connection.mock import MockConnection
+
+
+def _connected_scope(**kwargs):
+    conn = MockConnection("mock", **kwargs)
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    return scope
+
+
+def test_new_acquisition_ready_is_none_when_the_dialect_cannot_tell():
+    # The tri-state is the whole design: None means "no gate available", and the
+    # adapter falls back to timing rather than guessing a vendor's semantics.
+    scope = _connected_scope(idn="Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0")
+    assert scope.new_acquisition_ready() is None
+
+
+def test_new_acquisition_ready_reads_bit_zero_of_inr():
+    # The manual's own example (SDS800XHD guide p.829) polls INR? and tests
+    # state & 0x01 for "Acquisition finished".
+    scope = _connected_scope(
+        idn="Siglent Technologies,SDS824X HD,SDS08A0X804831,3.8.12.1.1.3.6",
+        custom_responses={"INR?": ["0", "1", "2", "3"]},
+    )
+    assert scope.new_acquisition_ready() is False  # 0 -> no new data
+    assert scope.new_acquisition_ready() is True  # 1 -> bit 0 set
+    assert scope.new_acquisition_ready() is False  # 2 -> other bit only
+    assert scope.new_acquisition_ready() is True  # 3 -> bit 0 set among others
+
+
+def test_new_acquisition_ready_is_none_when_the_query_fails():
+    # A failed gate must degrade to "cannot tell" for this tick, not raise into
+    # the poll loop and kill the session.
+    scope = _connected_scope(
+        idn="Siglent Technologies,SDS824X HD,SDS08A0X804831,3.8.12.1.1.3.6",
+        custom_responses={"INR?": "not-a-number"},
+    )
+    assert scope.new_acquisition_ready() is None

--- a/tests/test_oscilloscope_acquisition.py
+++ b/tests/test_oscilloscope_acquisition.py
@@ -73,10 +73,10 @@ def test_the_gate_parses_the_header_prefixed_reply_hardware_actually_sends():
         idn=MODERN_IDN,
         custom_responses={"INR?": ["INR 8193", "INR 8192", "INR 0", "INR 1"]},
     )
-    assert scope.new_acquisition_ready() is True   # 8193 -> bit 0 set
+    assert scope.new_acquisition_ready() is True  # 8193 -> bit 0 set
     assert scope.new_acquisition_ready() is False  # 8192 -> bit 13 only
     assert scope.new_acquisition_ready() is False  # 0 -> nothing latched
-    assert scope.new_acquisition_ready() is True   # 1 -> bit 0 set
+    assert scope.new_acquisition_ready() is True  # 1 -> bit 0 set
 
 
 def test_the_modern_mock_answers_inr_the_way_the_instrument_does():
@@ -90,7 +90,5 @@ def test_the_modern_mock_answers_inr_the_way_the_instrument_does():
 
     reply = scope._connection.query("INR?")
 
-    assert reply.upper().startswith("INR"), (
-        "the mock must reproduce the instrument's header prefix, or it re-hides the bug: {0!r}".format(reply)
-    )
+    assert reply.upper().startswith("INR"), "the mock must reproduce the instrument's header prefix, or it re-hides the bug: {0!r}".format(reply)
     assert scope.new_acquisition_ready() in (True, False), "the gate must resolve against the unpatched mock"

--- a/tests/test_oscilloscope_acquisition.py
+++ b/tests/test_oscilloscope_acquisition.py
@@ -48,3 +48,49 @@ def test_new_acquisition_ready_is_none_when_the_query_fails():
         custom_responses={"INR?": "not-a-number"},
     )
     assert scope.new_acquisition_ready() is None
+
+
+MODERN_IDN = "Siglent Technologies,SDS824X HD,SDS08A0X804831,3.8.12.1.1.3.6"
+
+
+def test_the_gate_parses_the_header_prefixed_reply_hardware_actually_sends():
+    """MEASURED on the real SDS824X HD (fw 3.8.12.1.1.3.6), 2026-07-30: INR?
+    answers "INR 8193" / "INR 8192" / "INR 0" -- HEADER-PREFIXED, not the bare
+    integer every test above injects. Only the ":"-prefixed modern queries
+    answer bare; legacy-style ones like INR? carry the header.
+
+    int("INR 8193") raises ValueError, which new_acquisition_ready() catches
+    and turns into None = "this dialect has no gate". Silently, every tick,
+    with no log -- so the modern new-acquisition gate never ran on the
+    instrument at all and the poll fell back to timing-based backoff. That is
+    the entire feature this module's docstring describes.
+
+    8193 = 8192 + 1: bit 0 (new signal acquired) set alongside an unrelated
+    bit 13, which is exactly why the mask matters and a bare equality would
+    not do.
+    """
+    scope = _connected_scope(
+        idn=MODERN_IDN,
+        custom_responses={"INR?": ["INR 8193", "INR 8192", "INR 0", "INR 1"]},
+    )
+    assert scope.new_acquisition_ready() is True   # 8193 -> bit 0 set
+    assert scope.new_acquisition_ready() is False  # 8192 -> bit 13 only
+    assert scope.new_acquisition_ready() is False  # 0 -> nothing latched
+    assert scope.new_acquisition_ready() is True   # 1 -> bit 0 set
+
+
+def test_the_modern_mock_answers_inr_the_way_the_instrument_does():
+    """The gap that let this ship: the modern mock had NO INR? handler at all,
+    so the query raised and the gate degraded to None in CI too. Every test
+    that exercised the gate injected a bare "1"/"0" through custom_responses
+    -- a shape the instrument never sends. With no unpatched test ever asking
+    the mock for INR?, nothing could notice.
+    """
+    scope = _connected_scope(idn=MODERN_IDN)
+
+    reply = scope._connection.query("INR?")
+
+    assert reply.upper().startswith("INR"), (
+        "the mock must reproduce the instrument's header prefix, or it re-hides the bug: {0!r}".format(reply)
+    )
+    assert scope.new_acquisition_ready() in (True, False), "the gate must resolve against the unpatched mock"

--- a/tests/test_oscilloscope_waveform_stride.py
+++ b/tests/test_oscilloscope_waveform_stride.py
@@ -216,6 +216,46 @@ def test_a_data_interval_mismatch_is_logged_once_per_transition_not_every_frame(
         assert len(onsets_after) == 1
 
 
+def test_a_strided_read_that_comes_back_short_raises_instead_of_truncating():
+    """Final-review fix (Important 4): the single-window strided read used
+    `codes` as-is and built its time axis over `len(codes)`, never comparing
+    that against the preamble's own record length. Nothing in this repo writes
+    :WAVeform:POINt -- but another program on the same instrument
+    (EasyScopeX, a colleague's LabVIEW driver) can leave it small, and then
+    every live frame is silently truncated with a time axis that looks
+    perfectly correct for the points that did arrive. This branch's stated
+    principle is that every read sets or verifies the state it depends on, and
+    silently wrong data is the worst artifact available here.
+
+    `conn.waveform_point` is set directly rather than by writing the SCPI
+    command, because "a value this driver never writes was left behind by
+    something else" is exactly the situation under test.
+    """
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+    conn.record_length = 1000
+    conn.waveform_point = 100  # a leftover window cap: 100 points of the 143 a stride of 7 should yield
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    with pytest.raises(exceptions.CommandError) as excinfo:
+        scope.get_waveform(1, provenance=False, stride=7)
+
+    message = str(excinfo.value)
+    assert "100" in message and "143" in message, message
+    assert ":WAVeform:POINt" in message, "the message must name the likeliest cause, or it is another unactionable read failure: {0}".format(message)
+
+
+def test_a_complete_strided_read_still_succeeds():
+    # The guard above must not fire on the normal case -- ceil(1000/7)=143
+    # points asked for, 143 delivered.
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+    conn.record_length = 1000
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    assert len(scope.get_waveform(1, provenance=False, stride=7).voltage) == 143
+
+
 def test_a_stride_needing_more_than_one_window_raises():
     """A strided record that would not fit in a single :WAVeform:DATA?
     transfer must raise rather than mis-assemble: the general chunking loop's

--- a/tests/test_oscilloscope_waveform_stride.py
+++ b/tests/test_oscilloscope_waveform_stride.py
@@ -1,0 +1,65 @@
+"""Tests for asking the instrument to stride waveform data on the wire.
+
+The gateway's live view renders at most MAX_FRAME_POINTS per frame
+(server/adapters.py), but until now the driver always fetched the entire
+record and strided it down after the transfer -- on a deep record that is
+megabytes crossing the wire to draw two thousand points, holding the
+session's single worker thread for the length of the transfer.
+
+`:WAVeform:INTerval` is instrument state, not a per-request argument: if
+`stride=None` left the setting untouched, a stride set by the live view
+would leak into the next CSV/JSON export on that session and hand someone a
+decimated file they believe is complete. So every read sets the interval
+explicitly -- including the default path, which resets it to 1.
+"""
+
+from scpi_control import Oscilloscope
+from scpi_control.connection.mock import MockConnection
+
+LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
+MODERN_IDN = "Siglent Technologies,SDS814X HD,MOCK0001,1.0.0.0"
+
+
+def _connected_scope(**kwargs):
+    conn = MockConnection("mock", **kwargs)
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    return scope
+
+
+def _recording_scope(**kwargs):
+    """A connected scope plus the list of every command it has written.
+
+    MockConnection already records every write it receives (`self.writes`),
+    so this just hands that list back alongside the scope -- no separate
+    recorder needed.
+    """
+    conn = MockConnection("mock", **kwargs)
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    return scope, conn.writes
+
+
+def test_a_stride_is_sent_before_the_read():
+    scope, sent = _recording_scope(idn=MODERN_IDN)
+    scope.get_waveform(1, provenance=False, stride=7)
+    assert ":WAVeform:INTerval 7" in sent
+
+
+def test_the_default_read_resets_the_stride_to_one():
+    # Not "leaves it alone": the interval is instrument state, so a stride left
+    # over from the live view would silently decimate an export.
+    scope, sent = _recording_scope(idn=MODERN_IDN)
+    scope.get_waveform(1, provenance=False)
+    assert ":WAVeform:INTerval 1" in sent
+
+
+def test_stride_is_not_sent_on_a_dialect_without_the_command():
+    scope, sent = _recording_scope(idn=LEGACY_IDN)
+    scope.get_waveform(1, provenance=False, stride=7)
+    assert not any("INTerval" in cmd for cmd in sent)
+
+
+def test_record_length_query_is_mapped_on_modern():
+    scope = _connected_scope(idn=MODERN_IDN, custom_responses={":ACQuire:POINts?": "1400000"})
+    assert scope.record_length() == 1400000

--- a/tests/test_oscilloscope_waveform_stride.py
+++ b/tests/test_oscilloscope_waveform_stride.py
@@ -117,6 +117,35 @@ def test_a_strided_read_returns_the_decimated_point_count_and_scaled_dt():
     assert dt == pytest.approx(7 / 20_000.0)
 
 
+def test_a_float_stride_is_coerced_to_an_integer_before_being_sent():
+    # `effective_stride = stride or 1` alone puts a float straight onto the
+    # wire (":WAVeform:INTerval 2.5") -- Task 3's minor asked to reject
+    # stride < 1, not to stop coercing to int. Restore the coercion.
+    scope, sent = _recording_scope(idn=MODERN_IDN)
+    scope.get_waveform(1, provenance=False, stride=2.5)
+    assert ":WAVeform:INTerval 2" in sent
+    assert not any("2.5" in cmd for cmd in sent)
+
+
+def test_a_stride_left_over_from_a_prior_read_does_not_leak_into_the_next_one():
+    """The behavioural version of test_the_default_read_resets_the_stride_to_one
+    above: that test only pins the command string. Now that the mock honours
+    :WAVeform:INTerval, the actual leak this class's docstring warns about is
+    expressible -- a strided read followed by a plain read on the SAME
+    connection must return the full record, not the previous stride's
+    decimated count.
+    """
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+    conn.record_length = 1000
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    scope.get_waveform(1, provenance=False, stride=7)
+    full = scope.get_waveform(1, provenance=False)
+
+    assert len(full.voltage) == 1000
+
+
 def test_a_stride_needing_more_than_one_window_raises():
     """A strided record that would not fit in a single :WAVeform:DATA?
     transfer must raise rather than mis-assemble: the general chunking loop's

--- a/tests/test_oscilloscope_waveform_stride.py
+++ b/tests/test_oscilloscope_waveform_stride.py
@@ -13,6 +13,8 @@ decimated file they believe is complete. So every read sets the interval
 explicitly -- including the default path, which resets it to 1.
 """
 
+import logging
+
 import numpy as np
 import pytest
 
@@ -144,6 +146,59 @@ def test_a_stride_left_over_from_a_prior_read_does_not_leak_into_the_next_one():
     full = scope.get_waveform(1, provenance=False)
 
     assert len(full.voltage) == 1000
+
+
+def test_a_data_interval_mismatch_is_logged_once_per_transition_not_every_frame(monkeypatch, caplog):
+    """Task 3 added a cross-check in ModernTransfer.acquire (waveform_transfer.py)
+    that compares the PREamble's DATA_INTERVAL against the stride we asked
+    for, and logs a warning on disagreement. It runs on EVERY acquire(),
+    including stride==1 on the export path -- so if real hardware's echo
+    disagreed with what this driver reads, the live view would log one
+    WARNING per frame, indefinitely, at up to four frames a second.
+
+    Same once-per-transition discipline as the poll-path fix: one WARNING
+    when the mismatch starts, one recovery record when it stops, nothing
+    while it persists.
+    """
+    import scpi_control.waveform_transfer as wt
+
+    scope = _connected_scope(idn=MODERN_IDN)
+    real_parse = wt.parse_modern_wavedesc
+    mismatch = {"on": True}
+
+    def fake_parse(payload, *, error_context=""):
+        meta = dict(real_parse(payload, error_context=error_context))
+        if mismatch["on"]:
+            meta["data_interval"] = meta["data_interval"] + 1
+        return meta
+
+    monkeypatch.setattr(wt, "parse_modern_wavedesc", fake_parse)
+
+    logger_name = "scpi_control.waveform_transfer"
+    with caplog.at_level(logging.INFO, logger=logger_name):
+        caplog.clear()
+        scope.get_waveform(1, provenance=False)  # mismatch starts
+        scope.get_waveform(1, provenance=False)  # steady state: still mismatched
+
+        # Filtered on "DATA_INTERVAL" too, not just level -- an unrelated INFO
+        # line ("Acquired N samples...") is logged by the same acquire() on
+        # every call and must not be mistaken for the mismatch/recovery record.
+        warnings = [r for r in caplog.records if r.name == logger_name and r.levelno == logging.WARNING and "DATA_INTERVAL" in r.getMessage()]
+        assert len(warnings) == 1, "a persistent mismatch must log once, not once per frame: {0}".format(warnings)
+        assert "channel 1" in warnings[0].getMessage()
+
+        mismatch["on"] = False
+        scope.get_waveform(1, provenance=False)  # recovers
+
+        recoveries = [r for r in caplog.records if r.name == logger_name and r.levelno == logging.INFO and "DATA_INTERVAL" in r.getMessage()]
+        assert len(recoveries) == 1, "the recovery must log exactly once: {0}".format(recoveries)
+        assert "channel 1" in recoveries[0].getMessage()
+
+        # Still exactly one warning overall -- the recovery must not be a
+        # second warning, and the earlier steady-state mismatch tick must not
+        # have logged again either.
+        warnings_after = [r for r in caplog.records if r.name == logger_name and r.levelno == logging.WARNING and "DATA_INTERVAL" in r.getMessage()]
+        assert len(warnings_after) == 1
 
 
 def test_a_stride_needing_more_than_one_window_raises():

--- a/tests/test_oscilloscope_waveform_stride.py
+++ b/tests/test_oscilloscope_waveform_stride.py
@@ -158,7 +158,13 @@ def test_a_data_interval_mismatch_is_logged_once_per_transition_not_every_frame(
 
     Same once-per-transition discipline as the poll-path fix: one WARNING
     when the mismatch starts, one recovery record when it stops, nothing
-    while it persists.
+    while it persists -- and the recovery record must be WARNING too, not a
+    quieter level: an operator or alerting pipeline filtering at WARNING (the
+    level the onset logs at) must see the disagreement both start AND clear,
+    or the log is exactly as ambiguous as it was before this fix for that
+    reader. A level-agnostic "a recovery record exists" assertion cannot tell
+    that design apart from one that quietly logs recovery at INFO, so this
+    pins the level explicitly.
     """
     import scpi_control.waveform_transfer as wt
 
@@ -175,7 +181,7 @@ def test_a_data_interval_mismatch_is_logged_once_per_transition_not_every_frame(
     monkeypatch.setattr(wt, "parse_modern_wavedesc", fake_parse)
 
     logger_name = "scpi_control.waveform_transfer"
-    with caplog.at_level(logging.INFO, logger=logger_name):
+    with caplog.at_level(logging.WARNING, logger=logger_name):
         caplog.clear()
         scope.get_waveform(1, provenance=False)  # mismatch starts
         scope.get_waveform(1, provenance=False)  # steady state: still mismatched
@@ -183,22 +189,25 @@ def test_a_data_interval_mismatch_is_logged_once_per_transition_not_every_frame(
         # Filtered on "DATA_INTERVAL" too, not just level -- an unrelated INFO
         # line ("Acquired N samples...") is logged by the same acquire() on
         # every call and must not be mistaken for the mismatch/recovery record.
-        warnings = [r for r in caplog.records if r.name == logger_name and r.levelno == logging.WARNING and "DATA_INTERVAL" in r.getMessage()]
-        assert len(warnings) == 1, "a persistent mismatch must log once, not once per frame: {0}".format(warnings)
-        assert "channel 1" in warnings[0].getMessage()
+        # Onset and recovery are both WARNING now, so they're told apart by
+        # message content ("may not be scaled" vs. "cleared"), not level.
+        onsets = [r for r in caplog.records if r.name == logger_name and r.levelno == logging.WARNING and "DATA_INTERVAL" in r.getMessage() and "may not be scaled" in r.getMessage()]
+        assert len(onsets) == 1, "a persistent mismatch must log once, not once per frame: {0}".format(onsets)
+        assert "channel 1" in onsets[0].getMessage()
 
         mismatch["on"] = False
         scope.get_waveform(1, provenance=False)  # recovers
 
-        recoveries = [r for r in caplog.records if r.name == logger_name and r.levelno == logging.INFO and "DATA_INTERVAL" in r.getMessage()]
+        recoveries = [r for r in caplog.records if r.name == logger_name and "DATA_INTERVAL" in r.getMessage() and "cleared" in r.getMessage()]
         assert len(recoveries) == 1, "the recovery must log exactly once: {0}".format(recoveries)
+        assert recoveries[0].levelno == logging.WARNING, "the recovery record must be WARNING, matching the onset's level"
         assert "channel 1" in recoveries[0].getMessage()
 
-        # Still exactly one warning overall -- the recovery must not be a
-        # second warning, and the earlier steady-state mismatch tick must not
-        # have logged again either.
-        warnings_after = [r for r in caplog.records if r.name == logger_name and r.levelno == logging.WARNING and "DATA_INTERVAL" in r.getMessage()]
-        assert len(warnings_after) == 1
+        # Still exactly one onset overall -- the recovery must not be logged
+        # as a second onset, and the earlier steady-state mismatch tick must
+        # not have logged another onset either.
+        onsets_after = [r for r in caplog.records if r.name == logger_name and r.levelno == logging.WARNING and "DATA_INTERVAL" in r.getMessage() and "may not be scaled" in r.getMessage()]
+        assert len(onsets_after) == 1
 
 
 def test_a_stride_needing_more_than_one_window_raises():

--- a/tests/test_oscilloscope_waveform_stride.py
+++ b/tests/test_oscilloscope_waveform_stride.py
@@ -287,12 +287,8 @@ def test_a_strided_trace_covers_the_same_time_window_as_an_unstrided_one():
     dt_strided = float(np.mean(np.diff(strided.time)))
     assert dt_strided == pytest.approx(7 * dt_full), "delivered points are `stride` samples apart"
     assert strided.time[0] == pytest.approx(full.time[0])
-    assert strided.time[-1] == pytest.approx(full.time[-1], rel=0.02), (
-        "the strided trace must still end at the end of the sweep"
-    )
-    assert strided.sample_rate == pytest.approx(full.sample_rate / 7), (
-        "the effective rate of a decimated trace is 1/stride of the acquisition rate"
-    )
+    assert strided.time[-1] == pytest.approx(full.time[-1], rel=0.02), "the strided trace must still end at the end of the sweep"
+    assert strided.sample_rate == pytest.approx(full.sample_rate / 7), "the effective rate of a decimated trace is 1/stride of the acquisition rate"
 
 
 def test_a_strided_read_that_fits_only_after_decimation_is_not_refused():
@@ -374,9 +370,7 @@ def test_the_modern_mock_reports_its_acquisition_point_count():
     raw = conn.query(":ACQuire:POINts?")
     assert raw.strip().upper() == "1.00E+03", "bare NR3, as the instrument sends: {0!r}".format(raw)
     assert scope.record_length() == 1000
-    assert scope.record_length() == _modern_preamble(conn)["wave_array_count"], (
-        "the point count and the preamble must describe the same record"
-    )
+    assert scope.record_length() == _modern_preamble(conn)["wave_array_count"], "the point count and the preamble must describe the same record"
 
 
 def test_the_default_modern_mock_can_also_say_how_long_its_record_is():

--- a/tests/test_oscilloscope_waveform_stride.py
+++ b/tests/test_oscilloscope_waveform_stride.py
@@ -13,7 +13,10 @@ decimated file they believe is complete. So every read sets the interval
 explicitly -- including the default path, which resets it to 1.
 """
 
-from scpi_control import Oscilloscope
+import numpy as np
+import pytest
+
+from scpi_control import Oscilloscope, exceptions
 from scpi_control.connection.mock import MockConnection
 
 LEGACY_IDN = "Siglent Technologies,SDS1104X-E,MOCK0001,1.0.0.0"
@@ -63,3 +66,69 @@ def test_stride_is_not_sent_on_a_dialect_without_the_command():
 def test_record_length_query_is_mapped_on_modern():
     scope = _connected_scope(idn=MODERN_IDN, custom_responses={":ACQuire:POINts?": "1400000"})
     assert scope.record_length() == 1400000
+
+
+def test_the_interval_write_precedes_the_preamble_read():
+    # The placement is load-bearing (see waveform_transfer.ModernTransfer.acquire):
+    # the preamble must be read back under the interval THIS call asked for, not
+    # whatever a previous caller (e.g. the live view) left set on the instrument --
+    # otherwise that stride leaks into whatever reads the preamble next. Pinned in
+    # the index-comparison style already used by
+    # test_modern_waveform_transfer.py::test_preamble_is_read_before_data, so a
+    # future reorder fails loudly instead of silently reintroducing the leak.
+    scope, sent = _recording_scope(idn=MODERN_IDN)
+    scope.get_waveform(1, provenance=False, stride=7)
+    sent_upper = [c.upper() for c in sent]
+    interval_idx = sent_upper.index(":WAVEFORM:INTERVAL 7")
+    preamble_idx = sent_upper.index(":WAVEFORM:PREAMBLE?")
+    assert interval_idx < preamble_idx
+
+
+def test_zero_stride_is_rejected():
+    scope = _connected_scope(idn=MODERN_IDN)
+    with pytest.raises(exceptions.InvalidParameterError):
+        scope.get_waveform(1, provenance=False, stride=0)
+
+
+def test_negative_stride_is_rejected():
+    # int(stride or 1) alone would collapse a negative stride to itself
+    # (not to 1) and write it straight onto the wire -- ":WAVeform:INTerval -3"
+    # -- unless it is rejected first.
+    scope = _connected_scope(idn=MODERN_IDN)
+    with pytest.raises(exceptions.InvalidParameterError):
+        scope.get_waveform(1, provenance=False, stride=-3)
+
+
+def test_a_strided_read_returns_the_decimated_point_count_and_scaled_dt():
+    """The test that would have caught the mock doing nothing: before the mock
+    honored :WAVeform:INTerval, a stride changed no bytes on the wire -- same
+    point count back, same dt. This pins both halves of striding actually
+    working: fewer points, and a time axis scaled to match.
+    """
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+    conn.record_length = 1000
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    wf = scope.get_waveform(1, provenance=False, stride=7)
+
+    assert len(wf.voltage) == 143  # ceil(1000 / 7)
+    dt = float(np.mean(np.diff(wf.time)))
+    assert dt == pytest.approx(7 / 20_000.0)
+
+
+def test_a_stride_needing_more_than_one_window_raises():
+    """A strided record that would not fit in a single :WAVeform:DATA?
+    transfer must raise rather than mis-assemble: the general chunking loop's
+    `start` bookkeeping is only valid in the same (strided) space as
+    :WAVeform:STARt when nothing is being decimated (stride == 1) -- see
+    ModernTransfer.acquire's else-branch comment.
+    """
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+    conn.record_length = 1000
+    conn.max_points = 100  # strided count at stride=2 (500) exceeds this
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    with pytest.raises(exceptions.FeatureNotSupportedError):
+        scope.get_waveform(1, provenance=False, stride=2)

--- a/tests/test_oscilloscope_waveform_stride.py
+++ b/tests/test_oscilloscope_waveform_stride.py
@@ -216,46 +216,6 @@ def test_a_data_interval_mismatch_is_logged_once_per_transition_not_every_frame(
         assert len(onsets_after) == 1
 
 
-def test_a_strided_read_that_comes_back_short_raises_instead_of_truncating():
-    """Final-review fix (Important 4): the single-window strided read used
-    `codes` as-is and built its time axis over `len(codes)`, never comparing
-    that against the preamble's own record length. Nothing in this repo writes
-    :WAVeform:POINt -- but another program on the same instrument
-    (EasyScopeX, a colleague's LabVIEW driver) can leave it small, and then
-    every live frame is silently truncated with a time axis that looks
-    perfectly correct for the points that did arrive. This branch's stated
-    principle is that every read sets or verifies the state it depends on, and
-    silently wrong data is the worst artifact available here.
-
-    `conn.waveform_point` is set directly rather than by writing the SCPI
-    command, because "a value this driver never writes was left behind by
-    something else" is exactly the situation under test.
-    """
-    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
-    conn.record_length = 1000
-    conn.waveform_point = 100  # a leftover window cap: 100 points of the 143 a stride of 7 should yield
-    scope = Oscilloscope("mock", connection=conn)
-    scope.connect()
-
-    with pytest.raises(exceptions.CommandError) as excinfo:
-        scope.get_waveform(1, provenance=False, stride=7)
-
-    message = str(excinfo.value)
-    assert "100" in message and "143" in message, message
-    assert ":WAVeform:POINt" in message, "the message must name the likeliest cause, or it is another unactionable read failure: {0}".format(message)
-
-
-def test_a_complete_strided_read_still_succeeds():
-    # The guard above must not fire on the normal case -- ceil(1000/7)=143
-    # points asked for, 143 delivered.
-    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
-    conn.record_length = 1000
-    scope = Oscilloscope("mock", connection=conn)
-    scope.connect()
-
-    assert len(scope.get_waveform(1, provenance=False, stride=7).voltage) == 143
-
-
 def test_a_stride_needing_more_than_one_window_raises():
     """A strided record that would not fit in a single :WAVeform:DATA?
     transfer must raise rather than mis-assemble: the general chunking loop's

--- a/tests/test_oscilloscope_waveform_stride.py
+++ b/tests/test_oscilloscope_waveform_stride.py
@@ -51,14 +51,6 @@ def test_a_stride_is_sent_before_the_read():
     assert ":WAVeform:INTerval 7" in sent
 
 
-def test_the_default_read_resets_the_stride_to_one():
-    # Not "leaves it alone": the interval is instrument state, so a stride left
-    # over from the live view would silently decimate an export.
-    scope, sent = _recording_scope(idn=MODERN_IDN)
-    scope.get_waveform(1, provenance=False)
-    assert ":WAVeform:INTerval 1" in sent
-
-
 def test_stride_is_not_sent_on_a_dialect_without_the_command():
     scope, sent = _recording_scope(idn=LEGACY_IDN)
     scope.get_waveform(1, provenance=False, stride=7)
@@ -130,12 +122,26 @@ def test_a_float_stride_is_coerced_to_an_integer_before_being_sent():
 
 
 def test_a_stride_left_over_from_a_prior_read_does_not_leak_into_the_next_one():
-    """The behavioural version of test_the_default_read_resets_the_stride_to_one
-    above: that test only pins the command string. Now that the mock honours
-    :WAVeform:INTerval, the actual leak this class's docstring warns about is
-    expressible -- a strided read followed by a plain read on the SAME
-    connection must return the full record, not the previous stride's
-    decimated count.
+    """THE interval-leak guard (Task 7). Pins the actual observable failure
+    mode -- not just the wire command -- so it cannot rot: a strided read
+    followed by a plain read on the SAME connection must return the full
+    record, not the previous stride's decimated count.
+
+    An earlier version of this suite also had
+    test_the_default_read_resets_the_stride_to_one, asserting only that
+    ":WAVeform:INTerval 1" appeared in the sent commands. It was removed as
+    redundant once this test existed: mutation-testing acquire() (making the
+    :WAVeform:INTerval write conditional on `stride is not None`, Task 7)
+    fails BOTH tests identically, and the command-string assertion is
+    strictly weaker -- it would also break on an inconsequential wire-format
+    change (e.g. a future dialect spelling the command differently) that
+    changes no observable behaviour, which this test would not.
+
+    If you are about to make the interval write in ModernTransfer.acquire()
+    (scpi_control/waveform_transfer.py) conditional -- e.g. "only write if it
+    differs from the last value" -- this is the test that will fail. Do not
+    work around it; the write must stay unconditional (see the comment at
+    that write site).
     """
     conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
     conn.record_length = 1000

--- a/tests/test_oscilloscope_waveform_stride.py
+++ b/tests/test_oscilloscope_waveform_stride.py
@@ -350,3 +350,44 @@ def test_a_stride_needing_more_than_one_window_raises():
 
     with pytest.raises(exceptions.FeatureNotSupportedError):
         scope.get_waveform(1, provenance=False, stride=2)
+
+
+def test_the_modern_mock_reports_its_acquisition_point_count():
+    """MEASURED on the real SDS824X HD (fw 3.8.12.1.1.3.6): :ACQuire:POINts?
+    answers a bare NR3 "1.00E+05". The modern mock had NO handler, so the
+    query raised, Oscilloscope.record_length() caught it and degraded to None
+    ("the dialect can't say"), and the live view's stride sizing -- which is
+    driven entirely by record_length() -- was therefore never exercised
+    against the modern mock at all. Same shape as the INR? gap: a query the
+    instrument answers, that the mock could only fail.
+
+    The count must agree with the preamble's own wave_array_count, or stride
+    sizing computes a ratio against a record length the transfer does not
+    have.
+    """
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+    conn.record_length = 1000
+    conn.waveform_source = "C1"
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    raw = conn.query(":ACQuire:POINts?")
+    assert raw.strip().upper() == "1.00E+03", "bare NR3, as the instrument sends: {0!r}".format(raw)
+    assert scope.record_length() == 1000
+    assert scope.record_length() == _modern_preamble(conn)["wave_array_count"], (
+        "the point count and the preamble must describe the same record"
+    )
+
+
+def test_the_default_modern_mock_can_also_say_how_long_its_record_is():
+    # record_length=None is the common fixture: the count then comes from the
+    # timebase/sample-rate window rather than an explicit override, and must
+    # still be answerable rather than raising.
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+    conn.waveform_source = "C1"
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    points = scope.record_length()
+    assert points is not None and points > 0
+    assert points == _modern_preamble(conn)["wave_array_count"]

--- a/tests/test_oscilloscope_waveform_stride.py
+++ b/tests/test_oscilloscope_waveform_stride.py
@@ -98,6 +98,12 @@ def test_a_strided_read_returns_the_decimated_point_count_and_scaled_dt():
     honored :WAVeform:INTerval, a stride changed no bytes on the wire -- same
     point count back, same dt. This pins both halves of striding actually
     working: fewer points, and a time axis scaled to match.
+
+    Both halves used to pass for compensating wrong reasons: the mock
+    reported a STRIDED horiz_interval and the driver used it unscaled, so the
+    dt assertion held while neither side matched the instrument. With the mock
+    corrected to hardware (preamble reports the full record and the raw sample
+    spacing), dt is only right because acquire() now multiplies by the stride.
     """
     conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
     conn.record_length = 1000
@@ -106,7 +112,7 @@ def test_a_strided_read_returns_the_decimated_point_count_and_scaled_dt():
 
     wf = scope.get_waveform(1, provenance=False, stride=7)
 
-    assert len(wf.voltage) == 143  # ceil(1000 / 7)
+    assert len(wf.voltage) == 142  # floor(1000 / 7) -- the instrument truncates
     dt = float(np.mean(np.diff(wf.time)))
     assert dt == pytest.approx(7 / 20_000.0)
 
@@ -214,6 +220,119 @@ def test_a_data_interval_mismatch_is_logged_once_per_transition_not_every_frame(
         # not have logged another onset either.
         onsets_after = [r for r in caplog.records if r.name == logger_name and r.levelno == logging.WARNING and "DATA_INTERVAL" in r.getMessage() and "may not be scaled" in r.getMessage()]
         assert len(onsets_after) == 1
+
+
+def _modern_preamble(conn):
+    """Parse what the mock would answer :WAVeform:PREamble? with right now."""
+    from scpi_control.connection.mock.siglent import build_waveform_preamble
+    from scpi_control.waveform_transfer import parse_ieee_block, parse_modern_wavedesc
+
+    payload = parse_ieee_block(build_waveform_preamble(conn), np.uint8).tobytes()
+    return parse_modern_wavedesc(payload)
+
+
+def test_the_preamble_reports_the_full_record_and_unstrided_spacing_at_any_stride():
+    """MEASURED on the real SDS824X HD (fw 3.8.12.1.1.3.6), 2026-07-30, at
+    ACQ:POINts=50000 with :WAVeform:INTerval 1/2/7/10:
+
+        INTerval | WAVE_ARRAY_1 | wave_array_count | DATA? pts | horiz_interval
+               1 |        50000 |            50000 |     50000 |        1.0e-08
+               2 |        50000 |            50000 |     25000 |        1.0e-08
+               7 |        50000 |            50000 |      7142 |        1.0e-08
+              10 |        50000 |            50000 |      5000 |        1.0e-08
+
+    Both count fields stay at the FULL record and HORIZ_INTERVAL does not
+    move, at every stride. This replaces the opposite assumption that
+    build_waveform_preamble carried (and said, in its own words, was "not yet
+    confirmed against real hardware" and would "change together" with
+    ModernTransfer.acquire if hardware disagreed). It does disagree.
+
+    Note the guide (p.755) calls WAVE_ARRAY_1 "the number of transmitted
+    bytes" -- the instrument does not honour that, so nothing in the preamble
+    reports the transmitted count and a reader must compute it.
+    """
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+    conn.record_length = 1000
+    conn.waveform_source = "C1"
+
+    conn.waveform_interval = 1
+    unstrided = _modern_preamble(conn)
+    conn.waveform_interval = 7
+    strided = _modern_preamble(conn)
+
+    assert unstrided["wave_array_count"] == 1000
+    assert strided["wave_array_count"] == 1000, "the count must not shrink with the stride"
+    assert strided["horiz_interval"] == pytest.approx(unstrided["horiz_interval"])
+    assert strided["horiz_interval"] == pytest.approx(1 / 20_000.0)
+    assert strided["data_interval"] == 7, "DATA_INTERVAL is what echoes the stride"
+
+
+def test_a_strided_trace_covers_the_same_time_window_as_an_unstrided_one():
+    """The bug the compensating mock hid. HORIZ_INTERVAL is the raw sample
+    spacing at every stride (hardware table above), so a time axis built as
+    `arange(n) * horiz_interval` spans only 1/stride of the real sweep --
+    on the instrument, a stride-7 live frame claimed 7.14e-5 s of a 5.0e-4 s
+    sweep. Decimating a trace must change how many points describe the
+    window, never how wide the window is.
+    """
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+    conn.record_length = 1000
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    full = scope.get_waveform(1, provenance=False)
+    strided = scope.get_waveform(1, provenance=False, stride=7)
+
+    dt_full = float(np.mean(np.diff(full.time)))
+    dt_strided = float(np.mean(np.diff(strided.time)))
+    assert dt_strided == pytest.approx(7 * dt_full), "delivered points are `stride` samples apart"
+    assert strided.time[0] == pytest.approx(full.time[0])
+    assert strided.time[-1] == pytest.approx(full.time[-1], rel=0.02), (
+        "the strided trace must still end at the end of the sweep"
+    )
+    assert strided.sample_rate == pytest.approx(full.sample_rate / 7), (
+        "the effective rate of a decimated trace is 1/stride of the acquisition rate"
+    )
+
+
+def test_a_strided_read_that_fits_only_after_decimation_is_not_refused():
+    """The per-transfer cap applies to what crosses the wire, which is the
+    DECIMATED count -- comparing the full record against :WAVeform:MAXPoint
+    refuses reads that fit comfortably. 1000 points at stride 20 is a
+    50-point transfer; a 100-point cap accommodates it easily.
+    """
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+    conn.record_length = 1000
+    conn.max_points = 100
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    assert len(scope.get_waveform(1, provenance=False, stride=20).voltage) == 50
+
+
+def test_a_strided_read_that_comes_back_short_raises_instead_of_truncating():
+    """Nothing in the preamble reports the transmitted count, so a short
+    window is invisible: unlike the stride==1 path nothing loops to collect a
+    remainder, and the time axis is sized off whatever arrived -- a truncated
+    record comes back looking well-formed, just missing its tail. The
+    expected count has to be computed (record // stride) and checked.
+
+    Driven here through :WAVeform:POINt, which caps the transfer. On the real
+    instrument that value is DERIVED from :WAVeform:INTerval (it read 714285 =
+    MAXPoint/7 after setting interval 7), so this stands in for any short
+    window rather than for one specific cause.
+    """
+    conn = MockConnection(idn=MODERN_IDN, sample_rate=20_000.0, timebase=1e-3)
+    conn.record_length = 1000
+    conn.waveform_point = 30  # 30 of the 142 points a stride of 7 should deliver
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+
+    with pytest.raises(exceptions.CommandError) as excinfo:
+        scope.get_waveform(1, provenance=False, stride=7)
+
+    message = str(excinfo.value)
+    assert "30" in message and "142" in message, message
 
 
 def test_a_stride_needing_more_than_one_window_raises():

--- a/tests/test_server_export_bounds.py
+++ b/tests/test_server_export_bounds.py
@@ -16,6 +16,8 @@ memory. This file covers the fix:
   pre-streaming implementation.
 """
 
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -292,21 +294,66 @@ class TestAFailingRecordLengthQueryDoesNotFailTheExport:
 
         assert response.status_code == 200, response.text
 
-    def test_the_modern_mock_really_cannot_answer_the_record_length_query(self):
-        # Pins what makes the two tests above meaningful: modern MAPS
-        # :ACQuire:POINts? (unlike legacy) and the mock cannot answer it, so
-        # the query is genuinely attempted and genuinely fails. If the mock
-        # ever grows a handler, those tests would silently stop covering the
-        # failing-query path and this one fails loudly instead.
+    def test_record_length_degrades_to_none_when_the_query_fails(self):
+        """Pins what makes the failing-query tests below meaningful: modern
+        MAPS :ACQuire:POINts? (unlike legacy), so the query is genuinely
+        attempted, and a failure must degrade to None rather than raise.
+
+        This used to rely on the modern mock having NO handler for the query.
+        It has one now -- the mock could previously only FAIL a query the real
+        instrument answers happily ("1.00E+05" on an SDS824X HD), which meant
+        record_length() and the live view's stride sizing were never exercised
+        against a working answer. The failure is therefore forced explicitly
+        here, which is also what keeps this test honest if the mock grows more
+        handlers later.
+        """
+        from scpi_control.connection.mock.base import MockConnection
+
+        instrument = Oscilloscope("mock", connection=MockConnection("mock", idn="Siglent Technologies,{0},MOCK0001,1.0.0.0".format(MODERN_MODEL), custom_responses={":ACQuire:POINts?": "not-a-number"}))
+        instrument.connect()
+        assert instrument.dialect == "modern"
+        assert instrument._has_command("get_acq_points"), "modern must map :ACQuire:POINts? -- otherwise record_length() short-circuits and no query is sent"
+        assert instrument.record_length() is None, "record_length() must degrade to None on a failing query, not raise"
+
+    def test_the_modern_mock_now_answers_the_record_length_query(self):
+        # The other half: with a working mock the query must actually resolve,
+        # so the healthy path above is real coverage and not another silent
+        # degrade-to-None.
         from scpi_control.connection.mock.base import MockConnection
 
         instrument = Oscilloscope("mock", connection=MockConnection("mock", idn="Siglent Technologies,{0},MOCK0001,1.0.0.0".format(MODERN_MODEL)))
         instrument.connect()
-        assert instrument.dialect == "modern"
-        assert instrument._has_command("get_acq_points"), "modern must map :ACQuire:POINts? -- otherwise record_length() short-circuits and no query is sent"
-        with pytest.raises(SiglentError):
-            instrument.query(instrument._get_command("get_acq_points"))
-        assert instrument.record_length() is None, "record_length() must degrade to None on a failing query, not raise"
+        points = instrument.record_length()
+        assert points is not None and points > 0, "the modern mock must answer :ACQuire:POINts? like the instrument does"
+
+    def _exports_still_succeed_with_a_failing_record_length(self, client):
+        """The Critical-1 path: :ACQuire:POINts? raising must not 504 an export.
+
+        Forced at the query, not by leaning on a missing mock handler, so this
+        keeps covering the failing path now that the mock answers.
+        """
+        real_query = Oscilloscope.query
+
+        def failing_query(self, command, *args, **kwargs):
+            if "ACQuire:POINts" in command:
+                raise SiglentError("forced record-length failure")
+            return real_query(self, command, *args, **kwargs)
+
+        return failing_query, real_query
+
+    def test_capture_csv_returns_200_when_the_record_length_query_fails(self, client):
+        failing_query, _ = self._exports_still_succeed_with_a_failing_record_length(client)
+        with patch.object(Oscilloscope, "query", failing_query):
+            sid = create_modern_mock_session(client)
+            response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+        assert response.status_code == 200, response.text
+
+    def test_waveform_json_returns_200_when_the_record_length_query_fails(self, client):
+        failing_query, _ = self._exports_still_succeed_with_a_failing_record_length(client)
+        with patch.object(Oscilloscope, "query", failing_query):
+            sid = create_modern_mock_session(client)
+            response = client.get("/api/sessions/{0}/scope/waveform?channels=1".format(sid))
+        assert response.status_code == 200, response.text
 
 
 class TestUnverifiableOversizedExportLogsAWarning:

--- a/tests/test_server_export_bounds.py
+++ b/tests/test_server_export_bounds.py
@@ -1,0 +1,224 @@
+"""Task 8: exports that cannot exhaust memory (scpi_control/server/api/scope.py).
+
+capture.csv and /scope/waveform used to fetch a scope's ENTIRE record and
+build the whole export body as one Python string/dict before ever writing a
+byte to the client -- unbounded, on a deep record that is gigabytes in server
+memory. This file covers the fix:
+
+- a record above MAX_EXPORT_POINTS is refused with 413 BEFORE any waveform is
+  fetched (never after a partial or full fetch);
+- the 413 detail names the actual point count;
+- an explicit max_points under the threshold bypasses the guard and succeeds,
+  striding the fetch itself rather than pulling the oversized record anyway;
+- capture.csv gained max_points, for parity with /scope/waveform;
+- both responses stream rather than build their whole body in memory;
+- a normal-sized CSV export is still byte-for-byte identical to the
+  pre-streaming implementation.
+"""
+
+import numpy as np
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")  # fastapi.testclient needs it
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scpi_control.oscilloscope import Oscilloscope  # noqa: E402
+from scpi_control.server.api import scope as scope_api  # noqa: E402
+from scpi_control.server.app import create_app  # noqa: E402
+from scpi_control.server.sessions import SessionManager  # noqa: E402
+from scpi_control.waveform import WaveformData  # noqa: E402
+
+
+@pytest.fixture()
+def client(gateway_auth):
+    store, headers, _raw = gateway_auth
+    manager = SessionManager()
+    app = create_app(manager, token_store=store)
+    with TestClient(app) as test_client:
+        test_client.headers.update(headers)
+        yield test_client
+    manager.close_all()
+
+
+def create_mock_session(client):
+    # Default (mock=True, no model) is the legacy dialect (SDS1104X-E) --
+    # deliberately unpatched, this is what exercises the record_length() is
+    # None path (see TestUnknownRecordLengthProceedsUnguarded below).
+    response = client.post("/api/sessions", json={"mock": True})
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def _fake_waveform(n=41, scale=1.0):
+    """Deterministic WaveformData, independent of the mock synth's own
+    nondeterminism (it evolves with elapsed time). The byte-identity proof
+    below needs the exact same array fed to both the reference algorithm and
+    the route under test, which a live capture cannot guarantee call to call.
+    """
+    t = np.arange(n, dtype=float) * 1e-6
+    v = (np.sin(np.linspace(0, 6.28, n)) * scale).astype(float)
+    return WaveformData(channel="C1", time=t, voltage=v, sample_rate=1e6, voltage_scale=0.5, voltage_offset=0.0)
+
+
+def _reference_build_csv(captures) -> str:
+    """Frozen copy of _build_csv exactly as it existed before Task 8 (a single
+    string, not a generator). This is the golden reference the streaming
+    rewrite must reproduce byte-for-byte for a normal-sized export -- proving
+    the rewrite didn't change the transformation, not merely eyeballing it.
+    """
+    n = min(len(w.voltage) for _, w in captures)
+    time_axis = captures[0][1].time
+    header = "time_s," + ",".join("C{0}_V".format(c) for c, _ in captures)
+    rows = [header]
+    for i in range(n):
+        rows.append("{0:.9g},{1}".format(float(time_axis[i]), ",".join("{0:.9g}".format(float(w.voltage[i])) for _, w in captures)))
+    return "\n".join(rows) + "\n"
+
+
+class TestByteIdentity:
+    def test_normal_csv_export_is_byte_identical_to_the_pre_streaming_algorithm(self, client, monkeypatch):
+        fixed = _fake_waveform(n=41)
+        monkeypatch.setattr(Oscilloscope, "get_waveform", lambda self, channel, provenance=True, stride=None: fixed)
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: len(fixed.voltage))
+        sid = create_mock_session(client)
+
+        response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+
+        assert response.status_code == 200
+        expected = _reference_build_csv([(1, fixed)])
+        assert response.content.decode("utf-8") == expected
+
+
+class TestStreamingResponseType:
+    # StreamingResponse never populates Content-Length (Starlette's
+    # Response.init_headers only derives it from a fully-built .body, which
+    # StreamingResponse never sets) -- a black-box, client-visible signal
+    # that the server did not build the whole response body in memory.
+
+    def test_capture_csv_is_a_streaming_response(self, client):
+        sid = create_mock_session(client)
+        response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+        assert response.status_code == 200
+        assert "content-length" not in response.headers
+
+    def test_waveform_json_is_a_streaming_response(self, client):
+        sid = create_mock_session(client)
+        response = client.get("/api/sessions/{0}/scope/waveform?channels=1".format(sid))
+        assert response.status_code == 200
+        assert "content-length" not in response.headers
+
+
+class TestSizeGuard:
+    def test_oversized_record_is_refused_before_any_fetch(self, client, monkeypatch):
+        fetched = []
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: scope_api.MAX_EXPORT_POINTS + 1)
+
+        def spy_get_waveform(self, channel, provenance=True, stride=None):
+            fetched.append(channel)
+            return _fake_waveform()
+
+        monkeypatch.setattr(Oscilloscope, "get_waveform", spy_get_waveform)
+        sid = create_mock_session(client)
+
+        response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+
+        assert response.status_code == 413
+        assert fetched == [], "get_waveform ran despite the record being known to exceed MAX_EXPORT_POINTS"
+
+    def test_413_detail_names_the_actual_point_count(self, client, monkeypatch):
+        total = scope_api.MAX_EXPORT_POINTS + 12345
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: total)
+        sid = create_mock_session(client)
+
+        response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+
+        assert response.status_code == 413
+        detail = response.json()["detail"]
+        assert str(total) in detail
+        assert "max_points={0}".format(scope_api.MAX_EXPORT_POINTS) in detail
+
+    def test_waveform_json_also_refuses_an_oversized_record(self, client, monkeypatch):
+        total = scope_api.MAX_EXPORT_POINTS + 1
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: total)
+        sid = create_mock_session(client)
+
+        response = client.get("/api/sessions/{0}/scope/waveform?channels=1".format(sid))
+
+        assert response.status_code == 413
+        assert str(total) in response.json()["detail"]
+
+
+class TestExplicitMaxPointsBypassesTheGuard:
+    def test_explicit_max_points_under_threshold_succeeds_on_an_oversized_record(self, client, monkeypatch):
+        # The record is well above MAX_EXPORT_POINTS, but the caller has
+        # explicitly bounded the export -- the 413's own suggested escape
+        # hatch ("pass max_points=<n>") must actually work, and must not
+        # fetch the oversized record and decimate it afterwards: the stride
+        # passed to get_waveform must already reflect the requested cap.
+        total = scope_api.MAX_EXPORT_POINTS + 5_000_000
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: total)
+        seen_strides = []
+
+        def fake_get_waveform(self, channel, provenance=True, stride=None):
+            seen_strides.append(stride)
+            return _fake_waveform(n=50)
+
+        monkeypatch.setattr(Oscilloscope, "get_waveform", fake_get_waveform)
+        sid = create_mock_session(client)
+
+        response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1&max_points=50".format(sid))
+
+        assert response.status_code == 200
+        rows = response.text.strip().splitlines()
+        assert len(rows) - 1 <= 50  # minus the header row
+        assert seen_strides and seen_strides[0] is not None and seen_strides[0] > 1, "the export did not stride the fetch -- it would have pulled the full oversized record"
+
+    def test_capture_csv_accepts_max_points(self, client, monkeypatch):
+        fixed = _fake_waveform(n=200)
+        monkeypatch.setattr(Oscilloscope, "get_waveform", lambda self, channel, provenance=True, stride=None: fixed)
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: len(fixed.voltage))
+        sid = create_mock_session(client)
+
+        full = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid)).text.strip().splitlines()
+        capped = client.get("/api/sessions/{0}/scope/capture.csv?channels=1&max_points=10".format(sid)).text.strip().splitlines()
+
+        assert len(capped) - 1 <= 10
+        assert len(capped) < len(full)
+
+    def test_waveform_json_max_points_under_threshold_returns_that_many_points(self, client, monkeypatch):
+        fixed = _fake_waveform(n=200)
+        monkeypatch.setattr(Oscilloscope, "get_waveform", lambda self, channel, provenance=True, stride=None: fixed)
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: len(fixed.voltage))
+        sid = create_mock_session(client)
+
+        body = client.get("/api/sessions/{0}/scope/waveform?channels=1&max_points=10".format(sid)).json()
+
+        assert len(body["channels"][0]["points"]) <= 10
+
+
+class TestUnknownRecordLengthProceedsUnguarded:
+    def test_default_legacy_dialect_cannot_report_record_length_and_still_exports(self, client):
+        # Documented decision (see _export_stride's docstring in scope.py):
+        # record_length() is None on the legacy dialect (no :ACQuire:POINts?
+        # mapping in LEGACY_COMMANDS) -- the record's size cannot be verified
+        # before the fetch on this dialect at all. This proceeds unstrided
+        # and unguarded exactly as every export did before this task, rather
+        # than refusing every legacy-dialect export outright.
+        sid = create_mock_session(client)
+
+        response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+
+        assert response.status_code == 200
+
+    def test_record_length_is_none_for_the_default_mock_dialect(self):
+        # Pins the assumption the test above relies on: if this ever stops
+        # being true (e.g. legacy grows an :ACQuire:POINts? mapping), that
+        # test would silently stop exercising the record_length()-is-None
+        # path it claims to.
+        from scpi_control.connection.mock.base import MockConnection
+
+        instrument = Oscilloscope("mock", connection=MockConnection("mock"))
+        instrument.connect()
+        assert instrument.dialect == "legacy"
+        assert instrument.record_length() is None

--- a/tests/test_server_export_bounds.py
+++ b/tests/test_server_export_bounds.py
@@ -309,7 +309,9 @@ class TestAFailingRecordLengthQueryDoesNotFailTheExport:
         """
         from scpi_control.connection.mock.base import MockConnection
 
-        instrument = Oscilloscope("mock", connection=MockConnection("mock", idn="Siglent Technologies,{0},MOCK0001,1.0.0.0".format(MODERN_MODEL), custom_responses={":ACQuire:POINts?": "not-a-number"}))
+        instrument = Oscilloscope(
+            "mock", connection=MockConnection("mock", idn="Siglent Technologies,{0},MOCK0001,1.0.0.0".format(MODERN_MODEL), custom_responses={":ACQuire:POINts?": "not-a-number"})
+        )
         instrument.connect()
         assert instrument.dialect == "modern"
         assert instrument._has_command("get_acq_points"), "modern must map :ACQuire:POINts? -- otherwise record_length() short-circuits and no query is sent"

--- a/tests/test_server_export_bounds.py
+++ b/tests/test_server_export_bounds.py
@@ -107,6 +107,33 @@ class TestByteIdentity:
         assert response.content.decode("utf-8") == expected
 
 
+class TestCsvChunksAreBatched:
+    # Final-review fix (Important 3): Starlette wraps a sync iterator in
+    # iterate_in_threadpool, which awaits anyio.to_thread.run_sync PER ITEM,
+    # and StreamingResponse sends one http.response.body message PER ITEM. One
+    # row per yield therefore meant one thread round-trip and one chunked frame
+    # PER SAMPLE -- 2M of each on the deep records this endpoint's memory bound
+    # exists for, where the pre-streaming code did one of each in total.
+
+    def test_rows_are_emitted_in_batches_not_one_chunk_per_row(self):
+        rows = 5000
+        captures = [(1, _fake_waveform(n=rows))]
+
+        chunks = list(scope_api._build_csv(captures))
+
+        # 1 header + ceil(5000 / CSV_ROWS_PER_CHUNK) row batches.
+        assert len(chunks) == 1 + -(-rows // scope_api.CSV_ROWS_PER_CHUNK)
+        assert len(chunks) < rows, "one chunk per row costs a threadpool hop and an ASGI body message per sample"
+
+    def test_batching_changes_no_bytes(self):
+        # The batch boundary must not land inside a row, or between rows
+        # without its newline: the concatenation has to be identical to the
+        # unbatched one, whatever the row count does modulo the batch size.
+        captures = [(1, _fake_waveform(n=scope_api.CSV_ROWS_PER_CHUNK * 2 + 7))]
+
+        assert "".join(scope_api._build_csv(captures)) == _reference_build_csv(captures)
+
+
 class TestStreamingResponseType:
     # StreamingResponse never populates Content-Length (Starlette's
     # Response.init_headers only derives it from a fully-built .body, which

--- a/tests/test_server_export_bounds.py
+++ b/tests/test_server_export_bounds.py
@@ -23,7 +23,7 @@ fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")  # fastapi.testclient needs it
 from fastapi.testclient import TestClient  # noqa: E402
 
-from scpi_control.exceptions import FeatureNotSupportedError  # noqa: E402
+from scpi_control.exceptions import FeatureNotSupportedError, SiglentError  # noqa: E402
 from scpi_control.oscilloscope import Oscilloscope  # noqa: E402
 from scpi_control.server.api import scope as scope_api  # noqa: E402
 from scpi_control.server.app import create_app  # noqa: E402
@@ -42,11 +42,27 @@ def client(gateway_auth):
     manager.close_all()
 
 
+MODERN_MODEL = "SDS824X HD"  # the modern-dialect model the rest of this branch's server tests use
+
+
 def create_mock_session(client):
     # Default (mock=True, no model) is the legacy dialect (SDS1104X-E) --
     # deliberately unpatched, this is what exercises the record_length() is
     # None path (see TestUnknownRecordLengthProceedsUnguarded below).
     response = client.post("/api/sessions", json={"mock": True})
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def create_modern_mock_session(client):
+    """A MODERN-dialect mock session. Every other test in this file uses the
+    default legacy mock, which is exactly the coverage gap that let a
+    modern-dialect 504 through: legacy has no "get_acq_points" mapping at all,
+    so record_length() returns early on _has_command and the query is never
+    sent. Modern DOES map :ACQuire:POINts? -- and the mock has no response for
+    it -- so this is the configuration where the query actually runs and fails.
+    """
+    response = client.post("/api/sessions", json={"mock": True, "model": MODERN_MODEL})
     assert response.status_code == 201, response.text
     return response.json()["id"]
 
@@ -223,6 +239,47 @@ class TestUnknownRecordLengthProceedsUnguarded:
         instrument.connect()
         assert instrument.dialect == "legacy"
         assert instrument.record_length() is None
+
+
+class TestAFailingRecordLengthQueryDoesNotFailTheExport:
+    # Final-review fix (Critical 1): _export_stride calls record_length()
+    # bare, and record_length() only guarded _has_command -- it did not catch a
+    # FAILING query. On a modern-dialect session whose instrument (or the mock)
+    # has no answer for :ACQuire:POINts?, the query raised, run_job re-raised,
+    # and the app-level handler turned it into a 504 for BOTH exports. Both
+    # returned 200 before this branch. record_length() now swallows like its
+    # sibling waveform_max_points() already did, so _export_stride falls into
+    # its designed size_verified=False branch instead.
+
+    def test_capture_csv_returns_200_on_a_modern_dialect_session(self, client):
+        sid = create_modern_mock_session(client)
+
+        response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+
+        assert response.status_code == 200, response.text
+
+    def test_waveform_json_returns_200_on_a_modern_dialect_session(self, client):
+        sid = create_modern_mock_session(client)
+
+        response = client.get("/api/sessions/{0}/scope/waveform?channels=1".format(sid))
+
+        assert response.status_code == 200, response.text
+
+    def test_the_modern_mock_really_cannot_answer_the_record_length_query(self):
+        # Pins what makes the two tests above meaningful: modern MAPS
+        # :ACQuire:POINts? (unlike legacy) and the mock cannot answer it, so
+        # the query is genuinely attempted and genuinely fails. If the mock
+        # ever grows a handler, those tests would silently stop covering the
+        # failing-query path and this one fails loudly instead.
+        from scpi_control.connection.mock.base import MockConnection
+
+        instrument = Oscilloscope("mock", connection=MockConnection("mock", idn="Siglent Technologies,{0},MOCK0001,1.0.0.0".format(MODERN_MODEL)))
+        instrument.connect()
+        assert instrument.dialect == "modern"
+        assert instrument._has_command("get_acq_points"), "modern must map :ACQuire:POINts? -- otherwise record_length() short-circuits and no query is sent"
+        with pytest.raises(SiglentError):
+            instrument.query(instrument._get_command("get_acq_points"))
+        assert instrument.record_length() is None, "record_length() must degrade to None on a failing query, not raise"
 
 
 class TestUnverifiableOversizedExportLogsAWarning:

--- a/tests/test_server_export_bounds.py
+++ b/tests/test_server_export_bounds.py
@@ -23,6 +23,7 @@ fastapi = pytest.importorskip("fastapi")
 pytest.importorskip("httpx")  # fastapi.testclient needs it
 from fastapi.testclient import TestClient  # noqa: E402
 
+from scpi_control.exceptions import FeatureNotSupportedError  # noqa: E402
 from scpi_control.oscilloscope import Oscilloscope  # noqa: E402
 from scpi_control.server.api import scope as scope_api  # noqa: E402
 from scpi_control.server.app import create_app  # noqa: E402
@@ -222,3 +223,126 @@ class TestUnknownRecordLengthProceedsUnguarded:
         instrument.connect()
         assert instrument.dialect == "legacy"
         assert instrument.record_length() is None
+
+
+class TestUnverifiableOversizedExportLogsAWarning:
+    # Review fix (Important 1): the unguarded legacy path had no runtime
+    # signal at all when the eventual fetch turned out to be oversized after
+    # the fact -- only a docstring. Prevention is impossible once the array
+    # is already in memory, but the operator deserves a log line, not silence.
+
+    def test_logs_a_warning_naming_the_actual_count_when_size_could_not_be_verified(self, client, monkeypatch, caplog):
+        # MAX_EXPORT_POINTS is shrunk to keep this test fast/light -- the
+        # array itself doesn't need to be huge, only larger than whatever
+        # the threshold is, to reach the "turned out oversized" branch.
+        monkeypatch.setattr(scope_api, "MAX_EXPORT_POINTS", 100)
+        oversized = _fake_waveform(n=107)
+        monkeypatch.setattr(Oscilloscope, "get_waveform", lambda self, channel, provenance=True, stride=None: oversized)
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: None)  # unverifiable dialect
+        sid = create_mock_session(client)
+
+        with caplog.at_level("WARNING", logger="scpi_control.server.api.scope"):
+            response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+
+        assert response.status_code == 200  # prevention is impossible after the fact -- this still succeeds
+        warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any("107" in w and "record_length" in w for w in warnings), warnings
+
+    def test_no_warning_when_the_unverifiable_fetch_is_actually_small(self, client, monkeypatch, caplog):
+        # The warning is specifically about turning out to be oversized, not
+        # about record_length() being unknown per se -- most legacy exports
+        # are small and must stay silent.
+        small = _fake_waveform(n=41)
+        monkeypatch.setattr(Oscilloscope, "get_waveform", lambda self, channel, provenance=True, stride=None: small)
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: None)
+        sid = create_mock_session(client)
+
+        with caplog.at_level("WARNING", logger="scpi_control.server.api.scope"):
+            response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+
+        assert response.status_code == 200
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+    def test_no_warning_when_size_was_verified_in_advance(self, client, monkeypatch, caplog):
+        # size_verified True (record_length() answered) must never trigger
+        # this specific warning, even if -- hypothetically -- the fetch
+        # somehow returned more than the recorded length.
+        fixed = _fake_waveform(n=41)
+        monkeypatch.setattr(Oscilloscope, "get_waveform", lambda self, channel, provenance=True, stride=None: fixed)
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: len(fixed.voltage))
+        sid = create_mock_session(client)
+
+        with caplog.at_level("WARNING", logger="scpi_control.server.api.scope"):
+            response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+
+        assert response.status_code == 200
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+
+class TestTransferCapTripBecomes413:
+    # Review fix (Important 2): record_length() and the fetch are two
+    # separate run_job calls with nothing holding the record between them, so
+    # a record that changes in that window -- or an instrument whose real
+    # transfer cap is smaller than assumed -- can still trip
+    # ModernTransfer's single-window ceiling (FeatureNotSupportedError),
+    # which subclasses SiglentError and would otherwise surface as an
+    # uncaught 500. It must become a 413 instead, consistent with the
+    # oversized-record refusal.
+
+    def test_capture_csv_turns_a_transfer_cap_trip_into_413(self, client, monkeypatch):
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: 10_000)
+
+        def raising_get_waveform(self, channel, provenance=True, stride=None):
+            raise FeatureNotSupportedError(
+                "Strided read of 10000 points (stride=200) exceeds this instrument's per-transfer cap of 50 points " "(:WAVeform:MAXPoint?); multi-window strided reads are not supported (test)"
+            )
+
+        monkeypatch.setattr(Oscilloscope, "get_waveform", raising_get_waveform)
+        sid = create_mock_session(client)
+
+        response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1&max_points=50".format(sid))
+
+        assert response.status_code == 413
+        detail = response.json()["detail"]
+        assert "max_points" in detail
+        assert "per-transfer" in detail
+
+    def test_waveform_json_turns_a_transfer_cap_trip_into_413(self, client, monkeypatch):
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: 10_000)
+
+        def raising_get_waveform(self, channel, provenance=True, stride=None):
+            raise FeatureNotSupportedError(
+                "Strided read of 10000 points (stride=200) exceeds this instrument's per-transfer cap of 50 points " "(:WAVeform:MAXPoint?); multi-window strided reads are not supported (test)"
+            )
+
+        monkeypatch.setattr(Oscilloscope, "get_waveform", raising_get_waveform)
+        sid = create_mock_session(client)
+
+        response = client.get("/api/sessions/{0}/scope/waveform?channels=1&max_points=50".format(sid))
+
+        assert response.status_code == 413
+        assert "max_points" in response.json()["detail"]
+
+
+class TestDefaultPathNeverStrides:
+    # Minor (export-side twin of the Task 7 guard): the guarantee that a
+    # default (no max_points) export is never silently decimated currently
+    # holds only by construction. Pin it directly, so a future change to the
+    # `cap is None` short-circuit in _export_stride cannot regress silently.
+
+    def test_default_path_passes_no_stride(self, client, monkeypatch):
+        fixed = _fake_waveform(n=41)
+        seen_strides = []
+
+        def fake_get_waveform(self, channel, provenance=True, stride=None):
+            seen_strides.append(stride)
+            return fixed
+
+        monkeypatch.setattr(Oscilloscope, "get_waveform", fake_get_waveform)
+        monkeypatch.setattr(Oscilloscope, "record_length", lambda self: len(fixed.voltage))
+        sid = create_mock_session(client)
+
+        response = client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+
+        assert response.status_code == 200
+        assert seen_strides == [None], "the default (no max_points) path must never pass a stride -- an export decimated without being asked is the failure this task must not create"

--- a/tests/test_server_limits.py
+++ b/tests/test_server_limits.py
@@ -38,42 +38,32 @@ def test_closing_a_session_frees_a_slot(capped_client):
     assert capped_client.post("/api/sessions", json={"label": "s", "mock": True}).status_code == 201
 
 
-def test_capture_csv_runs_off_the_event_loop(capped_client, monkeypatch):
-    calls = []
-    import scpi_control.server.api.scope as scope_api
-
-    original = scope_api.run_in_threadpool
-
-    async def spy(fn, *args, **kwargs):
-        calls.append(getattr(fn, "__name__", repr(fn)))
-        return await original(fn, *args, **kwargs)
-
-    monkeypatch.setattr(scope_api, "run_in_threadpool", spy)
+def test_capture_csv_runs_off_the_event_loop(capped_client):
+    # Task 8: _build_csv became a generator streamed via StreamingResponse, so
+    # the row-building work is no longer a single call routed through this
+    # module's run_in_threadpool -- Starlette's iterate_in_threadpool now
+    # drives each next() off the event loop instead (starlette.concurrency).
+    # The observable, black-box guarantee that replaces the old spy: a
+    # streaming response never carries a Content-Length header (Starlette only
+    # populates it from a fully-built .body, which StreamingResponse never
+    # sets -- see starlette.responses.Response.init_headers).
     sid = capped_client.post("/api/sessions", json={"label": "s", "mock": True}).json()["id"]
-    assert capped_client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid)).status_code == 200
-    # Name the specific function: asserting the list is merely non-empty would
-    # pass on any unrelated threadpool call in this module.
-    assert "_build_csv" in calls, "CSV serialization still runs on the event loop"
+    response = capped_client.get("/api/sessions/{0}/scope/capture.csv?channels=1".format(sid))
+    assert response.status_code == 200
+    assert "content-length" not in response.headers, "CSV export is not a streaming response"
 
 
-def test_capture_waveform_runs_off_the_event_loop(capped_client, monkeypatch):
+def test_capture_waveform_runs_off_the_event_loop(capped_client):
     # The waveform JSON route is the larger payload and the motivating
     # deep-memory scenario -- it deserves the same off-loop guarantee as CSV.
-    calls = []
-    import scpi_control.server.api.scope as scope_api
-
-    original = scope_api.run_in_threadpool
-
-    async def spy(fn, *args, **kwargs):
-        calls.append(getattr(fn, "__name__", repr(fn)))
-        return await original(fn, *args, **kwargs)
-
-    monkeypatch.setattr(scope_api, "run_in_threadpool", spy)
+    # See test_capture_csv_runs_off_the_event_loop above: Task 8 replaced the
+    # single run_in_threadpool(_build_waveform_response, ...) call with a
+    # streamed, per-channel generator, so the same Content-Length absence
+    # check is the black-box signal that the body is never fully built.
     sid = capped_client.post("/api/sessions", json={"label": "s", "mock": True}).json()["id"]
-    assert capped_client.get("/api/sessions/{0}/scope/waveform?channels=1".format(sid)).status_code == 200
-    # Name the specific function: asserting the list is merely non-empty would
-    # pass on any unrelated threadpool call in this module.
-    assert "_build_waveform_response" in calls, "waveform serialization still runs on the event loop"
+    response = capped_client.get("/api/sessions/{0}/scope/waveform?channels=1".format(sid))
+    assert response.status_code == 200
+    assert "content-length" not in response.headers, "waveform export is not a streaming response"
 
 
 class TestCreateAppMutualExclusionGuard:

--- a/tests/test_server_poll_gate.py
+++ b/tests/test_server_poll_gate.py
@@ -1,0 +1,121 @@
+"""ScopeAdapter.poll() gates the waveform fetch on new_acquisition_ready().
+
+Without this gate, poll() asks for a waveform on a fixed timer regardless of
+whether the scope has actually finished acquiring one. Against a real
+instrument at a slow timebase, that read blocks for the rest of the
+acquisition -- and the session's single worker thread is also the only thing
+servicing user commands, so every control in the web UI hangs for the length
+of the capture.
+
+These tests use a fake scope rather than a MockConnection-backed Oscilloscope:
+this is the adapter's decision logic under test, not SCPI wire behaviour.
+"""
+
+from scpi_control.server.adapters import MAX_FRAME_POINTS, ScopeAdapter
+
+
+class _FakeChannel:
+    enabled = True
+
+
+class _FakeWaveform:
+    time = [0.0, 1.0]
+    voltage = [0.0, 1.0]
+
+
+class _FakeScope:
+    """Records the stride it was asked for; answers new_acquisition_ready()
+    from a fixed sequence, raising if asked more than once per tick (the
+    underlying INR? register is read-and-clear -- a second read in the same
+    tick would consume a real event and get a meaningless answer)."""
+
+    def __init__(self, ready, record_length=None, max_points=None):
+        self._ready = iter(ready)
+        self._record_length = record_length
+        self._max_points = max_points
+        self.supported_channels = [1]
+        self.math1 = None
+        self.math2 = None
+        self.last_stride = None
+
+    def new_acquisition_ready(self):
+        return next(self._ready)
+
+    def record_length(self):
+        return self._record_length
+
+    def waveform_max_points(self):
+        return self._max_points
+
+    def get_channel(self, n):
+        return _FakeChannel()
+
+    def get_waveform(self, channel, provenance=False, stride=None):
+        self.last_stride = stride
+        return _FakeWaveform()
+
+
+def _adapter(ready, record_length=None, max_points=None):
+    scope = _FakeScope(ready, record_length=record_length, max_points=max_points)
+    adapter = ScopeAdapter()
+    published = []
+    return adapter, scope, published
+
+
+def test_the_first_tick_fetches_without_waiting_for_a_new_acquisition():
+    # Otherwise a scope sitting in Stop shows an empty canvas forever, when it
+    # has a perfectly good last frame to display.
+    adapter, scope, published = _adapter(ready=[False, False])
+    adapter.poll(scope, published.append, 1)
+    assert any(f["type"] == "waveform" for f in published)
+
+
+def test_a_later_tick_publishes_nothing_when_no_new_acquisition_landed():
+    adapter, scope, published = _adapter(ready=[False, False])
+    adapter.poll(scope, published.append, 1)  # first tick always fetches
+    published.clear()
+    adapter.poll(scope, published.append, 2)
+    assert published == []
+
+
+def test_a_later_tick_fetches_when_a_new_acquisition_landed():
+    adapter, scope, published = _adapter(ready=[False, True])
+    adapter.poll(scope, published.append, 1)
+    published.clear()
+    adapter.poll(scope, published.append, 2)
+    assert any(f["type"] == "waveform" for f in published)
+
+
+def test_a_dialect_without_the_gate_keeps_fetching_every_tick():
+    # The tri-state's whole purpose: None must not be read as False, or the live
+    # view dies on every non-Siglent scope.
+    adapter, scope, published = _adapter(ready=[None, None])
+    adapter.poll(scope, published.append, 1)
+    published.clear()
+    adapter.poll(scope, published.append, 2)
+    assert any(f["type"] == "waveform" for f in published)
+
+
+def test_the_stride_is_sized_from_the_record_length():
+    adapter, scope, published = _adapter(ready=[True], record_length=200_000)
+    adapter.poll(scope, published.append, 1)
+    assert scope.last_stride == 100  # ceil(200000 / MAX_FRAME_POINTS)
+
+
+def test_the_stride_also_respects_the_instruments_transfer_cap():
+    # A stride sized against MAX_FRAME_POINTS alone can still exceed a low
+    # :WAVeform:MAXPoint? cap, turning ModernTransfer's guard
+    # (FeatureNotSupportedError, waveform_transfer.py) into a total live-view
+    # outage on a model that reports a cap below MAX_FRAME_POINTS. Size
+    # against min(MAX_FRAME_POINTS, max_points) instead, so the guard is
+    # unreachable by construction.
+    adapter, scope, published = _adapter(ready=[True], record_length=200_000, max_points=500)
+    adapter.poll(scope, published.append, 1)
+    assert scope.last_stride == 400  # ceil(200000 / min(2000, 500))
+
+
+def test_max_frame_points_constant_is_what_the_stride_test_assumes():
+    # Pins the constant the two tests above compute their expectations from,
+    # so a change to it fails loudly here instead of silently invalidating
+    # the hand-computed assertions above.
+    assert MAX_FRAME_POINTS == 2000

--- a/tests/test_server_poll_gate.py
+++ b/tests/test_server_poll_gate.py
@@ -16,6 +16,20 @@ from scpi_control.server.adapters import MAX_FRAME_POINTS, ScopeAdapter
 
 class _FakeChannel:
     enabled = True
+    # The rest is only here so read_state() (which initial_frame calls) can
+    # read a channel without a real Oscilloscope.
+    voltage_scale = 1.0
+    voltage_offset = 0.0
+    coupling = "DC"
+    probe_ratio = 1.0
+
+
+class _FakeTrigger:
+    mode = "AUTO"
+    source = "C1"
+    level = 0.0
+    slope = "POS"
+    coupling = "DC"
 
 
 class _FakeWaveform:
@@ -37,6 +51,11 @@ class _FakeScope:
         self.math1 = None
         self.math2 = None
         self.last_stride = None
+        self.timebase = 1e-3
+        self.trigger = _FakeTrigger()
+
+    def acquisition_status(self):
+        return "STOP"
 
     def new_acquisition_ready(self):
         return next(self._ready)
@@ -94,6 +113,26 @@ def test_a_dialect_without_the_gate_keeps_fetching_every_tick():
     published.clear()
     adapter.poll(scope, published.append, 2)
     assert any(f["type"] == "waveform" for f in published)
+
+
+def test_a_new_viewer_gets_the_first_tick_exemption_again():
+    """Final-review fix (Important 2): the exemption was tracked per SESSION
+    but the canvas it protects belongs to a SUBSCRIBER. The frontend clears
+    every frame on unmount, and initial_frame publishes only a `state` frame --
+    so a viewer that reloads the page had an empty canvas and a flag saying "a
+    frame was already published", and on a scope sitting in Stop (INR? bit 0
+    never sets again) it stayed empty forever, with no error and no log line.
+    Seeding a new stream must re-arm the exemption.
+    """
+    adapter, scope, published = _adapter(ready=[False, False])
+    adapter.poll(scope, published.append, 1)  # first tick fetches under the exemption
+    assert any(f["type"] == "waveform" for f in published)
+
+    adapter.initial_frame(scope)  # a viewer (re)opens the stream: fresh, empty canvas
+
+    published.clear()
+    adapter.poll(scope, published.append, 2)
+    assert any(f["type"] == "waveform" for f in published), "a reloaded viewer with a cleared canvas must get a frame, not wait forever for an acquisition that never comes"
 
 
 def test_the_stride_is_sized_from_the_record_length():

--- a/tests/test_server_poll_logging.py
+++ b/tests/test_server_poll_logging.py
@@ -132,26 +132,35 @@ def test_a_query_that_degrades_inside_the_accessor_is_silent_by_design(caplog):
     _safe never sees an exception from them and its logging branch is
     unreachable. The labels promised log lines that could never be written.
 
-    A modern-dialect mock is exactly that situation for real: it has no
-    response for :ACQuire:POINts?, so record_length() genuinely fails and
-    genuinely degrades to None. The tick must still publish a frame and must
-    stay silent, since nothing was swallowed at this level.
+    This used to lean on the modern mock simply being unable to answer INR?
+    and :ACQuire:POINts?. It no longer can: the mock now answers BOTH the way
+    hardware does (header-prefixed "INR 8193", bare NR3 "1.00E+05"), because
+    each of those queries silently failing was itself a bug -- the first left
+    the new-acquisition gate inert on the instrument, the second meant stride
+    sizing was never exercised at all.
 
-    This test used to lean on INR? failing here too. It no longer does: the
-    modern mock now answers INR? the way hardware does (header-prefixed
-    "INR 8193"), because that query silently failing was itself the bug that
-    left the new-acquisition gate inert on the instrument. record_length()
-    still degrades, which is all this test needs.
+    So the degradation is forced explicitly now, which is what this test was
+    always really about: an accessor that swallows its own query failure gives
+    _safe nothing to log, and the tick must still publish a frame and stay
+    silent. Forcing it also means the test cannot quietly stop covering
+    anything the next time the mock grows a handler.
     """
     from scpi_control.connection.mock import MockConnection
     from scpi_control.oscilloscope import Oscilloscope
 
-    conn = MockConnection("mock", idn="Siglent Technologies,SDS824X HD,MOCK0001,1.0.0.0", channel_states={1: True, 2: False, 3: False, 4: False}, sample_rate=1_000_000.0, timebase=1e-3)
+    conn = MockConnection(
+        "mock",
+        idn="Siglent Technologies,SDS824X HD,MOCK0001,1.0.0.0",
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        sample_rate=1_000_000.0,
+        timebase=1e-3,
+        custom_responses={":ACQuire:POINts?": "not-a-number"},
+    )
     scope = Oscilloscope("mock", connection=conn)
     scope.connect()
     assert scope.dialect == "modern"
     assert scope.new_acquisition_ready() is not None, "the modern mock must answer INR? now -- a silently failing gate was the bug"
-    assert scope.record_length() is None, "fixture broken: the modern mock is expected to fail :ACQuire:POINts?"
+    assert scope.record_length() is None, "fixture broken: record_length() must degrade to None on the forced bad reply"
 
     adapter = ScopeAdapter()
     published = []

--- a/tests/test_server_poll_logging.py
+++ b/tests/test_server_poll_logging.py
@@ -1,0 +1,129 @@
+"""A poll-path query failure must stop being silent.
+
+The incident: a scope's channel-enabled query started raising SiglentError,
+_safe() swallowed it with no log line, and the channel silently read as "off"
+-- no frames, no error, no clue. Diagnosing the frozen live view took an hour
+of ruling out the transport, the bundle, auth, and the frontend, because
+nothing in the gateway ever said a query had failed.
+
+The fix must not become the next incident in the other direction: logging
+every tick of a persistent failure would write four lines a second at the
+0.25s poll interval and bury every other line in the log. So the discipline
+is once per transition -- one WARNING when a query starts failing, one
+recovery record when it starts succeeding again, nothing in between.
+
+These tests build the failing query with a fake scope whose channel accessor
+raises, rather than by monkeypatching _safe -- so the real _safe/poll() path
+is what's under test.
+"""
+
+import logging
+
+from scpi_control.exceptions import SiglentError
+from scpi_control.server.adapters import ScopeAdapter
+
+ADAPTERS_LOGGER = "scpi_control.server.adapters"
+
+
+class _RaisingChannel:
+    """A channel whose display query (the `.enabled` accessor) always fails,
+    exactly like the incident's channel-enabled read."""
+
+    @property
+    def enabled(self):
+        raise SiglentError("C1:TRA? timed out")
+
+
+class _OkChannel:
+    enabled = True
+
+
+class _FakeWaveform:
+    time = [0.0, 1.0]
+    voltage = [0.0, 1.0]
+
+
+class _FakeScope:
+    """Just enough surface for ScopeAdapter.poll(): one channel, no math, a
+    gate that always says "go", and a waveform read that never fails -- the
+    only thing under test is what happens when the channel accessor raises.
+    """
+
+    supported_channels = [1]
+    math1 = None
+    math2 = None
+
+    def __init__(self, channel):
+        self.channel = channel
+
+    def new_acquisition_ready(self):
+        return True
+
+    def record_length(self):
+        return 2
+
+    def waveform_max_points(self):
+        return 1000
+
+    def get_channel(self, n):
+        return self.channel
+
+    def get_waveform(self, channel, provenance=False, stride=None):
+        return _FakeWaveform()
+
+
+def _adapter_records(caplog, level=logging.WARNING):
+    """Records from OUR logger only, at-or-above `level`. Filtering by logger
+    name (not just clearing caplog) keeps these assertions robust to any
+    unrelated warning some other module happens to log during the same tick.
+    """
+    return [r for r in caplog.records if r.name == ADAPTERS_LOGGER and r.levelno >= level]
+
+
+def test_a_failed_poll_query_is_logged_once_per_transition(caplog):
+    adapter = ScopeAdapter()
+    scope = _FakeScope(_RaisingChannel())
+    with caplog.at_level(logging.WARNING, logger=ADAPTERS_LOGGER):
+        caplog.clear()
+        adapter.poll(scope, lambda frame: None, 1)
+        adapter.poll(scope, lambda frame: None, 2)
+
+    warnings = _adapter_records(caplog, logging.WARNING)
+    # One per tick would bury the log: at 0.25s a persistent failure would
+    # write four lines a second.
+    assert len(warnings) == 1, "a persistent failure must log once, not once per tick: {0}".format(warnings)
+    assert "channel 1" in warnings[0].getMessage(), "the warning must name the failing operation"
+
+
+def test_recovery_is_logged_so_the_log_shows_the_end_of_the_outage(caplog):
+    adapter = ScopeAdapter()
+    scope = _FakeScope(_RaisingChannel())
+    with caplog.at_level(logging.INFO, logger=ADAPTERS_LOGGER):
+        caplog.clear()
+        adapter.poll(scope, lambda frame: None, 1)  # fail
+        adapter.poll(scope, lambda frame: None, 2)  # fail (steady state, no new log)
+        scope.channel = _OkChannel()
+        adapter.poll(scope, lambda frame: None, 3)  # recover
+
+    warnings = _adapter_records(caplog, logging.WARNING)
+    all_records = [r for r in caplog.records if r.name == ADAPTERS_LOGGER]
+    recoveries = [r for r in all_records if r.levelno < logging.WARNING]
+
+    assert len(warnings) == 1, "the failure must still log exactly once: {0}".format(warnings)
+    # Without a recovery line, a reader of the log has no way to tell whether
+    # an outage that shows up as a WARNING is still ongoing.
+    assert len(recoveries) == 1, "a failure->success transition must log a recovery record: {0}".format(all_records)
+    assert "channel 1" in recoveries[0].getMessage(), "the recovery record must name the operation that recovered"
+
+
+def test_a_healthy_poll_logs_nothing(caplog):
+    adapter = ScopeAdapter()
+    scope = _FakeScope(_OkChannel())
+    with caplog.at_level(logging.INFO, logger=ADAPTERS_LOGGER):
+        caplog.clear()
+        adapter.poll(scope, lambda frame: None, 1)
+
+    # Filtered by logger name and level, not "caplog is entirely empty": that
+    # keeps this test robust to an unrelated record some other module logs.
+    at_or_above_warning = _adapter_records(caplog, logging.WARNING)
+    assert at_or_above_warning == [], "a normal tick must not log at WARNING or above: {0}".format(at_or_above_warning)

--- a/tests/test_server_poll_logging.py
+++ b/tests/test_server_poll_logging.py
@@ -133,10 +133,15 @@ def test_a_query_that_degrades_inside_the_accessor_is_silent_by_design(caplog):
     unreachable. The labels promised log lines that could never be written.
 
     A modern-dialect mock is exactly that situation for real: it has no
-    response for INR? or :ACQuire:POINts?, so both queries genuinely fail and
-    both accessors genuinely degrade to None. The tick must still publish a
-    frame (a gate we cannot read is "no gate", not "not ready") and must stay
-    silent, since nothing was swallowed at this level.
+    response for :ACQuire:POINts?, so record_length() genuinely fails and
+    genuinely degrades to None. The tick must still publish a frame and must
+    stay silent, since nothing was swallowed at this level.
+
+    This test used to lean on INR? failing here too. It no longer does: the
+    modern mock now answers INR? the way hardware does (header-prefixed
+    "INR 8193"), because that query silently failing was itself the bug that
+    left the new-acquisition gate inert on the instrument. record_length()
+    still degrades, which is all this test needs.
     """
     from scpi_control.connection.mock import MockConnection
     from scpi_control.oscilloscope import Oscilloscope
@@ -145,7 +150,7 @@ def test_a_query_that_degrades_inside_the_accessor_is_silent_by_design(caplog):
     scope = Oscilloscope("mock", connection=conn)
     scope.connect()
     assert scope.dialect == "modern"
-    assert scope.new_acquisition_ready() is None, "fixture broken: the modern mock is expected to fail INR?, degrading the gate to None"
+    assert scope.new_acquisition_ready() is not None, "the modern mock must answer INR? now -- a silently failing gate was the bug"
     assert scope.record_length() is None, "fixture broken: the modern mock is expected to fail :ACQuire:POINts?"
 
     adapter = ScopeAdapter()

--- a/tests/test_server_poll_logging.py
+++ b/tests/test_server_poll_logging.py
@@ -96,23 +96,32 @@ def test_a_failed_poll_query_is_logged_once_per_transition(caplog):
 
 
 def test_recovery_is_logged_so_the_log_shows_the_end_of_the_outage(caplog):
+    """The recovery record must be a WARNING, not a quieter level: an
+    operator or alerting pipeline filtering at WARNING -- the level the
+    onset failure logs at -- must see the outage both begin AND end, or the
+    log is exactly as ambiguous as it was before this fix for that reader.
+    A level-agnostic "a recovery record exists somewhere" assertion cannot
+    tell that design apart from a design that quietly logs recovery at INFO,
+    so this asserts the level explicitly.
+    """
     adapter = ScopeAdapter()
     scope = _FakeScope(_RaisingChannel())
-    with caplog.at_level(logging.INFO, logger=ADAPTERS_LOGGER):
+    with caplog.at_level(logging.WARNING, logger=ADAPTERS_LOGGER):
         caplog.clear()
         adapter.poll(scope, lambda frame: None, 1)  # fail
         adapter.poll(scope, lambda frame: None, 2)  # fail (steady state, no new log)
         scope.channel = _OkChannel()
         adapter.poll(scope, lambda frame: None, 3)  # recover
 
-    warnings = _adapter_records(caplog, logging.WARNING)
-    all_records = [r for r in caplog.records if r.name == ADAPTERS_LOGGER]
-    recoveries = [r for r in all_records if r.levelno < logging.WARNING]
+    all_records = _adapter_records(caplog, logging.WARNING)
+    failures = [r for r in all_records if "failed" in r.getMessage()]
+    recoveries = [r for r in all_records if "recovered" in r.getMessage()]
 
-    assert len(warnings) == 1, "the failure must still log exactly once: {0}".format(warnings)
+    assert len(failures) == 1, "the failure must still log exactly once: {0}".format(all_records)
     # Without a recovery line, a reader of the log has no way to tell whether
     # an outage that shows up as a WARNING is still ongoing.
     assert len(recoveries) == 1, "a failure->success transition must log a recovery record: {0}".format(all_records)
+    assert recoveries[0].levelno == logging.WARNING, "the recovery record must be WARNING, matching the failure's level"
     assert "channel 1" in recoveries[0].getMessage(), "the recovery record must name the operation that recovered"
 
 

--- a/tests/test_server_poll_logging.py
+++ b/tests/test_server_poll_logging.py
@@ -125,6 +125,39 @@ def test_recovery_is_logged_so_the_log_shows_the_end_of_the_outage(caplog):
     assert "channel 1" in recoveries[0].getMessage(), "the recovery record must name the operation that recovered"
 
 
+def test_a_query_that_degrades_inside_the_accessor_is_silent_by_design(caplog):
+    """Final-review fix (cheap 1): poll() passed label="acquisition ready
+    check" (and labels for record length / waveform max points) to _safe, but
+    all three accessors catch their own query failure and return None -- so
+    _safe never sees an exception from them and its logging branch is
+    unreachable. The labels promised log lines that could never be written.
+
+    A modern-dialect mock is exactly that situation for real: it has no
+    response for INR? or :ACQuire:POINts?, so both queries genuinely fail and
+    both accessors genuinely degrade to None. The tick must still publish a
+    frame (a gate we cannot read is "no gate", not "not ready") and must stay
+    silent, since nothing was swallowed at this level.
+    """
+    from scpi_control.connection.mock import MockConnection
+    from scpi_control.oscilloscope import Oscilloscope
+
+    conn = MockConnection("mock", idn="Siglent Technologies,SDS824X HD,MOCK0001,1.0.0.0", channel_states={1: True, 2: False, 3: False, 4: False}, sample_rate=1_000_000.0, timebase=1e-3)
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    assert scope.dialect == "modern"
+    assert scope.new_acquisition_ready() is None, "fixture broken: the modern mock is expected to fail INR?, degrading the gate to None"
+    assert scope.record_length() is None, "fixture broken: the modern mock is expected to fail :ACQuire:POINts?"
+
+    adapter = ScopeAdapter()
+    published = []
+    with caplog.at_level(logging.WARNING, logger=ADAPTERS_LOGGER):
+        caplog.clear()
+        adapter.poll(scope, published.append, 1)
+
+    assert any(frame.get("type") == "waveform" for frame in published), "an unreadable gate must not stall the live view"
+    assert _adapter_records(caplog, logging.WARNING) == [], "these three queries degrade inside the accessor -- the adapter has nothing to report"
+
+
 def test_a_healthy_poll_logs_nothing(caplog):
     adapter = ScopeAdapter()
     scope = _FakeScope(_OkChannel())

--- a/tests/test_server_worker_responsiveness.py
+++ b/tests/test_server_worker_responsiveness.py
@@ -20,6 +20,7 @@ blocking read reproducible without sleeping: the read blocks until the test
 releases the gate.
 """
 
+import itertools
 import threading
 
 import pytest
@@ -54,10 +55,35 @@ def _mock_session(waveform_gate, ready, poll_interval=0.05):
     return InstrumentSession.open("bench-1", mock=True, _connection=conn, poll_interval=poll_interval)
 
 
+def _scripted_clock(*values):
+    """A `time.monotonic` replacement: yields `values` in order, then repeats
+    the last one forever.
+
+    Repeating the tail rather than raising StopIteration matters: if a future
+    change to `_poll_if_due`/`_poll_tick` calls `monotonic()` more times than
+    a test anticipated, the test fails on a real (if surprising) assertion
+    against a plausible clock value instead of an opaque StopIteration -- and
+    any other thread that happens to call the patched `monotonic()` in the
+    same window gets a sane value rather than an exception.
+    """
+    it = itertools.chain(values, itertools.repeat(values[-1]))
+    return lambda: next(it)
+
+
 def test_a_user_job_is_not_starved_by_a_long_acquisition(monkeypatch):
     # Before the gate, the worker sat inside a blocking waveform read for the
     # whole acquisition and never looked at the job queue, so every control in
     # the UI hung for the length of the capture.
+    #
+    # Coupling note: this test's synchronization point is
+    # new_acquisition_ready() being invoked on the instrument exactly once per
+    # tick (see `_signal_then_answer` below). A future refactor that caches
+    # readiness across ticks, or moves the gate check somewhere that no
+    # longer calls the instrument's own method, would fail this test with
+    # "no poll tick ever reached the readiness check" even though the UI
+    # stayed perfectly responsive. That is the deliberate price of a
+    # mutation-proof synchronization point (see the module docstring), and is
+    # worth knowing before chasing it as a real regression.
     gate = threading.Event()
     session = _mock_session(waveform_gate=gate, ready=False)
     try:
@@ -76,18 +102,27 @@ def test_a_user_job_is_not_starved_by_a_long_acquisition(monkeypatch):
         # exactly the "passes for the wrong reason" trap the brief warns
         # about. new_acquisition_ready() is called unconditionally, before
         # the (possibly mutated-away) early-return, so wrapping it is a
-        # mutation-proof synchronization point.
+        # mutation-proof synchronization point. The answer itself is also
+        # recorded: a bare TimeoutError below cannot distinguish "the guard
+        # was deleted" from "new_acquisition_ready() could not answer at all"
+        # (adapters.py's `_safe(..., default=None)` would turn a raise into
+        # `None`, which the guard never treats as False) -- asserting the
+        # recorded answer really is `False` closes that gap.
         tick_reached_readiness_check = threading.Event()
+        readiness_answers = []
         real_ready = session._instrument.new_acquisition_ready
 
         def _signal_then_answer():
+            answer = real_ready()
+            readiness_answers.append(answer)
             tick_reached_readiness_check.set()
-            return real_ready()
+            return answer
 
         monkeypatch.setattr(session._instrument, "new_acquisition_ready", _signal_then_answer)
 
         session.subscribe(lambda message: None)
         assert tick_reached_readiness_check.wait(timeout=2.0), "no poll tick ever reached the readiness check"
+        assert readiness_answers[-1] is False, "new_acquisition_ready() did not answer False -- this test cannot tell a deleted guard from an unanswerable readiness query"
 
         result = session.submit(lambda scope: "job ran")
         assert result.result(timeout=2.0) == "job ran"
@@ -108,31 +143,29 @@ def test_the_poll_backs_off_to_the_duration_of_the_last_poll(monkeypatch):
     # threaded -- no InstrumentSession.open(), no worker thread started -- so
     # injecting a fake `time.monotonic` schedule cannot race a real tick.
     # `_poll_tick()` itself is a no-op here (no subscribers, state is still
-    # "connecting"), which is fine: the schedule is a function of the
-    # injected clock, not of what the tick actually did.
+    # "connecting"), which is fine: `_last_poll_duration`/`_next_poll_at` are
+    # a function of the injected clock, not of what the tick actually did.
     adapter = ADAPTERS["scope"]()
     session = InstrumentSession("bench", instrument=object(), mock=True, address=None, poll_interval=0.1, adapter=adapter)
 
     # First call: start=100.0, end=105.0 -> a poll "measured" at 5s, far
     # longer than poll_interval (0.1s).
-    clock = iter([100.0, 105.0])
-    monkeypatch.setattr("scpi_control.server.sessions.time.monotonic", lambda: next(clock))
+    monkeypatch.setattr("scpi_control.server.sessions.time.monotonic", _scripted_clock(100.0, 105.0))
     session._poll_if_due()
 
-    assert session.poll_log[-1][1] == 5.0
+    assert session._last_poll_duration == 5.0
     assert session._next_poll_at == 110.0  # 105.0 + max(0.1, 5.0)
 
     # Second call: the schedule says wait until 110.0. A clock reading before
-    # that must skip the tick entirely -- no new log entry.
-    logged_before = len(session.poll_log)
-    monkeypatch.setattr("scpi_control.server.sessions.time.monotonic", lambda: 108.0)
+    # that must skip the tick entirely -- neither field changes.
+    monkeypatch.setattr("scpi_control.server.sessions.time.monotonic", _scripted_clock(108.0))
     session._poll_if_due()
-    assert len(session.poll_log) == logged_before, "a tick ran before its scheduled time"
+    assert session._last_poll_duration == 5.0, "a tick ran before its scheduled time"
+    assert session._next_poll_at == 110.0, "a tick ran before its scheduled time"
 
-    # Third call: past the schedule -> the tick runs again.
-    clock = iter([110.0, 110.2])
-    monkeypatch.setattr("scpi_control.server.sessions.time.monotonic", lambda: next(clock))
+    # Third call: past the schedule -> the tick runs again, with a shorter
+    # duration this time.
+    monkeypatch.setattr("scpi_control.server.sessions.time.monotonic", _scripted_clock(110.0, 110.2))
     session._poll_if_due()
-    assert len(session.poll_log) == logged_before + 1
-    assert session.poll_log[-1][1] == pytest.approx(0.2)
+    assert session._last_poll_duration == pytest.approx(0.2)
     assert session._next_poll_at == pytest.approx(110.4)  # 110.2 + max(0.1, 0.2)

--- a/tests/test_server_worker_responsiveness.py
+++ b/tests/test_server_worker_responsiveness.py
@@ -1,0 +1,138 @@
+"""The regression test this whole sub-project exists for, and its backoff.
+
+InstrumentSession._worker is one loop per session: while the job queue is
+empty it waits ``timeout=poll_interval`` and then runs a poll tick -- and a
+poll tick that blocks inside a waveform read (a real Siglent at a slow
+timebase can take well over a second) leaves the worker unable to service
+ANY queued job for as long as the read takes. Every control in the web UI --
+a channel toggle, Run/Stop, ``/scope/state`` -- hangs for the length of the
+capture.
+
+Task 4's readiness gate (ScopeAdapter.poll: ``new_acquisition_ready()``) fixes
+this by never STARTING the blocking read on a tick that has nothing new to
+report. The test below proves that: a scope reporting "no new acquisition"
+must let a queued job run promptly, and the read that would have starved it
+must be the one thing standing between "prompt" and "starved" -- not a race
+against how fast the test happens to submit the job.
+
+``MockConnection(waveform_gate=...)`` (Task 2) is what makes the would-be
+blocking read reproducible without sleeping: the read blocks until the test
+releases the gate.
+"""
+
+import threading
+
+import pytest
+
+from scpi_control.connection.mock import MockConnection
+from scpi_control.server.adapters import ADAPTERS
+from scpi_control.server.sessions import InstrumentSession
+
+# A dialect new_acquisition_ready() can actually answer (Task 1): the modern
+# SDS824X HD, whose INR? bit 0 the gate reads. The legacy dialect has no such
+# command and new_acquisition_ready() always returns None there, which would
+# make `ready=False` impossible to construct.
+MODERN_IDN = "Siglent Technologies,SDS824X HD,SDS08A0X804831,3.8.12.1.1.3.6"
+
+
+def _mock_session(waveform_gate, ready, poll_interval=0.05):
+    """A connected mock scope session whose waveform-data read blocks on
+    ``waveform_gate`` and whose ``new_acquisition_ready()`` answers a fixed
+    ``ready`` forever (a constant scalar in MockConnection.custom_responses,
+    not a list, so every INR? query gets the same reply).
+    """
+    conn = MockConnection(
+        "mock",
+        idn=MODERN_IDN,
+        channel_states={1: True, 2: False, 3: False, 4: False},
+        trigger_status=["Stop"],
+        sample_rate=1_000_000.0,
+        timebase=1e-3,
+        custom_responses={"INR?": "1" if ready else "0"},
+        waveform_gate=waveform_gate,
+    )
+    return InstrumentSession.open("bench-1", mock=True, _connection=conn, poll_interval=poll_interval)
+
+
+def test_a_user_job_is_not_starved_by_a_long_acquisition(monkeypatch):
+    # Before the gate, the worker sat inside a blocking waveform read for the
+    # whole acquisition and never looked at the job queue, so every control in
+    # the UI hung for the length of the capture.
+    gate = threading.Event()
+    session = _mock_session(waveform_gate=gate, ready=False)
+    try:
+        # Simulate a live view already well into its stream (NOT the very
+        # first tick): ScopeAdapter.poll() always fetches unconditionally on
+        # the first-ever tick, gate or no gate, so it can show a scope's
+        # last-known frame instead of a blank canvas. That exemption is
+        # Task 4's OTHER behaviour and is not what this test is about -- the
+        # bug this test guards is a *later* tick stalling an ongoing stream.
+        session.adapter._published_a_frame = True
+
+        # Wait for a real poll tick to actually reach the readiness check
+        # before submitting the job. Without this, the job can win a race
+        # against the very first tick (submitted before any tick has run at
+        # all) and the test would pass whether or not the gate works --
+        # exactly the "passes for the wrong reason" trap the brief warns
+        # about. new_acquisition_ready() is called unconditionally, before
+        # the (possibly mutated-away) early-return, so wrapping it is a
+        # mutation-proof synchronization point.
+        tick_reached_readiness_check = threading.Event()
+        real_ready = session._instrument.new_acquisition_ready
+
+        def _signal_then_answer():
+            tick_reached_readiness_check.set()
+            return real_ready()
+
+        monkeypatch.setattr(session._instrument, "new_acquisition_ready", _signal_then_answer)
+
+        session.subscribe(lambda message: None)
+        assert tick_reached_readiness_check.wait(timeout=2.0), "no poll tick ever reached the readiness check"
+
+        result = session.submit(lambda scope: "job ran")
+        assert result.result(timeout=2.0) == "job ran"
+    finally:
+        # Always release the gate, even if an assertion above failed, so a
+        # broken gate cannot leave the worker thread blocked forever.
+        gate.set()
+        session.close()
+
+
+def test_the_poll_backs_off_to_the_duration_of_the_last_poll(monkeypatch):
+    # Belt and braces beside the readiness gate: if a gate ever misreports (or
+    # is unavailable, as on a non-Siglent dialect), a slow scope must degrade
+    # to a lower poll rate rather than piling up back-to-back tick attempts
+    # (and the blocking reads that go with them) the moment it recovers.
+    #
+    # This drives InstrumentSession._poll_if_due() directly and single
+    # threaded -- no InstrumentSession.open(), no worker thread started -- so
+    # injecting a fake `time.monotonic` schedule cannot race a real tick.
+    # `_poll_tick()` itself is a no-op here (no subscribers, state is still
+    # "connecting"), which is fine: the schedule is a function of the
+    # injected clock, not of what the tick actually did.
+    adapter = ADAPTERS["scope"]()
+    session = InstrumentSession("bench", instrument=object(), mock=True, address=None, poll_interval=0.1, adapter=adapter)
+
+    # First call: start=100.0, end=105.0 -> a poll "measured" at 5s, far
+    # longer than poll_interval (0.1s).
+    clock = iter([100.0, 105.0])
+    monkeypatch.setattr("scpi_control.server.sessions.time.monotonic", lambda: next(clock))
+    session._poll_if_due()
+
+    assert session.poll_log[-1][1] == 5.0
+    assert session._next_poll_at == 110.0  # 105.0 + max(0.1, 5.0)
+
+    # Second call: the schedule says wait until 110.0. A clock reading before
+    # that must skip the tick entirely -- no new log entry.
+    logged_before = len(session.poll_log)
+    monkeypatch.setattr("scpi_control.server.sessions.time.monotonic", lambda: 108.0)
+    session._poll_if_due()
+    assert len(session.poll_log) == logged_before, "a tick ran before its scheduled time"
+
+    # Third call: past the schedule -> the tick runs again.
+    clock = iter([110.0, 110.2])
+    monkeypatch.setattr("scpi_control.server.sessions.time.monotonic", lambda: next(clock))
+    session._poll_if_due()
+    assert len(session.poll_log) == logged_before + 1
+    assert session.poll_log[-1][1] == pytest.approx(0.2)
+    assert session._next_poll_at == pytest.approx(110.4)  # 110.2 + max(0.1, 0.2)

--- a/tests/wire_forms.py
+++ b/tests/wire_forms.py
@@ -769,6 +769,22 @@ WIRE_FORMS: List[WireForm] = [
         source=f"{MODERN_GUIDE} p.483",
         mock_kwargs={"idn": MODERN_IDN},
     ),
+    # "INR" appears on exactly one page of this 855-page guide -- p.829 -- and
+    # not as a COMMAND/QUERY SYNTAX/RESPONSE FORMAT entry: it is a C# EXAMPLE
+    # ("Acquisition Status" helper) that polls in a loop --
+    # `mbSession.RawIO.Write("INR?"); ... Int16 state = Convert.ToInt16(result);
+    # if ((state & 0x01) == 1) { Console.WriteLine("Acquisition finished"); ... }`
+    # -- exactly the bit new_acquisition_ready() (oscilloscope.py) reads.
+    # Documented by example, not by a syntax block: no concrete request/response
+    # PAIR is worked through (the snippet shows the bit test, never a literal
+    # "INR?" -> "N" value), so `response` is left unset rather than invented.
+    # LeCroy's MAUI Remote Control manual documents the same INR bit-0 register,
+    # at p.7-132/7-133 (see the `get_acq_status`/lecroy comment in
+    # oscilloscope.py's acquisition_status()) -- a different vendor guide for a
+    # different dialect/table not covered by this corpus (LeCroy is UNCITED
+    # throughout, see the module docstring), so it is referenced here rather
+    # than duplicated as a second WireForm entry.
+    WireForm(table="scope", dialect="modern", op="get_new_data", params={}, request="INR?", source=f"{MODERN_GUIDE} p.829", mock_kwargs={"idn": MODERN_IDN}),
     WireForm(table="scope", dialect="modern", op="run", params={}, request=":TRIGger:RUN", source=f"{MODERN_GUIDE} p.483", mock_kwargs={"idn": MODERN_IDN}),
     WireForm(table="scope", dialect="modern", op="stop", params={}, request=":TRIGger:STOP", source=f"{MODERN_GUIDE} p.484", mock_kwargs={"idn": MODERN_IDN}),
     # -- Channel control --
@@ -916,6 +932,17 @@ WIRE_FORMS: List[WireForm] = [
         mock_kwargs={"idn": MODERN_IDN},
         note="Mock default (1000.0) differs from the manual's example value (5.00E9); structure (bare NR3) is what's pinned.",
     ),
+    # p.36 lists :ACQuire:POINts in the ACQUire subsystem's command index only
+    # (query-only, no COMMAND SYNTAX -- just a "?" marker, no worked example).
+    # The full entry -- QUERY SYNTAX ":ACQuire:POINts?", RESPONSE FORMAT
+    # "<point> := Value in NR3 format... like 1.23E+2", EXAMPLE "ACQ:POIN?" ->
+    # "1.25E+08" -- is on p.43, cited below. (p.752's :WAVeform:POINt entry
+    # cross-references :ACQuire:POINts under its own RELATED COMMANDS footer --
+    # a pointer to this same command, not a second specification of it.)
+    # get_acq_points is not mocked (no :ACQuire:POINts? handler in the modern
+    # branch of connection/mock/siglent.py) -- request-only citation, same
+    # rationale as the get_time_offset entry above.
+    WireForm(table="scope", dialect="modern", op="get_acq_points", params={}, request=":ACQuire:POINts?", source=f"{MODERN_GUIDE} p.43", mock_kwargs={"idn": MODERN_IDN}),
     # -- Trigger settings --
     # p.482 <mode>:={SINGle|NORMal|AUTO|FTRIG}; EXAMPLE "TRIG:MODE SING" ->
     # ":TRIGger:MODE SINGle", response bare "SINGle". mode_to_wire('modern',

--- a/webapp/app/src/features/controls/HorizontalPanel.test.tsx
+++ b/webapp/app/src/features/controls/HorizontalPanel.test.tsx
@@ -1,0 +1,124 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HorizontalPanel } from "./HorizontalPanel";
+import { TriggerPanel } from "./TriggerPanel";
+import { api } from "../../api/client";
+import { useSession } from "../../store/session";
+
+const BASE_STATE = {
+  run_state: "STOP",
+  timebase: 0.001,
+  channels: {
+    "1": { enabled: true, voltage_scale: 0.5, voltage_offset: 0, coupling: "DC", probe_ratio: null },
+  },
+  trigger: { mode: "AUTO", source: null, level: null, slope: null, coupling: null },
+};
+
+function stateWithTimebase(timebase: number) {
+  return { ...BASE_STATE, timebase };
+}
+
+beforeEach(() => {
+  useSession.getState().clearSession();
+  useSession.getState().setSession({ id: "abc", label: "x", mock: true, address: null, state: "connected", idn: "", model: "", dialect: "legacy", num_channels: 4, viewers: 0, owner: "", kind: "scope" });
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("HorizontalPanel", () => {
+  it("renders without crashing before any scope state has arrived", () => {
+    expect(() => render(<HorizontalPanel />)).not.toThrow();
+    expect(screen.getByLabelText("Increase timebase")).toBeInTheDocument();
+  });
+
+  it("displays the timebase in engineering units, not decimals of seconds", () => {
+    useSession.getState().applyState(stateWithTimebase(5e-7));
+    render(<HorizontalPanel />);
+    expect(screen.getByText("500 ns")).toBeInTheDocument();
+
+    act(() => useSession.getState().applyState(stateWithTimebase(2e-6)));
+    expect(screen.getByText("2 µs")).toBeInTheDocument();
+
+    act(() => useSession.getState().applyState(stateWithTimebase(1e-3)));
+    expect(screen.getByText("1 ms")).toBeInTheDocument();
+  });
+
+  it("steps 1-2-5 per decade on increment -- from 1 ms this is 2 ms, then 5 ms, then 10 ms, never 101 ms", async () => {
+    useSession.getState().applyState(stateWithTimebase(0.001));
+    const patchTimebase = vi.spyOn(api, "patchTimebase").mockResolvedValue(BASE_STATE);
+    render(<HorizontalPanel />);
+
+    await userEvent.click(screen.getByLabelText("Increase timebase"));
+    await waitFor(() => expect(patchTimebase).toHaveBeenCalledWith("abc", 0.002));
+  });
+
+  it("continues the ladder across repeated increments, driven by the server-confirmed value", async () => {
+    useSession.getState().applyState(stateWithTimebase(0.002));
+    const patchTimebase = vi.spyOn(api, "patchTimebase").mockResolvedValue(BASE_STATE);
+    render(<HorizontalPanel />);
+
+    await userEvent.click(screen.getByLabelText("Increase timebase"));
+    await waitFor(() => expect(patchTimebase).toHaveBeenLastCalledWith("abc", 0.005));
+
+    act(() => useSession.getState().applyState(stateWithTimebase(0.005)));
+    await userEvent.click(screen.getByLabelText("Increase timebase"));
+    await waitFor(() => expect(patchTimebase).toHaveBeenLastCalledWith("abc", 0.01));
+  });
+
+  it("a sub-microsecond value is displayable and reachable by stepping down", async () => {
+    useSession.getState().applyState(stateWithTimebase(1e-6));
+    const patchTimebase = vi.spyOn(api, "patchTimebase").mockResolvedValue(BASE_STATE);
+    render(<HorizontalPanel />);
+    expect(screen.getByText("1 µs")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Decrease timebase"));
+    await waitFor(() => expect(patchTimebase).toHaveBeenCalledWith("abc", 5e-7));
+  });
+
+  it("sends the timebase as a float number of seconds, not a formatted string", async () => {
+    useSession.getState().applyState(stateWithTimebase(1e-6));
+    const patchTimebase = vi.spyOn(api, "patchTimebase").mockResolvedValue(BASE_STATE);
+    render(<HorizontalPanel />);
+
+    await userEvent.click(screen.getByLabelText("Decrease timebase"));
+    await waitFor(() => expect(patchTimebase).toHaveBeenCalled());
+    const sent = patchTimebase.mock.calls[0][1];
+    expect(sent).toBe(0.0000005);
+    expect(typeof sent).toBe("number");
+  });
+
+  it("cannot emit a value off the ladder -- the fastest rung has no further decrement, so negatives are unreachable", async () => {
+    useSession.getState().applyState(stateWithTimebase(1e-9));
+    const patchTimebase = vi.spyOn(api, "patchTimebase").mockResolvedValue(BASE_STATE);
+    render(<HorizontalPanel />);
+
+    expect(screen.getByText("1 ns")).toBeInTheDocument();
+    const decrement = screen.getByLabelText("Decrease timebase");
+    expect(decrement).toBeDisabled();
+
+    await userEvent.click(decrement);
+    expect(patchTimebase).not.toHaveBeenCalled();
+  });
+
+  it("cannot emit a value off the ladder at the slow end either", async () => {
+    useSession.getState().applyState(stateWithTimebase(10));
+    const patchTimebase = vi.spyOn(api, "patchTimebase").mockResolvedValue(BASE_STATE);
+    render(<HorizontalPanel />);
+
+    expect(screen.getByText("10 s")).toBeInTheDocument();
+    const increment = screen.getByLabelText("Increase timebase");
+    expect(increment).toBeDisabled();
+
+    await userEvent.click(increment);
+    expect(patchTimebase).not.toHaveBeenCalled();
+  });
+});
+
+describe("TriggerPanel no longer owns the timebase", () => {
+  it("does not render a Timebase control -- it moved to HorizontalPanel", () => {
+    useSession.getState().applyState(stateWithTimebase(0.001));
+    render(<TriggerPanel />);
+    expect(screen.queryByLabelText("Timebase")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Increase timebase")).not.toBeInTheDocument();
+  });
+});

--- a/webapp/app/src/features/controls/HorizontalPanel.test.tsx
+++ b/webapp/app/src/features/controls/HorizontalPanel.test.tsx
@@ -112,6 +112,33 @@ describe("HorizontalPanel", () => {
     await userEvent.click(increment);
     expect(patchTimebase).not.toHaveBeenCalled();
   });
+
+  // 0.101 s/div is the literal value the original free-decimal SpinBox
+  // defect produced (1 ms + one 100 ms stepper click). Anyone who already
+  // hit that bug has a scope sitting at exactly this off-ladder value, so
+  // snapping it to the nearest rung before stepping is the realistic first
+  // interaction with the new control, not an edge case.
+  it("snaps an off-ladder starting value (0.101, the original defect's output) to the nearest rung before stepping up", async () => {
+    useSession.getState().applyState(stateWithTimebase(0.101));
+    const patchTimebase = vi.spyOn(api, "patchTimebase").mockResolvedValue(BASE_STATE);
+    render(<HorizontalPanel />);
+
+    expect(screen.getByText("100 ms")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Increase timebase"));
+    await waitFor(() => expect(patchTimebase).toHaveBeenCalledWith("abc", 0.2));
+  });
+
+  it("snaps the same off-ladder starting value (0.101) to the nearest rung before stepping down", async () => {
+    useSession.getState().applyState(stateWithTimebase(0.101));
+    const patchTimebase = vi.spyOn(api, "patchTimebase").mockResolvedValue(BASE_STATE);
+    render(<HorizontalPanel />);
+
+    expect(screen.getByText("100 ms")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Decrease timebase"));
+    await waitFor(() => expect(patchTimebase).toHaveBeenCalledWith("abc", 0.05));
+  });
 });
 
 describe("TriggerPanel no longer owns the timebase", () => {

--- a/webapp/app/src/features/controls/HorizontalPanel.tsx
+++ b/webapp/app/src/features/controls/HorizontalPanel.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import { ApiError, api } from "../../api/client";
+import { GroupBox } from "../../ds/GroupBox";
+import { useSession } from "../../store/session";
+
+// The 1-2-5 ladder, 1 ns/div to 10 s/div -- the SDS824X HD's supported
+// horizontal range. No timebase-range query exists in scpi_commands.py to
+// derive this at runtime, so the endpoints are a documented constant, same
+// as scpi_control/gui/widgets/timebase_control.py's TIME_SCALES (the desktop
+// GUI's equivalent control). Keep the two lists in sync if either changes.
+//
+// A click can only move to an adjacent rung, and the rungs themselves never
+// go negative or fall below 1 ns/1 ns-equivalent resolution -- the ladder IS
+// the bound, by construction, not a min/max layered on top of it.
+const TIMEBASE_LADDER: ReadonlyArray<{ seconds: number; label: string }> = [
+  { seconds: 1e-9, label: "1 ns" },
+  { seconds: 2e-9, label: "2 ns" },
+  { seconds: 5e-9, label: "5 ns" },
+  { seconds: 10e-9, label: "10 ns" },
+  { seconds: 20e-9, label: "20 ns" },
+  { seconds: 50e-9, label: "50 ns" },
+  { seconds: 100e-9, label: "100 ns" },
+  { seconds: 200e-9, label: "200 ns" },
+  { seconds: 500e-9, label: "500 ns" },
+  { seconds: 1e-6, label: "1 µs" },
+  { seconds: 2e-6, label: "2 µs" },
+  { seconds: 5e-6, label: "5 µs" },
+  { seconds: 10e-6, label: "10 µs" },
+  { seconds: 20e-6, label: "20 µs" },
+  { seconds: 50e-6, label: "50 µs" },
+  { seconds: 100e-6, label: "100 µs" },
+  { seconds: 200e-6, label: "200 µs" },
+  { seconds: 500e-6, label: "500 µs" },
+  { seconds: 1e-3, label: "1 ms" },
+  { seconds: 2e-3, label: "2 ms" },
+  { seconds: 5e-3, label: "5 ms" },
+  { seconds: 10e-3, label: "10 ms" },
+  { seconds: 20e-3, label: "20 ms" },
+  { seconds: 50e-3, label: "50 ms" },
+  { seconds: 100e-3, label: "100 ms" },
+  { seconds: 200e-3, label: "200 ms" },
+  { seconds: 500e-3, label: "500 ms" },
+  { seconds: 1, label: "1 s" },
+  { seconds: 2, label: "2 s" },
+  { seconds: 5, label: "5 s" },
+  { seconds: 10, label: "10 s" },
+];
+
+const DEFAULT_TIMEBASE = 1e-3; // 1 ms/div -- used only before any scope state has arrived.
+
+/** Index of the ladder rung closest to `seconds`. Hardware echoes a value
+ *  back through the same float wire format it was sent in, so this tolerates
+ *  representational noise instead of requiring bit-exact equality. */
+function nearestIndex(seconds: number): number {
+  let best = 0;
+  let bestDiff = Infinity;
+  for (let i = 0; i < TIMEBASE_LADDER.length; i++) {
+    const diff = Math.abs(TIMEBASE_LADDER[i].seconds - seconds);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      best = i;
+    }
+  }
+  return best;
+}
+
+/** HorizontalPanel -- owns the timebase (time/div). A horizontal control,
+ *  not a trigger one: it used to live in TriggerPanel as a free-decimal
+ *  SpinBox, which let a single stepper click send 101 ms/div from 1 ms/div
+ *  and had no floor, so a negative sweep was one more click away. The ladder
+ *  replaces both the step and the min/max: every reachable value is a
+ *  documented 1-2-5 rung, so the instrument only ever sees a value it was
+ *  designed to accept. */
+export function HorizontalPanel() {
+  const session = useSession((s) => s.session);
+  const timebase = useSession((s) => s.scope?.timebase);
+  const [error, setError] = useState<string | null>(null);
+
+  const index = nearestIndex(timebase ?? DEFAULT_TIMEBASE);
+  const current = TIMEBASE_LADDER[index];
+
+  async function sendIndex(next: number) {
+    if (!session) return;
+    setError(null);
+    try {
+      await api.patchTimebase(session.id, TIMEBASE_LADDER[next].seconds);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.detail : String(err));
+    }
+  }
+
+  const stepperButtonStyle = (disabled: boolean) =>
+    ({
+      flex: 1,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      border: "none",
+      borderLeft: "1px solid var(--lc-border)",
+      background: "var(--lc-panel-2)",
+      color: "var(--lc-text-2)",
+      cursor: disabled ? "not-allowed" : "pointer",
+      fontSize: "8px",
+      lineHeight: 1,
+      padding: 0,
+    }) as const;
+
+  return (
+    <GroupBox title="Horizontal">
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-5)", fontSize: "var(--text-sm)" }}>
+          Timebase
+          <div
+            style={{
+              display: "inline-flex",
+              alignItems: "stretch",
+              height: "32px",
+              width: "140px",
+              background: "var(--lc-control)",
+              border: "1px solid var(--lc-border-strong)",
+              borderRadius: "var(--lc-radius-sm)",
+              overflow: "hidden",
+              fontFamily: "var(--font-ui)",
+            }}
+          >
+            <span
+              style={{
+                flex: 1,
+                minWidth: 0,
+                display: "flex",
+                alignItems: "center",
+                padding: "0 8px",
+                fontFamily: "var(--font-mono)",
+                fontSize: "var(--text-sm)",
+                color: "var(--lc-text)",
+              }}
+            >
+              {current.label}
+            </span>
+            <div style={{ display: "flex", flexDirection: "column", width: "18px", borderTop: "none" }}>
+              <button
+                type="button"
+                aria-label="Increase timebase"
+                disabled={index >= TIMEBASE_LADDER.length - 1}
+                onClick={() => sendIndex(index + 1)}
+                style={{ ...stepperButtonStyle(index >= TIMEBASE_LADDER.length - 1), borderBottom: "1px solid var(--lc-border)" }}
+              >
+                ▲
+              </button>
+              <button
+                type="button"
+                aria-label="Decrease timebase"
+                disabled={index <= 0}
+                onClick={() => sendIndex(index - 1)}
+                style={stepperButtonStyle(index <= 0)}
+              >
+                ▼
+              </button>
+            </div>
+          </div>
+          <span style={{ color: "var(--lc-text-2)" }}>/div</span>
+        </div>
+      </div>
+      {error && (
+        <div role="alert" style={{ padding: "8px 10px", borderRadius: "var(--radius-sm)", background: "color-mix(in srgb, var(--danger) 12%, transparent)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </div>
+      )}
+    </GroupBox>
+  );
+}

--- a/webapp/app/src/features/controls/ScopeToolbar.test.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.test.tsx
@@ -54,7 +54,7 @@ describe("ScopeToolbar", () => {
     await userEvent.click(screen.getByRole("button", { name: "JSON" }));
     await waitFor(() => expect(fetchMock).toHaveBeenCalled());
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe("/api/sessions/abc/scope/waveform?channels=1");
+    expect(url).toBe("/api/sessions/abc/scope/waveform?channels=1&max_points=0");
     const headers = new Headers(init.headers);
     expect(headers.get("Authorization")).toBe("Bearer scpi_wave");
   });
@@ -64,5 +64,13 @@ describe("ScopeToolbar", () => {
     render(<ScopeToolbar />);
     await userEvent.click(screen.getByRole("button", { name: "JSON" }));
     expect(await screen.findByRole("alert")).toHaveTextContent("missing bearer token");
+  });
+
+  it("surfaces an oversized-export 413's detail instead of a generic failure", async () => {
+    const detail = "record holds 5000000 points, exceeding MAX_EXPORT_POINTS (2000000); pass max_points=2000000 to proceed with a decimated export";
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "HTTPException", detail }), { status: 413 })));
+    render(<ScopeToolbar />);
+    await userEvent.click(screen.getByRole("button", { name: "JSON" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(detail);
   });
 });

--- a/webapp/app/src/features/controls/ScopeToolbar.tsx
+++ b/webapp/app/src/features/controls/ScopeToolbar.tsx
@@ -13,6 +13,13 @@ import { ScreenshotButton } from "../export/ScreenshotButton";
 // with no memoization, so a fresh `{}` per snapshot would loop forever while scope is null.
 const NO_CHANNELS: Record<string, ChannelState> = {};
 
+// Explicit max_points=0 asks the server for the full record. The server
+// treats an omitted max_points identically (docs/gateway/api.md: "0/omitted
+// = full resolution") -- there is no distinct wire value for "everything" --
+// but naming it here makes the choice visible at the call site instead of
+// something a reader has to infer from an absent parameter.
+const FULL_RECORD_MAX_POINTS = 0;
+
 export function ScopeToolbar({ viewToggle }: { viewToggle?: ReactNode }) {
   const session = useSession((s) => s.session);
   const runState = useSession((s) => s.scope?.run_state);
@@ -40,7 +47,7 @@ export function ScopeToolbar({ viewToggle }: { viewToggle?: ReactNode }) {
     if (!session) return;
     setError(null);
     try {
-      await downloadAuthenticated(api.waveformJsonUrl(session.id, enabled), "waveform.json");
+      await downloadAuthenticated(`${api.waveformJsonUrl(session.id, enabled)}&max_points=${FULL_RECORD_MAX_POINTS}`, "waveform.json");
     } catch (err) {
       setError(err instanceof ApiError ? err.detail : String(err));
     }

--- a/webapp/app/src/features/controls/TriggerPanel.test.tsx
+++ b/webapp/app/src/features/controls/TriggerPanel.test.tsx
@@ -31,7 +31,7 @@ describe("TriggerPanel null-tolerance", () => {
     // scope is still null here — this is the state right after setSession(), before the
     // first WS `state` broadcast lands.
     expect(() => render(<TriggerPanel />)).not.toThrow();
-    expect(screen.getByLabelText("Timebase")).toBeInTheDocument();
+    expect(screen.getByLabelText("Trigger level")).toBeInTheDocument();
   });
 
   it("still allows setting a value on a null trigger source", async () => {

--- a/webapp/app/src/features/controls/TriggerPanel.tsx
+++ b/webapp/app/src/features/controls/TriggerPanel.tsx
@@ -16,7 +16,6 @@ function withNull(options: string[], value: string | null) {
 export function TriggerPanel() {
   const session = useSession((s) => s.session);
   const trigger = useSession((s) => s.scope?.trigger);
-  const timebase = useSession((s) => s.scope?.timebase);
   const numChannels = session?.num_channels ?? 0;
   const [error, setError] = useState<string | null>(null);
 
@@ -25,16 +24,6 @@ export function TriggerPanel() {
     setError(null);
     try {
       await api.patchTrigger(session.id, patch);
-    } catch (err) {
-      setError(err instanceof ApiError ? err.detail : String(err));
-    }
-  }
-
-  async function sendTimebase(seconds: number) {
-    if (!session) return;
-    setError(null);
-    try {
-      await api.patchTimebase(session.id, seconds);
     } catch (err) {
       setError(err instanceof ApiError ? err.detail : String(err));
     }
@@ -79,16 +68,6 @@ export function TriggerPanel() {
             value={trigger?.level ?? 0}
             suffix=" V"
             onChange={(value) => send({ level: value })}
-          />
-        </div>
-        <div style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "var(--text-sm)" }}>
-          Timebase
-          <SpinBox
-            aria-label="Timebase"
-            value={timebase ?? 0}
-            decimals={6}
-            suffix=" s/div"
-            onChange={(value) => sendTimebase(value)}
           />
         </div>
       </div>

--- a/webapp/app/src/features/scope/ScopeBody.tsx
+++ b/webapp/app/src/features/scope/ScopeBody.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { AnalysisPanel } from "../controls/AnalysisPanel";
 import { ChannelsPanel } from "../controls/ChannelsPanel";
+import { HorizontalPanel } from "../controls/HorizontalPanel";
 import { MathPanel } from "../controls/MathPanel";
 import { ScopeToolbar } from "../controls/ScopeToolbar";
 import { TriggerPanel } from "../controls/TriggerPanel";
@@ -16,7 +17,7 @@ import { ViewModeToggle } from "../waveform/ViewModeToggle";
 import { Tabs } from "../../ds/Tabs";
 import { useSession } from "../../store/session";
 
-const RAIL_TABS = ["Channels", "Trigger", "Math", "Analysis", "Reference", "Log", "Measure"];
+const RAIL_TABS = ["Channels", "Horizontal", "Trigger", "Math", "Analysis", "Reference", "Log", "Measure"];
 
 /** Everything below the readout strip for an oscilloscope session: the control
  *  rail and the canvas. Only this component knows a scope has a rail -- the
@@ -33,6 +34,7 @@ export function ScopeBody() {
       <div style={{ width: "280px", flexShrink: 0, overflowY: "auto" }}>
         <Tabs tabs={RAIL_TABS} value={railTab} onChange={setRailTab}>
           {railTab === "Channels" && <ChannelsPanel />}
+          {railTab === "Horizontal" && <HorizontalPanel />}
           {railTab === "Trigger" && <TriggerPanel />}
           {railTab === "Math" && <MathPanel />}
           {railTab === "Analysis" && <AnalysisPanel />}


### PR DESCRIPTION
## Description

Makes the live view work correctly against a real Siglent SDS824X HD, and fixes the defects that
probing it uncovered.

The branch began as live-view work (a new-acquisition gate, instrument-side thinning, streamed
exports, a real timebase ladder). Validating the thinning assumptions against the instrument then
turned up a cluster of bugs that shared one shape: **the mock encoded a guess, the driver made the
matching guess, and the two agreed with each other rather than with the instrument.** CI was
green throughout, because both sides of every round-trip were wrong in the same direction.

The worst of them made every default waveform read on an HD scope 256x too small.

## Related Issues

<!-- none filed; found by probing hardware directly -->

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test coverage improvement
- [ ] CI/CD improvement

No API signature changes. `MeasurementUnavailableError` is new but subclasses `CommandError`, so
existing handlers keep catching it. **Data captured from an HD instrument before this change is
not recoverable by rescaling** — see the first item below.

## Changes Made

**Hardware-measured corrections** (all verified on an SDS824X HD, fw 3.8.12.1.1.3.6):

- **8-bit waveform volts were 256x too small — the default transfer width.** The preamble reports
  `Adc_bit=16` and `code_per_div=7680`, and reports *the same 7680* under `BYTE`, where the
  instrument sends only the high byte of the native code. A 3.075 Vpp signal read back as
  0.0119792 Vpp. The scope's own `:MEASure MEAN` (1.45474 V) agreed with the `WORD` read
  (1.45602 V), not the `BYTE` one. The mock hid it by hardcoding 25.0 (BYTE) / 6400.0 (WORD) —
  scaling the field by 256 across widths where the instrument does not.
- **A thinned trace claimed the wrong time window.** `HORIZ_INTERVAL` is the acquisition's sample
  spacing and does not track `:WAVeform:INTerval` (measured constant at 1.0e-08 across strides
  1/2/7/10), so a stride-7 frame spanned 7.14e-5 s of a 5.0e-4 s sweep — an x-axis wrong by 7x,
  and `sample_rate` wrong by the same factor, on every thinned frame.
- **`wave_array_count` is the FULL record at every stride**, not the strided count as assumed.
  `WAVE_ARRAY_1` is not a substitute either: the guide (p.755) calls it "the number of transmitted
  bytes" but the instrument leaves it at the full count. Nothing in the preamble reports what
  `DATA?` will send, so it is computed — by floor division (50000/7 -> 7142, not 7143).
- **The new-acquisition gate never ran.** `INR?` answers header-prefixed (`INR 8193`), not a bare
  integer; `new_acquisition_ready()` used `int()`, caught the `ValueError`, and returned `None` =
  "this dialect has no gate" — silently, every tick, with no log. The poll always fell back to
  timing-based backoff, the very thing the gate exists to avoid.
- **`****` is the instrument's "no value yet" marker**, not a malformed reply. It surfaced as a
  parse error and, in the gateway, as a `poll query failed` WARNING for a routine transient.
- **Two smaller ones from the same measurements:** the per-transfer cap is now compared against
  the decimated count (decimation is what brings a deep record under the cap, so comparing the
  full record refused reads that fit), and a short window raises instead of being scaled onto a
  plausible-looking axis.

**Mock fidelity** — each of these is a query the instrument answers happily that the mock could
only fail, or a shape it never sends:

- `:ACQuire:POINts?` had no handler, so `record_length()` degraded to `None` and the live view's
  stride sizing was never exercised in CI on any dialect.
- `INR?` had no handler at all on the modern personality.
- `:WAVeform:DATA?` uses the *general* variable-width IEEE header (`#5` for 50000 bytes), not the
  fixed `#9<9-digits>` of the guide's p.757 example, and carries two trailing newlines;
  `PREamble?` does use the 9-digit form, with one. The mock emitted a bare fixed `#9` for both, so
  the parser's tolerance was accidental rather than pinned.

## Testing

- [x] Tests pass locally (`make test` or `pytest tests/`)
- [x] Added tests for new functionality
- [x] Tested with real hardware (if applicable)
- [ ] All CI checks pass <!-- pending CI -->

### Test Details

**Test environment:**

- OS: Windows 11 Pro 10.0.26200
- Python version: 3.12.7
- Oscilloscope model (if applicable): Siglent SDS824X HD, fw 3.8.12.1.1.3.6 (real hardware, over
  LAN), plus the mock for every dialect

**Test results:**

```
2260 passed, 19 skipped, 176 warnings in 101.94s (0:01:41)
```

Full suite *including* the `slow` tests. LLM-marked files were excluded at the author's request
(`test_daq_llm`, `test_llm_tool_loop`, `test_llm_tool_support`, `test_report_llm_client`,
`test_report_llm_prompts`); they are hermetic either way — `conftest.py` patches the ollama SDK.

**Hardware verification of each fix:**

| check | result |
|---|---|
| BYTE vs WORD Vpp | 3.06667 vs 3.07083 (was 0.0119792 vs 3.075) |
| strided/unstrided time span ratio | 0.9998 (was 0.143) |
| dt and sample_rate ratio at stride 7 | 7.000 and 7.000 |
| `new_acquisition_ready()` | returns True/False (was `None` every tick) |
| a live `****` reading | raises `MeasurementUnavailableError` |
| `PREamble?` / `DATA?` framing | `#9...\n` / `#6100000...\n\n`, matching the mock |

The 256x fix and the time-axis fix were both mutation-tested: reintroducing each bug fails 4 and 2
tests respectively, so those guards are load-bearing rather than decorative.

## Code Quality

- [x] Code follows the project style guidelines (`make lint` passes)
- [x] Code is formatted with Black (`make format`)
- [x] Self-reviewed the code
- [x] Commented complex code sections
- [x] Updated docstrings for modified functions/classes
- [x] No new linting warnings introduced

`make lint` does not pass cleanly on `main` either — five test files are black-dirty and there are
pre-existing `F401`/`E203` findings in `vector_graphics.py`, `waveform.py`, `waveform_io.py`,
`measurement.py` and `oscilloscope.py`. This branch introduces none of those: the six files it
made dirty are reformatted, and the one import it orphaned is removed. The pre-existing ones are
deliberately left alone rather than buried in this diff.

## Documentation

- [x] Updated README.md (if needed) <!-- n/a -->
- [x] Updated CHANGELOG.md with changes
- [x] Added/updated docstrings
- [ ] Added/updated examples (if applicable) <!-- n/a -->
- [x] Updated type hints

Both changelog mirrors (`CHANGELOG.md` and `docs/about/changelog.md`) are updated and verified
byte-identical.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation

## Additional Notes

**Reviewers should know about the data-integrity consequence.** Waveform data captured from an HD
instrument before this change should be treated as unusable rather than rescaled by 256 — the
8-bit path also discarded the low byte, so it is lossy, not merely mis-scaled.

**Two commits cancel out.** `d991a00` added a short-read guard built on the assumption that a
non-zero `:WAVeform:POINt` meant another program had left a window cap behind. Hardware disproved
that (the value is *derived* by the instrument from `:WAVeform:INTerval` — it read 714285 =
MAXPoint/7), so `7d25986` reverts it and `c729067` reintroduces the guard on a correct basis. They
are kept rather than squashed because the revert is the honest record of an assumption being
tested and failing.

**Several tests changed premise, and each did so for a reason worth checking.**
`test_the_modern_mock_really_cannot_answer_the_record_length_query` said in its own comment that it
existed to fail loudly if the mock ever grew a handler — it did exactly that. Those tests were
leaning on the mock's *inability* rather than on a forced failure, so their coverage of the
degrade-to-None path would have silently evaporated. They now force the failure explicitly, and
the healthy path gained coverage it never had.

**One deliberate limitation.** The mock's `INR?` always reports "new data". Deriving it from
`trigger_status` looked more faithful, but the gateway builds its mock with
`trigger_status=["Stop"]`, which would make the mock demo's live view go dark after one frame — and
it contradicts the mock's own behaviour, since it synthesises a fresh acquisition on every read.
The read-and-clear latch is deliberately not modelled: there is no acquisition clock here to re-arm
it against, so any timing would be invented rather than observed.

**Scope of validation.** The instrument is modern-dialect, so none of this validates the legacy,
Tektronix or LeCroy paths. Most remaining `MISMATCH_DEFERRED` rows in the wire-form inventory are
legacy-dialect and stay unverifiable without that hardware.
