### PR TITLE
chore(release): 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0] - 2026-07-30
+
 ### ⚠️ Breaking Changes
 
 - A token name is now an identity rather than a unique credential. `scpi-web token add <name>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes only what happens when the token store is empty.
 - Revoking an identity now also closes that identity's live streams and releases the sessions
   they owned. A revoked colleague mid-capture loses their view, and their session becomes
-  immediately claimable. The revoke route's response code has changed from 204 to 200 with a
-  body carrying `{"devices", "streams", "sessions"}` counts — a wire-visible change for anyone
-  scripting against it.
+  immediately claimable.
+- Waveform values read from a high-resolution Siglent instrument in the default 8-bit transfer
+  mode change by a factor of 256 — they were that much too small, and are now correct. This is a
+  defect fix rather than an API change, but it is the change in this release most likely to
+  affect you, and it is listed here so it is not missed: **waveform data captured from an HD
+  instrument before 6.0.0 should be treated as unusable rather than rescaled**, because the
+  8-bit path also discarded the low byte. The full entry is under Fixed.
 
 ### Added
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0] - 2026-07-30
+
 ### ⚠️ Breaking Changes
 
 - A token name is now an identity rather than a unique credential. `scpi-web token add <name>`

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -27,9 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes only what happens when the token store is empty.
 - Revoking an identity now also closes that identity's live streams and releases the sessions
   they owned. A revoked colleague mid-capture loses their view, and their session becomes
-  immediately claimable. The revoke route's response code has changed from 204 to 200 with a
-  body carrying `{"devices", "streams", "sessions"}` counts — a wire-visible change for anyone
-  scripting against it.
+  immediately claimable.
+- Waveform values read from a high-resolution Siglent instrument in the default 8-bit transfer
+  mode change by a factor of 256 — they were that much too small, and are now correct. This is a
+  defect fix rather than an API change, but it is the change in this release most likely to
+  affect you, and it is listed here so it is not missed: **waveform data captured from an HD
+  instrument before 6.0.0 should be treated as unusable rather than rescaled**, because the
+  8-bit path also discarded the low byte. The full entry is under Fixed.
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "5.8.0"
+version = "6.0.0"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "5.8.0"
+__version__ = "6.0.0"
 
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError
 from scpi_control.oscilloscope import Oscilloscope


### PR DESCRIPTION
## Description

Cuts **6.0.0**. Four-file release commit: the `## [6.0.0] - 2026-07-30` heading in both changelog
mirrors, and the two hand-maintained version strings.

MAJOR rather than MINOR because the token/identity rework is wire- and API-visible. Full breaking
list is in the changelog; the two that break callers *silently* rather than loudly are
`DuplicateTokenName` being removed from `scpi_control.server.auth` (any `except DuplicateTokenName`
becomes an `ImportError`) and the revoke route changing from **204** to **200 with a body**
carrying `{"devices", "streams", "sessions"}` counts.

## Related Issues

<!-- none; release chore -->

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [x] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test coverage improvement
- [ ] CI/CD improvement

## Changes Made

- `CHANGELOG.md` — inserted `## [6.0.0] - 2026-07-30` directly beneath `## [Unreleased]` and above
  the existing `###` sections, so those 44 entries now belong to 6.0.0. `[Unreleased]` is kept, not
  renamed.
- `docs/about/changelog.md` — mirrored (enforced by `tests/test_changelog_mirror.py`).
- `pyproject.toml` — `version = "6.0.0"`.
- `scpi_control/__init__.py` — `__version__ = "6.0.0"` (agreement enforced by
  `tests/test_version_consistency.py`).

**Release contents** — 44 entries across eight merged PRs (#127–#134):

| section | entries |
|---|---|
| ⚠️ Breaking Changes | 5 |
| Added | 18 |
| Changed | 2 |
| Fixed | 19 |

## Testing

- [x] Tests pass locally (`make test` or `pytest tests/`)
- [x] Added tests for new functionality <!-- n/a for a release chore -->
- [ ] Tested with real hardware (if applicable) <!-- n/a; #134 covered the hardware work -->
- [ ] All CI checks pass <!-- pending CI -->

### Test Details

**Test environment:**

- OS: Windows 11 Pro 10.0.26200
- Python version: 3.12.7
- Oscilloscope model (if applicable): n/a for this chore

**Test results:**

```
2260 passed, 19 skipped, 176 warnings in 55.34s
```

Full suite *including* `slow`. LLM-marked files excluded at the author's request; they are hermetic
either way. The two release gates were run first and separately: `test_changelog_mirror.py` and
`test_version_consistency.py`, 4 passed.

## Code Quality

- [x] Code follows the project style guidelines (`make lint` passes)
- [x] Code is formatted with Black (`make format`)
- [x] Self-reviewed the code
- [x] Commented complex code sections <!-- n/a -->
- [x] Updated docstrings for modified functions/classes <!-- n/a -->
- [x] No new linting warnings introduced

CI's actual gates are clean: `black --check scpi_control/ examples/` → 195 files unchanged, and
`flake8 --select=E9,F63,F7,F82` → 0. Note `make lint` is *stricter than CI* and does not pass on
`main` either — it also covers `tests/` (5 pre-existing black-dirty files) and all flake8 codes
(162 findings, which CI runs under `--exit-zero`). This PR introduces none of them and changes no
Python beyond a version string.

## Documentation

- [x] Updated README.md (if needed) <!-- n/a -->
- [x] Updated CHANGELOG.md with changes
- [x] Added/updated docstrings <!-- n/a -->
- [x] Added/updated examples (if applicable) <!-- n/a -->
- [x] Updated type hints <!-- n/a -->

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works <!-- n/a -->
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation

## Additional Notes

**PyPI summary is 387 / 512 characters** — checked before cutting, since an over-length summary is
what failed the v3.2.0 publish.

**Remaining steps after this merges, in order** — none of them are done yet:

1. `git tag v6.0.0 && git push origin v6.0.0`. The tag push starts `build-executables.yml`, whose
   `softprops/action-gh-release@v2` step **creates and publishes the GitHub release itself, with an
   empty body** — so `gh release create` would fail `HTTP 422: tag_name already exists`.
2. `gh release edit v6.0.0 --notes-file <extracted 6.0.0 section>` to fill that empty body.
3. `gh workflow run publish.yml --ref v6.0.0` to reach PyPI. `publish.yml` fires on
   *release published* or `workflow_dispatch`, but the release above is created with
   `GITHUB_TOKEN`, and GitHub does not let `GITHUB_TOKEN` events trigger other workflows — so it
   never fires on its own and **the manual dispatch is the only path to PyPI**. This is the
   irreversible step.

Verify the upload against `SCPI-Instrument-Control`, not `scpi-control` — the latter 404s forever
and is not evidence of a failed publish.
