### PR TITLE
ci: move the macOS builds off retired and deprecated runner images

### DIFF
--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -5,6 +5,15 @@ on:
     tags:
       - "v*.*.*" # Trigger on version tags like v0.3.2, v1.0.0
   workflow_dispatch: # Allow manual trigger from GitHub Actions UI
+    inputs:
+      release_tag:
+        description: "Existing release tag to build from and upload to (e.g. v6.0.0). Blank = a dev build that uploads nothing."
+        required: false
+        default: ""
+      platforms:
+        description: "Which platforms to build on a manual run: all, or a comma-separated subset of windows,macos-arm64,macos-x64,linux. Limiting it leaves the other already-published assets untouched."
+        required: false
+        default: "all"
 
 permissions:
   contents: write # Required to upload release assets
@@ -12,11 +21,14 @@ permissions:
 jobs:
   build-windows:
     name: Build Windows Executable
+    if: ${ github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || contains(inputs.platforms, 'windows') }
     runs-on: windows-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -34,7 +46,9 @@ jobs:
         id: get_version
         shell: bash
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ -n "${{ inputs.release_tag }}" ]]; then
+            echo "version=${{ inputs.release_tag }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
             echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
             echo "version=dev-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -61,9 +75,10 @@ jobs:
           retention-days: 30
 
       - name: Upload to release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.release_tag != ''
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.release_tag || github.ref_name }}
           files: dist/SiglentGUI-${{ steps.get_version.outputs.version }}-Windows-x64.zip
           draft: false
           prerelease: false
@@ -72,11 +87,14 @@ jobs:
 
   build-macos-arm64:
     name: Build macOS Application (Apple Silicon)
-    runs-on: macos-14 # M1 runner for native ARM64
+    if: ${ github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || contains(inputs.platforms, 'macos-arm64') }
+    runs-on: macos-15 # Apple Silicon. macos-14 is deprecated (actions/runner-images)
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -93,7 +111,9 @@ jobs:
       - name: Get version from tag
         id: get_version
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ -n "${{ inputs.release_tag }}" ]]; then
+            echo "version=${{ inputs.release_tag }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
             echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
             echo "version=dev-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -123,9 +143,10 @@ jobs:
           retention-days: 30
 
       - name: Upload to release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.release_tag != ''
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.release_tag || github.ref_name }}
           files: dist/SiglentGUI-${{ steps.get_version.outputs.version }}-macOS-arm64.zip
           draft: false
           prerelease: false
@@ -134,11 +155,19 @@ jobs:
 
   build-macos-x64:
     name: Build macOS Application (Intel)
-    runs-on: macos-13 # Intel runner for x86_64
+    if: ${ github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || contains(inputs.platforms, 'macos-x64') }
+    runs-on: macos-15-intel # Intel x86_64. macos-13 was RETIRED 2025-12-04 and a job
+    # requesting it never schedules -- it sits queued until GitHub's 24h limit and the run
+    # is cancelled, which is why no release before 6.0.0 ever carried an Intel asset (and
+    # why create-release-notes, which needs: this job, never ran either). macos-15-intel is
+    # the documented migration target and is the LAST x86_64 image: it goes away in
+    # August 2027, after which GitHub-hosted Intel macOS builds are not possible at all.
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -155,7 +184,9 @@ jobs:
       - name: Get version from tag
         id: get_version
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ -n "${{ inputs.release_tag }}" ]]; then
+            echo "version=${{ inputs.release_tag }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
             echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
             echo "version=dev-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -185,9 +216,10 @@ jobs:
           retention-days: 30
 
       - name: Upload to release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.release_tag != ''
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.release_tag || github.ref_name }}
           files: dist/SiglentGUI-${{ steps.get_version.outputs.version }}-macOS-x86_64.zip
           draft: false
           prerelease: false
@@ -196,11 +228,14 @@ jobs:
 
   build-linux:
     name: Build Linux Binary
+    if: ${ github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || contains(inputs.platforms, 'linux') }
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -235,7 +270,9 @@ jobs:
       - name: Get version from tag
         id: get_version
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ -n "${{ inputs.release_tag }}" ]]; then
+            echo "version=${{ inputs.release_tag }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
             echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
             echo "version=dev-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -260,9 +297,10 @@ jobs:
           retention-days: 30
 
       - name: Upload to release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.release_tag != ''
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.release_tag || github.ref_name }}
           files: dist/SiglentGUI-${{ steps.get_version.outputs.version }}-Linux-x86_64.tar.gz
           draft: false
           prerelease: false
@@ -278,6 +316,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
 
       - name: Get version
         id: get_version

--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   build-windows:
     name: Build Windows Executable
-    if: ${ github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || contains(inputs.platforms, 'windows') }
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || contains(inputs.platforms, 'windows') }}
     runs-on: windows-latest
 
     steps:
@@ -87,7 +87,7 @@ jobs:
 
   build-macos-arm64:
     name: Build macOS Application (Apple Silicon)
-    if: ${ github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || contains(inputs.platforms, 'macos-arm64') }
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || contains(inputs.platforms, 'macos-arm64') }}
     runs-on: macos-15 # Apple Silicon. macos-14 is deprecated (actions/runner-images)
 
     steps:
@@ -155,7 +155,7 @@ jobs:
 
   build-macos-x64:
     name: Build macOS Application (Intel)
-    if: ${ github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || contains(inputs.platforms, 'macos-x64') }
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || contains(inputs.platforms, 'macos-x64') }}
     runs-on: macos-15-intel # Intel x86_64. macos-13 was RETIRED 2025-12-04 and a job
     # requesting it never schedules -- it sits queued until GitHub's 24h limit and the run
     # is cancelled, which is why no release before 6.0.0 ever carried an Intel asset (and
@@ -228,7 +228,7 @@ jobs:
 
   build-linux:
     name: Build Linux Binary
-    if: ${ github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || contains(inputs.platforms, 'linux') }
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || contains(inputs.platforms, 'linux') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

`build-macos-x64` asked for `macos-13`, which GitHub **retired on 2025-12-04**. A job requesting a
retired label doesn't fail — it sits queued until the 24-hour limit and the run is cancelled.

Two consequences, both silent, both present on every release so far:

- **No release has ever carried an Intel macOS asset.** v5.6.0, v5.7.0, v5.7.1, v5.8.0 and v6.0.0
  each shipped exactly three: Linux-x86_64, macOS-arm64, Windows-x64. Intel Mac users have never
  had a native download.
- **`create-release-notes` has never run**, because it `needs:` that job. That is why every release
  body has been empty and filled in by hand.

## Related Issues

<!-- none filed; found while checking why the v6.0.0 build hung -->

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test coverage improvement
- [x] CI/CD improvement

## Changes Made

- **`build-macos-x64`: `macos-13` → `macos-15-intel`.** The documented migration target, and the
  **last** x86_64 image — it disappears in **August 2027**, after which GitHub-hosted Intel macOS
  builds are not possible at all. Worth knowing before anyone plans around it.
- **`build-macos-arm64`: `macos-14` → `macos-15`.** `macos-14` is now marked deprecated in
  `actions/runner-images`, i.e. on the same path `macos-13` took.
- **`release_tag` dispatch input.** A manual run can name an existing release, so a missing asset
  can be backfilled without moving a published tag: `checkout` takes the tagged source while the
  workflow file comes from the branch holding the fixed label. The version flows into
  `APP_VERSION`, which reaches `CFBundleVersion`/`CFBundleShortVersionString` — so a backfilled
  `.app` carries the real tag rather than `dev-<sha>`, which is what made the naive
  "dispatch on a branch and rename the artifact" approach unacceptable.
- **`platforms` dispatch input.** Limits which jobs a manual run builds, so backfilling one asset
  doesn't rebuild and overwrite the three that already shipped and were tested.

A tag push is never filtered: every guard short-circuits on `github.event_name`, so release builds
behave exactly as before.

## Testing

- [ ] Tests pass locally (`make test` or `pytest tests/`) <!-- n/a: no Python changed -->
- [ ] Added tests for new functionality <!-- n/a -->
- [x] Tested with real hardware (if applicable) <!-- n/a; exercised against real runners instead -->
- [ ] All CI checks pass <!-- pending -->

### Test Details

Verified by dispatching this branch against the v6.0.0 tag
(`--ref fix/macos-runner-labels -f release_tag=v6.0.0 -f platforms=macos-x64`):

| check | result |
|---|---|
| `macos-15-intel` schedules | **started in 4 seconds** (vs. `macos-13` queued 5h, then 24h on earlier releases) |
| platform filter | Windows / Linux / arm64 all correctly **skipped** — published assets untouched |
| asset upload to an existing release | see the run linked in the comments |

## Code Quality

- [x] Code follows the project style guidelines (`make lint` passes) <!-- no Python changed -->
- [x] Code is formatted with Black (`make format`) <!-- n/a -->
- [x] Self-reviewed the code
- [x] Commented complex code sections
- [ ] Updated docstrings for modified functions/classes <!-- n/a -->
- [x] No new linting warnings introduced

## Documentation

- [ ] Updated README.md (if needed) <!-- see Additional Notes -->
- [ ] Updated CHANGELOG.md with changes <!-- CI-only; no user-facing library change -->
- [ ] Added/updated docstrings <!-- n/a -->
- [ ] Added/updated examples (if applicable) <!-- n/a -->
- [ ] Updated type hints <!-- n/a -->

## Additional Notes

**A brace bug on the way in, worth flagging because the check that should have caught it didn't.**
The platform guards first went out as `${ ... }` instead of `${{ ... }}` — they were generated with
`str.format()`, which collapses doubled braces. `yaml.safe_load` still passed, because at the YAML
layer the guard is just a string. GitHub rejected the workflow on dispatch. **Actions expression
syntax is a separate layer that a YAML parse does not validate**; the dispatch API is the only
thing that reads it. Fixed in the second commit.

**Two follow-ups this surfaces, deliberately not done here:**

1. `create-release-notes` will now actually run on the next tag. It uses `append_body: true`, so it
   appends its installation section to whatever body exists. Since release notes have been written
   by hand up to now, the next release will get both — worth deciding which should own the body
   before v6.0.1.
2. The download docs list three platforms. Once an Intel asset genuinely ships, the README and docs
   should mention it.
