### PR TITLE
docs: list the Intel macOS download alongside Apple Silicon

### DIFF
--- a/docs/development/BUILDING_EXECUTABLES.md
+++ b/docs/development/BUILDING_EXECUTABLES.md
@@ -151,7 +151,8 @@ python scripts/build_executable.py --archive
 This creates:
 
 - **Windows**: `SiglentGUI-v0.3.1-Windows-x64.zip`
-- **macOS**: `SiglentGUI-v0.3.1-macOS-arm64.zip`
+- **macOS (Apple Silicon)**: `SiglentGUI-v0.3.1-macOS-arm64.zip`
+- **macOS (Intel)**: `SiglentGUI-v0.3.1-macOS-x86_64.zip`
 - **Linux**: `SiglentGUI-v0.3.1-Linux-x86_64.tar.gz`
 
 Each archive includes:
@@ -164,7 +165,7 @@ Each archive includes:
 
 When you push a version tag (e.g., `v0.3.2`), GitHub Actions will:
 
-1. Build executables on Windows, macOS, and Linux runners
+1. Build executables on four runners: Windows, macOS on Apple Silicon, macOS on Intel, and Linux
 2. Create platform-specific archives
 3. Upload to GitHub Releases
 4. Add installation instructions to the release notes

--- a/docs/development/TESTING_BUILD_WORKFLOW.md
+++ b/docs/development/TESTING_BUILD_WORKFLOW.md
@@ -239,7 +239,8 @@ Once builds complete:
 2. Scroll to **Artifacts** section
 3. Download each artifact:
    - `windows-executable`
-   - `macos-executable`
+   - `macos-arm64-executable`
+   - `macos-x64-executable`
    - `linux-executable`
 
 **Or download from Releases:**
@@ -249,6 +250,7 @@ Once builds complete:
 3. Download the attachments:
    - `SiglentGUI-v0.3.1-test-Windows-x64.zip`
    - `SiglentGUI-v0.3.1-test-macOS-arm64.zip`
+   - `SiglentGUI-v0.3.1-test-macOS-x86_64.zip`
    - `SiglentGUI-v0.3.1-test-Linux-x86_64.tar.gz`
 
 ---


### PR DESCRIPTION
## Description

v6.0.0 is the first release to carry `SiglentGUI-vX-macOS-x86_64.zip` (backfilled after #136 fixed the retired `macos-13` runner label). The docs that enumerate release artifacts still listed a single macOS entry.

## Type of Change

- [x] Documentation update

## Changes Made

- `docs/development/BUILDING_EXECUTABLES.md` — archive list splits macOS into Apple Silicon and Intel; the automated-release description now says four runners rather than three.
- `docs/development/TESTING_BUILD_WORKFLOW.md` — adds the Intel zip to the release attachments, and **corrects the artifact name**: it said `macos-executable`, but the workflow has long uploaded `macos-arm64-executable` (and now `macos-x64-executable`). That name was wrong before this release, independently of the Intel work.

## Testing

- [x] Self-reviewed the code
- [ ] All CI checks pass <!-- pending -->

Docs-only; no code paths touched.

## Additional Notes

Two things I deliberately did **not** change:

1. **Version strings in the examples** (`v0.3.1`, `v0.3.2`) are stale throughout both files. I left them alone — half-updating them would read worse than leaving them internally consistent. Worth a separate sweep if you want the examples to match reality.
2. **The user-facing install page** (`docs/getting-started/installation.md`) does not mention the standalone downloads at all — it covers PyPI only. Adding a downloads section there would reach more users than either file in this PR, but it is a new section rather than a correction, so I left the call to you.

The release-notes template in `build-executables.yml` already listed both macOS variants correctly; it simply never ran, because `create-release-notes` needed the broken Intel job.