### PR TITLE
docs: add a standalone downloads section to the install page

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,6 +9,47 @@ This page describes how to install SCPI Instrument Control, a universal Python l
 - **Network**: Ethernet connection to oscilloscope
 - **Oscilloscope**: Siglent SDS series with SCPI support
 
+## Standalone Downloads
+
+If you only want the desktop GUI and would rather not install Python at all, every release
+attaches a prebuilt bundle for each platform. These carry their own Python runtime and every
+dependency, so the Python requirement above does not apply — the network and instrument
+requirements still do.
+
+**[Download the latest release](https://github.com/little-did-I-know/SCPI-Instrument-Control/releases/latest)**
+
+| Platform | File | How to run |
+| --- | --- | --- |
+| Windows (x64) | `SiglentGUI-<version>-Windows-x64.zip` | Extract, then run `SiglentGUI.exe` |
+| macOS (Apple Silicon) | `SiglentGUI-<version>-macOS-arm64.zip` | Extract, then open `SiglentGUI.app` |
+| macOS (Intel) | `SiglentGUI-<version>-macOS-x86_64.zip` | Extract, then open `SiglentGUI.app` |
+| Linux (x86_64) | `SiglentGUI-<version>-Linux-x86_64.tar.gz` | `tar -xzf SiglentGUI-*.tar.gz`, then `./SiglentGUI` |
+
+The bundles are large — roughly 200-300 MB — because each one carries its own Python runtime,
+PyQt6 and the scientific stack.
+
+The Intel macOS build is available from **v6.0.0 onward**. Earlier releases shipped an Apple
+Silicon build only.
+
+### Which macOS build do I need?
+
+Apple menu → **About This Mac**, or run `uname -m` in Terminal:
+
+- `arm64` → Apple Silicon (M1/M2/M3/M4) → the **arm64** download
+- `x86_64` → Intel → the **x86_64** download
+
+### First launch warnings
+
+The executables are **not code-signed**, so each operating system will question them the first
+time. This is expected, and the workaround is per-platform:
+
+- **macOS**: right-click the app → **Open** → confirm. Double-clicking alone will refuse it.
+- **Windows**: SmartScreen shows "Windows protected your PC" → **More info** → **Run anyway**.
+- **Linux**: no warning, but you may need `chmod +x SiglentGUI` before the binary will run.
+
+These bundles give you the desktop GUI only. To use the library from your own scripts, or to run
+the `scpi-web` browser gateway, install the Python package as described below.
+
 ## Basic Installation
 
 Install the base package using pip:


### PR DESCRIPTION
## Description

The install page covered `pip` only. A user who wanted the desktop GUI **without installing Python** had nowhere to be sent — the prebuilt bundles were described only in the development docs and on the release page itself.

Follows #137, which fixed the artifact lists in the development docs but deliberately left this larger, user-facing gap open for a decision.

## Type of Change

- [x] Documentation update

## Changes Made

A new **Standalone Downloads** section in `docs/getting-started/installation.md`, placed above **Basic Installation**:

- A link to the latest release, and a table of all four platforms — Windows x64, macOS Apple Silicon, macOS Intel, Linux x86_64 — with the file to grab and how to run it.
- **How to tell Apple Silicon from Intel** (`uname -m`, or About This Mac), since that is the one choice a reader can get wrong and end up with a bundle that will not launch.
- **First-launch warnings.** The executables are not code-signed, so every OS questions them. The per-platform workarounds come from `docs/development/CODE_SIGNING.md`, which records that signing is not enabled: macOS needs right-click → Open (double-clicking alone refuses), Windows needs More info → Run anyway, Linux may need `chmod +x`.
- A note that the **Intel macOS build starts at v6.0.0**, so someone on an older release does not go hunting for a file that was never attached.
- A closing line that these bundles are the **GUI alone** — the library and the `scpi-web` gateway still come from PyPI.

## Testing

- [x] Self-reviewed the code
- [x] Verified with `mkdocs build --strict` (passes; no broken links or nav changes needed)
- [ ] All CI checks pass <!-- pending -->

Docs-only; no code paths touched.

## Additional Notes

The section deliberately does **not** claim the Requirements list is irrelevant to these downloads. Only the Python requirement stops applying — the network and instrument requirements still hold, and the wording says so.

Sizes are given as a range (~200-300 MB) rather than exact figures, so the page does not go stale every release. For reference, v6.0.0 shipped 206 MB (arm64), 228 MB (x86_64), 260 MB (Windows) and 289 MB (Linux).