### PR TITLE
fix: probe-attenuation scaling and four more backend-review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - PSU: `ovp_level`/`ocp_level` on SPD1305X/SPD1168X now raise `NotImplementedError` instead of silently sending a command the firmware discards. No SPD1000X programming manual documents a SCPI protection subsystem; set protection on the front panel. (Same honesty gate the SPD3303X received in v5.0.0.)
 - Oscilloscope: setting `trigger.trigger_type` to a type the connected dialect cannot express (everything except `EDGE` on Tektronix) now raises `FeatureNotSupportedError` instead of silently leaving the scope on its previous trigger.
-
-### Changed
-
 - Oscilloscope: setting an invalid trigger type now raises `ValueError` (consistent with the mode/slope setters) where it previously raised `InvalidParameterError`; callers catching `SiglentError` around `trigger.trigger_type` assignments should catch `ValueError` too.
 
 ### Fixed
@@ -21,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Oscilloscope (modern Siglent): waveform captures are now scaled by the channel's probe attenuation ratio. Verified against an SDS824X HD: the wire preamble's gain/offset exclude the probe factor, so 10x-probe captures previously read 10x too small.
 - Oscilloscope (modern Siglent): `trigger.trigger_type = "SLEW"/"GLIT"/"INTV"` now sends the dialect's real tokens (`SLOPe`/`PULSE`/`INTerval`) instead of legacy spellings the scope rejects.
 - Connection: a timeout during a sized binary read (e.g. slow screenshot start) now raises `SiglentTimeoutError` and keeps the session usable, instead of misclassifying as a dead connection.
-- Mock: the modern mock now answers `:CHANnel<n>:PROBe?`, `:CHANnel<n>:BWLimit?`, `:TIMebase:DELay?`, and `*OPC?` with hardware-measured response shapes, rejects invalid probe/trigger-type parameters with `-224` like real firmware, and reports probe-free preamble gain — so provenance channel snapshots are exercised in CI.
+- Mock: the modern mock now answers `:CHANnel<n>:PROBe?`, `:CHANnel<n>:BWLimit?`, `:TIMebase:DELay?`, and `*OPC?` with hardware-measured response shapes, rejects invalid probe/trigger-type parameters with `-224` like real firmware, and reports probe-free preamble gain — so provenance channel snapshots are exercised in CI. The mock also now seeds the modern dialect's default channel coupling as `DC` instead of the legacy `D1M` token.
 
 ## [6.0.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- PSU: `ovp_level`/`ocp_level` on SPD1305X/SPD1168X now raise `NotImplementedError` instead of silently sending a command the firmware discards. No SPD1000X programming manual documents a SCPI protection subsystem; set protection on the front panel. (Same honesty gate the SPD3303X received in v5.0.0.)
+- Oscilloscope: setting `trigger.trigger_type` to a type the connected dialect cannot express (everything except `EDGE` on Tektronix) now raises `FeatureNotSupportedError` instead of silently leaving the scope on its previous trigger.
+
+### Changed
+
+- Oscilloscope: setting an invalid trigger type now raises `ValueError` (consistent with the mode/slope setters) where it previously raised `InvalidParameterError`; callers catching `SiglentError` around `trigger.trigger_type` assignments should catch `ValueError` too.
+
+### Fixed
+
+- Oscilloscope (modern Siglent): waveform captures are now scaled by the channel's probe attenuation ratio. Verified against an SDS824X HD: the wire preamble's gain/offset exclude the probe factor, so 10x-probe captures previously read 10x too small.
+- Oscilloscope (modern Siglent): `trigger.trigger_type = "SLEW"/"GLIT"/"INTV"` now sends the dialect's real tokens (`SLOPe`/`PULSE`/`INTerval`) instead of legacy spellings the scope rejects.
+- Connection: a timeout during a sized binary read (e.g. slow screenshot start) now raises `SiglentTimeoutError` and keeps the session usable, instead of misclassifying as a dead connection.
+- Mock: the modern mock now answers `:CHANnel<n>:PROBe?`, `:CHANnel<n>:BWLimit?`, `:TIMebase:DELay?`, and `*OPC?` with hardware-measured response shapes, rejects invalid probe/trigger-type parameters with `-224` like real firmware, and reports probe-free preamble gain — so provenance channel snapshots are exercised in CI.
+
 ## [6.0.0] - 2026-07-30
 
 ### ⚠️ Breaking Changes

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- PSU: `ovp_level`/`ocp_level` on SPD1305X/SPD1168X now raise `NotImplementedError` instead of silently sending a command the firmware discards. No SPD1000X programming manual documents a SCPI protection subsystem; set protection on the front panel. (Same honesty gate the SPD3303X received in v5.0.0.)
+- Oscilloscope: setting `trigger.trigger_type` to a type the connected dialect cannot express (everything except `EDGE` on Tektronix) now raises `FeatureNotSupportedError` instead of silently leaving the scope on its previous trigger.
+- Oscilloscope: setting an invalid trigger type now raises `ValueError` (consistent with the mode/slope setters) where it previously raised `InvalidParameterError`; callers catching `SiglentError` around `trigger.trigger_type` assignments should catch `ValueError` too.
+
+### Fixed
+
+- Oscilloscope (modern Siglent): waveform captures are now scaled by the channel's probe attenuation ratio. Verified against an SDS824X HD: the wire preamble's gain/offset exclude the probe factor, so 10x-probe captures previously read 10x too small.
+- Oscilloscope (modern Siglent): `trigger.trigger_type = "SLEW"/"GLIT"/"INTV"` now sends the dialect's real tokens (`SLOPe`/`PULSE`/`INTerval`) instead of legacy spellings the scope rejects.
+- Connection: a timeout during a sized binary read (e.g. slow screenshot start) now raises `SiglentTimeoutError` and keeps the session usable, instead of misclassifying as a dead connection.
+- Mock: the modern mock now answers `:CHANnel<n>:PROBe?`, `:CHANnel<n>:BWLimit?`, `:TIMebase:DELay?`, and `*OPC?` with hardware-measured response shapes, rejects invalid probe/trigger-type parameters with `-224` like real firmware, and reports probe-free preamble gain — so provenance channel snapshots are exercised in CI. The mock also now seeds the modern dialect's default channel coupling as `DC` instead of the legacy `D1M` token.
+
 ## [6.0.0] - 2026-07-30
 
 ### ⚠️ Breaking Changes

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -106,7 +106,20 @@ class MockConnection(BaseConnection):
         self._waveform_gate: Optional[threading.Event] = waveform_gate
         self._signals: Dict[int, Union["SignalSpec", Callable[[], "SignalSpec"]]] = dict(signals) if signals else {}
         self._acquisition_counts: Dict[int, int] = {}
-        self._channel_coupling: Dict[int, str] = {ch: "D1M" for ch in channels}
+        # Coupling default is dialect-specific: modern wire vocabulary is
+        # {DC,AC,GND} (scpi_commands.py's _COUPLING_FROM_WIRE); legacy/LeCroy
+        # speak {D1M,A1M,D50,A50,GND}. "D1M" (DC, 1MOhm) previously seeded
+        # EVERY dialect unconditionally, so a fresh modern-dialect channel's
+        # own `coupling` getter -- whose wire parser only recognizes
+        # {DC,AC,GND} -- raised ValueError("Unrecognized modern coupling mode
+        # response: 'D1M'") before any coupling write ever happened. That
+        # exception is not individually caught by Channel.get_configuration()
+        # (task 5, audit High-11), so it blanked the ENTIRE channel
+        # provenance snapshot to None, not just coupling -- the same failure
+        # shape the modern BWLimit?/TIMebase:DELay? gaps produced elsewhere
+        # in this file. Tektronix already overrides this below with its own
+        # "DC" default for the identical reason; modern needs the same.
+        self._channel_coupling: Dict[int, str] = {ch: ("DC" if self.scope_dialect == "modern" else "D1M") for ch in channels}
         # Legacy scope probe attenuation / bandwidth-limit state (Task 14,
         # audit L3): the GUI's channel refresh reads both on every poll.
         self.probe_ratios: Dict[int, float] = {ch: 1.0 for ch in channels}
@@ -148,6 +161,10 @@ class MockConnection(BaseConnection):
 
         self.sample_rate = sample_rate
         self.timebase = timebase
+        # Modern :TIMebase:DELay state (guide p.473; task 5, audit High-11):
+        # trigger-offset delay, seconds. MEASURED on a real SDS824X HD (fw
+        # 3.8.12.1.1.3.6) 2026-07-31: "0.00E+00" at the default (no delay).
+        self.timebase_delay: float = 0.0
         self.trigger_type = "EDGE"
         self.trigger_source = "C1"
         if self.scope_dialect == "modern":
@@ -640,6 +657,20 @@ class MockConnection(BaseConnection):
                 return self.psu_idn
             else:
                 return self.idn
+
+        if upper == "*OPC?":
+            # IEEE 488.2 SS10.18: "1" is placed in the Output Queue once all
+            # pending operations complete. MEASURED on a real SDS824X HD (fw
+            # 3.8.12.1.1.3.6) 2026-07-31: "1". Universal across every
+            # personality/dialect this mock speaks (scope legacy/modern,
+            # PSU, AWG, DAQ) -- *OPC? is IEEE-488.2 common-command
+            # vocabulary, not a vendor/dialect-specific query, so this
+            # answers before any personality/mode dispatch below, unlike the
+            # scope-only modern handlers in connection/mock/siglent.py.
+            # oscilloscope.py's wait_complete() previously had no answer to
+            # this query at all and raised SiglentTimeoutError on every
+            # dialect.
+            return "1"
 
         # SYST:ERR? for the three instrument classes that expose get_error()
         # (psu_scpi_commands.py:70, awg_scpi_commands.py:65,

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -70,6 +70,41 @@ _MOCK_SIMPLE_VALUES: Dict[str, str] = {
     "DUTY": "5.000E+01",
 }
 
+# Full :TRIGger:TYPE enum, uppercased, verbatim from SDS800X HD guide EN11G
+# p.485: {EDGE|PULSE|SLOPe|INTerval|PATTern|RUNT|WINDow|DROPout|VIDeo|
+# QUALified|NEDGe|DELay|SHOLd|IIC|SPI|UART|LIN|CAN|FLEXray|CANFd|IIS|M1553|
+# SENT|A429}. Used to validate the write handler below instead of accepting
+# any word (measured on hardware 2026-07-31: an invalid token queues -224 and
+# leaves the trigger type unchanged).
+_MODERN_TRIGGER_TYPES = frozenset(
+    {
+        "EDGE",
+        "PULSE",
+        "SLOPE",
+        "INTERVAL",
+        "PATTERN",
+        "RUNT",
+        "WINDOW",
+        "DROPOUT",
+        "VIDEO",
+        "QUALIFIED",
+        "NEDGE",
+        "DELAY",
+        "SHOLD",
+        "IIC",
+        "SPI",
+        "UART",
+        "LIN",
+        "CAN",
+        "FLEXRAY",
+        "CANFD",
+        "IIS",
+        "M1553",
+        "SENT",
+        "A429",
+    }
+)
+
 
 def handle_write(conn, command: str) -> bool:
     """Handle a Siglent-dialect (legacy or modern) scope write. Returns True if consumed."""
@@ -140,7 +175,11 @@ def handle_write(conn, command: str) -> bool:
                 conn.trigger_status = ["Stop"]
             return True
         if match := re.match(r":TRIGger:TYPE\s+(\w+)", command, re.IGNORECASE):
-            conn.trigger_type = match.group(1).upper()
+            token = match.group(1).upper()
+            if token not in _MODERN_TRIGGER_TYPES:
+                conn.push_error(-224, "Illegal parameter value")
+                return True  # consumed, ignored, error queued
+            conn.trigger_type = token
             return True
         if match := re.match(r":TRIGger:EDGE:SOURce\s+(\w+)", command, re.IGNORECASE):
             conn.trigger_source = match.group(1).upper()

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -156,12 +156,30 @@ def handle_write(conn, command: str) -> bool:
         if match := re.match(r":CHANnel(\d+):PROBe\s+(.+)", command, re.IGNORECASE):
             conn.push_error(-224, "Illegal parameter value")
             return True  # consumed, ignored, error queued -- ratio left as-is
+        # :CHANnel:BWLimit -- guide p.50, <bwlimit>:={FULL|20M|200M} (task 5,
+        # audit High-11). Stored in the SAME `bandwidth_limits` dict the
+        # legacy BWL write handler below already maintains (task 14) rather
+        # than a second piece of state -- see the modern query handler for
+        # why that dict has to carry both vocabularies.
+        if match := re.match(r":CHANnel(\d+):BWLimit\s+(FULL|20M|200M)", command, re.IGNORECASE):
+            conn.bandwidth_limits[int(match.group(1))] = match.group(2).upper()
+            return True
         if match := re.match(r":TIMebase:SCALe\s+(.+)", command, re.IGNORECASE):
             value = float(match.group(1))
             if conn.reject_if_invalid(value, name="TIMebase:SCALe"):
                 return True
             conn.timebase = value
             conn.timebase_updates.append(conn.timebase)
+            return True
+        # :TIMebase:DELay -- guide p.473, EXAMPLE "TIM:DEL 1.00E-05" (task 5,
+        # audit High-11). Trigger-offset delay may legitimately be negative
+        # (pre-trigger) or zero, so it is not gated on positivity, mirroring
+        # :TRIGger:EDGE:LEVel above.
+        if match := re.match(r":TIMebase:DELay\s+(.+)", command, re.IGNORECASE):
+            value = float(match.group(1))
+            if conn.reject_if_invalid(value, name="TIMebase:DELay", positive=False):
+                return True
+            conn.timebase_delay = value
             return True
         # :MEASure <ON|OFF> (p.337). Matched before the :MEASure:SIMPle forms
         # below; the required whitespace after the mnemonic means this pattern
@@ -408,6 +426,31 @@ def handle_query(conn, command: str) -> Optional[str]:
             # MEASURED on a real SDS824X HD 2026-07-31: "1.00E+00" at the
             # default 1x ratio -- same bare-NR3 shape as SCALe?/OFFSet? above.
             return _format_nr3(conn.probe_ratios.get(int(match.group(1)), 1.0))
+        if match := re.match(r":CHANNEL(\d+):BWLIMIT\?", upper):  # p.50
+            # MEASURED on a real SDS824X HD 2026-07-31: "FULL" at the default
+            # (no bandwidth limiting). Reuses the SAME per-channel
+            # `bandwidth_limits` state the legacy BWL?/BWL write handler
+            # below already maintains (task 14) rather than inventing a
+            # second store, since the two dialects describe the same
+            # physical setting -- only the wire vocabulary differs (legacy
+            # {ON,OFF} vs modern {FULL,20M,200M}, guide p.50). The dict
+            # therefore mixes both vocabularies depending on which dialect's
+            # write handler last touched it (never both -- a single
+            # MockConnection speaks one fixed dialect): map the legacy
+            # default/writes (OFF/ON) into modern tokens, and pass through
+            # anything already in modern form (from the :CHANnel:BWLimit
+            # write handler above) unchanged.
+            stored = conn.bandwidth_limits.get(int(match.group(1)), "OFF")
+            if stored == "OFF":
+                return "FULL"
+            if stored == "ON":
+                return "20M"
+            return stored
+        if upper == ":TIMEBASE:DELAY?":  # bare NR3, p.473
+            # MEASURED on a real SDS824X HD 2026-07-31: "0.00E+00" at the
+            # default (no trigger delay) -- same bare-NR3 shape as
+            # TIMebase:SCALe? below.
+            return _format_nr3(conn.timebase_delay)
         if upper == ":TIMEBASE:SCALE?":  # bare NR3, p.476
             return _format_nr3(conn.timebase)
         if upper == ":ACQUIRE:SRATE?":  # bare NR3, p.46

--- a/scpi_control/connection/mock/siglent.py
+++ b/scpi_control/connection/mock/siglent.py
@@ -132,6 +132,30 @@ def handle_write(conn, command: str) -> bool:
         if match := re.match(r":CHANnel(\d+):COUPling\s+(\w+)", command, re.IGNORECASE):
             conn._channel_coupling[int(match.group(1))] = match.group(2).upper()
             return True
+        # :CHANnel:PROBe -- guide p.57. Two documented argument forms:
+        # "VALue,<ratio>" (<ratio> in NR3, documented range [1E-6, 1E6]) and
+        # "DEFault" (resets to 1x, p.57). Any other form -- e.g. the bare
+        # "PROBe 10" a caller might send by analogy with the legacy ATTN
+        # command -- is rejected: MEASURED on a real SDS824X HD 2026-07-31,
+        # ':CHANnel1:PROBe 10' queued -224 and left the ratio unchanged, it
+        # did not accept the value.
+        if match := re.match(r":CHANnel(\d+):PROBe\s+VALue,([\dEe.+-]+)", command, re.IGNORECASE):
+            ch = int(match.group(1))
+            value = float(match.group(2))
+            # A probe ratio is a magnitude (documented range [1E-6, 1E6],
+            # p.57) -- gated on positivity like the legacy ATTN handler
+            # above, and load-bearing here: build_waveform_preamble divides
+            # by this value to report the BNC-frame gain/offset.
+            if conn.reject_if_invalid(value, name="PROBe", max_magnitude=1e6):
+                return True
+            conn.probe_ratios[ch] = value
+            return True
+        if match := re.match(r":CHANnel(\d+):PROBe\s+DEFault", command, re.IGNORECASE):
+            conn.probe_ratios[int(match.group(1))] = 1.0
+            return True
+        if match := re.match(r":CHANnel(\d+):PROBe\s+(.+)", command, re.IGNORECASE):
+            conn.push_error(-224, "Illegal parameter value")
+            return True  # consumed, ignored, error queued -- ratio left as-is
         if match := re.match(r":TIMebase:SCALe\s+(.+)", command, re.IGNORECASE):
             value = float(match.group(1))
             if conn.reject_if_invalid(value, name="TIMebase:SCALe"):
@@ -380,6 +404,10 @@ def handle_query(conn, command: str) -> Optional[str]:
             return _format_nr3(conn._voltage_offsets.get(int(match.group(1)), 0.0))
         if match := re.match(r":CHANNEL(\d+):COUPLING\?", upper):  # DC|AC|GND, p.51
             return conn._channel_coupling.get(int(match.group(1)), "DC")
+        if match := re.match(r":CHANNEL(\d+):PROBE\?", upper):  # bare NR3, p.58
+            # MEASURED on a real SDS824X HD 2026-07-31: "1.00E+00" at the
+            # default 1x ratio -- same bare-NR3 shape as SCALe?/OFFSet? above.
+            return _format_nr3(conn.probe_ratios.get(int(match.group(1)), 1.0))
         if upper == ":TIMEBASE:SCALE?":  # bare NR3, p.476
             return _format_nr3(conn.timebase)
         if upper == ":ACQUIRE:SRATE?":  # bare NR3, p.46
@@ -643,8 +671,17 @@ def build_waveform_preamble(conn) -> bytes:
     struct.pack_into("<i", desc, _MODERN_WAVE_ARRAY_COUNT, record_length)
     struct.pack_into("<i", desc, _MODERN_FIRST_POINT, conn.waveform_start)
     struct.pack_into("<i", desc, _MODERN_DATA_INTERVAL, conn.waveform_interval)
-    struct.pack_into("<f", desc, _MODERN_VERTICAL_GAIN, conn._voltage_scales.get(channel, 1.0))
-    struct.pack_into("<f", desc, _MODERN_VERTICAL_OFFSET, conn._voltage_offsets.get(channel, 0.0))
+    # VERTICAL_GAIN/VERTICAL_OFFSET are probe-FREE (BNC frame), MEASURED on a
+    # real SDS824X HD (fw 3.8.12.1.1.3.6) 2026-07-31: with :CHANnel1:PROBe
+    # VALue,1.00E+01 the display read 20 V/div but the preamble still
+    # reported gain 2.0, and a 1.0 V displayed offset stayed voff 1.0 at
+    # 10x. So the mock reports scale/offset DIVIDED by the probe ratio here,
+    # while _synthesize_modern_codes (above) keeps encoding codes against the
+    # DISPLAYED scale/offset unchanged -- ModernTransfer.acquire is what
+    # multiplies the probe ratio back in on the way out.
+    probe_ratio = conn.probe_ratios.get(channel, 1.0)
+    struct.pack_into("<f", desc, _MODERN_VERTICAL_GAIN, conn._voltage_scales.get(channel, 1.0) / probe_ratio)
+    struct.pack_into("<f", desc, _MODERN_VERTICAL_OFFSET, conn._voltage_offsets.get(channel, 0.0) / probe_ratio)
     struct.pack_into("<f", desc, _MODERN_CODE_PER_DIV, code_per_div)
     struct.pack_into("<h", desc, _MODERN_ADC_BIT, _MODERN_ADC_BIT_VALUE)
     # NOT scaled by the interval -- the instrument reports the raw sample

--- a/scpi_control/connection/socket.py
+++ b/scpi_control/connection/socket.py
@@ -191,6 +191,9 @@ class SocketConnection(BaseConnection):
                     return data
                 else:
                     return self._read_ieee_block()
+            except socket.timeout:
+                command_context = f"after '{self._last_command}' " if self._last_command else ""
+                raise exceptions.SiglentTimeoutError(f"Raw read timeout {command_context}from {self.host}:{self.port}")
             except socket.error as e:
                 self._connected = False
                 command_context = f" after '{self._last_command}'" if self._last_command else ""

--- a/scpi_control/psu_models.py
+++ b/scpi_control/psu_models.py
@@ -103,8 +103,12 @@ PSU_MODEL_REGISTRY = {
         output_specs=[
             OutputSpec(1, 30.0, 5.0, 150.0, 0.001, 0.001),
         ],
-        has_ovp=True,
-        has_ocp=True,
+        # No SPD1000X programming manual in docs/ documents a protection
+        # subsystem; the generic SOUR{ch}:VOLT:PROT fallback previously used
+        # here is uncitable and silently discarded by SPD firmware (same class
+        # as audit H18 on the SPD3303X). Backend review 2026-07-31, High-3.
+        has_ovp=False,
+        has_ocp=False,
         has_timer=False,
         has_waveform=False,
         has_tracking=False,
@@ -119,8 +123,12 @@ PSU_MODEL_REGISTRY = {
         output_specs=[
             OutputSpec(1, 16.0, 8.0, 128.0, 0.001, 0.001),
         ],
-        has_ovp=True,
-        has_ocp=True,
+        # No SPD1000X programming manual in docs/ documents a protection
+        # subsystem; the generic SOUR{ch}:VOLT:PROT fallback previously used
+        # here is uncitable and silently discarded by SPD firmware (same class
+        # as audit H18 on the SPD3303X). Backend review 2026-07-31, High-3.
+        has_ovp=False,
+        has_ocp=False,
         has_timer=False,
         has_waveform=False,
         has_tracking=False,

--- a/scpi_control/scpi_commands.py
+++ b/scpi_control/scpi_commands.py
@@ -678,6 +678,44 @@ _SLOPE_FROM_WIRE = {
     "tektronix": {"RISE": "POS", "FALL": "NEG"},
     "lecroy": {"POS": "POS", "NEG": "NEG"},
 }
+
+_TRIGGER_TYPES = {"EDGE", "SLEW", "GLIT", "INTV", "RUNT", "PATTERN"}
+_TRIGGER_TYPE_TO_WIRE = {
+    # Legacy TRSE types ARE the public vocabulary (legacy guide TRSE section).
+    "legacy": {t: t for t in _TRIGGER_TYPES},
+    # SDS800X HD guide EN11G p.485: :TRIGger:TYPE {EDGE|PULSE|SLOPe|INTerval|
+    # PATTern|RUNT|WINDow|DROPout|VIDeo|...}. Public SLEW = slope trigger,
+    # public GLIT = pulse/glitch trigger (MAUI-descended naming).
+    "modern": {"EDGE": "EDGE", "SLEW": "SLOPe", "GLIT": "PULSE", "INTV": "INTerval", "RUNT": "RUNT", "PATTERN": "PATTern"},
+    # Only EDGE is spelled identically across Tek families: TBS is {EDGe|PULSe}
+    # (p.161) while MSO2 (p.2-682) and MSO456 (p.2-1426) use WIDth for the
+    # pulse class. The pulse-class token diverges per family, so everything but
+    # EDGE gates as FeatureNotSupportedError until per-family maps exist.
+    "tektronix": {"EDGE": "EDGE"},
+    # LeCroy TRIG_SELECT types (MAUI p.7-36) -- ancestor of the legacy tokens.
+    "lecroy": {t: t for t in _TRIGGER_TYPES},
+}
+_TRIGGER_TYPE_FROM_WIRE = {
+    "legacy": {t: t for t in _TRIGGER_TYPES},
+    "modern": {"EDGE": "EDGE", "SLOPE": "SLEW", "PULSE": "GLIT", "INTERVAL": "INTV", "RUNT": "RUNT", "PATTERN": "PATTERN"},
+    "tektronix": {"EDGE": "EDGE"},
+    "lecroy": {t: t for t in _TRIGGER_TYPES},
+}
+
+
+def trigger_type_to_wire(dialect: str, trig_type: str) -> str:
+    return _to_wire(_TRIGGER_TYPE_TO_WIRE, _TRIGGER_TYPES, dialect, trig_type, "trigger type")
+
+
+def trigger_type_from_wire(dialect: str, raw: str) -> str:
+    # Unlike slope/coupling, a scope can legitimately sit in a type this API
+    # cannot set (VIDeo, DROPout, IIC, ... via front panel). Reads must not
+    # explode a state snapshot, so unmapped wire tokens pass through
+    # uppercased instead of raising the way _from_wire does.
+    token = _last_token(raw)
+    return _TRIGGER_TYPE_FROM_WIRE.get(dialect, {}).get(token, token)
+
+
 _COUPLING_TO_WIRE = {
     "legacy": {"DC": "D1M", "AC": "A1M", "GND": "GND"},
     "modern": {"DC": "DC", "AC": "AC", "GND": "GND"},

--- a/scpi_control/trigger.py
+++ b/scpi_control/trigger.py
@@ -13,6 +13,8 @@ from scpi_control.scpi_commands import (
     slope_from_wire,
     slope_to_wire,
     source_from_wire,
+    trigger_type_from_wire,
+    trigger_type_to_wire,
 )
 
 if TYPE_CHECKING:
@@ -166,9 +168,13 @@ class Trigger:
         if not is_flat_trigger(self._dialect):
             self._scope.write(self._cmd("set_trigger_source", src=channel_token(self._dialect, channel)))
         else:
-            # Get current trigger type to preserve it
+            # Get current trigger type to preserve it. self.trigger_type now
+            # yields a PUBLIC token, so it needs converting back to a wire
+            # token before going out on the wire (identity for legacy/lecroy
+            # today, but keeps the frames straight).
             current_type = self.trigger_type
-            self._scope.write(self._cmd("set_trigger_select", type=current_type, src=channel))
+            wire_type = trigger_type_to_wire(self._dialect, current_type)
+            self._scope.write(self._cmd("set_trigger_select", type=wire_type, src=channel))
         logger.info(f"Trigger source set to {channel}")
 
     def set_source(self, channel: Union[int, str]) -> None:
@@ -183,12 +189,13 @@ class Trigger:
             Trigger type: 'EDGE', 'SLEW', 'GLIT', 'INTV', 'RUNT', 'PATTERN', etc.
         """
         if not is_flat_trigger(self._dialect):
-            return self._scope.query(self._cmd("get_trigger_type")).strip().upper()
+            response = self._scope.query(self._cmd("get_trigger_type")).strip()
+            return trigger_type_from_wire(self._dialect, response)
         response = self._scope.query(self._cmd("get_trigger_select"))
         # Response format: "EDGE,SR,C1,..."
         parts = response.split(",")
         if len(parts) >= 1 and parts[0].strip():
-            return parts[0].strip().split()[-1].upper()  # tolerates a residual 'TRSE ' echo
+            return trigger_type_from_wire(self._dialect, parts[0])
         return "EDGE"
 
     @trigger_type.setter
@@ -197,19 +204,17 @@ class Trigger:
 
         Args:
             trig_type: Type - 'EDGE', 'SLEW', 'GLIT', 'INTV', 'RUNT', 'PATTERN'
+
+        Raises:
+            ValueError: If trig_type is not in the public vocabulary
+            FeatureNotSupportedError: If this dialect cannot express it
         """
-        trig_type = trig_type.upper()
-        valid_types = ["EDGE", "SLEW", "GLIT", "INTV", "RUNT", "PATTERN"]
-
-        if trig_type not in valid_types:
-            raise exceptions.InvalidParameterError(f"Invalid trigger type: {trig_type}. Must be one of {valid_types}.")
-
+        wire = trigger_type_to_wire(self._dialect, trig_type)
         if not is_flat_trigger(self._dialect):
-            self._scope.write(self._cmd("set_trigger_type", type=trig_type))
+            self._scope.write(self._cmd("set_trigger_type", type=wire))
         else:
-            # Get current source to preserve it
             current_source = self.source
-            self._scope.write(self._cmd("set_trigger_select", type=trig_type, src=current_source))
+            self._scope.write(self._cmd("set_trigger_select", type=wire, src=current_source))
         logger.info(f"Trigger type set to {trig_type}")
 
     def set_edge_trigger(self, source: str = "C1", slope: str = "POS") -> None:

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -390,8 +390,15 @@ class LeCroyTransfer:
 _MODERN_COMM_TYPE = 32  # short: 0=byte, 1=word
 _MODERN_WAVE_ARRAY_COUNT = 116  # long: number of data points
 _MODERN_DATA_INTERVAL = 136  # long: = :WAVeform:INTerval, echoed back (p.755)
-_MODERN_VERTICAL_GAIN = 156  # float: V/div, no probe attenuation
-_MODERN_VERTICAL_OFFSET = 160  # float
+# VERTICAL_GAIN/VERTICAL_OFFSET (156/160) are probe-FREE (BNC frame) --
+# CONFIRMED on real hardware, not just the guide's wording: on a real
+# SDS824X HD (fw 3.8.12.1.1.3.6, measured 2026-07-31), setting
+# :CHANnel1:PROBe VALue,1.00E+01 makes the display read 20 V/div while this
+# field still reports 2.0, and a 1.0 V displayed offset stays 1.0 at 10x.
+# ModernTransfer.acquire multiplies both by the probe ratio (queried via
+# :CHANnel:PROBe?) to recover the displayed (probe-referred) values.
+_MODERN_VERTICAL_GAIN = 156  # float: V/div, no probe attenuation (measured 2026-07-31)
+_MODERN_VERTICAL_OFFSET = 160  # float, also probe-free -- see comment above
 _MODERN_CODE_PER_DIV = 164  # float
 _MODERN_ADC_BIT = 172  # short: front-end resolution (p.756). 16 on an SDS824X HD
 _MODERN_HORIZ_INTERVAL = 176  # float: 1/sample_rate
@@ -604,6 +611,17 @@ class ModernTransfer:
         if meta["code_per_div"] == 0:
             raise exceptions.CommandError(f"Modern WAVEDESC code_per_div is 0 ({preamble_context})")
 
+        # Hardware truth (SDS824X HD fw 3.8.12.1.1.3.6, measured 2026-07-31):
+        # the preamble's VERTICAL_GAIN and VERTICAL_OFFSET are probe-FREE
+        # (BNC frame). With :CHANnel1:PROBe VALue,1.00E+01 the display reads
+        # 20 V/div but the preamble still reports gain 2.0, and a 1.0 V
+        # displayed offset stays voff 1.0 at 10x. The p.756 note "without
+        # probe attenuation" is literal. Multiply the BNC-frame result by the
+        # probe ratio or every 10x-probe capture is 10x too small. Queried
+        # ONCE per acquire (not per chunking window below) -- the ratio is
+        # channel state, not something that changes mid-transfer.
+        probe_ratio = float(scope.query(scope._get_command("get_probe_ratio", ch=channel)))
+
         # The one thing code cannot settle: whether a real instrument's
         # DATA_INTERVAL echo (and therefore its HORIZ_INTERVAL scaling, used
         # below for the time axis) actually reflects the stride we requested.
@@ -742,7 +760,11 @@ class ModernTransfer:
         effective_code_per_div = meta["code_per_div"]
         if meta["comm_type"] == 0 and meta["adc_bit"] > 8:
             effective_code_per_div /= 256.0
-        voltage = codes.astype(np.float64) * (meta["vertical_gain"] / effective_code_per_div) - meta["vertical_offset"]
+        # probe_ratio (queried above, once per acquire) converts the BNC-frame
+        # result back to the probe-referred (displayed) volts -- see the
+        # probe_ratio comment above and the _MODERN_VERTICAL_GAIN comment at
+        # the top of this module.
+        voltage = (codes.astype(np.float64) * (meta["vertical_gain"] / effective_code_per_div) - meta["vertical_offset"]) * probe_ratio
 
         # SDS Series Programming Guide EN11G p.759 ("Read Waveform Data",
         # Step 4): "time value(S) = delay-(timebase*grid/2)+index*interval".
@@ -789,8 +811,10 @@ class ModernTransfer:
             sample_rate=(1.0 / point_interval) if point_interval else None,
             record_length=n,
             timebase=timebase,
-            voltage_scale=meta["vertical_gain"],
-            voltage_offset=meta["vertical_offset"],
+            # Also probe-referred (display frame), consistent with `voltage`
+            # above and with provenance's :CHANnel:SCALe? readback.
+            voltage_scale=meta["vertical_gain"] * probe_ratio,
+            voltage_offset=meta["vertical_offset"] * probe_ratio,
         )
 
 

--- a/tests/test_modern_waveform_transfer.py
+++ b/tests/test_modern_waveform_transfer.py
@@ -297,6 +297,68 @@ def test_the_parser_accepts_the_block_shapes_the_instrument_actually_sends():
     assert parse_ieee_block(legacy_prefixed_empty, np.int8).size == 0
 
 
+class TestProbeAttenuationScaling:
+    """Backend review 2026-07-31 High-1, measured on SDS824X HD fw 3.8.12.1.1.3.6:
+    preamble VERTICAL_GAIN/VERTICAL_OFFSET are probe-FREE (BNC frame). At probe
+    10x the display reads 20 V/div but the preamble still says gain=2.0. The
+    driver must multiply by the probe ratio; the mock must keep the preamble
+    probe-free. These two tests pin OPPOSITE sides of the wire so the pair
+    cannot co-validate a shared wrong assumption."""
+
+    def test_mock_preamble_gain_is_probe_free(self, modern_scope):
+        # Wire-level pin of the hardware measurement: scale 20 V/div at probe
+        # 10x -> preamble vertical_gain 2.0 (NOT 20.0).
+        conn = modern_scope._connection
+        modern_scope.channel1.probe_ratio = 10.0
+        modern_scope.channel1.voltage_scale = 20.0
+
+        meta = _preamble_under(conn, "BYTE")
+
+        assert meta["vertical_gain"] == pytest.approx(2.0)
+
+    def test_acquire_multiplies_by_probe_ratio(self):
+        """Expectations adjusted from the brief's illustrative "* 10" form, as
+        its own NOTE anticipates: the mock synthesizes codes against the
+        DISPLAYED :CHANnel:SCALe/:OFFSet (unaffected by a probe-ratio-only
+        change), so the correctly probe-compensated round trip recovers the
+        SAME displayed volts at 10x as at 1x -- not 10x more of them. Without
+        the driver's probe_ratio multiply, the BNC-frame preamble gain alone
+        (scale/probe) decodes the 10x capture at 1/10 the correct volts; that
+        1/10 is what this test actually catches (confirmed by reverting just
+        the multiply -- see the report).
+
+        Uses an explicit noise-free signal/sample_rate rather than the
+        `modern_scope` fixture's defaults: channel 1's default square wave
+        (1 kHz) against that fixture's default 1 kHz sample_rate aliases
+        badly (14 points/acquisition), so successive free-run acquisitions'
+        ptp is not stably comparable -- the same reason the round-trip tests
+        above configure their own MockConnection instead of reusing it.
+        """
+        conn = MockConnection(
+            idn=MODERN_IDN,
+            timebase=1e-3,
+            sample_rate=20_000.0,
+            signals={1: SignalSpec(kind="sine", frequency=200.0, amplitude=1.0, noise_rms=0.0)},
+        )
+        scope = Oscilloscope("mock", connection=conn)
+        scope.connect()
+
+        wf_1x = scope.get_waveform(1)
+        scope.channel1.probe_ratio = 10.0
+        wf_10x = scope.get_waveform(1)
+
+        assert wf_10x.voltage_scale == pytest.approx(wf_1x.voltage_scale)
+        assert np.ptp(wf_10x.voltage) == pytest.approx(np.ptp(wf_1x.voltage), rel=0.05)
+        scope.disconnect()
+
+    def test_mock_rejects_bare_probe_set_form_like_hardware(self, modern_scope):
+        # Measured 2026-07-31: ':CHANnel1:PROBe 10' -> -224, setting unchanged.
+        conn = modern_scope._connection
+        conn.write(":CHANnel1:PROBe 10")
+        assert conn.error_queue and conn.error_queue[0][0] == -224
+        assert conn.query(":CHANnel1:PROBe?") == "1.00E+00"
+
+
 def test_the_mock_frames_data_the_way_the_instrument_does():
     """The mock emitted a bare fixed-width "#9..." with no trailing bytes for
     BOTH replies, so CI never exercised the variable-width header or the

--- a/tests/test_provenance_populated.py
+++ b/tests/test_provenance_populated.py
@@ -1,0 +1,46 @@
+"""Backend review 2026-07-31 finding High-11: four modern queries the real scope
+answers (measured fw 3.8.12.1.1.3.6: :CHANnel1:BWLimit? -> 'FULL',
+:TIMebase:DELay? -> '0.00E+00', *OPC? -> '1', :CHANnel1:PROBe? -> '1.00E+00',
+task 4) raised timeouts on the mock, so every CI provenance channel snapshot
+was all-None and no test noticed. Channel.get_configuration() (channel.py)
+does not individually try/except its `bandwidth_limit` read the way it does
+`probe_ratio`/`unit` -- so a SiglentTimeoutError from an unanswered BWLimit?
+propagated out of get_configuration() entirely, was caught by the blanket
+per-channel `except Exception` in AcquisitionProvenance.from_scope
+(provenance.py), and blanked EVERY field of that channel's snapshot, not just
+bandwidth_limit. This file pins the now-populated snapshot so the emptiness
+class cannot return silently."""
+
+from scpi_control.connection.mock import MockConnection
+from scpi_control.oscilloscope import Oscilloscope
+
+MODERN_IDN = "Siglent Technologies,SDS824X HD,SDS08A0X804831,3.8.12.1.1.3.6"
+
+
+def test_modern_mock_provenance_channel_snapshot_is_populated():
+    conn = MockConnection(idn=MODERN_IDN)
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    wf = scope.get_waveform(1)
+    ch = wf.provenance.channels[1]
+    assert ch.probe_ratio == 1.0
+    # channel.py's modern bandwidth_limit getter (channel.py ~L237-241)
+    # normalizes the wire FULL/20M/200M vocabulary to the driver's public
+    # ON/OFF vocabulary: FULL (no limiting -- the hardware-measured default)
+    # maps to public "OFF". "FULL" itself is the wire token, never the
+    # public property value, on this dialect.
+    assert ch.bandwidth_limit == "OFF"
+    assert ch.voltage_scale is not None
+    assert ch.voltage_offset is not None
+    assert ch.coupling is not None
+    assert ch.enabled is not None
+
+
+def test_modern_mock_answers_opc():
+    conn = MockConnection(idn=MODERN_IDN)
+    scope = Oscilloscope("mock", connection=conn)
+    scope.connect()
+    # wait_complete() (oscilloscope.py) queries *OPC? and returns None
+    # unconditionally -- the invariant under test is that the query does not
+    # raise SiglentTimeoutError, not any particular return value.
+    assert scope.wait_complete() is None

--- a/tests/test_socket_connection.py
+++ b/tests/test_socket_connection.py
@@ -515,3 +515,29 @@ class TestReadRawIeeeBlock:
 
         assert conn.read_raw() == blob
         assert mock_socket.recv.call_count == 1
+
+
+class TestSocketReadRawTimeout:
+    """Test that socket timeouts in read_raw are classified as timeouts, not dead connections."""
+
+    def test_sized_read_timeout_raises_timeout_and_keeps_session(self, mock_socket):
+        """recv raises socket.timeout during sized-read; must not kill the session."""
+        mock_socket.recv.side_effect = socket.timeout("timed out")
+
+        conn = SocketConnection("192.168.1.100")
+        conn.connect()
+
+        with pytest.raises(TimeoutError):
+            conn.read_raw(100)
+        assert conn.is_connected
+
+    def test_block_read_timeout_raises_timeout_and_keeps_session(self, mock_socket):
+        """recv raises socket.timeout during block-read; must not kill the session."""
+        mock_socket.recv.side_effect = socket.timeout("timed out")
+
+        conn = SocketConnection("192.168.1.100")
+        conn.connect()
+
+        with pytest.raises(TimeoutError):
+            conn.read_raw(None)
+        assert conn.is_connected

--- a/tests/test_socket_connection.py
+++ b/tests/test_socket_connection.py
@@ -532,7 +532,28 @@ class TestSocketReadRawTimeout:
         assert conn.is_connected
 
     def test_block_read_timeout_raises_timeout_and_keeps_session(self, mock_socket):
-        """recv raises socket.timeout during block-read; must not kill the session."""
+        """recv raises socket.timeout during block-read; must not kill the session.
+
+        Which layer actually provides this protection: for the size=None path,
+        `_read_ieee_block()`'s own internal `except socket.timeout` handler
+        (socket.py:224-233) converts the raw `socket.timeout` to
+        `SiglentTimeoutError` before it ever reaches `read_raw()`'s try/except.
+        That handler predates this task's fix, so on its own this test does
+        NOT exercise the `except socket.timeout` clause this task added to
+        `read_raw()` (socket.py:194-196) - it was already green before that
+        clause existed.
+
+        The `read_raw()`-level clause is a second, defensive layer: it only
+        fires if a raw `socket.timeout` ever escapes `_read_ieee_block()`
+        uncaught (e.g. a future change to that method's internal handling).
+        Mutation-verified: with `_read_ieee_block()`'s internal timeout
+        handler temporarily neutralized (recv's socket.timeout left to
+        propagate through its outer `except socket.error` re-raise), this
+        test still passed - because `read_raw()`'s clause caught it instead.
+        That confirms the two layers together make the invariant below
+        mutation-proof, even though neither layer alone is exercised in
+        isolation by this single test.
+        """
         mock_socket.recv.side_effect = socket.timeout("timed out")
 
         conn = SocketConnection("192.168.1.100")

--- a/tests/test_spd_protection_warning.py
+++ b/tests/test_spd_protection_warning.py
@@ -1,9 +1,13 @@
-"""SPD3303X has no OVP/OCP subsystem (QS0503X-E01B p.36) -- audit H18.
+"""Siglent SPD PSUs have no citable SCPI protection subsystem -- audit H18 + backend review 2026-07-31 finding High-3.
 
-As of v5.0.0, `has_ovp`/`has_ocp` are False for the SPD3303X/-E and ovp_level/
-ocp_level raise NotImplementedError instead of silently discarding the command:
-someone raising voltage on a 12V DUT believing protection is armed is the
-failure this guard exists to prevent.
+SPD3303X: QS0503X-E01B p.36 lists the full command set; no protection commands (v5.0.0).
+SPD1305X/SPD1168X: no SPD1000X programming manual exists in docs/; the generic
+SOURce:VOLTage:PROTection fallback they previously used is not documented for these
+models anywhere we can cite, and the corpus gate requires citations. Front-panel
+OVP/OCP exists on the SPD1000X series, so if a programming manual documenting
+protection commands is added to docs/ later, implement them with citations and
+flip has_ovp/has_ocp back. Until then: honesty gate. Believing OVP is armed when
+the firmware discarded the command is the failure this guard prevents.
 """
 
 import pytest
@@ -12,9 +16,9 @@ from scpi_control.connection.mock import MockConnection
 from scpi_control.power_supply import PowerSupply
 
 
-@pytest.fixture
-def spd():
-    conn = MockConnection(psu_mode=True, psu_idn="Siglent Technologies,SPD3303X,SPD123456,1.0")
+@pytest.fixture(params=["SPD3303X", "SPD1305X", "SPD1168X"])
+def spd(request):
+    conn = MockConnection(psu_mode=True, psu_idn=f"Siglent Technologies,{request.param},SPD123456,1.0")
     psu = PowerSupply(connection=conn, host="mock")
     psu.connect()
     return psu

--- a/tests/test_trigger_type_tokens.py
+++ b/tests/test_trigger_type_tokens.py
@@ -1,0 +1,66 @@
+"""Trigger *type* selection per dialect -- backend review 2026-07-31, finding High-2.
+
+The public vocabulary (EDGE/SLEW/GLIT/INTV/RUNT/PATTERN) is the legacy TRSE one.
+Modern scopes spell these :TRIGger:TYPE {EDGE|PULSE|SLOPe|INTerval|RUNT|PATTern}
+(SDS800X HD guide p.485); before this fix the legacy tokens were sent verbatim and
+the scope silently stayed on EDGE. Tek families only share EDGE (TBS p.161 has
+{EDGe|PULSe}, MSO2/MSO456 use WIDth) -> everything else gates loudly.
+"""
+
+import pytest
+
+from scpi_control import exceptions
+from scpi_control.connection.mock import MockConnection
+from scpi_control.oscilloscope import Oscilloscope
+from scpi_control.scpi_commands import trigger_type_from_wire, trigger_type_to_wire
+
+MODERN_IDN = "Siglent Technologies,SDS824X HD,SDS08A0X804831,3.8.12.1.1.3.6"
+
+
+def modern_scope():
+    conn = MockConnection(idn=MODERN_IDN)
+    scope = Oscilloscope(connection=conn, host="mock")
+    scope.connect()
+    return scope, conn
+
+
+def test_modern_setter_sends_manual_tokens():
+    scope, conn = modern_scope()
+    scope.trigger.trigger_type = "SLEW"
+    assert conn.writes[-1] == ":TRIGger:TYPE SLOPe"
+    scope.trigger.trigger_type = "GLIT"
+    assert conn.writes[-1] == ":TRIGger:TYPE PULSE"
+    scope.trigger.trigger_type = "INTV"
+    assert conn.writes[-1] == ":TRIGger:TYPE INTerval"
+
+
+def test_modern_round_trip_returns_public_vocabulary():
+    scope, _ = modern_scope()
+    scope.trigger.trigger_type = "SLEW"
+    assert scope.trigger.trigger_type == "SLEW"
+
+
+def test_modern_getter_passes_through_unsettable_types():
+    # A scope can sit in VIDeo (front panel); reads must not explode a snapshot.
+    assert trigger_type_from_wire("modern", "VIDeo") == "VIDEO"
+
+
+def test_tektronix_gates_everything_but_edge():
+    assert trigger_type_to_wire("tektronix", "EDGE") == "EDGE"
+    for t in ("SLEW", "GLIT", "INTV", "RUNT", "PATTERN"):
+        with pytest.raises(exceptions.FeatureNotSupportedError):
+            trigger_type_to_wire("tektronix", t)
+
+
+def test_unknown_public_token_raises_value_error():
+    with pytest.raises(ValueError):
+        trigger_type_to_wire("modern", "BOGUS")
+
+
+def test_mock_rejects_invalid_modern_type_like_hardware():
+    # Measured 2026-07-31: invalid parameter queues -224, setting unchanged.
+    scope, conn = modern_scope()
+    scope.trigger.trigger_type = "EDGE"
+    conn.write(":TRIGger:TYPE NONSENSE")
+    assert conn.error_queue and conn.error_queue[0][0] == -224
+    assert scope.trigger.trigger_type == "EDGE"

--- a/tests/wire_forms.py
+++ b/tests/wire_forms.py
@@ -911,11 +911,29 @@ WIRE_FORMS: List[WireForm] = [
     ),
     # p.50 EXAMPLE: "CHAN1:BWL 20M" -> "CHANnel1:BWLimit 20M";
     # <bwlimit>:={FULL|20M|200M} -- matches channel.py's modern wire vocabulary
-    # (FULL/20M) exactly. Not mocked (no BWLimit handler in the modern branch).
+    # (FULL/20M) exactly. Backend review 2026-07-31 (Task 5, audit High-11)
+    # added a modern BWLimit set/query handler to connection/mock/siglent.py
+    # (the "Not mocked" gap this comment used to describe).
     WireForm(
         table="scope", dialect="modern", op="set_bandwidth_limit", params={"ch": 1, "limit": "20M"}, request=":CHANnel1:BWLimit 20M", source=f"{MODERN_GUIDE} p.50", mock_kwargs={"idn": MODERN_IDN}
     ),
-    WireForm(table="scope", dialect="modern", op="get_bandwidth_limit", params={"ch": 1}, request=":CHANnel1:BWLimit?", source=f"{MODERN_GUIDE} p.50", mock_kwargs={"idn": MODERN_IDN}),
+    # RESPONSE FORMAT is a bare wire token (p.50); MEASURED on a real SDS824X
+    # HD (fw 3.8.12.1.1.3.6) 2026-07-31: "FULL" at the default (no bandwidth
+    # limiting engaged), queried on a fresh mock with no prior set. `parsed`
+    # is channel.py's PUBLIC value, not the wire token: the modern
+    # bandwidth_limit getter normalizes FULL/20M/200M to public ON/OFF
+    # (channel.py ~L237-241), so FULL on the wire parses to public "OFF".
+    WireForm(
+        table="scope",
+        dialect="modern",
+        op="get_bandwidth_limit",
+        params={"ch": 1},
+        request=":CHANnel1:BWLimit?",
+        response="FULL",
+        parsed="OFF",
+        source=f"{MODERN_GUIDE} p.50",
+        mock_kwargs={"idn": MODERN_IDN},
+    ),
     # -- Timebase control --
     # p.476 EXAMPLE: "TIM:SCAL 1.00E-07" -> "TIMebase:SCALe 1.00E-07".
     WireForm(table="scope", dialect="modern", op="set_time_div", params={"tdiv": "1.00E-07"}, request=":TIMebase:SCALe 1.00E-07", source=f"{MODERN_GUIDE} p.476", mock_kwargs={"idn": MODERN_IDN}),
@@ -930,12 +948,26 @@ WIRE_FORMS: List[WireForm] = [
         source=f"{MODERN_GUIDE} p.476",
         mock_kwargs={"idn": MODERN_IDN},
     ),
-    # p.473 EXAMPLE: "TIM:DEL 1.00E-05" -> "TIMebase:DELay 1.00E-05".
+    # p.473 EXAMPLE: "TIM:DEL 1.00E-05" -> "TIMebase:DELay 1.00E-05". Backend
+    # review 2026-07-31 (Task 5, audit High-11) added a modern TIMebase:DELay
+    # set/query handler to connection/mock/siglent.py (the "not mocked" gap
+    # this comment used to describe).
     WireForm(table="scope", dialect="modern", op="set_time_offset", params={"offset": "1.00E-05"}, request=":TIMebase:DELay 1.00E-05", source=f"{MODERN_GUIDE} p.473", mock_kwargs={"idn": MODERN_IDN}),
-    # get_time_offset is not mocked (no TIMebase:DELay? handler in the modern
-    # branch of connection/mock/siglent.py -- only TIMebase:SCALe? is
-    # implemented there) -- request-only citation.
-    WireForm(table="scope", dialect="modern", op="get_time_offset", params={}, request=":TIMebase:DELay?", source=f"{MODERN_GUIDE} p.473", mock_kwargs={"idn": MODERN_IDN}),
+    # RESPONSE FORMAT is bare NR3 (p.473), same shape as TIMebase:SCALe?
+    # above. MEASURED on a real SDS824X HD (fw 3.8.12.1.1.3.6) 2026-07-31:
+    # "0.00E+00" at the default (no trigger delay), queried on a fresh mock
+    # with no prior set.
+    WireForm(
+        table="scope",
+        dialect="modern",
+        op="get_time_offset",
+        params={},
+        request=":TIMebase:DELay?",
+        response="0.00E+00",
+        parsed=0.0,
+        source=f"{MODERN_GUIDE} p.473",
+        mock_kwargs={"idn": MODERN_IDN},
+    ),
     # p.46 EXAMPLE: "ACQ:SRAT?" -> "5.00E+09" -> ":ACQuire:SRATe?", bare NR3.
     WireForm(
         table="scope",

--- a/tests/wire_forms.py
+++ b/tests/wire_forms.py
@@ -962,20 +962,15 @@ WIRE_FORMS: List[WireForm] = [
     # p.484 <type>:={EDGE|PULSE|SLOPe|INTerval|PATTern|RUNT|WINDow|DROPout|
     # VIDeo|QUALified|NEDGe|DELay|SHOLd|IIC|SPI|UART|LIN|CAN|FLEXray|CANFd|
     # IIS|M1553|SENT|A429} -- EXAMPLE "TRIG:TYPE EDGE" -> "EDGE" bare. EDGE is
-    # both a valid manual enum member and a valid trigger.py public value
-    # (trigger.py's valid_types = ["EDGE","SLEW","GLIT","INTV","RUNT",
-    # "PATTERN"], sent as-is with no type_to_wire/type_from_wire translation
-    # table anywhere in scpi_commands.py) -- this pins the EDGE case, which is
-    # correct. NOTE (not a wire-form defect, no entry recorded: the {type}
-    # placeholder is a free parameter, not part of the table template): three
-    # of trigger.py's six public values have no modern equivalent at all --
-    # "SLEW"/"GLIT"/"INTV" are not members of the manual's <type> enum (the
-    # nearest concepts are spelled "SLOPe"/"PULSE"/"INTerval"). Sending
-    # set_trigger_type(type="SLEW") on modern would write ":TRIGger:TYPE SLEW",
-    # which this manual does not document at all -- likely rejected on real
-    # hardware. Flagged here for visibility; not a MODERN_COMMANDS table
-    # mismatch (the template ":TRIGger:TYPE {type}" is exactly right) so no
-    # WireForm entry is recorded for it.
+    # both a valid manual enum member and a valid trigger.py public value, so
+    # it pins the identity case. Backend review 2026-07-31, finding High-2: the
+    # other three of trigger.py's six public values have no modern equivalent
+    # at all -- "SLEW"/"GLIT"/"INTV" are not members of the manual's <type>
+    # enum (the nearest concepts are spelled "SLOPe"/"PULSE"/"INTerval"). This
+    # is no longer a gap: _TRIGGER_TYPE_TO_WIRE / _TRIGGER_TYPE_FROM_WIRE
+    # (scpi_commands.py) and the trigger_type_to_wire()/trigger_type_from_wire()
+    # wrappers now translate at the dialect boundary, exercised by the two
+    # entries below (p.485).
     WireForm(table="scope", dialect="modern", op="set_trigger_type", params={"type": "EDGE"}, request=":TRIGger:TYPE EDGE", source=f"{MODERN_GUIDE} p.484", mock_kwargs={"idn": MODERN_IDN}),
     WireForm(
         table="scope",
@@ -987,6 +982,8 @@ WIRE_FORMS: List[WireForm] = [
         source=f"{MODERN_GUIDE} p.484",
         mock_kwargs={"idn": MODERN_IDN},
     ),
+    WireForm(table="scope", dialect="modern", op="set_trigger_type", params={"type": "SLOPe"}, request=":TRIGger:TYPE SLOPe", source=f"{MODERN_GUIDE} p.485", mock_kwargs={"idn": MODERN_IDN}),
+    WireForm(table="scope", dialect="modern", op="get_trigger_type", params={}, request=":TRIGger:TYPE?", response="EDGE", source=f"{MODERN_GUIDE} p.485", mock_kwargs={"idn": MODERN_IDN}),
     # p.495 <source>:={C<n>|D<d>|EX|EX5|LINE}; EXAMPLE "TRIG:EDGE:SOUR C1" ->
     # ":TRIGger:EDGE:SOURce C1", response bare "C1".
     WireForm(table="scope", dialect="modern", op="set_trigger_source", params={"src": "C1"}, request=":TRIGger:EDGE:SOURce C1", source=f"{MODERN_GUIDE} p.495", mock_kwargs={"idn": MODERN_IDN}),

--- a/tests/wire_forms.py
+++ b/tests/wire_forms.py
@@ -848,35 +848,31 @@ WIRE_FORMS: List[WireForm] = [
     # p.51 EXAMPLE: "CHAN1:COUP AC" -> "CHANnel1:COUPling AC";
     # <coupling_mode>:={DC|AC|GND}.
     WireForm(table="scope", dialect="modern", op="set_coupling", params={"ch": 1, "coupling": "AC"}, request=":CHANnel1:COUPling AC", source=f"{MODERN_GUIDE} p.51", mock_kwargs={"idn": MODERN_IDN}),
+    # RESPONSE FORMAT is a bare wire token (p.51). Backend review 2026-07-31
+    # (Task 5, audit High-11) fixed the mock-fixture bug this entry used to
+    # document as MISMATCH_DEFERRED: MockConnection was seeding
+    # `_channel_coupling` with the LEGACY wire token "D1M" unconditionally
+    # for every dialect (connection/mock/base.py), so a freshly constructed
+    # modern MockConnection's own Channel.coupling getter raised
+    # "ValueError: Unrecognized modern coupling mode response: 'D1M'" before
+    # any set_coupling call. connection/mock/base.py now seeds the default
+    # per-dialect ("DC" for modern, "D1M" otherwise, mirroring the existing
+    # tektronix override a few lines below it), so a fresh modern channel 1
+    # answers the documented default "DC" -- the wire template and
+    # coupling_to_wire/coupling_from_wire mappings (scpi_commands.py) were
+    # already correct for modern ({'DC':'DC','AC':'AC','GND':'GND'}, matching
+    # p.51's <coupling_mode>:={DC|AC|GND} exactly); only the mock's default
+    # state was wrong.
     WireForm(
         table="scope",
         dialect="modern",
         op="get_coupling",
         params={"ch": 1},
         request=":CHANnel1:COUPling?",
-        response="D1M",
+        response="DC",
+        parsed="DC",
         source=f"{MODERN_GUIDE} p.51",
-        status=MISMATCH_DEFERRED,
         mock_kwargs={"idn": MODERN_IDN},
-        note=(
-            "[medium severity] Request matches exactly ('<channel>:COUPling?'). "
-            "The wire template and coupling_to_wire/coupling_from_wire mappings "
-            "(scpi_commands.py) are both correct for modern -- {'DC':'DC', "
-            "'AC':'AC', 'GND':'GND'}, matching p.51's <coupling_mode>:={DC|AC|GND} "
-            "exactly. The bug is in the mock fixture only: MockConnection seeds "
-            "'_channel_coupling' with the LEGACY wire token 'D1M' unconditionally "
-            "for every dialect (connection/mock/base.py, ~line 82: \"{ch: 'D1M' "
-            'for ch in channels}", no scope_dialect branch, unlike trigger_mode/ '
-            "trigger_slope a few lines below which do branch on dialect). 'D1M' "
-            "is not a member of the modern enum, so Channel.coupling on a freshly "
-            "constructed modern MockConnection (before any set_coupling call) "
-            "raises 'ValueError: Unrecognized modern coupling mode response: "
-            "'D1M'' via coupling_from_wire() -- a real, reachable crash against "
-            "this test fixture, though it cannot happen against real hardware "
-            "(this is a mock-state defect, not a driver or table defect). Queued "
-            "for a mock fix (seed _channel_coupling per-dialect), not a code-table "
-            "change."
-        ),
     ),
     # p.57 EXAMPLE: "CHAN1:PROB VAL,1.00E+02" -> "CHANnel1:PROBe VALue,1.00E+02";
     # <attenuation>:={DEFault|VALue}. Backend review 2026-07-31 (Task 4) added

--- a/tests/wire_forms.py
+++ b/tests/wire_forms.py
@@ -879,9 +879,10 @@ WIRE_FORMS: List[WireForm] = [
         ),
     ),
     # p.57 EXAMPLE: "CHAN1:PROB VAL,1.00E+02" -> "CHANnel1:PROBe VALue,1.00E+02";
-    # <attenuation>:={DEFault|VALue}. Not mocked (no PROBe handler in the
-    # modern branch of connection/mock/siglent.py) -- request-only citation,
-    # same pattern as the legacy get_probe_ratio/set_bandwidth_limit entries.
+    # <attenuation>:={DEFault|VALue}. Backend review 2026-07-31 (Task 4) added
+    # a modern PROBe set/query handler to connection/mock/siglent.py (the
+    # "Not mocked" gap this comment used to describe), driven by the same
+    # hardware measurement that fixed ModernTransfer.acquire's probe scaling.
     WireForm(
         table="scope",
         dialect="modern",
@@ -891,7 +892,23 @@ WIRE_FORMS: List[WireForm] = [
         source=f"{MODERN_GUIDE} p.57",
         mock_kwargs={"idn": MODERN_IDN},
     ),
-    WireForm(table="scope", dialect="modern", op="get_probe_ratio", params={"ch": 1}, request=":CHANnel1:PROBe?", source=f"{MODERN_GUIDE} p.57", mock_kwargs={"idn": MODERN_IDN}),
+    # RESPONSE FORMAT is bare NR3 (p.57 EXAMPLE response "1.00E+02", after the
+    # VALue,1.00E+02 set above) -- same bare-NR3 shape as SCALe?/OFFSet?
+    # above. Queried here on a FRESH mock (no prior set), so the value is the
+    # documented default (DEFault = "1X", p.57) rather than the manual's
+    # post-set example value -- same divergence-is-fine rule as the
+    # get_voltage_div entry above: only the bare-NR3 structure is pinned.
+    WireForm(
+        table="scope",
+        dialect="modern",
+        op="get_probe_ratio",
+        params={"ch": 1},
+        request=":CHANnel1:PROBe?",
+        response="1.00E+00",
+        parsed=1.0,
+        source=f"{MODERN_GUIDE} p.57",
+        mock_kwargs={"idn": MODERN_IDN},
+    ),
     # p.50 EXAMPLE: "CHAN1:BWL 20M" -> "CHANnel1:BWLimit 20M";
     # <bwlimit>:={FULL|20M|200M} -- matches channel.py's modern wire vocabulary
     # (FULL/20M) exactly. Not mocked (no BWLimit handler in the modern branch).


### PR DESCRIPTION
Wave 1 of the 2026-07-31 SCPI backend review: the five highest-severity findings, each fixed as a driver + mock + regression-test triple so the mock-and-driver-agree-and-both-are-wrong class cannot recur.

## Fixes

**Probe attenuation in modern waveform scaling** (hardware-confirmed). Measured on the real SDS824X HD (fw 3.8.12.1.1.3.6): the `:WAVeform:PREamble?` VERTICAL_GAIN/VERTICAL_OFFSET are probe-free (BNC frame) — at a 10x probe setting the display reads 20 V/div but the preamble still reports gain 2.0, so every capture with a non-1x probe read low by the probe ratio. `ModernTransfer.acquire` now queries `:CHANnel<n>:PROBe?` and scales the BNC-frame result; the mock's preamble moved to the BNC frame (`gain = scale/probe`) while its synthesis stays display-frame, so removing the driver multiply or the mock division each fails a distinct test (mutation-checked).

**Trigger-type dialect tokens.** The public vocabulary (EDGE/SLEW/GLIT/INTV/RUNT/PATTERN) was sent verbatim to every dialect; modern scopes want `:TRIGger:TYPE {SLOPe|PULSE|INTerval|…}` (guide p.485) and silently stayed on EDGE. New `_TRIGGER_TYPE_TO_WIRE`/`_FROM_WIRE` maps follow the existing mode/slope/coupling pattern; Tektronix gates everything but EDGE as `FeatureNotSupportedError` (the pulse-class token diverges per family); the mock now rejects invalid types with `-224` like real firmware.

**SPD1305X/SPD1168X protection honesty gate.** These models declared `has_ovp/has_ocp=True` but fell through to generic `SOUR{ch}:VOLT:PROT`, which SPD firmware silently discards — protection believed armed, never armed. Same gate the SPD3303X received in v5.0.0; the guard tests now run per model.

**Socket sized-read timeout classification.** `read_raw` lacked the `except socket.timeout` clause `read()` has, so a transient slow response (e.g. screenshot start) became `SiglentConnectionError` and marked the session dead. Now raises `SiglentTimeoutError` and the session survives.

**Modern mock query gaps.** `:CHANnel<n>:PROBe?`, `:BWLimit?`, `:TIMebase:DELay?`, and `*OPC?` timed out on the mock (real hardware answers all four), which — together with the mock seeding every dialect's coupling default with the legacy `D1M` token — blanked every provenance channel snapshot to all-None in CI with nothing noticing. Handlers added with hardware-measured response shapes, the coupling default is dialect-aware, and a new test pins the populated snapshot.

## Breaking changes

- `ovp_level`/`ocp_level` on SPD1305X/SPD1168X now raise `NotImplementedError` (set protection on the front panel; no SPD1000X programming manual documents a SCPI protection subsystem).
- Setting a trigger type the connected dialect cannot express now raises `FeatureNotSupportedError` instead of silently leaving the previous trigger; an invalid trigger type now raises `ValueError` (was `InvalidParameterError`), consistent with the mode/slope setters.

## Verification

- Broad suite: 2316 passed / 19 skipped / 0 failed (baseline at branch point: 2287 / 19).
- New wire behaviors carry manual citations or measured-on-hardware comments; corpus entries added for the new commands (`test_wire_conformance` enforces citations).
- Hardware ground truth gathered live on 2026-07-31 (probe frames, error-queue codes, response shapes), with settings restored and verified after probing.
