### PR TITLE
fix: data-collection honesty — DAQ block header, overload sentinels, Tek window, legacy WORD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PSU: `ovp_level`/`ocp_level` on SPD1305X/SPD1168X now raise `NotImplementedError` instead of silently sending a command the firmware discards. No SPD1000X programming manual documents a SCPI protection subsystem; set protection on the front panel. (Same honesty gate the SPD3303X received in v5.0.0.)
 - Oscilloscope: setting `trigger.trigger_type` to a type the connected dialect cannot express (everything except `EDGE` on Tektronix) now raises `FeatureNotSupportedError` instead of silently leaving the scope on its previous trigger.
 - Oscilloscope: setting an invalid trigger type now raises `ValueError` (consistent with the mode/slope setters) where it previously raised `InvalidParameterError`; callers catching `SiglentError` around `trigger.trigger_type` assignments should catch `ValueError` too.
+- DAQ: an overload reading is no longer returned as the raw `9.9E+37` sentinel. `Reading` gains an `overload: bool` field; overload readings carry `value=NaN` with `overload=True`. Code that compared readings against `9.9e37` should check `reading.overload` instead.
+- Oscilloscope (legacy Siglent): `acquire(..., format="WORD")` now raises `FeatureNotSupportedError` instead of returning fabricated data. The legacy programming guide documents no way to request 16-bit samples; use `format="BYTE"`.
 
 ### Fixed
 
@@ -19,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Oscilloscope (modern Siglent): `trigger.trigger_type = "SLEW"/"GLIT"/"INTV"` now sends the dialect's real tokens (`SLOPe`/`PULSE`/`INTerval`) instead of legacy spellings the scope rejects.
 - Connection: a timeout during a sized binary read (e.g. slow screenshot start) now raises `SiglentTimeoutError` and keeps the session usable, instead of misclassifying as a dead connection.
 - Mock: the modern mock now answers `:CHANnel<n>:PROBe?`, `:CHANnel<n>:BWLimit?`, `:TIMebase:DELay?`, and `*OPC?` with hardware-measured response shapes, rejects invalid probe/trigger-type parameters with `-224` like real firmware, and reports probe-free preamble gain — so provenance channel snapshots are exercised in CI. The mock also now seeds the modern dialect's default channel coupling as `DC` instead of the legacy `D1M` token.
+- DAQ: `R?` responses are parsed as the IEEE 488.2 definite-length block the instrument actually sends, so the first reading of every batch is no longer silently discarded. Because `R?` erases readings on the instrument, those readings were previously unrecoverable.
+- DAQ: reading tokens that cannot be parsed are now logged at warning level instead of being dropped silently at debug level.
+- Oscilloscope (Tektronix): captures now widen the transfer window before measuring it, so a narrow `DATa:STOP` left behind by another program or a recalled setup no longer truncates every capture indefinitely.
+- Mock: the DAQ mock wraps `R?` in a definite-length block (leaving `READ?`/`FETCh?` bare, as the instrument does) and the Tektronix mock models the `DATa:STARt`/`DATa:STOP` window, so both regressions are now catchable in CI.
 
 ## [6.0.0] - 2026-07-30
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PSU: `ovp_level`/`ocp_level` on SPD1305X/SPD1168X now raise `NotImplementedError` instead of silently sending a command the firmware discards. No SPD1000X programming manual documents a SCPI protection subsystem; set protection on the front panel. (Same honesty gate the SPD3303X received in v5.0.0.)
 - Oscilloscope: setting `trigger.trigger_type` to a type the connected dialect cannot express (everything except `EDGE` on Tektronix) now raises `FeatureNotSupportedError` instead of silently leaving the scope on its previous trigger.
 - Oscilloscope: setting an invalid trigger type now raises `ValueError` (consistent with the mode/slope setters) where it previously raised `InvalidParameterError`; callers catching `SiglentError` around `trigger.trigger_type` assignments should catch `ValueError` too.
+- DAQ: an overload reading is no longer returned as the raw `9.9E+37` sentinel. `Reading` gains an `overload: bool` field; overload readings carry `value=NaN` with `overload=True`. Code that compared readings against `9.9e37` should check `reading.overload` instead.
+- Oscilloscope (legacy Siglent): `acquire(..., format="WORD")` now raises `FeatureNotSupportedError` instead of returning fabricated data. The legacy programming guide documents no way to request 16-bit samples; use `format="BYTE"`.
 
 ### Fixed
 
@@ -19,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Oscilloscope (modern Siglent): `trigger.trigger_type = "SLEW"/"GLIT"/"INTV"` now sends the dialect's real tokens (`SLOPe`/`PULSE`/`INTerval`) instead of legacy spellings the scope rejects.
 - Connection: a timeout during a sized binary read (e.g. slow screenshot start) now raises `SiglentTimeoutError` and keeps the session usable, instead of misclassifying as a dead connection.
 - Mock: the modern mock now answers `:CHANnel<n>:PROBe?`, `:CHANnel<n>:BWLimit?`, `:TIMebase:DELay?`, and `*OPC?` with hardware-measured response shapes, rejects invalid probe/trigger-type parameters with `-224` like real firmware, and reports probe-free preamble gain — so provenance channel snapshots are exercised in CI. The mock also now seeds the modern dialect's default channel coupling as `DC` instead of the legacy `D1M` token.
+- DAQ: `R?` responses are parsed as the IEEE 488.2 definite-length block the instrument actually sends, so the first reading of every batch is no longer silently discarded. Because `R?` erases readings on the instrument, those readings were previously unrecoverable.
+- DAQ: reading tokens that cannot be parsed are now logged at warning level instead of being dropped silently at debug level.
+- Oscilloscope (Tektronix): captures now widen the transfer window before measuring it, so a narrow `DATa:STOP` left behind by another program or a recalled setup no longer truncates every capture indefinitely.
+- Mock: the DAQ mock wraps `R?` in a definite-length block (leaving `READ?`/`FETCh?` bare, as the instrument does) and the Tektronix mock models the `DATa:STARt`/`DATa:STOP` window, so both regressions are now catchable in CI.
 
 ## [6.0.0] - 2026-07-30
 

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -708,7 +708,17 @@ class MockConnection(BaseConnection):
             # anchored at the end: MEAS:*? and read_remove's "R?" commands
             # carry trailing arguments (e.g. "MEAS:VOLT:DC? AUTO,AUTO,(@101)"
             # or "R? 10"), which a full-string anchor would reject.
-            if re.match(r"^(READ\?|FETC\??|MEAS:[\w:]*\?|R\?)", upper):
+
+            # R? wraps its CSV payload in an IEEE 488.2 definite-length block
+            # (34970A/34972A Command Reference p.40; worked example p.41:
+            # `R? 2` -> `#231+2.87536000E-04,+3.18131400E-03`). READ?/FETC?/
+            # MEAS:*? send the same CSV bare (p.49-50, 16-17), so only R? is
+            # wrapped here -- answering them all alike is what hid the parser
+            # bug from CI.
+            if re.match(r"^R\?", upper):
+                payload = self.daq_readings
+                return f"#{len(str(len(payload)))}{len(payload)}{payload}"
+            if re.match(r"^(READ\?|FETC\??|MEAS:[\w:]*\?)", upper):
                 return self.daq_readings
 
         # Function generator (AWG) queries

--- a/scpi_control/connection/mock/base.py
+++ b/scpi_control/connection/mock/base.py
@@ -80,6 +80,14 @@ class MockConnection(BaseConnection):
         daq_idn: str = "Keysight Technologies,34970A,MY12345678,A.01.02",
         daq_readings: str = "1.234,2.345,3.456",
         tek_badges: Optional[Dict[int, Dict[str, str]]] = None,
+        # DATa:STARt/STOP window state (MSO4/5/6 PM p.2-341/2-342). Defaults
+        # match the manual's own defaults: DATa:STARt is 1-based and starts
+        # at 1; data_stop=None means "no window narrower than the record has
+        # been set" (WFMOutpre:NR_Pt? then reports the full record). Tests
+        # pass data_stop explicitly to seed a stale narrow window left by a
+        # prior script or a recalled setup.
+        data_start: int = 1,
+        data_stop: Optional[int] = None,
         # strict: When True (the default as of v5.0.0), unmatched PSU/AWG/DAQ
         # queries raise TimeoutError instead of returning "", matching real
         # instruments. Pass strict=False to restore the old lenient
@@ -189,6 +197,12 @@ class MockConnection(BaseConnection):
         # Tektronix wire-vocabulary state (shared across tek_tbs/tek_mso variants)
         self.tek_stop_after = "RUNSTOP"
         self.data_source: int = 1
+        # DATa:STARt/STOP window (MSO4/5/6 PM p.2-341/2-342): the write
+        # handler in tektronix.py updates these; WFMOutpre:NR_Pt? and the
+        # CURVe? response both read them so the mock's reported point count
+        # and its actual transmitted bytes agree, matching real hardware.
+        self.data_start: int = data_start
+        self.data_stop: Optional[int] = data_stop
         self.probe_gains: Dict[int, float] = {ch: 0.1 for ch in channels}
         self.holdoff_time = 0.0
         # Measurement badges: slot -> {"type": ..., "source": ...}. Seed via
@@ -214,6 +228,13 @@ class MockConnection(BaseConnection):
         self.error_queue: List[Tuple[int, str]] = []
         self.writes: List[str] = []
         self.queries: List[str] = []
+        # Combined, call-ORDER trace of every write and query. writes/queries
+        # above are each append-only to their own list, so neither alone can
+        # show a write's position relative to a query -- this is what lets a
+        # test assert "X was sent before Y" across the two (e.g. the Tek
+        # DATa:STARt/STOP window-widening writes happening before the
+        # WFMOutpre:NR_Pt? query that measures it).
+        self.command_log: List[str] = []
         self.timebase_updates: List[float] = []
         self.scale_updates: Dict[int, List[float]] = {ch: [] for ch in channels}
         self.waveform_requests: List[int] = []
@@ -331,6 +352,7 @@ class MockConnection(BaseConnection):
 
         command = command.strip()
         self.writes.append(command)
+        self.command_log.append(command)
 
         if command.upper() in ("*CLS", "*RST"):
             # Real instruments clear the error queue on both *CLS and *RST
@@ -637,6 +659,7 @@ class MockConnection(BaseConnection):
 
         command = command.strip()
         self.queries.append(command)
+        self.command_log.append(command)
 
         if command in self.custom_responses:
             override = self.custom_responses[command]

--- a/scpi_control/connection/mock/tektronix.py
+++ b/scpi_control/connection/mock/tektronix.py
@@ -163,7 +163,21 @@ def handle_write(conn, command: str) -> bool:
         conn.data_source = int(match.group(1))
         conn._last_waveform_channel = conn.data_source
         return True
-    if re.match(r"DATA:(ENCDG|WIDTH|START|STOP)\s+", upper):
+    if match := re.match(r"DATA:START\s+(\d+)", upper):
+        # MSO4/5/6 PM p.2-341: DATa:STARt is the first point of the window
+        # CURVe?/NR_Pt? operate on. Storing it (rather than discarding the
+        # write, as before) is what lets a test seed or observe the window a
+        # driver is measuring/widening.
+        conn.data_start = int(match.group(1))
+        return True
+    if match := re.match(r"DATA:STOP\s+(\d+)", upper):
+        # MSO4/5/6 PM p.2-341/2-342: DATa:STOP is the last point of the
+        # window; the manual is explicit that a record-length change is NOT
+        # automatically reflected here, which is the whole hazard this state
+        # models (a stale STOP left behind by a prior script or recall).
+        conn.data_stop = int(match.group(1))
+        return True
+    if re.match(r"DATA:(ENCDG|WIDTH)\s+", upper):
         return True
     if upper == "CURVE?":
         conn.waveform_requests.append(conn.data_source)
@@ -227,7 +241,14 @@ def handle_query(conn, command: str) -> Optional[str]:
     if upper == "TRIGGER:A:HOLDOFF:TIME?":
         return _format_nr3(conn.holdoff_time)
     if upper == "WFMOUTPRE:NR_PT?":
-        return str(mock_synth.point_count(conn, conn.data_source))
+        # MSO4/5/6 programmer manual p.2-1461: NR_Pt? reports the points that will
+        # be TRANSMITTED for the current DATa:STARt/STOP window, not the acquisition
+        # record length (p.2-1455's own example: a 1250-point record reporting
+        # NR_PT 1000). Modelling the window is what lets a test catch a driver that
+        # measures the record through a stale window.
+        record = mock_synth.point_count(conn, conn.data_source)
+        stop = record if conn.data_stop is None else min(conn.data_stop, record)
+        return str(max(0, stop - conn.data_start + 1))
     if upper == "WFMOUTPRE:XINCR?":
         return _format_nr3(1.0 / conn.sample_rate)
     if upper == "WFMOUTPRE:XZERO?":
@@ -261,4 +282,14 @@ def build_waveform_response(conn) -> bytes:
     # Tek's converter is (code - yoff)*ymult + yzero with yoff=yzero=0 here, so
     # codes carry no channel-offset term (include_offset=False).
     payload = mock_synth.payload_for(conn, conn.data_source, include_offset=False)
-    return _build_ieee_block(payload)  # CURVe? responses are a bare IEEE block
+    # CURVe? only transmits the DATa:STARt/STOP window -- the same semantics
+    # WFMOutpre:NR_Pt? reports above (MSO4/5/6 PM p.2-1461) -- so the actual
+    # byte count returned here must agree with NR_Pt?'s answer. Sliced here,
+    # not inside the shared payload_for()/point_count() (also used by the
+    # Siglent/LeCroy personalities, which never touch data_start/data_stop),
+    # so those dialects are unaffected.
+    record = len(payload)
+    stop = record if conn.data_stop is None else min(conn.data_stop, record)
+    start = max(1, conn.data_start)
+    windowed = payload[start - 1 : stop]
+    return _build_ieee_block(windowed)  # CURVe? responses are a bare IEEE block

--- a/scpi_control/data_logger.py
+++ b/scpi_control/data_logger.py
@@ -10,7 +10,10 @@ Features:
     - Multi-channel scanning with configurable sample rates
     - Support for voltage, current, resistance, temperature measurements
     - Alarm/limit checking and scaling (mx+b)
-    - Data logging with timestamps
+    - Data logging; `Reading.timestamp` is populated only if the caller sets it
+      -- this module never reads it back from the instrument. Instrument-side
+      timestamps would require FORMat:READing:TIME (34970A/34972A Command
+      Reference p.411), which this library does not enable.
     - Context manager support for automatic connection management
 
 Feedback:
@@ -37,6 +40,10 @@ class Reading:
 
     value: float
     channel: Optional[int] = None
+    # Never set by this module -- callers must supply it themselves. This is
+    # NOT "when the instrument sampled": getting that would require enabling
+    # FORMat:READing:TIME (34970A/34972A Command Reference p.411) and parsing
+    # the returned time stamp, which this library does not do.
     timestamp: Optional[float] = None
     unit: Optional[str] = None
     alarm_state: Optional[str] = None

--- a/scpi_control/data_logger.py
+++ b/scpi_control/data_logger.py
@@ -40,16 +40,49 @@ class Reading:
     timestamp: Optional[float] = None
     unit: Optional[str] = None
     alarm_state: Optional[str] = None
+    # True when the instrument reported an overload instead of a measurement
+    # (34970A/34972A Command Reference p.251: "the instrument gives an overload
+    # indication: +-OVLD from the front panel or +-9.9E+37 from the remote
+    # interface"). `value` is NaN in that case -- an impossible reading must not
+    # enter the record as a number.
+    overload: bool = False
 
     def __repr__(self) -> str:
-        parts = [f"{self.value}"]
-        if self.unit:
+        parts = ["OVLD" if self.overload else f"{self.value}"]
+        if self.unit and not self.overload:
             parts[0] += f" {self.unit}"
         if self.channel:
             parts.append(f"ch={self.channel}")
         if self.timestamp:
             parts.append(f"t={self.timestamp:.3f}s")
         return f"Reading({', '.join(parts)})"
+
+
+# 34970A/34972A Command Reference p.251/266/275/839/905/946/1128: an overload
+# reads back as +-9.9E+37. Test on magnitude -- the sign follows the input.
+# NOT to be confused with TRIG:COUNt?'s infinite-count sentinel 9.90000200E+37
+# (p.1501), which is a different query this parser never sees.
+_OVERLOAD_MAGNITUDE = 9.9e37
+
+
+def _strip_definite_length_block(response: str) -> str:
+    """Return the payload of an IEEE 488.2 definite-length block, or the input unchanged.
+
+    `R?` wraps its CSV payload in `#<n><length>` (34970A/34972A Command Reference
+    p.40, example p.41); `DATA:REMove?`/`FETCh?`/`READ?` send the same CSV bare
+    (p.334-335, 16-17, 49-50). Both must parse, so the header is optional.
+    """
+    text = response.strip()
+    if not text.startswith("#"):
+        return text
+    if len(text) < 2 or not text[1].isdigit() or text[1] == "0":
+        return text
+    digits = int(text[1])
+    header_end = 2 + digits
+    length_field = text[2:header_end]
+    if len(length_field) < digits or not length_field.isdigit():
+        return text
+    return text[header_end : header_end + int(length_field)]
 
 
 class DataLogger:
@@ -698,14 +731,18 @@ class DataLogger:
     # --- Helper Methods ---
 
     def _parse_readings(self, response: str) -> List[Reading]:
-        """Parse comma-separated readings from response string."""
+        """Parse comma-separated readings from response string.
+
+        `R?` wraps the CSV in an IEEE 488.2 definite-length block; other
+        readback queries send it bare (see `_strip_definite_length_block`).
+        """
         readings = []
 
         if not response or response.strip() == "":
             return readings
 
-        # Split by comma and parse each value
-        values = response.strip().split(",")
+        # Strip an optional definite-length block header, then split by comma.
+        values = _strip_definite_length_block(response).split(",")
 
         for val in values:
             val = val.strip()
@@ -713,12 +750,18 @@ class DataLogger:
                 continue
 
             try:
-                # Try to parse as float
-                reading = Reading(value=float(val))
-                readings.append(reading)
+                value = float(val)
             except ValueError:
-                # May contain additional info like channel or alarm state
-                logger.debug(f"Could not parse reading value: {val}")
+                # Never swallow this silently: R? erases readings on the
+                # instrument, so a token we cannot parse is data the caller
+                # can never get back.
+                logger.warning("Discarding unparseable DAQ reading token %r", val)
+                continue
+
+            if abs(value) >= _OVERLOAD_MAGNITUDE:
+                readings.append(Reading(value=float("nan"), overload=True))
+            else:
+                readings.append(Reading(value=value))
 
         return readings
 

--- a/scpi_control/data_logger.py
+++ b/scpi_control/data_logger.py
@@ -13,7 +13,7 @@ Features:
     - Data logging; `Reading.timestamp` is populated only if the caller sets it
       -- this module never reads it back from the instrument. Instrument-side
       timestamps would require FORMat:READing:TIME (34970A/34972A Command
-      Reference p.411), which this library does not enable.
+      Reference p.417-424), which this library does not enable.
     - Context manager support for automatic connection management
 
 Feedback:
@@ -42,8 +42,8 @@ class Reading:
     channel: Optional[int] = None
     # Never set by this module -- callers must supply it themselves. This is
     # NOT "when the instrument sampled": getting that would require enabling
-    # FORMat:READing:TIME (34970A/34972A Command Reference p.411) and parsing
-    # the returned time stamp, which this library does not do.
+    # FORMat:READing:TIME (34970A/34972A Command Reference p.417-424) and
+    # parsing the returned time stamp, which this library does not do.
     timestamp: Optional[float] = None
     unit: Optional[str] = None
     alarm_state: Optional[str] = None

--- a/scpi_control/measurement.py
+++ b/scpi_control/measurement.py
@@ -88,6 +88,22 @@ class Measurement:
                 self._scope.write(self._scope._get_command("set_meas_immed_type", type=wire_type))
                 self._scope.write(self._scope._get_command("set_meas_immed_source", ch=channel))
                 response = self._scope.query(self._scope._get_command("get_meas_immed_value"))
+                # No sentinel check here (unlike the DAQ overload check in
+                # data_logger.py and the "****" check below for the modern
+                # dialect): MEASUrement:IMMed:VALue? is a TBS1000C-family
+                # command (TBS p.121, per scpi_commands.py), and that manual
+                # is not available in this repo to confirm what it returns
+                # when no valid measurement exists. The 4/5/6 Series MSO
+                # Programmer Manual (also in docs/) documents a 9.91E+37
+                # "invalid value" sentinel for unrelated subsystems (cursor
+                # readouts p.2-393/2-429, cycle-cycle measurement statistics
+                # p.2-610-2-615, unset trigger thresholds in Appendix C) but
+                # never for this specific query, and that manual's own
+                # RESUlts:CURRentacq:MEAN/MINimum/PK2PK/POPUlation? examples
+                # (p.2-690/2-691, the badge-path command actually used below)
+                # show ordinary numbers with no sentinel mentioned. Applying
+                # the MSO family's convention to a TBS1000C-only command would
+                # be a guess, not a citation -- do not add a check without one.
                 try:
                     return float(response.strip())
                 except ValueError as e:

--- a/scpi_control/waveform.py
+++ b/scpi_control/waveform.py
@@ -151,6 +151,9 @@ class Waveform:
         Raises:
             InvalidParameterError: If channel number is invalid
             CommandError: If acquisition fails
+            FeatureNotSupportedError: If the active dialect's transfer
+                doesn't support the requested format (e.g. 'WORD' on legacy
+                Siglent or Tektronix)
         """
         validate_channel(self._scope, channel)
 

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -113,7 +113,9 @@ class SiglentTransfer:
 
         Args:
             channel: Channel number (1-4)
-            format: Data format - 'BYTE' or 'WORD' (default: 'BYTE')
+            format: Data format - 'BYTE' only ('WORD' raises
+                FeatureNotSupportedError; this dialect has no documented
+                width selector)
             stride: Unused on this dialect -- legacy Siglent has no documented
                 :WAVeform:INTerval-equivalent command, so nothing is written.
                 Accepted only so callers can pass it uniformly regardless of
@@ -302,6 +304,20 @@ class TektronixTransfer:
             scope.write(command)
             raw = scope.read_raw()
         codes = parse_ieee_block(raw, np.int8, error_context=f"host {scope.host}:{scope.port}, command '{command}'")
+
+        # Detects a short/truncated transfer (NR_Pt? promised more samples
+        # than CURVe? actually delivered). It does NOT catch a rejected
+        # DATa:STOP write-back: in that case NR_Pt? and CURVe? would agree on
+        # the stale window, so this comparison would see no mismatch.
+        if n_points != len(codes):
+            logger.warning(
+                "WFMOutpre:NR_Pt? promised %d points but CURVe? returned %d (host %s:%s, channel %d) -- the record may be truncated.",
+                n_points,
+                len(codes),
+                scope.host,
+                scope.port,
+                channel,
+            )
 
         voltage = (codes.astype(np.float64) - yoff) * ymult + yzero
         time = xzero + (np.arange(len(codes)) - pt_off) * xincr

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -225,6 +225,12 @@ class SiglentTransfer:
         return time
 
 
+# "or larger" per the MSO4/5/6 manual p.2-341/2-342 -- deliberately above any
+# shipping Tek record length so the window always covers the whole record; the
+# instrument clamps to its own maximum and NR_Pt? then reports the real count.
+_TEK_MAX_RECORD_POINTS = 1_000_000_000
+
+
 class TektronixTransfer:
     """CURVe? transfer scaled by the WFMOutpre preamble (Tek PMs, Task 7 citations)."""
 
@@ -257,9 +263,18 @@ class TektronixTransfer:
         scope.write(scope._get_command("set_data_source", ch=channel))
         scope.write(scope._get_command("set_data_encoding"))
         scope.write(scope._get_command("set_data_width"))
-        n_points = int(float(scope.query(scope._get_command("get_wfm_nr_pt"))))
+        # Widen the transfer window BEFORE asking how many points it holds.
+        # NR_Pt? is window-relative (MSO4/5/6 manual p.2-1461), so querying it
+        # first measures whatever narrow window a prior script or a recalled
+        # setup left behind -- and the old code then wrote that same number
+        # back to DATa:STOP, making the truncation permanent. p.2-341/2-342
+        # sanctions exactly this: "set DATa:STARt to 1 and DATa:STOP to the
+        # maximum record length, or larger". Using "or larger" avoids needing
+        # HORizontal:RECOrdlength?, whose spelling we cannot cite for the
+        # TBS1000/MSO2 families (their manuals are not in docs/).
         scope.write(scope._get_command("set_data_start", start=1))
-        scope.write(scope._get_command("set_data_stop", stop=n_points))
+        scope.write(scope._get_command("set_data_stop", stop=_TEK_MAX_RECORD_POINTS))
+        n_points = int(float(scope.query(scope._get_command("get_wfm_nr_pt"))))
         xincr = float(scope.query(scope._get_command("get_wfm_xincr")))
         xzero = float(scope.query(scope._get_command("get_wfm_xzero")))
         # WFMOutpre:PT_Off? is MSO2-only (absent from the TBS1000C WFMOutpre

--- a/scpi_control/waveform_transfer.py
+++ b/scpi_control/waveform_transfer.py
@@ -123,8 +123,22 @@ class SiglentTransfer:
             WaveformData object with time and voltage arrays
 
         Raises:
+            FeatureNotSupportedError: If format='WORD' is requested
+            InvalidParameterError: If an invalid format is requested
             CommandError: If acquisition fails
         """
+        # Validate format pre-flight, before any wire access
+        fmt = format.upper()
+        if fmt == "WORD":
+            raise exceptions.FeatureNotSupportedError(
+                "format='WORD' is not supported on the legacy Siglent dialect: the programming guide "
+                "(RC01020-E01C) documents no command to select 16-bit transfer width -- WAVEFORM_SETUP/WFSU "
+                "(p.144-145) sets only sparsing, point count and first point -- and WF? DAT2 answers one byte "
+                "per sample (p.141-142). Use format='BYTE'."
+            )
+        if fmt != "BYTE":
+            raise exceptions.InvalidParameterError(f"Invalid format: {format}")
+
         # Get channel configuration
         ch = f"C{channel}"
         voltage_scale = self._scope.waveform._get_voltage_scale(ch)
@@ -139,13 +153,8 @@ class SiglentTransfer:
             self._scope.write(waveform_command)
             raw_data = self._scope.read_raw()
 
-        # Parse waveform data
-        if format == "BYTE":
-            dtype = np.int8
-        elif format == "WORD":
-            dtype = np.int16
-        else:
-            raise exceptions.InvalidParameterError(f"Invalid format: {format}")
+        # Parse waveform data - only BYTE is supported on legacy dialect
+        dtype = np.int8
 
         error_context = f"host {self._scope.host}:{self._scope.port}, command '{waveform_command}'"
         voltage_data = parse_ieee_block(raw_data, dtype, error_context=error_context)

--- a/tests/test_daq_reading_parser.py
+++ b/tests/test_daq_reading_parser.py
@@ -1,0 +1,94 @@
+"""The DAQ reading parser must survive the wire shapes real hardware sends.
+
+Backend review 2026-07-31, finding High-8. Two independent defects, both
+invisible against the old mock because it answered R? with the same bare CSV
+it answered READ? with:
+
+1. `R?` wraps its payload in an IEEE 488.2 definite-length block (34970A/34972A
+   Command Reference p.40, worked example p.41: `R? 2` ->
+   `#231+2.87536000E-04,+3.18131400E-03`). Splitting that on commas makes
+   float("#231+2.87536000E-04") raise, and the old parser swallowed the failure
+   at debug level -- silently dropping the FIRST reading of every batch. `R?`
+   erases readings on the instrument, so the data is unrecoverable.
+2. An overload reads back as +-9.9E+37 (p.251, 266, 275, 839, 905, 946, 1128:
+   "the instrument gives an overload indication: +-OVLD from the front panel or
+   +-9.9E+37 from the remote interface"). float() accepts it happily, so an
+   impossible value entered the record as a real measurement.
+
+DATA:REMove? / FETCh? / READ? are bare CSV (p.334-335, 16-17, 49-50), so the
+block header is OPTIONAL -- the parser handles both.
+"""
+
+import math
+
+import pytest
+
+from scpi_control.connection.mock import MockConnection
+from scpi_control.data_logger import DataLogger
+
+DAQ_IDN = "Agilent Technologies,34970A,MY12345678,1.0"
+
+# The manual's own worked example, p.41.
+MANUAL_R_RESPONSE = "#231+2.87536000E-04,+3.18131400E-03"
+
+
+def _logger(**kwargs):
+    conn = MockConnection(daq_mode=True, daq_idn=DAQ_IDN, **kwargs)
+    dl = DataLogger("mock", connection=conn)
+    dl.connect()
+    return dl, conn
+
+
+class TestDefiniteLengthBlock:
+    def test_manual_example_yields_both_readings(self):
+        dl, _ = _logger()
+        readings = dl._parse_readings(MANUAL_R_RESPONSE)
+        assert [r.value for r in readings] == [pytest.approx(2.87536e-04), pytest.approx(3.181314e-03)]
+
+    def test_bare_csv_still_parses(self):
+        # FETCh?/READ?/DATA:REMove? are documented bare CSV -- header is optional.
+        dl, _ = _logger()
+        readings = dl._parse_readings("+4.27150000E+02,+1.32130000E+03")
+        assert [r.value for r in readings] == [pytest.approx(427.15), pytest.approx(1321.3)]
+
+    def test_mock_r_query_is_block_wrapped_and_read_is_not(self):
+        # Wire-level pin: this is the mock half of the fix. If the mock ever
+        # goes back to answering R? bare, this fails even though the parser
+        # would still "work" -- that is the point.
+        dl, conn = _logger(daq_readings="1.234,2.345,3.456")
+        assert conn.query("R? 3").startswith("#")
+        assert not conn.query("READ?").startswith("#")
+
+    def test_read_and_remove_keeps_every_reading(self):
+        # End-to-end through the real command path (R? {max_readings}).
+        dl, _ = _logger(daq_readings="1.234,2.345,3.456")
+        readings = dl.read_and_remove(3)
+        assert [r.value for r in readings] == [pytest.approx(1.234), pytest.approx(2.345), pytest.approx(3.456)]
+
+
+class TestOverloadSentinel:
+    @pytest.mark.parametrize("token", ["+9.9E+37", "-9.9E+37", "+9.90000000E+37"])
+    def test_overload_is_marked_not_recorded_as_a_value(self, token):
+        dl, _ = _logger()
+        readings = dl._parse_readings(f"+1.00000000E+00,{token},+2.00000000E+00")
+        assert len(readings) == 3
+        assert readings[1].overload is True
+        assert math.isnan(readings[1].value)
+        # neighbours untouched
+        assert readings[0].overload is False
+        assert readings[2].value == pytest.approx(2.0)
+
+    def test_ordinary_large_value_is_not_treated_as_overload(self):
+        dl, _ = _logger()
+        (reading,) = dl._parse_readings("+1.00000000E+30")
+        assert reading.overload is False
+        assert reading.value == pytest.approx(1e30)
+
+
+class TestUnparseableTokens:
+    def test_unparseable_token_is_visible_not_swallowed(self, caplog):
+        dl, _ = _logger()
+        with caplog.at_level("WARNING"):
+            readings = dl._parse_readings("+1.00000000E+00,NOT_A_NUMBER")
+        assert [r.value for r in readings] == [pytest.approx(1.0)]
+        assert any("NOT_A_NUMBER" in rec.message for rec in caplog.records)

--- a/tests/test_tek_record_window.py
+++ b/tests/test_tek_record_window.py
@@ -1,0 +1,70 @@
+"""A Tektronix capture must return the full record, not whatever window was left behind.
+
+Backend review 2026-07-31. WFMOutpre:NR_Pt? is window-relative -- MSO4/5/6
+programmer manual p.2-1461: "returns the number of points for the DATa:SOUrce
+waveform that will be transmitted in response to a CURVe? query" (the manual's
+own example on p.2-1455 shows a 1250-point record reporting NR_PT 1000). The old
+code queried NR_Pt? FIRST and then wrote DATa:STOP back to that same number, so a
+narrow window left by a prior script or a recalled setup truncated every capture
+forever, unrecoverably.
+
+The fix is the manual's own instruction, p.2-341/2-342: "Changes to the record
+length value are not automatically reflected in the data:stop value... If you
+always want to transfer complete waveforms, set DATa:STARt to 1 and DATa:STOP to
+the maximum record length, or larger." Widening FIRST needs no record-length
+query, so it works on every Tek family (only the MSO4/5/6 manual is available
+here; HORizontal:RECOrdlength?'s spelling is unverified for TBS1000/MSO2).
+"""
+
+from scpi_control.connection.mock import MockConnection
+from scpi_control.oscilloscope import Oscilloscope
+
+TEK_IDN = "TEKTRONIX,MSO46,C012345,CF:91.1CT FV:1.20.3"
+
+
+def _scope(**kwargs):
+    # sample_rate/timebase give a 14,000-point full record (14 divisions x
+    # 1e6 Sa/s x 1ms/div, matching the defaults used elsewhere for Tek/LeCroy
+    # synthesis, e.g. test_mock_synthesis.py) -- large enough that the
+    # manual's own Appendix D scenario (p.D-2: "a previous session left
+    # DATa:STOP at 25 on a 10000-point record") and a full capture are
+    # unmistakably different sizes.
+    kwargs.setdefault("sample_rate", 1_000_000.0)
+    kwargs.setdefault("timebase", 1e-3)
+    conn = MockConnection(idn=TEK_IDN, **kwargs)
+    scope = Oscilloscope(connection=conn, host="mock")
+    scope.connect()
+    return scope, conn
+
+
+def test_stale_narrow_window_does_not_truncate_the_capture():
+    # Seed the exact hazard: a previous session left DATa:STOP at 25 on a
+    # much larger record (the manual's own Appendix D scenario, p.D-2).
+    scope, conn = _scope(data_stop=25)
+    wf = scope.get_waveform(1)
+    assert len(wf.voltage) > 25
+
+
+def test_acquire_widens_the_window_before_asking_how_many_points():
+    scope, conn = _scope(data_stop=25)
+    scope.get_waveform(1)
+    # Ordering is the whole point: measuring first and writing the measured
+    # value back is what made the truncation permanent. conn.writes and
+    # conn.queries (connection/mock/base.py) are each append-only to their
+    # OWN list, so neither alone can show a write's position relative to a
+    # query -- conn.command_log is a combined, call-order trace of both
+    # (added alongside this test) that makes the ordering observable.
+    log = [c.upper() for c in conn.command_log]
+    widen = [i for i, c in enumerate(log) if "DATA:STAR" in c or "DATA:STOP" in c]
+    measure = [i for i, c in enumerate(log) if "NR_PT" in c]
+    assert widen, f"no DATa:STARt/STOP write observed in {log}"
+    assert measure, f"no NR_Pt? query observed in {log} -- if queries are not recorded in this log, find the log that records them (see the adaptation note) rather than deleting this assertion"
+    assert max(widen) < min(measure), f"window was measured before it was widened: {log}"
+
+
+def test_mock_nr_pt_is_window_relative():
+    # Wire-level pin of the manual's semantics. This is the mock half: if
+    # NR_PT? ever goes back to ignoring the window, the driver test above
+    # stops being able to detect the bug.
+    _, conn = _scope(data_stop=25)
+    assert int(float(conn.query("WFMOUTPRE:NR_PT?"))) == 25

--- a/tests/test_tek_record_window.py
+++ b/tests/test_tek_record_window.py
@@ -58,7 +58,7 @@ def test_acquire_widens_the_window_before_asking_how_many_points():
     widen = [i for i, c in enumerate(log) if "DATA:STAR" in c or "DATA:STOP" in c]
     measure = [i for i, c in enumerate(log) if "NR_PT" in c]
     assert widen, f"no DATa:STARt/STOP write observed in {log}"
-    assert measure, f"no NR_Pt? query observed in {log} -- if queries are not recorded in this log, find the log that records them (see the adaptation note) rather than deleting this assertion"
+    assert measure, f"no NR_Pt? query observed in {log}"
     assert max(widen) < min(measure), f"window was measured before it was widened: {log}"
 
 

--- a/tests/test_waveform_transfer.py
+++ b/tests/test_waveform_transfer.py
@@ -95,10 +95,10 @@ class TestSiglentPathUnchanged:
         conn = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, sample_rate=1_000.0, timebase=1e-3)
         scope = Oscilloscope("mock", connection=conn)
         scope.connect()
-        before = list(conn.writes)
+        before_log = list(conn.command_log)
         with pytest.raises(exceptions.FeatureNotSupportedError):
             scope.waveform.acquire(1, format="WORD")
-        assert [w for w in conn.writes[len(before) :] if "WF?" in w.upper()] == []
+        assert conn.command_log[len(before_log) :] == []
         scope.disconnect()
 
 

--- a/tests/test_waveform_transfer.py
+++ b/tests/test_waveform_transfer.py
@@ -79,6 +79,28 @@ class TestSiglentPathUnchanged:
         assert any(w.startswith("C1:WF?") for w in conn.writes)
         scope.disconnect()
 
+    def test_word_format_raises_before_touching_the_wire(self):
+        """Legacy has no documented way to ask for 16-bit samples.
+
+        RC01020-E01C documents only WAVEFORM_SETUP/WFSU (p.144-145: Sparsing,
+        Number of points, First point, and an SPO-only TYPE flag) -- no width
+        selector anywhere, and CFMT/COMM_ORDER are LeCroy commands absent from
+        this guide. WF? DAT2's response is one byte per sample (p.141-142's
+        worked example transfers 70 bytes for 70 points). The old code sent the
+        same request and reinterpreted the bytes as int16, returning half the
+        samples as plausible-but-wrong voltages with no error.
+
+        The failure must be pre-flight: no waveform request may be sent.
+        """
+        conn = MockConnection("mock", idn=LEGACY_IDN, channel_states={1: True}, sample_rate=1_000.0, timebase=1e-3)
+        scope = Oscilloscope("mock", connection=conn)
+        scope.connect()
+        before = list(conn.writes)
+        with pytest.raises(exceptions.FeatureNotSupportedError):
+            scope.waveform.acquire(1, format="WORD")
+        assert [w for w in conn.writes[len(before) :] if "WF?" in w.upper()] == []
+        scope.disconnect()
+
 
 def build_wavedesc(
     codes: bytes,
@@ -92,16 +114,16 @@ def build_wavedesc(
 ) -> bytes:
     desc = bytearray(346)
     desc[0:8] = b"WAVEDESC"
-    struct.pack_into("<h", desc, 32, comm_type)          # COMM_TYPE: 0=byte, 1=word
-    struct.pack_into("<i", desc, 36, 346)                # WAVE_DESCRIPTOR length
-    struct.pack_into("<i", desc, 40, 0)                  # USER_TEXT length
-    struct.pack_into("<i", desc, 48, trigtime_len)       # TRIGTIME_ARRAY length
-    struct.pack_into("<i", desc, 52, ristime_len)        # RIS_TIME_ARRAY length
-    struct.pack_into("<i", desc, 116, len(codes))        # WAVE_ARRAY_COUNT
-    struct.pack_into("<f", desc, 156, gain)              # VERTICAL_GAIN
-    struct.pack_into("<f", desc, 160, offset)            # VERTICAL_OFFSET
-    struct.pack_into("<f", desc, 176, hinterval)         # HORIZ_INTERVAL
-    struct.pack_into("<d", desc, 180, hoffset)           # HORIZ_OFFSET
+    struct.pack_into("<h", desc, 32, comm_type)  # COMM_TYPE: 0=byte, 1=word
+    struct.pack_into("<i", desc, 36, 346)  # WAVE_DESCRIPTOR length
+    struct.pack_into("<i", desc, 40, 0)  # USER_TEXT length
+    struct.pack_into("<i", desc, 48, trigtime_len)  # TRIGTIME_ARRAY length
+    struct.pack_into("<i", desc, 52, ristime_len)  # RIS_TIME_ARRAY length
+    struct.pack_into("<i", desc, 116, len(codes))  # WAVE_ARRAY_COUNT
+    struct.pack_into("<f", desc, 156, gain)  # VERTICAL_GAIN
+    struct.pack_into("<f", desc, 160, offset)  # VERTICAL_OFFSET
+    struct.pack_into("<f", desc, 176, hinterval)  # HORIZ_INTERVAL
+    struct.pack_into("<d", desc, 180, hoffset)  # HORIZ_OFFSET
     # DATA_ARRAY_1 follows the two optional time arrays; pad them with the
     # declared number of filler bytes so data_offset has something to skip.
     return bytes(desc) + b"\x00" * (trigtime_len + ristime_len) + codes


### PR DESCRIPTION
Wave 2 of the 2026-07-31 backend review: four silent wrong-data bugs in the data-collection path. Each fix lands driver + mock + regression test together, because in every case the mock was answering what the parser expected rather than what the instrument sends — which is exactly why none of these were caught in CI.

Every wire behaviour here was researched against the vendor manuals first; the citations are in the code comments.

## Fixes

**DAQ readings: the first reading of every batch was being discarded.** Keysight's `R?` wraps its CSV payload in an IEEE 488.2 definite-length block — the manual's own worked example is `#231+2.87536000E-04,+3.18131400E-03` (34970A/34972A Command Reference p.40-41). Splitting that on commas makes the first token unparseable, and the old parser swallowed the failure at debug level. Because `R?` *erases* readings on the instrument, that data was unrecoverable. The header is now stripped — and treated as **optional**, since `DATA:REMove?`, `READ?` and `FETCh?` are documented as bare CSV (p.334-335, 16-17, 49-50).

**DAQ readings: overloads were recorded as measurements.** An overload reads back as `±9.9E+37` (p.251 and six other places: "the instrument gives an overload indication: ±OVLD from the front panel or ±9.9E+37 from the remote interface"). `float()` accepts it happily. Overload readings now carry `value=NaN` with a new `Reading.overload` flag, so an impossible value can't enter the record as a number. Marked rather than raised, deliberately: `start_logging` catches per-poll exceptions, so raising would discard the whole scan batch.

**Tektronix: captures were silently truncated, permanently.** `WFMOutpre:NR_Pt?` reports the current *transfer window*, not the record length (MSO4/5/6 manual p.2-1461). The old code queried it first and then wrote `DATa:STOP` back to that same number — re-affirming whatever narrow window a prior script or a recalled setup left behind, with no way to ever widen it again. The fix is the manual's own instruction (p.2-341/2-342): *"the DATa:STOP value must be explicitly changed to ensure the entire record is transmitted... set DATa:STARt to 1 and DATa:STOP to the maximum record length, or larger."* Widening before measuring also avoids needing `HORizontal:RECOrdlength?`, whose spelling can't be cited for the TBS1000/MSO2 families (their manuals aren't in the repo). The point-count query now serves as a transfer-truncation check.

**Legacy Siglent: `format="WORD"` returned fabricated samples.** The legacy guide documents no way to request 16-bit transfers — `WAVEFORM_SETUP`/`WFSU` (p.144-145) sets only sparsing, point count and first point, and `CFMT`/`COMM_ORDER` are LeCroy commands absent from that guide; `WF? DAT2` answers one byte per sample (p.141-142). The old code sent the same request and reinterpreted the bytes as int16 — half the samples, plausible-looking wrong voltages, no error. It now raises `FeatureNotSupportedError` before anything reaches the wire.

## Deliberately not done

- **Tektronix `MEASUrement:IMMed:VALue?` sentinel.** The MSO4/5/6 manual has a `9.91E+37` invalid-value convention but never ties it to this query, which is TBS1000C-only — and that manual isn't in the repo. Applying another family's convention would be a guess, not a citation, so the gap is documented at the call site instead.
- **Instrument-side DAQ timestamps.** These need `FORMat:READing:TIME` (p.417-424), which also changes the token stream the parser assumes. The docs were corrected to stop advertising timestamps the module never populated, rather than fabricating a receipt time and calling it an acquisition time.

## Breaking changes

- `Reading` gains `overload: bool`; overload readings are `NaN` instead of `9.9e37`. Code comparing against `9.9e37` should check `reading.overload`.
- Legacy `acquire(..., format="WORD")` raises `FeatureNotSupportedError` instead of returning data.

## Verification

- 2329 passed / 19 skipped / 0 failed on the exact tree being pushed (baseline at branch point: 2318 / 19); black and flake8 gates clean; the `docs/about/changelog.md` mirror is verified byte-identical.
- Both DAQ guards and the Tektronix guard are mutation-checked: with each fix reverted, the matching test fails and reproduces the original bug.
- The mock changes are load-bearing — windowing only `NR_Pt?` left the `CURVe?` payload full-length, which would have let the truncation test pass vacuously even with the bug present.
