### PR TITLE
chore(release): 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0] - 2026-08-04
+
 ### ⚠️ Breaking Changes
 
 - PSU: `ovp_level`/`ocp_level` on SPD1305X/SPD1168X now raise `NotImplementedError` instead of silently sending a command the firmware discards. No SPD1000X programming manual documents a SCPI protection subsystem; set protection on the front panel. (Same honesty gate the SPD3303X received in v5.0.0.)

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0] - 2026-08-04
+
 ### ⚠️ Breaking Changes
 
 - PSU: `ovp_level`/`ocp_level` on SPD1305X/SPD1168X now raise `NotImplementedError` instead of silently sending a command the firmware discards. No SPD1000X programming manual documents a SCPI protection subsystem; set protection on the front panel. (Same honesty gate the SPD3303X received in v5.0.0.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "6.0.0"
+version = "7.0.0"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "6.0.0"
+__version__ = "7.0.0"
 
 from scpi_control.capabilities import ScopeCapabilities
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError


### PR DESCRIPTION
MAJOR release. This cycle carries **15 breaking changes** across four merged branches (#139, #140, #141, #143, #144), all under one theme: **the library must not report a value the instrument never gave it, and must not silently discard a command.**

## What changed in this release

Every gate is backed by a manual citation, and every one has a mutation-tested guard.

**Stopped fabricating values**
- `trigger.level` returned a hardcoded `0.0` for any source with no documented level command
- The DAQ `9.9E+37` overload sentinel was stored as a real measurement
- Legacy `format="WORD"` reinterpreted an 8-bit stream as int16 — half the samples, plausible garbage volts, no error
- Terminator-only responses came back as `""`, which is how one late newline shifted every later answer by one query
- Truncated socket reads were returned as success, indistinguishable from a complete capture

**Stopped discarding commands silently**
- SPD3303X CH3 accepted setpoint writes its firmware drops (it is a DIP-switch rail with no SCPI path); switching it on/off still works, because that *is* documented
- Unrecognized PSU models advertised OVP/OCP nobody can cite
- Tektronix `trigger.coupling = "AC"` sent a token absent from the Tek vocabulary

**And made the gaps discoverable** — `scope.capabilities` / `psu.capabilities`, typed vocabulary enums validated before the wire, and structured error context, so a caller can ask before calling instead of catching.

## Migration

The changelog's ⚠️ section is the authoritative list. The most likely to bite:

- `trigger.level` on a `LINE` source (legacy/LeCroy/Tek) or a Tek external input now raises `FeatureNotSupportedError` instead of returning `0.0`. Note `trigger.get_configuration()` reports it as `None` rather than raising, so trigger dumps still work.
- `psu.output3.voltage`/`current` on an SPD3303X now raise. Select the rail voltage on the front-panel DIP switch; `enable()`/`disable()` are unchanged.
- `OutputSpec`/`PSUCapability` are frozen — use `dataclasses.replace()`.
- `FeatureNotSupportedError` now subclasses `NotImplementedError`, and `InvalidParameterError` subclasses `ValueError`, so existing handlers for those keep working.
- A response that is only a terminator now raises `SiglentTimeoutError` rather than returning `""` (except through `VISAConnection.query()`, which delegates to pyvisa — documented in the entry).

## Release checklist

- [x] `## [7.0.0] - 2026-08-04` inserted under `[Unreleased]`, which stays in place and empty
- [x] `CHANGELOG.md` and `docs/about/changelog.md` identical (mirror test passes)
- [x] `pyproject.toml` and `scpi_control/__init__.py` both at 7.0.0 (consistency test passes)
- [x] PyPI summary 387 chars, under the 512 hard limit
- [x] Full suite: **2703 passed, 19 skipped, 0 failed**
- [x] `black --check --line-length 200` and `flake8 --select=E9,F63,F7,F82` clean