### PR TITLE
chore(release): 7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.1] - 2026-08-07
+
 ### Added
 
 - Docs: `docs/images/social-preview.png`, a purpose-built 1280×640 GitHub social-preview card. Links shared to Reddit/HN/X/Discord previously rendered the default GitHub card. Upload it under **Settings → Social preview**; `BRANDING.md` has the steps (it used to point at `resources/Test Equipment.png`, which is 1024×1024 and gets cropped to 2:1).
@@ -15,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- README rewritten as a showcase, 1008 → ~280 lines. The GUI manual, the inline API reference, the v1.0.0 migration guide, and the maintainer build/publish steps are now linked to their existing homes on the docs site (`docs/gui/`, `docs/user-guide/`, `docs/about/changelog.md`, `docs/development/`) rather than duplicated. The four things that lived *only* in the README — the supported-instrument list, the CLI table, the GUI's Power Supply and Data Logger tabs, and the interactive-tutorial link — are kept.
+- README rewritten as a showcase, 1008 → 269 lines. The GUI manual, the inline API reference, the v1.0.0 migration guide, and the maintainer build/publish steps are now linked to their existing homes on the docs site (`docs/gui/`, `docs/user-guide/`, `docs/about/changelog.md`, `docs/development/`) rather than duplicated. The four things that lived *only* in the README — the supported-instrument list, the CLI table, the GUI's Power Supply and Data Logger tabs, and the interactive-tutorial link — are kept.
 - README now leads with a runnable hardware-free example. The previous quick start needed an instrument at `192.168.1.100` before it did anything.
 - Docs landing page uses the live-trace GUI screenshot instead of the disconnected one.
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.1] - 2026-08-07
+
 ### Added
 
 - Docs: `docs/images/social-preview.png`, a purpose-built 1280×640 GitHub social-preview card. Links shared to Reddit/HN/X/Discord previously rendered the default GitHub card. Upload it under **Settings → Social preview**; `BRANDING.md` has the steps (it used to point at `resources/Test Equipment.png`, which is 1024×1024 and gets cropped to 2:1).
@@ -15,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- README rewritten as a showcase, 1008 → ~280 lines. The GUI manual, the inline API reference, the v1.0.0 migration guide, and the maintainer build/publish steps are now linked to their existing homes on the docs site (`docs/gui/`, `docs/user-guide/`, `docs/about/changelog.md`, `docs/development/`) rather than duplicated. The four things that lived *only* in the README — the supported-instrument list, the CLI table, the GUI's Power Supply and Data Logger tabs, and the interactive-tutorial link — are kept.
+- README rewritten as a showcase, 1008 → 269 lines. The GUI manual, the inline API reference, the v1.0.0 migration guide, and the maintainer build/publish steps are now linked to their existing homes on the docs site (`docs/gui/`, `docs/user-guide/`, `docs/about/changelog.md`, `docs/development/`) rather than duplicated. The four things that lived *only* in the README — the supported-instrument list, the CLI table, the GUI's Power Supply and Data Logger tabs, and the interactive-tutorial link — are kept.
 - README now leads with a runnable hardware-free example. The previous quick start needed an instrument at `192.168.1.100` before it did anything.
 - Docs landing page uses the live-trace GUI screenshot instead of the disconnected one.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "7.0.0"
+version = "7.0.1"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "7.0.0"
+__version__ = "7.0.1"
 
 from scpi_control.capabilities import ScopeCapabilities
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError


### PR DESCRIPTION
Documentation-only release cutting the work merged in #146.

## Why a patch bump

No library code changed. `scripts/media/` is excluded from the distribution
(`recursive-exclude scripts *`, and `packages.find` includes only
`scpi_control*`), so nothing importable moves. The only thing a PyPI user
receives differently is the rendered README.

## Contents

- README rewritten as a showcase, 1008 -> 269 lines, leading with a runnable
  hardware-free example.
- New generated assets: `mock-demo.gif`, `social-preview.png`,
  `gui-live-view.png`, `gui-fft.png` — each produced by driving the real
  library against the built-in mock, with generators in `scripts/media/`.
- Dropped the incorrect CAN/LIN protocol-decode claim; only `I2CDecoder`,
  `SPIDecoder` and `UARTDecoder` exist.
- Removed two byte-identical duplicate screenshots.
- Recorded a known mock fidelity gap: `:MEASure` queries return fixed
  constants that do not track the synthesized waveform.

## Release checklist

- [x] `## [7.0.1] - 2026-08-07` inserted under `[Unreleased]`, sections moved beneath it
- [x] `cp CHANGELOG.md docs/about/changelog.md` (test_changelog_mirror passes)
- [x] `pyproject.toml` and `scpi_control/__init__.py` both at 7.0.1 (test_version_consistency passes)
- [x] PyPI summary 387 / 512 chars
- [x] `black --check --line-length 200 scpi_control/ examples/` clean
- [x] `flake8 scpi_control/ --select=E9,F63,F7,F82` clean
- [x] 2688 passed, 19 skipped locally (`-m "not slow" -n 8`)

Tagging and the PyPI publish dispatch are **not** done in this PR.
