### PR TITLE
docs: extend the README badge row, and fix the codecov-action file input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,10 @@ jobs:
         uses: codecov/codecov-action@v7
         if: matrix.python-version == '3.11'
         with:
-          file: ./coverage.xml
+          # `files` (plural). codecov-action v4+ dropped `file`, and passing it only
+          # produces a warning -- the step still goes green while the path is ignored
+          # and the CLI falls back to searching the tree for a report.
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- CI: the Codecov upload step passed `file:`, an input `codecov/codecov-action` dropped at v4. It was silently ignored — the run logged `Unexpected input(s) 'file'`, stayed green, and uploaded only because the CLI falls back to searching the tree for a report. Now `files:`, so the explicit path is honoured.
+
 ### Changed
 
 - README badges regrouped into two rows and extended from six to nine. The first row answers "should I install this?" (version, downloads, release status, Python versions, platform); the second answers "is this looked after?" (CI, coverage, docs, licence). New badges: monthly PyPI downloads, PyPI release status, and supported platforms. The platform badge is static and linked to the CI workflow, since that job's ubuntu/windows/macos matrix is the only thing backing the claim — it needs updating by hand if an OS ever leaves the matrix. Because `pyproject.toml` sets `readme = README.md`, these also appear on the PyPI project page from the next release onward.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- README badges regrouped into two rows and extended from six to nine. The first row answers "should I install this?" (version, downloads, release status, Python versions, platform); the second answers "is this looked after?" (CI, coverage, docs, licence). New badges: monthly PyPI downloads, PyPI release status, and supported platforms. The platform badge is static and linked to the CI workflow, since that job's ubuntu/windows/macos matrix is the only thing backing the claim — it needs updating by hand if an OS ever leaves the matrix. Because `pyproject.toml` sets `readme = README.md`, these also appear on the PyPI project page from the next release onward.
+
 ## [7.0.1] - 2026-08-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # SCPI Instrument Control
 
-[![CI](https://github.com/little-did-I-know/SCPI-Instrument-Control/actions/workflows/ci.yml/badge.svg)](https://github.com/little-did-I-know/SCPI-Instrument-Control/actions/workflows/ci.yml)
+<!-- Two rows by intent: the first answers "should I install this?", the second
+     "is this looked after?". The platform badge is static -- it is linked to the
+     CI workflow because that matrix (ubuntu/windows/macos) is its only evidence,
+     so if an OS ever leaves the matrix this badge has to be updated by hand. -->
 [![PyPI version](https://img.shields.io/pypi/v/SCPI-Instrument-Control.svg)](https://pypi.org/project/SCPI-Instrument-Control/)
+[![Downloads](https://img.shields.io/pypi/dm/SCPI-Instrument-Control.svg)](https://pypistats.org/packages/scpi-instrument-control)
+[![Status](https://img.shields.io/pypi/status/SCPI-Instrument-Control.svg)](https://pypi.org/project/SCPI-Instrument-Control/)
 [![Python Version](https://img.shields.io/pypi/pyversions/SCPI-Instrument-Control)](https://pypi.org/project/SCPI-Instrument-Control/)
+[![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey.svg)](https://github.com/little-did-I-know/SCPI-Instrument-Control/actions/workflows/ci.yml)
+
+[![CI](https://github.com/little-did-I-know/SCPI-Instrument-Control/actions/workflows/ci.yml/badge.svg)](https://github.com/little-did-I-know/SCPI-Instrument-Control/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/little-did-I-know/SCPI-Instrument-Control/branch/main/graph/badge.svg)](https://codecov.io/gh/little-did-I-know/SCPI-Instrument-Control)
 [![Docs](https://img.shields.io/badge/docs-mkdocs-blue.svg)](https://little-did-I-know.github.io/SCPI-Instrument-Control/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- CI: the Codecov upload step passed `file:`, an input `codecov/codecov-action` dropped at v4. It was silently ignored — the run logged `Unexpected input(s) 'file'`, stayed green, and uploaded only because the CLI falls back to searching the tree for a report. Now `files:`, so the explicit path is honoured.
+
 ### Changed
 
 - README badges regrouped into two rows and extended from six to nine. The first row answers "should I install this?" (version, downloads, release status, Python versions, platform); the second answers "is this looked after?" (CI, coverage, docs, licence). New badges: monthly PyPI downloads, PyPI release status, and supported platforms. The platform badge is static and linked to the CI workflow, since that job's ubuntu/windows/macos matrix is the only thing backing the claim — it needs updating by hand if an OS ever leaves the matrix. Because `pyproject.toml` sets `readme = README.md`, these also appear on the PyPI project page from the next release onward.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- README badges regrouped into two rows and extended from six to nine. The first row answers "should I install this?" (version, downloads, release status, Python versions, platform); the second answers "is this looked after?" (CI, coverage, docs, licence). New badges: monthly PyPI downloads, PyPI release status, and supported platforms. The platform badge is static and linked to the CI workflow, since that job's ubuntu/windows/macos matrix is the only thing backing the claim — it needs updating by hand if an OS ever leaves the matrix. Because `pyproject.toml` sets `readme = README.md`, these also appear on the PyPI project page from the next release onward.
+
 ## [7.0.1] - 2026-08-07
 
 ### Added


### PR DESCRIPTION
Extends the README badge row from six badges to nine, and fixes a latent bug in the Codecov upload step found while verifying that the badges actually render.

## Badges

Six become nine, split into two rows by the question each answers:

- **Package facts** — version, downloads, release status, Python versions, platform
- **Project health** — CI, coverage, docs, licence

The three new ones are monthly PyPI downloads, PyPI release status, and supported platforms. Because `pyproject.toml` sets `readme = README.md`, these reach the PyPI project page at the next release with no extra work.

Two choices worth a reviewer's attention:

- **The platform badge is static**, so it is linked to the CI workflow rather than to PyPI — that job's ubuntu/windows/macos matrix is the only evidence backing the claim. If an OS ever leaves the matrix, this badge has to be updated by hand and nothing will fail to say so.
- **Downloads uses shields `pypi/dm`**, which reports installs with mirror traffic excluded (~2.6k/month). The pepy.tech equivalent renders more reliably but counts mirrors, inflating the figure roughly 3.5x. Honest number preferred over the flattering one. The trade-off is that `pypi/dm` intermittently renders `rate limited by upstream service`, and GitHub's camo proxy caches whatever it fetched, so it can sit that way for a while.

All nine URLs were render-checked: every one returns HTTP 200, and eight report correct labels (`pypi: v7.0.1`, `status: stable`, `python: 3.9 … 3.14`, `platform: linux | macOS | windows`, `CI - passing`, `docs: mkdocs`, `License: MIT`).

## Codecov upload fix

The ninth badge is the coverage one, and it reads `unknown`. Chasing that turned up a real bug in `ci.yml`.

The step passed `file:`, an input `codecov/codecov-action` dropped at v4. It does not fail the step — the run logs `##[warning]Unexpected input(s) 'file'` and carries on, so the explicit path has been ignored on every run. Uploads still landed only because the CLI falls back to searching the tree and happens to find `coverage.xml` at the repo root. Now `files:`.

## Why the coverage badge still reads `unknown` after this PR

This PR does **not** fix that, and cannot — the cause is outside the repo.

The project was renamed `Siglent-Oscilloscope` → `SCPI-Instrument-Control`, and the Codecov project kept the old slug. Uploads are still *accepted* (the token maps by internal repo ID, so the step goes green and `fail_ci_if_error` never triggers) but never *processed*. The uploader prints its own destination in the CI log:

```
results will be available at:
https://app.codecov.io/github/little-did-i-know/siglent-oscilloscope/commit/5e35525…
```

Codecov's last processed commit is 2026-01-05, frozen at 12.47% from when the suite was much smaller. Actual coverage is now **49.75%** across 2,644 passing tests. The old slug's badge shows the stale `12%`; the current slug has no project at all, hence `unknown`.

Fixing it needs a **Resync** in the Codecov UI so it picks up the rename — a manual step, not a code change. Note that flipping `fail_ci_if_error` to `true` would not have caught this, since the upload genuinely succeeds.

## Out of scope, noted

- CI installs `[dev,web]` but not `[gui]`, so PyQt6 modules count as uncovered lines the suite can never exercise. Excluding them would measure what is actually under test.
- `actions/checkout@v7` and `actions/setup-python@v7` are pinned across the workflows; they resolved fine in the run inspected, so they were left alone.

## Verification

- `tests/test_changelog_mirror.py` — 2 passed (CHANGELOG and `docs/about/changelog.md` in sync)
- `ci.yml` parses as valid YAML; the codecov step's inputs were inspected post-edit
- All nine badge URLs fetched and their rendered labels checked
