### PR TITLE
fix(report-generator): stop reporting bugs as ordinary generation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Report generation: `MarkdownReportGenerator.generate()` and `PDFReportGenerator.generate()` caught `Exception` around their whole write path, so a programming error (e.g. an `AttributeError` from a report model change) was indistinguishable from an environmental failure (permission denied, disk full, a bad output path) -- both just returned `False`, and the real bug was visible only as a log line. They now catch only `OSError`; every other exception propagates. This is not a signature change -- `generate()` still returns `bool` and no caller needs updating -- but a caller that previously saw `False` for a latent bug will now see the exception instead.
 - Oscilloscope (legacy Siglent dialect): `channel.unit` no longer returns the raw echoed response. Real hardware answers `C1:UNIT?` with the header still attached (`C1:UNIT V`, RC01020-E01C p.137); previously that header was returned verbatim, so `scope.channel1.unit` came back as `"C1:UNIT V"` instead of `"V"`. Code that worked around the old value should drop the workaround. The mock's `C1:UNIT?` answer was updated to match the same header-echoed form.
 - CI: the Codecov upload step passed `file:`, an input `codecov/codecov-action` dropped at v4. It was silently ignored — the run logged `Unexpected input(s) 'file'`, stayed green, and uploaded only because the CLI falls back to searching the tree for a report. Now `files:`, so the explicit path is honoured.
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Report generation: `MarkdownReportGenerator.generate()` and `PDFReportGenerator.generate()` caught `Exception` around their whole write path, so a programming error (e.g. an `AttributeError` from a report model change) was indistinguishable from an environmental failure (permission denied, disk full, a bad output path) -- both just returned `False`, and the real bug was visible only as a log line. They now catch only `OSError`; every other exception propagates. This is not a signature change -- `generate()` still returns `bool` and no caller needs updating -- but a caller that previously saw `False` for a latent bug will now see the exception instead.
 - Oscilloscope (legacy Siglent dialect): `channel.unit` no longer returns the raw echoed response. Real hardware answers `C1:UNIT?` with the header still attached (`C1:UNIT V`, RC01020-E01C p.137); previously that header was returned verbatim, so `scope.channel1.unit` came back as `"C1:UNIT V"` instead of `"V"`. Code that worked around the old value should drop the workaround. The mock's `C1:UNIT?` answer was updated to match the same header-echoed form.
 - CI: the Codecov upload step passed `file:`, an input `codecov/codecov-action` dropped at v4. It was silently ignored — the run logged `Unexpected input(s) 'file'`, stayed green, and uploaded only because the CLI falls back to searching the tree for a report. Now `files:`, so the explicit path is honoured.
 

--- a/scpi_control/report_generator/generators/base.py
+++ b/scpi_control/report_generator/generators/base.py
@@ -20,7 +20,14 @@ class BaseReportGenerator(ABC):
             output_path: Path to save the generated report
 
         Returns:
-            True if successful, False otherwise
+            True if the report was written successfully. False means the
+            report could not be written for an environmental reason -- an I/O
+            failure such as permission denied, disk full, or a bad output
+            path (anything an implementation catches as OSError). A
+            programming error (AttributeError, TypeError, KeyError, etc.) is
+            not reported as False: implementations let it propagate, so a
+            defect in report rendering is never indistinguishable from an
+            I/O failure.
         """
         pass
 

--- a/scpi_control/report_generator/generators/markdown_generator.py
+++ b/scpi_control/report_generator/generators/markdown_generator.py
@@ -48,7 +48,12 @@ class MarkdownReportGenerator(BaseReportGenerator):
             output_path: Path to save the report
 
         Returns:
-            True if successful, False otherwise
+            True if the report was written to output_path, False if writing it
+            failed for an environmental reason (permission denied, disk full,
+            a bad output path -- anything that raises OSError). A programming
+            error (AttributeError, TypeError, etc.) is not reported as False;
+            it propagates so a defect in report rendering is never
+            indistinguishable from an I/O failure.
         """
         if not self.validate_report(report):
             logger.error("Report validation failed")
@@ -70,7 +75,11 @@ class MarkdownReportGenerator(BaseReportGenerator):
 
             return True
 
-        except Exception as e:
+        except OSError as e:
+            # Environmental failure (permission denied, disk full, a bad
+            # path, ...) -- this is the documented False case. Anything else
+            # (AttributeError, TypeError, KeyError, ...) is a programming
+            # error and must propagate rather than be reported as False.
             logger.exception(f"Failed to generate Markdown report: {e}")
             return False
 

--- a/scpi_control/report_generator/generators/pdf_generator.py
+++ b/scpi_control/report_generator/generators/pdf_generator.py
@@ -374,7 +374,12 @@ class PDFReportGenerator(BaseReportGenerator):
             output_path: Path to save the report
 
         Returns:
-            True if successful, False otherwise
+            True if the report was written to output_path, False if writing it
+            failed for an environmental reason (permission denied, disk full,
+            a bad output path -- anything that raises OSError). A programming
+            error (AttributeError, TypeError, etc.) is not reported as False;
+            it propagates so a defect in report rendering is never
+            indistinguishable from an I/O failure.
         """
         if not self.validate_report(report):
             logger.error("Report validation failed")
@@ -475,7 +480,11 @@ class PDFReportGenerator(BaseReportGenerator):
 
             return True
 
-        except Exception as e:
+        except OSError as e:
+            # Environmental failure (permission denied, disk full, a bad
+            # path, ...) -- this is the documented False case. Anything else
+            # (AttributeError, TypeError, KeyError, ...) is a programming
+            # error and must propagate rather than be reported as False.
             logger.exception(f"Failed to generate PDF report: {e}")
             return False
 

--- a/tests/test_markdown_generator_error_handling.py
+++ b/tests/test_markdown_generator_error_handling.py
@@ -1,0 +1,72 @@
+"""MarkdownReportGenerator.generate() must distinguish environmental failures
+(OSError -- permission denied, disk full, a bad output path) from programming
+errors (AttributeError, TypeError, ...). Only the former is documented to
+return `False`; the latter must propagate rather than being reported as a
+plain `False` indistinguishable from a full disk (audit 2026-08-09, L2).
+"""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from scpi_control.report_generator.generators.markdown_generator import MarkdownReportGenerator
+from scpi_control.report_generator.models.report_data import (
+    ReportMetadata,
+    TestReport,
+    TestSection,
+    WaveformData,
+)
+
+
+def make_report():
+    """A minimal but complete TestReport, including one waveform."""
+    t = np.arange(100) / 1e6
+    waveform = WaveformData(
+        channel="C1",
+        time=t,
+        voltage=np.sin(2 * np.pi * 10_000 * t),
+        sample_rate=1e6,
+        record_length=100,
+    )
+    section = TestSection(title="Rise Time", content="Measured on C1.", waveforms=[waveform])
+    metadata = ReportMetadata(title="Bench Check", technician="robin", test_date=datetime(2026, 7, 16))
+    return TestReport(metadata=metadata, sections=[section])
+
+
+def test_generate_returns_true_and_writes_the_file_on_the_happy_path(tmp_path):
+    out = tmp_path / "r.md"
+    assert MarkdownReportGenerator().generate(make_report(), out) is True
+    assert out.exists()
+    assert "Bench Check" in out.read_text(encoding="utf-8")
+
+
+def test_oserror_writing_the_file_is_still_reported_as_false(tmp_path):
+    """A bad output path (nonexistent parent directory) is an environmental
+    failure. The documented `False` contract must be preserved for it.
+
+    include_plots=False so the plots-dir mkdir(parents=True, exist_ok=True)
+    doesn't create the missing parent directory as a side effect before the
+    write is attempted -- that would silently defeat this test.
+    """
+    out = tmp_path / "does_not_exist" / "r.md"
+    assert MarkdownReportGenerator(include_plots=False).generate(make_report(), out) is False
+    assert not out.exists()
+
+
+def test_a_programming_error_propagates_instead_of_returning_false(tmp_path, monkeypatch):
+    """Pins the defect: an AttributeError from a bug in report rendering must
+    not be swallowed and reported as a plain False -- it must be raised so it
+    is visible, instead of masquerading as an environmental failure."""
+    generator = MarkdownReportGenerator()
+
+    def _boom(self, report, base_path):
+        raise AttributeError("simulated programming error in report rendering")
+
+    monkeypatch.setattr(MarkdownReportGenerator, "_generate_content", _boom)
+
+    out = tmp_path / "r.md"
+    with pytest.raises(AttributeError):
+        generator.generate(make_report(), out)
+
+    assert not out.exists()

--- a/tests/test_pdf_generator_error_handling.py
+++ b/tests/test_pdf_generator_error_handling.py
@@ -1,0 +1,74 @@
+"""PDFReportGenerator.generate() must distinguish environmental failures
+(OSError -- permission denied, disk full, a bad output path) from programming
+errors (AttributeError, TypeError, ...). Only the former is documented to
+return `False`; the latter must propagate rather than being reported as a
+plain `False` indistinguishable from a full disk (audit 2026-08-09, L2).
+
+Needs reportlab (the report-generator extra); CI's test job installs
+`.[dev,web]` only, so this skips cleanly there -- same pattern as
+tests/test_report_generators.py and tests/test_pdf_page_framework.py.
+"""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+pytest.importorskip("reportlab")
+
+from scpi_control.report_generator.generators.pdf_generator import PDFReportGenerator  # noqa: E402
+from scpi_control.report_generator.models.report_data import (  # noqa: E402
+    ReportMetadata,
+    TestReport,
+    TestSection,
+    WaveformData,
+)
+
+
+def make_report():
+    """A minimal but complete TestReport, including one waveform."""
+    t = np.arange(100) / 1e6
+    waveform = WaveformData(
+        channel="C1",
+        time=t,
+        voltage=np.sin(2 * np.pi * 10_000 * t),
+        sample_rate=1e6,
+        record_length=100,
+    )
+    section = TestSection(title="Rise Time", content="Measured on C1.", waveforms=[waveform])
+    metadata = ReportMetadata(title="Bench Check", technician="robin", test_date=datetime(2026, 7, 16))
+    return TestReport(metadata=metadata, sections=[section])
+
+
+def test_generate_returns_true_and_writes_the_file_on_the_happy_path(tmp_path):
+    out = tmp_path / "r.pdf"
+    assert PDFReportGenerator().generate(make_report(), out) is True
+    assert out.stat().st_size > 0
+
+
+def test_oserror_writing_the_file_is_still_reported_as_false(tmp_path):
+    """A bad output path (nonexistent parent directory) is an environmental
+    failure -- reportlab's canvas can't open the file and raises
+    FileNotFoundError (an OSError) from inside doc.build(). The documented
+    `False` contract must be preserved for it."""
+    out = tmp_path / "does_not_exist" / "r.pdf"
+    assert PDFReportGenerator().generate(make_report(), out) is False
+    assert not out.exists()
+
+
+def test_a_programming_error_propagates_instead_of_returning_false(tmp_path, monkeypatch):
+    """Pins the defect: an AttributeError from a bug in report rendering must
+    not be swallowed and reported as a plain False -- it must be raised so it
+    is visible, instead of masquerading as an environmental failure."""
+    generator = PDFReportGenerator()
+
+    def _boom(self, report):
+        raise AttributeError("simulated programming error in report rendering")
+
+    monkeypatch.setattr(PDFReportGenerator, "_generate_header", _boom)
+
+    out = tmp_path / "r.pdf"
+    with pytest.raises(AttributeError):
+        generator.generate(make_report(), out)
+
+    assert not out.exists()


### PR DESCRIPTION
## Description

Both report generators ended `generate()` with `except Exception: logger.exception(...); return False`. That treats two unrelated situations identically:

- **An environmental failure** — permission denied, disk full, a bad output path. Returning `False` here is correct and is exactly what the documented contract promises.
- **A programming error** — an `AttributeError` because a report model changed, a `TypeError`, a `KeyError`. These returned `False` too, so a genuine bug surfaced to the user as "Failed to generate report" and lived only in a log line, indistinguishable from a full disk.

This narrows the catch to `OSError` in both generators. Environmental failures still return `False` as documented; everything else propagates, so real bugs crash loudly.

Logged as L2 (MEDIUM) in the git-excluded `AUDIT.md` §2026-08-09.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] Test coverage improvement
- [ ] Breaking change

**Deliberately non-breaking.** The signature, the return type and all 30 call sites are unchanged.

## Changes Made

- **`markdown_generator.py` and `pdf_generator.py`:** `except Exception` → `except OSError` in `generate()`. Nothing beyond `OSError` was added.
- **`generators/base.py`:** the ABC docstring now states what `False` means — the report could not be written — and that programming errors propagate rather than being reported as `False`. Both concrete generators' docstrings updated to match.
- **Two new test files**, 6 tests total.

### Why the contract was not changed

`BaseReportGenerator.generate() -> bool` is published on an ABC with **30 call sites**, including tests asserting `generate(...) is True`. The GUI's `success = generator.generate(...)` / `if not success: QMessageBox.warning(...)` pattern is *right* for a desktop app — an export failure should not kill the application.

The pathology was never the `bool`. It was that one `except` clause could not distinguish a disk-full error from a bug. Narrowing it fixes that precisely, with no version bump and no caller changes. Raising instead, or returning a result object, would have broken every call site and forced a MAJOR bump for no proportionate gain.

Proper layering: catch broadly at the UI boundary where a crash is unacceptable, narrowly in the library where hiding bugs is unacceptable. All four GUI call sites (`main_window.py:444/534/579`, `comparison_dialog.py:364`) already sit inside `try`/`except Exception` blocks that show a dialog, so the UI side needed no change — verified independently after an initial claim to the contrary turned out to be wrong.

## Testing

- [x] Tests pass locally
- [x] Added tests for new functionality
- [ ] Tested with real hardware (not applicable)
- [ ] All CI checks pass (pending)

```
tests/test_markdown_generator_error_handling.py   3 passed  (new)
tests/test_pdf_generator_error_handling.py        3 passed  (new)
report-generator tests total                     31 passed
pytest -m "not slow" -n 8 -q                   2700 passed, 19 skipped
tests/test_changelog_mirror.py                    2 passed
```

Each generator is covered for all three cases: an `OSError` during write still returns `False` (the documented behaviour 30 call sites depend on), a programming error now propagates instead of being swallowed, and the happy path still returns `True` and writes the file.

**Mutation-checked:** restoring `except Exception` makes the regression test fail with `DID NOT RAISE AttributeError`. The reviewer reproduced this independently rather than taking it from the report.

**CI parity:** `reportlab` is not installed in CI (the test job installs `.[dev,web]`; reportlab lives in the `report-generator` extra). The new PDF test file uses the same module-level `pytest.importorskip("reportlab")` convention as the existing PDF tests. Verified by blocking `reportlab` at import time with a `sys.meta_path` blocker: `collected 0 items / 1 skipped` — it skips, it does not error.

## Code Quality

- [x] `black --check --line-length 200` clean
- [x] Self-reviewed
- [x] Updated docstrings for modified methods

## Documentation

- [x] `CHANGELOG.md` updated **and mirrored** to `docs/about/changelog.md` in the same commit

## Additional Notes

**A related gap this PR does *not* close, now logged as L2b.** The review read both generators end-to-end rather than just the diff and found **eight inner `except Exception` handlers** in plot and image helpers, sitting between the newly-narrowed outer handler and the actual work:

- `markdown_generator.py:448-495`, `:628-652`
- `pdf_generator.py:497-503`, `:721-726`, `:1009-1034`, `:1216-1233`, `:1237-1256`, `:1332-1349`

An error originating inside any of those — a programming error, or a genuine `OSError` such as disk-full while saving one plot's PNG — is caught there, logged, and degraded to missing content. `generate()` then returns **`True`**. The report is produced, silently missing a plot, and the caller is told it succeeded.

That is arguably a worse shape than the original L2, which at least returned `False`. It looks like deliberate graceful degradation for optional decorative content, which is defensible — but it is undocumented and no caller can detect it. Left alone here because this PR is deliberately scoped to the main file-write path, and because changing degradation behaviour deserves its own decision. Filed as **L2b** in `AUDIT.md`.

**Expect a `CHANGELOG.md` conflict** with #150 and #151 — all three add entries under `## [Unreleased]`. The resolution is the same trivial one each time: keep every entry in its own section.
