### PR TITLE
chore(release): 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.1.0] - 2026-08-09
+
 ### Added
 
 - Five examples for features that had none: `math_channels.py` (waveform arithmetic), `reference_waveforms.py` (golden-reference comparison), `screen_capture_example.py`, `measurement_badges_example.py` (Tektronix badge pooling), and `protocol_decoding.py` (I2C/SPI/UART).

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.1.0] - 2026-08-09
+
 ### Added
 
 - Five examples for features that had none: `math_channels.py` (waveform arithmetic), `reference_waveforms.py` (golden-reference comparison), `screen_capture_example.py`, `measurement_badges_example.py` (Tektronix badge pooling), and `protocol_decoding.py` (I2C/SPI/UART).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SCPI-Instrument-Control"
-version = "7.0.1"
+version = "7.1.0"
 # NOTE: this is the PyPI summary and has a hard 512-character cap. Check the length
 # before every release -- the v3.2.0 publish failed on exactly this.
 description = "Universal Python library for SCPI test equipment over Ethernet, USB, GPIB or serial. One API for oscilloscopes (Siglent, Tektronix, LeCroy), AWGs, power supplies and DAQ units, with waveform capture and provenance, FFT analysis, a PyQt6 GUI, a browser lab gateway, PDF/Markdown reports with local-LLM analysis, and high-fidelity mock instruments for developing with no hardware attached."

--- a/scpi_control/__init__.py
+++ b/scpi_control/__init__.py
@@ -25,7 +25,7 @@ For automated test report generation:
     from scpi_control.report_generator import ReportGenerator
 """
 
-__version__ = "7.0.1"
+__version__ = "7.1.0"
 
 from scpi_control.capabilities import ScopeCapabilities
 from scpi_control.exceptions import CommandError, SiglentConnectionError, SiglentError, SiglentTimeoutError


### PR DESCRIPTION
## Description

Cuts **7.1.0**. Version strings bumped in `pyproject.toml` and `scpi_control/__init__.py`; `## [7.1.0] - 2026-08-09` inserted under `## [Unreleased]` so the existing sections belong to this release; changelog mirrored.

## Type of Change

- [x] Documentation update
- [ ] Breaking change

## What's in it

**Added** — five examples for features that had none: `math_channels.py`, `reference_waveforms.py`, `screen_capture_example.py`, `measurement_badges_example.py`, `protocol_decoding.py`.

**Changed** — every network-facing example now takes `--host` defaulting to `mock` and runs with no instrument attached; the execution guard covers **33 of 36 examples, up from 15**; examples exit non-zero on failure instead of reporting success; the README hero GIF is now a tour of examples actually running, and appears on the docs landing page and examples README too.

**Fixed** — three real library defects:
- **Serial decoders could fabricate phantom events** — bytes never on the wire — when a frame began near the end of a captured buffer. Affected real hardware as much as the mock.
- **Report generators masked programming errors** as ordinary failures, so a bug was indistinguishable from a full disk.
- **`channel.unit` returned the raw echoed response** (`"C1:UNIT V"` instead of `"V"`) against a legacy-dialect scope.

Plus the docs landing page's Quick Example, which called `scope.measure.frequency()` — a method that does not exist.

## Why MINOR and not MAJOR

Three of those fixes change observable behaviour: `channel.unit` returns a different string, decoders report fewer events, and `generate()` raises where it returned `False`. v7.0.0 classified similarly-shaped changes as ⚠️ Breaking.

The difference is that each 7.0.0 case changed behaviour during **normal** operation, whereas all three of these differ only when something was **already wrong** — a fabricated byte, a masked bug, a garbled unit string. Correct code against correct inputs sees no change, so there is no ⚠️ Breaking Changes section.

The one caveat worth stating: a caller that wrapped `if not generate(...)` around a latent bug will now see an exception it did not previously handle.

## Testing

- [x] Full suite: **2753 passed, 19 skipped** (`report_ai_qa.py` deselected — it does live Ollama inference and pulls ~18 GB locally; it runs normally in CI, which has no Ollama)
- [x] `black --check --line-length 200 scpi_control/ examples/` → 209 files unchanged
- [x] flake8, CI's exact gates → blocking pass returns 0
- [x] `test_version_consistency.py` and `test_changelog_mirror.py` → 4 passed
- [x] PyPI summary length **387 / 512**

## Release steps after merge

1. `git tag v7.1.0 && git push origin v7.1.0` — starts `build-executables.yml`, which creates and publishes the GitHub release itself with an empty body
2. `gh release edit v7.1.0 --notes-file <extracted section>` to fill the notes
3. `gh workflow run publish.yml --ref v7.1.0` — the only thing that actually reaches PyPI, since `publish.yml` never fires on its own (the release is created with `GITHUB_TOKEN`, and GitHub does not let `GITHUB_TOKEN` events trigger other workflows)

Step 3 is the irreversible one and will be confirmed before running.